### PR TITLE
Add a PR template into the repository

### DIFF
--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,8 @@
+# Description
+The description of the main changes of your pull request
+
+# Related Issue(s)
+- Closes [#106](https://github.com/delta-io/delta-rs/issues/106)
+
+# Documentation
+Share links to useful documentation


### PR DESCRIPTION
It could be interesting to have a PR template in the repository when people are creating a PR.
The template may contain description, issue-related, documentation, or conventions...

WDYT @houqp @rtyler?