### PR TITLE
add crates.io and api doc link to rust workspace readme

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,9 @@
 Deltalake
 =========
 
+[![crates.io](https://img.shields.io/crates/v/deltalake.svg?style=flat-square)](https://crates.io/crates/deltalake)
+[![api_doc](https://img.shields.io/badge/doc-api-blue)](https://docs.rs/deltalake/0.1.1/deltalake/)
+
 Native Delta Lake implementation in Rust
 
 


### PR DESCRIPTION
# Description

Add crates.io and api doc link to rust workspace readme.