### PR TITLE
Support EKS(K8s) service account authentication for S3 backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,9 @@ dependencies = [
  "regex",
  "reqwest",
  "rusoto_core",
+ "rusoto_credential",
  "rusoto_s3",
+ "rusoto_sts",
  "serde",
  "serde_json",
  "serial_test",
@@ -689,6 +691,12 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "dtoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
 
 [[package]]
 name = "encode_unicode"
@@ -2018,7 +2026,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "serde",
- "serde_urlencoded",
+ "serde_urlencoded 0.7.0",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -2124,6 +2132,21 @@ dependencies = [
  "sha2",
  "time 0.2.25",
  "tokio",
+]
+
+[[package]]
+name = "rusoto_sts"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f93005e0c3b9e40a424b50ca71886d2445cc19bb6cdac3ac84c2daff482eb59"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "rusoto_core",
+ "serde_urlencoded 0.6.1",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2311,6 +2334,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "serde",
+ "url",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -51,7 +51,7 @@ async-trait = "0.1"
 rust-dataframe-ext = []
 datafusion-ext = ["datafusion", "crossbeam"]
 azure = ["azure_core", "azure_storage", "reqwest"]
-s3 = ["rusoto_core", "rusoto_s3"]
+s3 = ["rusoto_core", "rusoto_credential", "rusoto_s3", "rusoto_sts"]
 
 [dev-dependencies]
 utime = "0.3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,7 +32,9 @@ azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust", optional 
 
 # S3
 rusoto_core = { version = "0.46", optional = true }
+rusoto_credential = { version = "0.46", optional = true }
 rusoto_s3 = { version = "0.46", optional = true }
+rusoto_sts = { version = "0.46", optional = true }
 
 # Cannot use branch constraint due to https://github.com/PyO3/maturin/issues/389
 arrow  = { git = "https://github.com/apache/arrow.git", rev = "05b36567bd8216bec71b796fe3bb6811c71abbec" }


### PR DESCRIPTION
# Description
The standard `ChainProvider` used in `rusoto` does not support credentials from a web token file by default. This authentication method is only relevant in the context of the `S3StorageBackend` and when running the client libraries in pods on EKS (that themselves are attached to Service Accounts with relevant IAM roles). 

I've tested this change on an actual cluster and it works. 

# Documentation
* `WebIdentityProvider`: https://docs.rs/rusoto_sts/0.45.0/rusoto_sts/struct.WebIdentityProvider.html