### PR TITLE
Add json_schema field in Schema Python binding

### DIFF
--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -132,8 +132,9 @@ class Field:
 
 
 class Schema:
-    def __init__(self, fields: List[Field]):
+    def __init__(self, fields: List[Field], json_value: Dict[str, Any]):
         self.fields = fields
+        self.json_value = json_value
 
     def __str__(self) -> str:
         field_strs = [str(f) for f in self.fields]
@@ -142,19 +143,22 @@ class Schema:
     def __repr__(self) -> str:
         return self.__str__()
 
+    def json(self) -> Dict[str, Any]:
+        return self.json_schema
 
-def schema_from_json(json_data: str) -> Schema:
-    return Schema(
-        [
+    @classmethod
+    def from_json(cls, json_data: str) -> "Schema":
+        json_value = json.loads(json_data)
+        fields = [
             Field(
                 name=field["name"],
                 type=DataType.from_dict(field),
                 nullable=field["nullable"],
                 metadata=field.get("metadata"),
             )
-            for field in json.loads(json_data)["fields"]
+            for field in json_value["fields"]
         ]
-    )
+        return cls(fields=fields, json_value=json_value)
 
 
 def pyarrow_datatype_from_dict(json_dict: Dict) -> pyarrow.DataType:

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -5,7 +5,7 @@ import pyarrow
 from pyarrow.dataset import dataset
 
 from .deltalake import RawDeltaTable
-from .schema import Schema, pyarrow_schema_from_json, schema_from_json
+from .schema import Schema, pyarrow_schema_from_json
 
 
 class DeltaTable:
@@ -25,7 +25,7 @@ class DeltaTable:
         self._table.load_version(version)
 
     def schema(self) -> Schema:
-        return schema_from_json(self._table.schema_json())
+        return Schema.from_json(self._table.schema_json())
 
     def pyarrow_schema(self) -> pyarrow.Schema:
         return pyarrow_schema_from_json(self._table.arrow_schema_json())

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -16,6 +16,10 @@ def test_table_schema():
     table_path = "../rust/tests/data/simple_table"
     dt = DeltaTable(table_path)
     schema = dt.schema()
+    assert schema.json_value == {
+        "fields": [{"metadata": {}, "name": "id", "nullable": True, "type": "long"}],
+        "type": "struct",
+    }
     assert len(schema.fields) == 1
     field = schema.fields[0]
     assert field.name == "id"


### PR DESCRIPTION
# Description
- This PR keeps the `json_schema` returned by Rust in the `Schema` Python binding object
- It provides the functionality to create a StructType PySpark structure using JSON format without having the `pyspark[sql] `dependency in delta-rs

# Documentation
https://spark.apache.org/docs/3.0.1/api/python/pyspark.sql.html#pyspark.sql.types.StructType.fromJson