### PR TITLE
Add ChainProvider for AWS S3Client

### DIFF
--- a/rust/src/storage/s3.rs
+++ b/rust/src/storage/s3.rs
@@ -4,6 +4,7 @@ use std::{fmt, pin::Pin};
 use chrono::{DateTime, FixedOffset, Utc};
 use futures::Stream;
 use log::debug;
+use rusoto_core::credential::ChainProvider;
 use rusoto_core::{Region, RusotoError};
 use rusoto_s3::{
     GetObjectRequest, HeadObjectRequest, ListObjectsV2Request, PutObjectRequest, S3Client, S3,
@@ -119,7 +120,11 @@ pub struct S3StorageBackend {
 
 impl S3StorageBackend {
     pub fn new() -> Self {
-        let client = S3Client::new(Region::default());
+        let client = S3Client::new_with(
+            rusoto_core::HttpClient::new().expect("failed to create request dispatcher"),
+            ChainProvider::new(),
+            Region::default(),
+        );
         Self { client }
     }
 }


### PR DESCRIPTION
# Description
The `S3Client` in Rusoto crate, for the S3 storage, should use the standard AWS Tool Chain using the `ChainProvider`. 
The `rusoto_core::ChainProvider` is a convenience for attempting to source access credentials using all the methods in the same order as AWS tools.

The provider has a default timeout of 30 seconds. We can reduce if we want:
```
let mut provider = ChainProvider::new();
// you can overwrite the default timeout like this:
provider.set_timeout(Duration::from_secs(60));
```

# Documentation
https://github.com/rusoto/rusoto/blob/master/AWS-CREDENTIALS.md

