### PR TITLE
Add proper StorageError::NotFound error handling for s3 HEAD request

### DIFF
--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -222,6 +222,9 @@ impl From<RusotoError<rusoto_s3::HeadObjectError>> for StorageError {
             RusotoError::Service(rusoto_s3::HeadObjectError::NoSuchKey(_)) => {
                 StorageError::NotFound
             }
+            // rusoto tries to parse response body which is missing in HEAD request
+            // see https://github.com/rusoto/rusoto/issues/716
+            RusotoError::Unknown(r) if r.status == 404 => StorageError::NotFound,
             _ => StorageError::S3Head { source: error },
         }
     }

--- a/rust/tests/s3_test.rs
+++ b/rust/tests/s3_test.rs
@@ -9,6 +9,8 @@ mod s3 {
      * Should there be test failures, or if you need more files uploaded into this account, let him
      * know
      */
+    use deltalake::StorageError;
+
     fn setup() {
         std::env::set_var("AWS_REGION", "us-west-2");
         std::env::set_var("AWS_ACCESS_KEY_ID", "AKIAX7EGEQ7FT6CLQGWH");
@@ -73,5 +75,17 @@ mod s3 {
         assert_eq!(table.version, 0);
         assert_eq!(table.min_writer_version, 2);
         assert_eq!(table.min_reader_version, 1);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_s3_head_obj() {
+        setup();
+
+        let key = "s3://deltars/missing";
+        let backend = deltalake::get_backend_for_uri(key).unwrap();
+        let err = backend.head_obj(key).await.err().unwrap();
+
+        assert!(matches!(err, StorageError::NotFound));
     }
 }


### PR DESCRIPTION
Fixes #103.

In upstream issue users report that GET does not return `GetObjectError::NoSuchKey`, however that wan't the case for me when I tested it. It makes sense this to be reproducible only for HEAD calls, since rusoto has shared parsers for both which parses response body, however there's none for HEAD. Hence, response code is used to determine Not Found response 