### PR TITLE
use default region for S3StorageBackend (#42)

### DIFF
--- a/rust/src/storage/s3.rs
+++ b/rust/src/storage/s3.rs
@@ -29,7 +29,7 @@ pub struct S3StorageBackend {
 
 impl S3StorageBackend {
     pub fn new() -> Self {
-        let client = S3Client::new(Region::UsEast2);
+        let client = S3Client::new(Region::default());
         Self { client }
     }
 }


### PR DESCRIPTION
Addresses #42

Using Region::default() instead of a specific hard coded region.

This will allow the user to set the region using one of AWS' config files **HOWEVER** the region (as far as I understand) is irrelevant when working with s3:// URI's and buckets in general because their names are globally unique.