### PR TITLE
Add dynamodb lock implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         toolchain: stable
         override: true
     - name: build and lint with clippy
-      run: cargo clippy --features azure,datafusion-ext,s3
+      run: cargo clippy --features azure,datafusion-ext,s3,dynamodb
 
   test:
     strategy:
@@ -77,4 +77,4 @@ jobs:
       - name: Setup localstack
         run: docker-compose up setup
       - name: Run tests
-        run: cargo test s3 --verbose --features s3
+        run: cargo test s3 --verbose --features s3,dynamodb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,12 +612,14 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "maplit",
  "parquet",
  "pretty_assertions",
  "regex",
  "reqwest",
  "rusoto_core",
  "rusoto_credential",
+ "rusoto_dynamodb",
  "rusoto_s3",
  "rusoto_sts",
  "serde",
@@ -1345,6 +1347,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
@@ -2196,6 +2204,20 @@ dependencies = [
  "shlex",
  "tokio",
  "zeroize",
+]
+
+[[package]]
+name = "rusoto_dynamodb"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f26af40f36409cb8fae3069690f78f638f747b55c7b90f338d5ed36016b0cda"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/build/setup_localstack.sh
+++ b/build/setup_localstack.sh
@@ -23,11 +23,9 @@ function wait_for() {
 wait_for "S3" "aws s3api list-buckets --endpoint-url=$ENDPOINT"
 
 echo "Uploading S3 test delta tables..."
-aws s3 rm s3://deltars --recursive --endpoint-url=$ENDPOINT > /dev/null 2>&1
-aws s3api delete-bucket --bucket deltars --endpoint-url=$ENDPOINT
-aws s3api create-bucket --bucket deltars --endpoint-url=$ENDPOINT
-aws s3 sync /data/golden s3://deltars/golden/ --endpoint-url=$ENDPOINT > /dev/null
-aws s3 sync /data/simple s3://deltars/simple/ --endpoint-url=$ENDPOINT > /dev/null
+aws s3api create-bucket --bucket deltars --endpoint-url=$ENDPOINT > /dev/null 2>&1
+aws s3 sync /data/golden s3://deltars/golden/ --delete --endpoint-url=$ENDPOINT > /dev/null
+aws s3 sync /data/simple s3://deltars/simple/ --delete --endpoint-url=$ENDPOINT > /dev/null
 
 wait_for "DynamoDB" "aws dynamodb list-tables --endpoint-url=$ENDPOINT"
 

--- a/build/setup_localstack.sh
+++ b/build/setup_localstack.sh
@@ -5,22 +5,40 @@ export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
 export ENDPOINT=http://localstack:4566
 
-retries=10 #seconds
-until aws s3api list-buckets --endpoint-url=$ENDPOINT > /dev/null 2>&1
-do
-  if [ "$retries" -lt "0" ]; then
-    echo 'S3 is still offline after 10 retries';
-    exit 1;
-  fi
-  echo 'waiting on S3 to start...'
-  sleep 5
-  retries=$((retries - 1))
-done
 
-echo 'S3 is running'
+function wait_for() {
+  retries=10
+  until eval $2 > /dev/null 2>&1
+  do
+    if [ "$retries" -lt "0" ]; then
+      echo "$1 is still offline after 10 retries";
+      exit 1;
+    fi
+    echo "Waiting on $1 to start..."
+    sleep 5
+    retries=$((retries - 1))
+  done
+}
 
+wait_for "S3" "aws s3api list-buckets --endpoint-url=$ENDPOINT"
+
+echo "Uploading S3 test delta tables..."
+aws s3 rm s3://deltars --recursive --endpoint-url=$ENDPOINT > /dev/null 2>&1
+aws s3api delete-bucket --bucket deltars --endpoint-url=$ENDPOINT
 aws s3api create-bucket --bucket deltars --endpoint-url=$ENDPOINT
-aws s3 sync /data/golden s3://deltars/golden/ --endpoint-url=$ENDPOINT
-aws s3 sync /data/simple s3://deltars/simple/ --endpoint-url=$ENDPOINT
+aws s3 sync /data/golden s3://deltars/golden/ --endpoint-url=$ENDPOINT > /dev/null
+aws s3 sync /data/simple s3://deltars/simple/ --endpoint-url=$ENDPOINT > /dev/null
 
-echo localstack is configured!
+wait_for "DynamoDB" "aws dynamodb list-tables --endpoint-url=$ENDPOINT"
+
+echo "Creating DynamoDB test lock table..."
+aws dynamodb delete-table --table-name test_table --endpoint-url=$ENDPOINT > /dev/null 2>&1
+aws dynamodb create-table --table-name test_table --endpoint-url=$ENDPOINT \
+    --attribute-definitions \
+        AttributeName=key,AttributeType=S \
+    --key-schema \
+        AttributeName=key,KeyType=HASH \
+    --provisioned-throughput \
+        ReadCapacityUnits=10,WriteCapacityUnits=10 > /dev/null
+
+echo Localstack is configured!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
       - PORT_WEB_UI=8080
       - DOCKER_HOST=unix:///var/run/docker.sock
       - HOST_TMP_FOLDER=${TMPDIR}
-    volumes:
-      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:4566/health" ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,6 +37,8 @@ rusoto_core = { version = "0.46", optional = true }
 rusoto_credential = { version = "0.46", optional = true }
 rusoto_s3 = { version = "0.46", optional = true }
 rusoto_sts = { version = "0.46", optional = true }
+rusoto_dynamodb = { version = "0.46", optional = true }
+maplit = { version = "1", optional = true }
 
 # Cannot use branch constraint due to https://github.com/PyO3/maturin/issues/389
 arrow  = { git = "https://github.com/apache/arrow.git", rev = "05b36567bd8216bec71b796fe3bb6811c71abbec" }
@@ -54,6 +56,7 @@ rust-dataframe-ext = []
 datafusion-ext = ["datafusion", "crossbeam"]
 azure = ["azure_core", "azure_storage", "reqwest"]
 s3 = ["rusoto_core", "rusoto_credential", "rusoto_s3", "rusoto_sts"]
+dynamodb = ["rusoto_dynamodb", "maplit"]
 
 [build-dependencies]
 glibc_version = "0"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -11,6 +11,10 @@ extern crate serde;
 extern crate serde_json;
 extern crate thiserror;
 
+#[cfg(feature = "dynamodb")]
+#[macro_use]
+extern crate maplit;
+
 pub mod action;
 mod delta;
 mod delta_arrow;

--- a/rust/src/storage/s3/dynamodb.rs
+++ b/rust/src/storage/s3/dynamodb.rs
@@ -1,0 +1,427 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use rusoto_core::RusotoError;
+use rusoto_dynamodb::*;
+use uuid::Uuid;
+
+pub struct DynamoLock {
+    client: DynamoDbClient,
+    opts: Options,
+}
+
+#[derive(Clone, Debug)]
+pub struct Options {
+    pub partition_key_value: String,
+    pub table_name: String,
+    pub owner_name: String,
+    pub lease_duration: u64,
+    pub sleep_millis: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct LockItem {
+    pub owner_name: String,
+    pub record_version_number: String,
+    pub lease_duration: u64,
+    pub is_released: bool,
+    pub data: Option<String>,
+    pub lookup_time: u128,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum DynamoError {
+    #[error("Dynamo table not found")]
+    TableNotFound,
+
+    #[error("Conditional check failed")]
+    ConditionalCheckFailed,
+
+    #[error("DynamoDB item has invalid schema")]
+    InvalidItemSchema,
+
+    #[error("Could not acquire lock for {0} sec")]
+    TimedOut(u64),
+
+    #[error("Put item error: {0}")]
+    PutItemError(RusotoError<PutItemError>),
+
+    #[error("Update item error: {0}")]
+    UpdateItemError(#[from] RusotoError<UpdateItemError>),
+
+    #[error("Get item error: {0}")]
+    GetItemError(RusotoError<GetItemError>),
+
+    #[error("Delete item error: {0}")]
+    DeleteItemError(#[from] RusotoError<DeleteItemError>),
+}
+
+pub const PARTITION_KEY_NAME: &str = "key";
+pub const OWNER_NAME: &str = "ownerName";
+pub const RECORD_VERSION_NUMBER: &str = "recordVersionNumber";
+pub const IS_RELEASED: &str = "isReleased";
+pub const LEASE_DURATION: &str = "leaseDuration";
+pub const DATA: &str = "data";
+
+mod expressions {
+    pub const ACQUIRE_LOCK_THAT_DOESNT_EXIST: &str = "attribute_not_exists(#pk)";
+
+    pub const PK_EXISTS_AND_IS_RELEASED: &str = "attribute_exists(#pk) AND #ir = :ir";
+
+    pub const PK_EXISTS_AND_RVN_MATCHES: &str = "attribute_exists(#pk) AND #rvn = :rvn";
+
+    pub const PK_EXISTS_AND_OWNER_RVN_MATCHES: &str =
+        "attribute_exists(#pk) AND #rvn = :rvn AND #on = :on";
+
+    pub const UPDATE_IS_RELEASED_AND_DATA: &str = "SET #ir = :ir, #d = :d";
+
+    pub const UPDATE_IS_RELEASED: &str = "SET #ir = :ir";
+}
+
+mod vars {
+    pub const PK_PATH: &str = "#pk";
+    pub const RVN_PATH: &str = "#rvn";
+    pub const RVN_VALUE: &str = ":rvn";
+    pub const IS_RELEASED_PATH: &str = "#ir";
+    pub const IS_RELEASED_VALUE: &str = ":ir";
+    pub const OWNER_NAME_PATH: &str = "#on";
+    pub const OWNER_NAME_VALUE: &str = ":on";
+    pub const DATA_PATH: &str = "#d";
+    pub const DATA_VALUE: &str = ":d";
+}
+
+mod options {
+    pub const PARTITION_KEY_VALUE: &str = "DYNAMO_LOCK_PARTITION_KEY_VALUE";
+    pub const TABLE_NAME: &str = "DYNAMO_LOCK_TABLE_NAME";
+    pub const OWNER_NAME: &str = "DYNAMO_LOCK_OWNER_NAME";
+    pub const LEASE_DURATION: &str = "DYNAMO_LOCK_LEASE_DURATION";
+    pub const SLEEP_MILLIS: &str = "DYNAMO_LOCK_SLEEP_MILLIS";
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        fn str_env(key: &str, default: String) -> String {
+            std::env::var(key).unwrap_or(default)
+        }
+
+        fn u64_env(key: &str, default: u64) -> u64 {
+            std::env::var(key)
+                .ok()
+                .and_then(|e| e.parse::<u64>().ok())
+                .unwrap_or(default)
+        }
+
+        Self {
+            partition_key_value: str_env(options::PARTITION_KEY_VALUE, "delta-rs".to_string()),
+            table_name: str_env(options::TABLE_NAME, "delta_rs_lock_table".to_string()),
+            owner_name: str_env(options::OWNER_NAME, Uuid::new_v4().to_string()),
+            lease_duration: u64_env(options::LEASE_DURATION, 20),
+            sleep_millis: u64_env(options::SLEEP_MILLIS, 1000),
+        }
+    }
+}
+
+impl DynamoLock {
+    pub fn new(client: DynamoDbClient, opts: Options) -> Self {
+        Self { client, opts }
+    }
+
+    pub async fn acquire_lock(&self) -> Result<LockItem, DynamoError> {
+        let mut state = AcquireLockState {
+            client: self,
+            active_lock: None,
+            started: Instant::now(),
+            timeout_in: Duration::from_millis(self.opts.sleep_millis),
+        };
+
+        loop {
+            match state.try_acquire_lock().await {
+                Ok(lock) => return Ok(lock),
+                Err(DynamoError::ConditionalCheckFailed) => {
+                    if state.has_timed_out() {
+                        return Err(DynamoError::TimedOut(state.started.elapsed().as_secs()));
+                    }
+                    tokio::time::sleep(Duration::from_millis(self.opts.sleep_millis)).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    pub async fn get_lock(&self) -> Result<Option<LockItem>, DynamoError> {
+        let output = self
+            .client
+            .get_item(GetItemInput {
+                consistent_read: Some(true),
+                table_name: self.opts.table_name.clone(),
+                key: hashmap! {
+                    PARTITION_KEY_NAME.to_string() => attr(self.opts.partition_key_value.clone())
+                },
+                ..Default::default()
+            })
+            .await?;
+
+        if let Some(item) = output.item {
+            let get_value = |key| -> Result<String, DynamoError> {
+                Ok(item
+                    .get(key)
+                    .and_then(|r| r.s.as_ref())
+                    .ok_or(DynamoError::InvalidItemSchema)?
+                    .clone())
+            };
+
+            let lease_duration = get_value(LEASE_DURATION)?
+                .parse::<u64>()
+                .map_err(|_| DynamoError::InvalidItemSchema)?;
+
+            return Ok(Some(LockItem {
+                owner_name: get_value(OWNER_NAME)?,
+                record_version_number: get_value(RECORD_VERSION_NUMBER)?,
+                lease_duration,
+                is_released: item.contains_key(IS_RELEASED),
+                data: get_value(DATA).ok(),
+                lookup_time: now_millis(),
+            }));
+        }
+
+        Ok(None)
+    }
+
+    pub async fn release_lock(&self, lock: &LockItem) -> Result<(), DynamoError> {
+        let mut names = hashmap! {
+            vars::PK_PATH.to_string() => PARTITION_KEY_NAME.to_string(),
+            vars::RVN_PATH.to_string() => RECORD_VERSION_NUMBER.to_string(),
+            vars::OWNER_NAME_PATH.to_string() => OWNER_NAME.to_string(),
+            vars::IS_RELEASED_PATH.to_string() => IS_RELEASED.to_string(),
+        };
+        let mut values = hashmap! {
+            vars::IS_RELEASED_VALUE.to_string() => attr("1"),
+            vars::RVN_VALUE.to_string() => attr(&lock.record_version_number),
+            vars::OWNER_NAME_VALUE.to_string() => attr(&lock.owner_name),
+        };
+
+        let update: &str;
+        if let Some(ref data) = lock.data {
+            update = expressions::UPDATE_IS_RELEASED_AND_DATA;
+            names.insert(vars::DATA_PATH.to_string(), DATA.to_string());
+            values.insert(vars::DATA_VALUE.to_string(), attr(data));
+        } else {
+            update = expressions::UPDATE_IS_RELEASED;
+        }
+
+        self.client
+            .update_item(UpdateItemInput {
+                table_name: self.opts.table_name.clone(),
+                key: hashmap! {
+                    PARTITION_KEY_NAME.to_string() => attr(self.opts.partition_key_value.clone())
+                },
+                condition_expression: Some(
+                    expressions::PK_EXISTS_AND_OWNER_RVN_MATCHES.to_string(),
+                ),
+                update_expression: Some(update.to_string()),
+                expression_attribute_names: Some(names),
+                expression_attribute_values: Some(values),
+                ..Default::default()
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn upsert_item(
+        &self,
+        data: Option<String>,
+        condition_expression: Option<String>,
+        expression_attribute_names: Option<HashMap<String, String>>,
+        expression_attribute_values: Option<HashMap<String, AttributeValue>>,
+    ) -> Result<LockItem, DynamoError> {
+        let lookup_time = now_millis();
+        let rvn = Uuid::new_v4().to_string();
+
+        let mut item = hashmap! {
+            PARTITION_KEY_NAME.to_string() => attr(self.opts.partition_key_value.clone()),
+            OWNER_NAME.to_string() => attr(&self.opts.owner_name),
+            RECORD_VERSION_NUMBER.to_string() => attr(&rvn),
+            LEASE_DURATION.to_string() => attr(&self.opts.lease_duration),
+        };
+
+        if let Some(ref d) = data {
+            item.insert(DATA.to_string(), attr(d));
+        }
+
+        self.client
+            .put_item(PutItemInput {
+                table_name: self.opts.table_name.clone(),
+                item,
+                condition_expression,
+                expression_attribute_names,
+                expression_attribute_values,
+                ..Default::default()
+            })
+            .await?;
+
+        Ok(LockItem {
+            owner_name: self.opts.owner_name.clone(),
+            record_version_number: rvn,
+            lease_duration: self.opts.lease_duration,
+            is_released: false,
+            data,
+            lookup_time,
+        })
+    }
+}
+
+impl LockItem {
+    fn is_expired(&self) -> bool {
+        if self.is_released {
+            return true;
+        }
+        now_millis() - self.lookup_time > (self.lease_duration as u128) * 1000
+    }
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+}
+
+pub fn attr<T: ToString>(s: T) -> AttributeValue {
+    AttributeValue {
+        s: Some(s.to_string()),
+        ..Default::default()
+    }
+}
+
+struct AcquireLockState<'a> {
+    client: &'a DynamoLock,
+    active_lock: Option<LockItem>,
+    started: Instant,
+    timeout_in: Duration,
+}
+
+impl<'a> AcquireLockState<'a> {
+    fn has_timed_out(&self) -> bool {
+        self.started.elapsed() > self.timeout_in
+    }
+
+    async fn try_acquire_lock(&mut self) -> Result<LockItem, DynamoError> {
+        match self.client.get_lock().await? {
+            None => {
+                // there's no lock, we good to acquire it
+                Ok(self.upsert_new_lock().await?)
+            }
+            Some(existing) if existing.is_released => {
+                // lock is released by a caller, we good to acquire it
+                Ok(self.upsert_released_lock(existing.data).await?)
+            }
+            Some(existing) => {
+                // there's existing lock and it's out first attempt to acquire it
+                if self.active_lock.is_none() {
+                    // first we store it, extend timeout period and try again later
+                    return self.set_new_active_lock_and_fail(existing);
+                }
+
+                // there's existing lock and we've already tried to acquire it, let's try again
+                let active = self.active_lock.as_ref().unwrap();
+                let active_rvn = &active.record_version_number;
+
+                // let's check store rvn against current lock from dynamo
+                if active_rvn == &existing.record_version_number {
+                    // rvn matches
+                    if active.is_expired() {
+                        // the lock is expired and we're safe to try to acquire it
+                        self.upsert_expired_lock(active_rvn, existing.data).await
+                    } else {
+                        // the lock is not yet expired, try again later
+                        Err(DynamoError::ConditionalCheckFailed)
+                    }
+                } else {
+                    // rvn doesn't match, meaning that other worker acquire it before us
+                    // let's change active lock with new one and extend timeout period
+                    self.set_new_active_lock_and_fail(existing)
+                }
+            }
+        }
+    }
+
+    fn set_new_active_lock_and_fail(&mut self, lock: LockItem) -> Result<LockItem, DynamoError> {
+        self.extend_timeout_by(lock.lease_duration);
+        self.active_lock = Some(lock);
+
+        Err(DynamoError::ConditionalCheckFailed)
+    }
+
+    fn extend_timeout_by(&mut self, seconds: u64) {
+        self.timeout_in = Duration::from_secs(self.timeout_in.as_secs() + seconds)
+    }
+
+    async fn upsert_new_lock(&self) -> Result<LockItem, DynamoError> {
+        self.client
+            .upsert_item(
+                None,
+                Some(expressions::ACQUIRE_LOCK_THAT_DOESNT_EXIST.to_string()),
+                Some(hashmap! {
+                    vars::PK_PATH.to_string() => PARTITION_KEY_NAME.to_string(),
+                }),
+                None,
+            )
+            .await
+    }
+
+    async fn upsert_released_lock(&self, data: Option<String>) -> Result<LockItem, DynamoError> {
+        self.client
+            .upsert_item(
+                data,
+                Some(expressions::PK_EXISTS_AND_IS_RELEASED.to_string()),
+                Some(hashmap! {
+                    vars::PK_PATH.to_string() => PARTITION_KEY_NAME.to_string(),
+                    vars::IS_RELEASED_PATH.to_string() => IS_RELEASED.to_string(),
+                }),
+                Some(hashmap! {
+                    vars::IS_RELEASED_VALUE.to_string() => attr("1")
+                }),
+            )
+            .await
+    }
+
+    async fn upsert_expired_lock(
+        &self,
+        existing_rvn: &str,
+        data: Option<String>,
+    ) -> Result<LockItem, DynamoError> {
+        self.client
+            .upsert_item(
+                data,
+                Some(expressions::PK_EXISTS_AND_RVN_MATCHES.to_string()),
+                Some(hashmap! {
+                  vars::PK_PATH.to_string() => PARTITION_KEY_NAME.to_string(),
+                  vars::RVN_PATH.to_string() => RECORD_VERSION_NUMBER.to_string(),
+                }),
+                Some(hashmap! {
+                    vars::RVN_VALUE.to_string() => attr(existing_rvn)
+                }),
+            )
+            .await
+    }
+}
+
+impl From<RusotoError<PutItemError>> for DynamoError {
+    fn from(error: RusotoError<PutItemError>) -> Self {
+        match error {
+            RusotoError::Service(PutItemError::ConditionalCheckFailed(_)) => {
+                DynamoError::ConditionalCheckFailed
+            }
+            _ => DynamoError::PutItemError(error),
+        }
+    }
+}
+
+impl From<RusotoError<GetItemError>> for DynamoError {
+    fn from(error: RusotoError<GetItemError>) -> Self {
+        match error {
+            RusotoError::Service(GetItemError::ResourceNotFound(_)) => DynamoError::TableNotFound,
+            _ => DynamoError::GetItemError(error),
+        }
+    }
+}

--- a/rust/src/storage/s3/dynamodb_lock.rs
+++ b/rust/src/storage/s3/dynamodb_lock.rs
@@ -309,7 +309,7 @@ impl DynamoDbLockClient {
             update = expressions::UPDATE_IS_RELEASED;
         }
 
-        self.client.update_item(UpdateItemInput {
+        let result = self.client.update_item(UpdateItemInput {
             table_name: self.opts.table_name.clone(),
             key: hashmap! {
                 PARTITION_KEY_NAME.to_string() => attr(self.opts.partition_key_value.clone())
@@ -335,7 +335,6 @@ impl DynamoDbLockClient {
         expression_attribute_names: Option<HashMap<String, String>>,
         expression_attribute_values: Option<HashMap<String, AttributeValue>>,
     ) -> Result<LockItem, DynamoError> {
-        let lookup_time = now_millis();
         let rvn = Uuid::new_v4().to_string();
 
         let mut item = hashmap! {
@@ -366,7 +365,7 @@ impl DynamoDbLockClient {
             lease_duration: self.opts.lease_duration,
             is_released: false,
             data,
-            lookup_time,
+            lookup_time: now_millis(),
         })
     }
 }

--- a/rust/src/storage/s3/dynamodb_lock.rs
+++ b/rust/src/storage/s3/dynamodb_lock.rs
@@ -107,11 +107,6 @@ pub enum DynamoError {
     #[error("Conditional check failed")]
     ConditionalCheckFailed,
 
-    /// Error that is returned by [`DynamoDbLockClient::release_lock`] when the given lock
-    /// has been already expired and could not be released.
-    #[error("Lock is expired")]
-    LockIsExpired,
-
     /// The required field of [`LockItem`] is missing in DynamoDB record or has incompatible type.
     #[error("DynamoDB item has invalid schema")]
     InvalidItemSchema,

--- a/rust/src/storage/s3/dynamodb_lock.rs
+++ b/rust/src/storage/s3/dynamodb_lock.rs
@@ -202,7 +202,7 @@ impl DynamoDbLockClient {
     }
 
     /// Attempts to acquire a lock until it either acquires the lock or the error is found.
-    /// It it does not see the existing DynamoDB record then it's immediately created and
+    /// If it does not see an existing DynamoDB record then it's immediately created and
     /// returned to the caller. If it does see a lock, it will take its lease duration into
     /// consideration. If the lock is deemed stale (it's not released by its owner within lease
     /// duration), then this will acquire and return it.

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -16,7 +16,6 @@ use tokio::io::AsyncReadExt;
 use super::{parse_uri, ObjectMeta, StorageBackend, StorageError};
 
 #[cfg(feature = "dynamodb")]
-#[allow(dead_code)]
 pub mod dynamodb_lock;
 
 impl From<RusotoError<rusoto_s3::GetObjectError>> for StorageError {

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -17,7 +17,7 @@ use super::{parse_uri, ObjectMeta, StorageBackend, StorageError};
 
 #[cfg(feature = "dynamodb")]
 #[allow(dead_code)]
-pub mod dynamodb;
+pub mod dynamodb_lock;
 
 impl From<RusotoError<rusoto_s3::GetObjectError>> for StorageError {
     fn from(error: RusotoError<rusoto_s3::GetObjectError>) -> Self {

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -15,6 +15,10 @@ use tokio::io::AsyncReadExt;
 
 use super::{parse_uri, ObjectMeta, StorageBackend, StorageError};
 
+#[cfg(feature = "dynamodb")]
+#[allow(dead_code)]
+pub mod dynamodb;
+
 impl From<RusotoError<rusoto_s3::GetObjectError>> for StorageError {
     fn from(error: RusotoError<rusoto_s3::GetObjectError>) -> Self {
         match error {

--- a/rust/tests/dynamodb_test.rs
+++ b/rust/tests/dynamodb_test.rs
@@ -64,7 +64,7 @@ mod dynamodb {
 
         // save some arbitrary data into the lock item
         existing.data = Some("test".to_string());
-        lock.release_lock(&existing).await.unwrap();
+        assert!(lock.release_lock(&existing).await.unwrap());
 
         let released = lock.get_lock().await.unwrap().unwrap();
         // the lock from dynamodb should be the same, but with is_released=true field
@@ -91,13 +91,10 @@ mod dynamodb {
         assert!(now.elapsed().as_millis() > 3000);
 
         // cannot release the lock since it's been expired by other client
-        match c1.release_lock(&l1).await {
-            Err(DynamoError::LockIsExpired) => (),
-            r => panic!("{:?}", r),
-        }
+        assert!(!c1.release_lock(&l1).await.unwrap());
 
         // the owner successfully expires a lock
-        c2.release_lock(&l2).await.unwrap();
+        assert!(c2.release_lock(&l2).await.unwrap());
 
         // check what it is true
         let current = c1.get_lock().await.unwrap().unwrap();

--- a/rust/tests/dynamodb_test.rs
+++ b/rust/tests/dynamodb_test.rs
@@ -4,11 +4,12 @@ extern crate maplit;
 
 #[cfg(feature = "dynamodb")]
 mod dynamodb {
-    use deltalake::s3::dynamodb_lock::{attr, DynamoDbLockClient, Options, PARTITION_KEY_NAME};
+    use deltalake::s3::dynamodb_lock::{
+        attr, DynamoDbLockClient, DynamoError, Options, PARTITION_KEY_NAME,
+    };
     use rusoto_core::Region;
     use rusoto_dynamodb::*;
-    use serial_test::serial;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     async fn create_dynamo_lock(key: &str, owner: &str) -> DynamoDbLockClient {
         let table_name = "test_table";
@@ -23,7 +24,8 @@ mod dynamodb {
             table_name: table_name.to_string(),
             owner_name: owner.to_string(),
             lease_duration: 3,
-            sleep_millis: 200,
+            refresh_period: Duration::from_millis(500),
+            additional_time_to_wait_for_lock: Duration::from_millis(500),
         };
         let _ = client
             .delete_item(DeleteItemInput {
@@ -38,7 +40,6 @@ mod dynamodb {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_acquire_get_release_flow() {
         let lock = create_dynamo_lock("test_acquire_get_release_flow", "worker").await;
 
@@ -74,5 +75,67 @@ mod dynamodb {
         );
         // check that the data above is stored successfully
         assert_eq!(released.data, existing.data);
+    }
+
+    #[tokio::test]
+    async fn test_acquire_expired_lock() {
+        let c1 = create_dynamo_lock("test_acquire_expired_lock", "w1").await;
+        let c2 = create_dynamo_lock("test_acquire_expired_lock", "w2").await;
+
+        let l1 = c1.acquire_lock().await.unwrap();
+
+        let now = Instant::now();
+        let l2 = c2.acquire_lock().await.unwrap();
+
+        // ensure that we've waiter for more than lease_duration
+        assert!(now.elapsed().as_millis() > 3000);
+
+        // cannot release the lock since it's been expired by other client
+        match c1.release_lock(&l1).await {
+            Err(DynamoError::LockIsExpired) => (),
+            r => panic!("{:?}", r),
+        }
+
+        // the owner successfully expires a lock
+        c2.release_lock(&l2).await.unwrap();
+
+        // check what it is true
+        let current = c1.get_lock().await.unwrap().unwrap();
+        assert!(current.is_released);
+        assert_eq!(current.record_version_number, l2.record_version_number);
+    }
+
+    #[tokio::test]
+    async fn test_acquire_expired_lock_multiple_workers() {
+        let origin = create_dynamo_lock("test_acquire_expired_lock_multiple_workers", "o").await;
+        let c1 = create_dynamo_lock("test_acquire_expired_lock_multiple_workers", "w1").await;
+        let c2 = create_dynamo_lock("test_acquire_expired_lock_multiple_workers", "w2").await;
+
+        let _ = origin.acquire_lock().await.unwrap();
+        let f1 = tokio::spawn(async move { c1.acquire_lock().await });
+        let f2 = tokio::spawn(async move { c2.acquire_lock().await });
+
+        let acquired = match (f1.await.unwrap(), f2.await.unwrap()) {
+            (Ok(lock), Err(DynamoError::TimedOut(_))) => {
+                // first got the lock
+                assert_eq!(lock.owner_name, "w1");
+                lock
+            }
+            (Err(DynamoError::TimedOut(_)), Ok(lock)) => {
+                // second got the lock
+                assert_eq!(lock.owner_name, "w2");
+                lock
+            }
+            (r1, r2) => {
+                panic!("{:?}, {:?}", r1, r2)
+            }
+        };
+
+        let current = origin.get_lock().await.unwrap().unwrap();
+
+        assert_eq!(
+            acquired.record_version_number,
+            current.record_version_number
+        );
     }
 }

--- a/rust/tests/dynamodb_test.rs
+++ b/rust/tests/dynamodb_test.rs
@@ -4,13 +4,13 @@ extern crate maplit;
 
 #[cfg(feature = "dynamodb")]
 mod dynamodb {
-    use deltalake::s3::dynamodb::{attr, DynamoLock, Options, PARTITION_KEY_NAME};
+    use deltalake::s3::dynamodb_lock::{attr, DynamoDbLockClient, Options, PARTITION_KEY_NAME};
     use rusoto_core::Region;
     use rusoto_dynamodb::*;
     use serial_test::serial;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    async fn create_dynamo_lock(key: &str, owner: &str) -> DynamoLock {
+    async fn create_dynamo_lock(key: &str, owner: &str) -> DynamoDbLockClient {
         let table_name = "test_table";
         std::env::set_var("AWS_ACCESS_KEY_ID", "test");
         std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
@@ -34,7 +34,7 @@ mod dynamodb {
                 ..Default::default()
             })
             .await;
-        DynamoLock::new(client, opts)
+        DynamoDbLockClient::new(client, opts)
     }
 
     #[tokio::test]

--- a/rust/tests/dynamodb_test.rs
+++ b/rust/tests/dynamodb_test.rs
@@ -1,0 +1,78 @@
+#[cfg(feature = "dynamodb")]
+#[macro_use]
+extern crate maplit;
+
+#[cfg(feature = "dynamodb")]
+mod dynamodb {
+    use deltalake::s3::dynamodb::{attr, DynamoLock, Options, PARTITION_KEY_NAME};
+    use rusoto_core::Region;
+    use rusoto_dynamodb::*;
+    use serial_test::serial;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    async fn create_dynamo_lock(key: &str, owner: &str) -> DynamoLock {
+        let table_name = "test_table";
+        std::env::set_var("AWS_ACCESS_KEY_ID", "test");
+        std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+        let client = DynamoDbClient::new(Region::Custom {
+            name: "custom".to_string(),
+            endpoint: "http://localhost:4566".to_string(),
+        });
+        let opts = Options {
+            partition_key_value: key.to_string(),
+            table_name: table_name.to_string(),
+            owner_name: owner.to_string(),
+            lease_duration: 3,
+            sleep_millis: 200,
+        };
+        let _ = client
+            .delete_item(DeleteItemInput {
+                key: hashmap! {
+                    PARTITION_KEY_NAME.to_string() => attr(key)
+                },
+                table_name: table_name.to_string(),
+                ..Default::default()
+            })
+            .await;
+        DynamoLock::new(client, opts)
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_acquire_get_release_flow() {
+        let lock = create_dynamo_lock("test_acquire_get_release_flow", "worker").await;
+
+        let item = lock.acquire_lock().await.unwrap();
+        assert_eq!(item.owner_name, "worker");
+        assert_eq!(item.lease_duration, 3);
+        assert!(item.data.is_none());
+        assert_eq!(item.is_released, false);
+        assert_eq!(
+            item.lookup_time / 1000,
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as u128
+        );
+
+        let mut existing = lock.get_lock().await.unwrap().unwrap();
+        //verify that in dynamodb it is the same lock
+        assert_eq!(item.record_version_number, existing.record_version_number);
+        // although it is the same lock, but lookup time is different
+        assert_ne!(item.lookup_time, existing.lookup_time);
+
+        // save some arbitrary data into the lock item
+        existing.data = Some("test".to_string());
+        lock.release_lock(&existing).await.unwrap();
+
+        let released = lock.get_lock().await.unwrap().unwrap();
+        // the lock from dynamodb should be the same, but with is_released=true field
+        assert_eq!(released.is_released, true);
+        assert_eq!(
+            released.record_version_number,
+            existing.record_version_number
+        );
+        // check that the data above is stored successfully
+        assert_eq!(released.data, existing.data);
+    }
+}


### PR DESCRIPTION
# Description
This PR adds dynamo distributive lock ported from https://github.com/awslabs/amazon-dynamodb-lock-client

Note that not every feature is ported from java lock client to easy the integration. 

In addition, this port also introduces additional feature, it is the extending a timeout duration on each time exiting lock changes its rvn. Meaning that there's other clients trying to acquire a lock and they were more successful, so instead retuning  None (due to timeout as in original java version) this implementation extends the wait duration by adding another `lease_duration` to the try acquire loop.

