### PR TITLE
Fix the decimal type in Python schema.

### DIFF
--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -180,8 +180,8 @@ def pyarrow_datatype_from_dict(json_dict: Dict) -> pyarrow.DataType:
         return pyarrow.type_for_alias(f'{type_class}{type_info["bitWidth"]}[{unit}]')
     elif type_class.startswith("decimal"):
         type_info = json_dict["type"]
-        return pyarrow.type_for_alias(
-            f'{type_class}({type_info["precision"]},{type_info["scale"]})'
+        return pyarrow.decimal128(
+            precision=type_info["precision"], scale=type_info["scale"]
         )
     else:
         return pyarrow.type_for_alias(type_class)

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -48,6 +48,25 @@ def test_table_schema_pyarrow_020():
     assert field.metadata is None
 
 
+def test_schema_pyarrow_from_decimal_type():
+    field_name = "decimal_test"
+    metadata = {b"metadata_k": b"metadata_v"}
+    precision = 20
+    scale = 2
+    pyarrow_field = pyarrow_field_from_dict(
+        {
+            "name": field_name,
+            "nullable": False,
+            "metadata": metadata,
+            "type": {"name": "decimal", "precision": precision, "scale": scale},
+        }
+    )
+    assert pyarrow_field.name == field_name
+    assert pyarrow_field.type == pyarrow.decimal128(precision=precision, scale=scale)
+    assert dict(pyarrow_field.metadata) == metadata
+    assert pyarrow_field.nullable is False
+
+
 def test_schema_delta_types():
     field_name = "column1"
     metadata = {"metadata_k": "metadata_v"}

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1,4 +1,3 @@
-import os
 from threading import Barrier, Thread
 
 import pytest

--- a/rust/tests/delta_arrow_test.rs
+++ b/rust/tests/delta_arrow_test.rs
@@ -1,0 +1,14 @@
+extern crate deltalake;
+use arrow::datatypes::DataType as ArrowDataType;
+
+#[test]
+fn test_arrow_from_delta_decimal_type() {
+    let precision = 20;
+    let scale = 2;
+    let decimal_type = String::from(format!["decimal({p},{s})", p=precision, s=scale]);
+    let decimal_field = deltalake::SchemaDataType::primitive(decimal_type);
+    assert_eq!(
+        <ArrowDataType as From<&deltalake::SchemaDataType>>::from(&decimal_field),
+        ArrowDataType::Decimal(precision, scale)
+    );
+}


### PR DESCRIPTION
- The method `type_for_alias()` of pyarrow is not available for the decimal type, I changed the conversion by creating the decimal128 type directly
- Add test on the decimal conversion for arrow schema