### PR TITLE
Refactoring of ArrowSchema conversion

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::io::{BufRead, BufReader, Cursor};
 
+use arrow::error::ArrowError;
 use chrono::{DateTime, FixedOffset, Utc};
 use futures::StreamExt;
 use log::debug;
@@ -59,6 +60,11 @@ pub enum DeltaTableError {
     ParquetError {
         #[from]
         source: ParquetError,
+    },
+    #[error("Failed to convert into Arrow schema: {}", .source)]
+    ArrowError {
+        #[from]
+        source: ArrowError,
     },
     #[error("Invalid table path: {}", .source)]
     UriError {

--- a/rust/tests/delta_arrow_test.rs
+++ b/rust/tests/delta_arrow_test.rs
@@ -1,5 +1,6 @@
 extern crate deltalake;
 use arrow::datatypes::DataType as ArrowDataType;
+use std::convert::TryFrom;
 
 #[test]
 fn test_arrow_from_delta_decimal_type() {
@@ -8,7 +9,24 @@ fn test_arrow_from_delta_decimal_type() {
     let decimal_type = String::from(format!["decimal({p},{s})", p = precision, s = scale]);
     let decimal_field = deltalake::SchemaDataType::primitive(decimal_type);
     assert_eq!(
-        <ArrowDataType as From<&deltalake::SchemaDataType>>::from(&decimal_field),
+        <ArrowDataType as TryFrom<&deltalake::SchemaDataType>>::try_from(&decimal_field).unwrap(),
         ArrowDataType::Decimal(precision, scale)
     );
+}
+
+#[test]
+fn test_arrow_from_delta_wrong_decimal_type() {
+    let precision = 20;
+    let scale = "wrong";
+    let decimal_type = String::from(format!["decimal({p},{s})", p = precision, s = scale]);
+    let _error = format!(
+        "Invalid precision or scale decimal type for Arrow: {}",
+        scale
+    );
+    let decimal_field = deltalake::SchemaDataType::primitive(decimal_type);
+    assert!(matches!(
+        <ArrowDataType as TryFrom<&deltalake::SchemaDataType>>::try_from(&decimal_field)
+            .unwrap_err(),
+        arrow::error::ArrowError::SchemaError(_error),
+    ));
 }

--- a/rust/tests/write_exploration.rs
+++ b/rust/tests/write_exploration.rs
@@ -2,6 +2,8 @@ extern crate chrono;
 extern crate deltalake;
 extern crate utime;
 
+use std::convert::TryFrom;
+
 use arrow::{
     array::{as_primitive_array, Array},
     datatypes::Schema as ArrowSchema,
@@ -129,7 +131,7 @@ impl DeltaWriter {
         batch: &RecordBatch,
     ) -> Result<InMemoryWriteableCursor, DeltaWriterError> {
         let schema = &metadata.schema;
-        let arrow_schema = <ArrowSchema as From<&Schema>>::from(schema);
+        let arrow_schema = <ArrowSchema as TryFrom<&Schema>>::try_from(schema).unwrap();
         let arrow_schema_ref = Arc::new(arrow_schema);
 
         let writer_properties = WriterProperties::builder()
@@ -385,7 +387,8 @@ async fn smoke_test() {
         json!({ "id": "H", "value": 56, "modified": "2021-02-01" }),
     ];
 
-    let arrow_schema_ref = Arc::new(<ArrowSchema as From<&Schema>>::from(&metadata.schema));
+    let arrow_schema_ref =
+        Arc::new(<ArrowSchema as TryFrom<&Schema>>::try_from(&metadata.schema).unwrap());
     let record_batch =
         record_batch_from_json_buffer(arrow_schema_ref, json_rows.as_slice()).unwrap();
 
@@ -424,7 +427,8 @@ async fn smoke_test() {
         json!({ "id": "F", "value": 152, "modified": "2021-02-02" }),
     ];
 
-    let arrow_schema_ref = Arc::new(<ArrowSchema as From<&Schema>>::from(&metadata.schema));
+    let arrow_schema_ref =
+        Arc::new(<ArrowSchema as TryFrom<&Schema>>::try_from(&metadata.schema).unwrap());
     let record_batch =
         record_batch_from_json_buffer(arrow_schema_ref, json_rows.as_slice()).unwrap();
 


### PR DESCRIPTION
Refactoring of ArrowSchema, using `TryForm` trait and raise an `ArrowError` when there is an error in the conversion of the Schema.
Related to the issue: #93