### PR TITLE
Fix Delta <> Arrow schema timestamp

### DIFF
--- a/rust/src/delta_arrow.rs
+++ b/rust/src/delta_arrow.rs
@@ -95,7 +95,7 @@ impl TryFrom<&schema::SchemaDataType> for ArrowDataType {
                     }
                     "timestamp" => {
                         // Microsecond precision timestamp without a timezone.
-                        Ok(ArrowDataType::Time64(TimeUnit::Microsecond))
+                        Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
                     }
                     s => Err(ArrowError::SchemaError(format!(
                         "Invalid data type for Arrow: {}",


### PR DESCRIPTION
# Description

This fixes an incorrect schema mapping for `timestamp` from delta to arrow


# Documentation

The protocol talks about timestamp being a microsecond precision value with no time zone. The Arrow `Time64` only stores the time portion of a timestamp, so the mapping was incorrect.
