### PR TITLE
bump arrow to 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,8 +91,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrow"
-version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=6c3547347e9d95f7d0c77d5949cb8fcf6983ca9b#6c3547347e9d95f7d0c77d5949cb8fcf6983ca9b"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d74faf1b951f686da25c0cf575c6f654beb3fd461fa3caabd2dbd68fe715513"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -103,6 +104,7 @@ dependencies = [
  "lazy_static",
  "lexical-core",
  "num",
+ "packed_simd_2",
  "prettytable-rs",
  "rand",
  "regex",
@@ -625,8 +627,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=6c3547347e9d95f7d0c77d5949cb8fcf6983ca9b#6c3547347e9d95f7d0c77d5949cb8fcf6983ca9b"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6ae9406efcba149c6f3bc41b98b6fcc6851fd54ed4affa176ac448de080557"
 dependencies = [
  "ahash 0.6.2",
  "arrow",
@@ -636,11 +639,15 @@ dependencies = [
  "crossbeam",
  "futures",
  "hashbrown",
+ "log",
+ "md-5",
  "num_cpus",
+ "ordered-float 2.0.1",
  "parquet",
  "paste",
  "pin-project-lite 0.2.3",
  "rustyline",
+ "sha2 0.9.2",
  "sqlparser",
  "tokio 0.2.24",
 ]
@@ -677,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "deltalake-python"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "deltalake",
  "env_logger",
@@ -736,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "dirs-next"
-version = "1.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf36e65a80337bea855cd4ef9b8401ffce06a7baedf2e85ec467b1ac3f6e82b6"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if 1.0.0",
  "dirs-sys-next",
@@ -836,11 +843,13 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "flatbuffers"
-version = "0.6.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a788f068dd10687940565bf4b5480ee943176cbd114b12e811074bcf7c04e4b9"
+checksum = "eb62c3be460921b3073057e5b2b08ae1682077b84ac6b341f70840693ae51c21"
 dependencies = [
+ "bitflags",
  "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -884,6 +893,16 @@ checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1477,6 +1496,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
 name = "lock_api"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,6 +1544,17 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
 
 [[package]]
 name = "md5"
@@ -1675,13 +1711,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -1875,10 +1911,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dacdec97876ef3ede8c50efc429220641a0b11ba0048b4b0c357bccbc47c5204"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+
+[[package]]
+name = "packed_simd_2"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3278e0492f961fd4ae70909f56b2723a7e8d01a228427294e19cdfdebda89a17"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libm",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1907,11 +1962,12 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "3.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow.git?rev=6c3547347e9d95f7d0c77d5949cb8fcf6983ca9b#6c3547347e9d95f7d0c77d5949cb8fcf6983ca9b"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7af8b51dcae8625a26d55387b17ff922436a78cdf57eed630d546e9924b36f"
 dependencies = [
  "arrow",
- "base64 0.13.0",
+ "base64 0.12.3",
  "brotli",
  "byteorder",
  "chrono",
@@ -2483,12 +2539,14 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "6.3.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0d5e7b0219a3eadd5439498525d4765c59b7c993ef0c12244865cd2d988413"
+checksum = "8227301bfc717136f0ecbd3d064ba8199e44497a0bdd46bb01ede4387cfd2cec"
 dependencies = [
- "cfg-if 0.1.10",
+ "bitflags",
+ "cfg-if 1.0.0",
  "dirs-next",
+ "fs2",
  "libc",
  "log",
  "memchr",
@@ -2735,9 +2793,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqlparser"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fa7478852b3ea28f0d21a42b2d7dade24ba4aa72e22bf66982e4b587a7f608"
+checksum = "e3a3da41f3ddf62cbf92635ace62dd037fad9a91c6871c514fbd404e2059f27d"
 dependencies = [
  "log",
 ]
@@ -2946,7 +3004,7 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "log",
- "ordered-float",
+ "ordered-float 1.1.1",
  "threadpool",
 ]
 
@@ -3514,18 +3572,18 @@ checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
 
 [[package]]
 name = "zstd"
-version = "0.5.4+zstd.1.4.7"
+version = "0.6.0+zstd.1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69996ebdb1ba8b1517f61387a883857818a66c8a295f487b1ffd8fd9d2c82910"
+checksum = "d4e44664feba7f2f1a9f300c1f6157f2d1bfc3c15c6f3cf4beabf3f5abe9c237"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "2.0.6+zstd.1.4.7"
+version = "3.0.0+zstd.1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98aa931fb69ecee256d44589d19754e61851ae4769bf963b385119b1cc37a49e"
+checksum = "d9447afcd795693ad59918c7bbffe42fdd6e467d708f3537e3dc14dc598c573f"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -3533,9 +3591,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.18+zstd.1.4.7"
+version = "1.4.19+zstd.1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6e8778706838f43f771d80d37787cb2fe06dafe89dd3aebaf6721b9eaec81"
+checksum = "ec24a9273d24437afb8e71b16f3d9a5d569193cccdb7896213b59f552f387674"
 dependencies = [
  "cc",
  "glob",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -25,7 +25,7 @@ features = ["extension-module", "abi3", "abi3-py36"]
 [dependencies.deltalake]
 path = "../rust"
 version = "0.*"
-features = ["s3", "azure"]
+features = ["s3", "azure", "simd"]
 
 [package.metadata.maturin]
 name = "deltalake"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,10 +31,9 @@ azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust", optional 
 rusoto_core = { version = "0.43", optional = true }
 rusoto_s3 = { version = "0.43", optional = true }
 
-# Cannot use branch constraint due to https://github.com/PyO3/maturin/issues/389
-arrow  = { git = "https://github.com/apache/arrow.git", rev = "6c3547347e9d95f7d0c77d5949cb8fcf6983ca9b" }
-datafusion = { git = "https://github.com/apache/arrow.git", rev = "6c3547347e9d95f7d0c77d5949cb8fcf6983ca9b", optional = true }
-parquet = { git = "https://github.com/apache/arrow.git", rev = "6c3547347e9d95f7d0c77d5949cb8fcf6983ca9b" }
+arrow  = { version = "3.0.0" }
+datafusion = { version = "3.0.0", optional = true }
+parquet = { version = "3.0.0" }
 crossbeam = { version = "0", optional = true }
 cfg-if = "1"
 async-trait = "0.1"
@@ -47,6 +46,7 @@ rust-dataframe-ext = []
 datafusion-ext = ["datafusion", "crossbeam"]
 azure = ["azure_core", "azure_storage"]
 s3 = ["rusoto_core", "rusoto_s3"]
+simd = ["arrow/simd", "datafusion/simd"]
 
 [dev-dependencies]
 utime = "0.3"


### PR DESCRIPTION
Now that I think about it, we will not be able to publish to crates.io anyway even with the stable arrow version bump due to dependency on azure sdk, which doesn't have a creates.io release yet.