### PR TITLE
[ISSUE-82] Add serial to handle concurrent s3 test execution

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,3 +50,4 @@ s3 = ["rusoto_core", "rusoto_s3"]
 
 [dev-dependencies]
 utime = "0.3"
+serial_test = "*"

--- a/rust/tests/s3_test.rs
+++ b/rust/tests/s3_test.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate serial_test;
+
 #[cfg(feature = "s3")]
 mod s3 {
     /*
@@ -13,6 +16,7 @@ mod s3 {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_s3_simple() {
         setup();
         let table =
@@ -47,6 +51,7 @@ mod s3 {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_s3_simple_with_trailing_slash() {
         setup();
         let table =
@@ -60,6 +65,7 @@ mod s3 {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_s3_simple_golden() {
         setup();
 


### PR DESCRIPTION
As described in https://github.com/delta-io/delta-rs/issues/82, it looks like the shared rusoto hyper client singleton is breaking our tests. Ultimately, the shared hyper client used by rusoto _may_ cause many other problems for delta-rs use cases, but this PR is intended to just fix CI for now.

Solution implemented is to use [serial_test](https://github.com/palfrey/serial_test) to serialize s3_test functions only without requiring the entire delta-rs suite to be ran serially.

Tested many times locally and all outputs look as below (pass, pass, pass):

```
cargo test --test s3_test                                                                                                                           christianw at C02Y104ZJGH8 (--)(issue-82/s3_test_workaround)
    Finished test [unoptimized + debuginfo] target(s) in 0.34s
     Running target/debug/deps/s3_test-76614a0b4a8defbc

running 3 tests
test s3::test_s3_simple_with_trailing_slash ... ok
test s3::test_s3_simple ... ok
test s3::test_s3_simple_golden ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```