### PR TITLE
Update Cargo.toml to use the latest HEAD on parquet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # parquet = "1.0.0-SNAPSHOT"
-parquet = { git = "https://github.com/apache/arrow", brach = "6d15de4752cf632f8b6b5bfff16c2f5abaa34e76" }
+parquet = { git = "https://github.com/apache/arrow" }
 rusoto_core = "0.43"
 rusoto_s3 = "0.43"
 tokio = "0.2.10"


### PR DESCRIPTION
The previously referenced commit didn't resolve for me anyway. Build works with the HEAD of master.