### PR TITLE
fix windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,15 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-10.15
+          - windows-2019
 
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     # the whole target dir is over 400MB cache limit, so we have to split up

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,7 +360,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim 0.8.0",
@@ -609,6 +618,7 @@ dependencies = [
  "libc",
  "log",
  "parquet",
+ "pretty_assertions",
  "regex",
  "reqwest",
  "rusoto_core",
@@ -618,6 +628,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tempdir",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -627,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "deltalake-python"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arrow",
  "deltalake",
@@ -646,6 +657,12 @@ dependencies = [
  "helix",
  "tokio",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
@@ -834,6 +851,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -1637,6 +1660,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,6 +1797,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "pretty_assertions"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f297542c27a7df8d45de2b0e620308ab883ad232d06c14b76ac3e144bda50184"
+dependencies = [
+ "ansi_term 0.12.1",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
+
+[[package]]
 name = "prettytable-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +1923,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -1924,6 +1981,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -1956,6 +2028,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core 0.6.2",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2595,6 +2676,16 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -59,3 +59,4 @@ s3 = ["rusoto_core", "rusoto_credential", "rusoto_s3", "rusoto_sts"]
 utime = "0.3"
 serial_test = "*"
 pretty_assertions = "0"
+tempdir = "0"

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -12,8 +12,19 @@ use uuid::Uuid;
 
 mod rename;
 
-/// NOTE: The file storage backend is not multi-writer safe in Windows due to lack of support for
-/// native atomic file rename system call.
+/// Multi-writer support for different platforms:
+///
+/// * Modern Linux kernels are well supported. However because Linux implementation leverages
+/// `RENAME_NOREPLACE`, older versions of the kernel might not work depending on what filesystem is
+/// being used:
+///   *  ext4 requires >= Linux 3.15
+///   *  btrfs, shmem, and cif requires >= Linux 3.17
+///   *  xfs requires >= Linux 4.0
+///   *  ext2, minix, reiserfs, jfs, vfat, and bpf requires >= Linux 4.9
+/// * Darwin is supported but not fully tested.
+/// * Windows is not supported because we are not using native atomic file rename system call.
+/// Patches welcome.
+/// * Support for other platforms are not implemented at the moment.
 #[derive(Default, Debug)]
 pub struct FileStorageBackend {
     root: String,

--- a/rust/src/storage/file/rename.rs
+++ b/rust/src/storage/file/rename.rs
@@ -1,61 +1,81 @@
 use crate::StorageError;
-use std::ffi::CString;
 
-#[cfg(target_os = "linux")]
-const RENAME_NOREPLACE: libc::c_uint = 1;
+#[cfg(windows)]
+mod imp {
+    use super::*;
 
-#[cfg(target_os = "linux")]
-extern "C" {
-    fn renameat2(
-        olddirfd: libc::c_int,
-        oldpath: *const libc::c_char,
-        newdirfd: libc::c_int,
-        newpath: *const libc::c_char,
-        flags: libc::c_uint,
-    ) -> libc::c_int;
-}
-
-pub fn rename(from: &str, to: &str) -> Result<(), StorageError> {
-    let ret = unsafe {
-        let from = to_c_string(from)?;
-        let to = to_c_string(to)?;
-        platform_specific_rename(from.as_ptr(), to.as_ptr())
-    };
-
-    if ret != 0 {
-        std::fs::remove_file(from).unwrap_or(());
-
-        let e = errno::errno();
-        if let libc::EEXIST = e.0 {
-            return Err(StorageError::AlreadyExists(String::from(to)));
+    pub fn atomic_rename(from: &str, to: &str) -> Result<(), StorageError> {
+        // doing best effort in windows since there is no native atomic rename support
+        if std::fs::metadata(to).is_ok() {
+            return Err(StorageError::AlreadyExists(to.to_string()));
         }
-
-        return Err(StorageError::Io {
-            source: custom_io_error(format!("{}", e)),
-        });
-    }
-
-    Ok(())
-}
-
-unsafe fn platform_specific_rename(from: *const libc::c_char, to: *const libc::c_char) -> i32 {
-    cfg_if::cfg_if! {
-        if #[cfg(target_os = "linux")] {
-            renameat2(libc::AT_FDCWD, from, libc::AT_FDCWD, to, RENAME_NOREPLACE)
-        } else if #[cfg(target_os = "macos")] {
-            libc::renamex_np(from, to, libc::RENAME_EXCL)
-        } else {
-            unimplemented!()
-        }
+        std::fs::rename(from, to).map_err(|e| {
+            StorageError::other_std_io_err(format!("failed to rename {} to {}: {}", from, to, e))
+        })
     }
 }
 
-fn to_c_string(p: &str) -> Result<CString, StorageError> {
-    CString::new(p).map_err(|e| StorageError::Generic(format!("{}", e)))
+#[cfg(unix)]
+mod imp {
+    use super::*;
+    use std::ffi::CString;
+
+    #[cfg(target_os = "linux")]
+    const RENAME_NOREPLACE: libc::c_uint = 1;
+
+    #[cfg(target_os = "linux")]
+    extern "C" {
+        fn renameat2(
+            olddirfd: libc::c_int,
+            oldpath: *const libc::c_char,
+            newdirfd: libc::c_int,
+            newpath: *const libc::c_char,
+            flags: libc::c_uint,
+        ) -> libc::c_int;
+    }
+
+    fn to_c_string(p: &str) -> Result<CString, StorageError> {
+        CString::new(p).map_err(|e| StorageError::Generic(format!("{}", e)))
+    }
+
+    pub fn atomic_rename(from: &str, to: &str) -> Result<(), StorageError> {
+        let ret = unsafe {
+            let from = to_c_string(from)?;
+            let to = to_c_string(to)?;
+            platform_specific_rename(from.as_ptr(), to.as_ptr())
+        };
+
+        if ret != 0 {
+            let e = errno::errno();
+            if let libc::EEXIST = e.0 {
+                return Err(StorageError::AlreadyExists(String::from(to)));
+            }
+
+            return Err(StorageError::other_std_io_err(format!(
+                "failed to rename {} to {}: {}",
+                from, to, e
+            )));
+        }
+
+        Ok(())
+    }
+
+    unsafe fn platform_specific_rename(from: *const libc::c_char, to: *const libc::c_char) -> i32 {
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "linux")] {
+                renameat2(libc::AT_FDCWD, from, libc::AT_FDCWD, to, RENAME_NOREPLACE)
+            } else if #[cfg(target_os = "macos")] {
+                libc::renamex_np(from, to, libc::RENAME_EXCL)
+            } else {
+                unimplemented!()
+            }
+        }
+    }
 }
 
-fn custom_io_error(desc: String) -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::Other, desc)
+#[inline]
+pub fn atomic_rename(from: &str, to: &str) -> Result<(), StorageError> {
+    imp::atomic_rename(from, to)
 }
 
 #[cfg(test)]
@@ -64,41 +84,56 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
     use std::path::{Path, PathBuf};
-    use uuid::Uuid;
 
     #[test]
-    fn test_rename() {
-        let tmp = std::env::temp_dir().join(Uuid::new_v4().to_string());
-        std::fs::create_dir_all(&tmp).unwrap();
-        let a = create_file(&tmp, "a");
-        let b = create_file(&tmp, "b");
-        let c = &tmp.join("c");
+    fn test_atomic_rename() {
+        let tmp_dir = tempdir::TempDir::new("test_atomic_rename").unwrap();
+        let a = create_file(&tmp_dir.path(), "a");
+        let b = create_file(&tmp_dir.path(), "b");
+        let c = &tmp_dir.path().join("c");
+
+        // unsuccessful move not_exists to C, not_exists is missing
+        match atomic_rename("not_exists", c.to_str().unwrap()) {
+            Err(StorageError::Io { source: e }) => {
+                cfg_if::cfg_if! {
+                    if #[cfg(target_os = "windows")] {
+                        assert_eq!(
+                            e.to_string(),
+                            format!(
+                                "failed to rename not_exists to {}: The system cannot find the file specified. (os error 2)",
+                                c.to_str().unwrap()
+                            )
+                        );
+                    } else {
+                        assert_eq!(
+                            e.to_string(),
+                            format!(
+                                "failed to rename not_exists to {}: No such file or directory",
+                                c.to_str().unwrap()
+                            )
+                        );
+                    }
+                }
+            }
+            Err(e) => panic!(format!("expect std::io::Error, got: {:#}", e)),
+            Ok(()) => panic!("expect rename to fail with Err, but got Ok"),
+        }
 
         // successful move A to C
         assert!(a.exists());
         assert!(!c.exists());
-        rename(a.to_str().unwrap(), c.to_str().unwrap()).unwrap();
+        atomic_rename(a.to_str().unwrap(), c.to_str().unwrap()).unwrap();
         assert!(!a.exists());
         assert!(c.exists());
 
-        // unsuccessful move B to C, C already exists, B is deleted afterwards
+        // unsuccessful move B to C, C already exists, B is not deleted
         assert!(b.exists());
-        match rename(b.to_str().unwrap(), c.to_str().unwrap()) {
+        match atomic_rename(b.to_str().unwrap(), c.to_str().unwrap()) {
             Err(StorageError::AlreadyExists(p)) => assert_eq!(p, c.to_str().unwrap()),
             _ => panic!("unexpected"),
         }
-        assert!(!b.exists());
+        assert!(b.exists());
         assert_eq!(std::fs::read_to_string(c).unwrap(), "a");
-
-        // unsuccessful move B to C, B is missing
-        match rename(b.to_str().unwrap(), c.to_str().unwrap()) {
-            Err(StorageError::Io { source: e }) => {
-                assert_eq!(e.to_string(), "No such file or directory")
-            }
-            _ => panic!("unexpected"),
-        }
-
-        std::fs::remove_dir_all(&tmp).unwrap();
     }
 
     fn create_file(dir: &Path, name: &str) -> PathBuf {

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -15,7 +15,7 @@ pub mod file;
 #[cfg(feature = "s3")]
 pub mod s3;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, PartialEq)]
 pub enum UriError {
     #[error("Invalid URI scheme: {0}")]
     InvalidScheme(String),
@@ -203,6 +203,14 @@ pub enum StorageError {
         #[from]
         source: UriError,
     },
+}
+
+impl StorageError {
+    pub fn other_std_io_err(desc: String) -> Self {
+        Self::Io {
+            source: std::io::Error::new(std::io::ErrorKind::Other, desc),
+        }
+    }
 }
 
 impl From<std::io::Error> for StorageError {


### PR DESCRIPTION
# Description

Fix windows build, which was blocking us from releasing a windows
python client. Added mac and window build to the build matrix.

# Related Issue(s)

Also move rename temp file clean up logic into put_obj method in
preparation for moving the temp file creation logic into optimistic
delta commit loop. See https://github.com/delta-io/delta-rs/issues/135.

