### PR TITLE
Add a simple integration test which relies on the golden data set in S3

### DIFF
--- a/rust/tests/s3_test.rs
+++ b/rust/tests/s3_test.rs
@@ -6,11 +6,15 @@ mod s3 {
      * Should there be test failures, or if you need more files uploaded into this account, let him
      * know
      */
-    #[tokio::test]
-    async fn test_s3_simple() {
+    fn setup() {
         std::env::set_var("AWS_REGION", "us-west-2");
         std::env::set_var("AWS_ACCESS_KEY_ID", "AKIAX7EGEQ7FT6CLQGWH");
         std::env::set_var("AWS_SECRET_ACCESS_KEY", "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");
+    }
+
+    #[tokio::test]
+    async fn test_s3_simple() {
+        setup();
         let table =
             deltalake::open_table("s3://deltars/simple")
                 .await
@@ -40,5 +44,19 @@ mod s3 {
                 dataChange: true
             }
         );
+    }
+
+    #[tokio::test]
+    async fn test_s3_simple_golden() {
+        setup();
+
+        let table =
+            deltalake::open_table("s3://deltars/golden/data-reader-array-primitives")
+                .await
+                .unwrap();
+        println!("{}", table);
+        assert_eq!(table.version, 0);
+        assert_eq!(table.min_writer_version, 2);
+        assert_eq!(table.min_reader_version, 1);
     }
 }


### PR DESCRIPTION
I have synced the golden data set from the connectors.git repository to the
Azure and S3 storage containers we're using for our integration tests:

Synced at 4fd7f370b53b99b5aa91b384d1dcf13a123d37ea

    cd connectors/golden-tables/src/test/resources/golden
    rclone sync . deltars:deltars/golden
    rclone sync .  deltars-azure:golden

This of course relies on a local rclone configuration on my machine with write
access :smile_cat:

I trust that @houqp and @nevi-me can do more interesting tests with this data

Fixes #55