### PR TITLE
Fix update logic.

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -440,9 +440,7 @@ impl DeltaTable {
     pub async fn update(&mut self) -> Result<(), DeltaTableError> {
         match self.get_last_checkpoint().await {
             Ok(last_check_point) => {
-                if self.last_check_point.is_none()
-                    || self.last_check_point == Some(last_check_point)
-                {
+                if self.last_check_point != Some(last_check_point) {
                     self.last_check_point = Some(last_check_point);
                     self.restore_checkpoint(last_check_point).await?;
                     self.version = last_check_point.version + 1;


### PR DESCRIPTION
This prevents duplicate loading of already loaded checkpoints, and
replaying json despite a newer checkpoint being available.

closes #123 

The behavior has been tested using the approach discussed in #123.

1. start: 5 commits `createCommits(5, "<some delta path>")`

```
reading delta table: "<some path>"
[apply_logs_after_current_version] applied 0
[apply_logs_after_current_version] applied 1
[apply_logs_after_current_version] applied 2
[apply_logs_after_current_version] applied 3
[apply_logs_after_current_version] applied 4
[apply_logs_after_current_version] end of log : 5, rollback
initial table loaded, version 4
waiting on keypress for update, current version 4
```

2. 4 more commits: no checkpoints yet

```
updating ...
[update] process started
[update] no previous checkpoint, trying version = 5 ff
[apply_logs_after_current_version] applied 5
[apply_logs_after_current_version] applied 6
[apply_logs_after_current_version] applied 7
[apply_logs_after_current_version] applied 8
[apply_logs_after_current_version] end of log : 9, rollback
waiting on keypress for update, current version 8
```

3. 4 more commits: new checkpoint at v10

```
updating ...
[update] process started
[update] retrieved previous checkpoint CheckPoint { version: 10, size: 13, parts: None }, previous = None
[update] determined to load a checkpoint: CheckPoint { version: 10, size: 13, parts: None }
[restore_checkpoint]: CheckPoint { version: 10, size: 13, parts: None }
[apply_logs_after_current_version] applied 11
[apply_logs_after_current_version] applied 12
[apply_logs_after_current_version] end of log : 13, rollback
waiting on keypress for update, current version 12
```

4. 4 more commits: no new checkpoint, still at v10

```
updating ...
[update] process started
[update] retrieved previous checkpoint CheckPoint { version: 10, size: 13, parts: None }, previous = Some(CheckPoint { version: 10, size: 13, parts: None })
[apply_logs_after_current_version] applied 12
[apply_logs_after_current_version] applied 13
[apply_logs_after_current_version] applied 14
[apply_logs_after_current_version] applied 15
[apply_logs_after_current_version] applied 16
[apply_logs_after_current_version] end of log : 17, rollback
waiting on keypress for update, current version 16
```

OK: no checkpoint loaded, replaying deltas only.

```
updating ...
[update] process started
[update] retrieved previous checkpoint CheckPoint { version: 20, size: 23, parts: None }, previous = Some(CheckPoint { version: 10, size: 13, parts: None })
[update] determined to load a checkpoint: CheckPoint { version: 20, size: 23, parts: None }
[restore_checkpoint]: CheckPoint { version: 20, size: 23, parts: None }
[apply_logs_after_current_version] end of log : 21, rollback
```

OK: checkpoint for version 20 loaded
