### PR TITLE
Fix json method in Python binding

### DIFF
--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -144,7 +144,7 @@ class Schema:
         return self.__str__()
 
     def json(self) -> Dict[str, Any]:
-        return self.json_schema
+        return self.json_value
 
     @classmethod
     def from_json(cls, json_data: str) -> "Schema":

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -16,7 +16,7 @@ def test_table_schema():
     table_path = "../rust/tests/data/simple_table"
     dt = DeltaTable(table_path)
     schema = dt.schema()
-    assert schema.json_value == {
+    assert schema.json() == {
         "fields": [{"metadata": {}, "name": "id", "nullable": True, "type": "long"}],
         "type": "struct",
     }


### PR DESCRIPTION
# Description
Fix the `json()` method in Python binding 

# Related Issue(s)
#121
