### PR TITLE
Ensure that Schema.from_json builds all DataTypes correctly

### DIFF
--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -52,7 +52,7 @@ class DataType:
                 if isinstance(json_field["type"], str):
                     data_type = cls(json_field["type"])
                 else:
-                    data_type =  cls.from_dict(json_field["type"])
+                    data_type = cls.from_dict(json_field["type"])
                 field = Field(
                     name=json_field["name"],
                     type=data_type,

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -9,6 +9,7 @@ from deltalake.schema import (
     MapType,
     StructType,
     pyarrow_field_from_dict,
+    Schema,
 )
 
 
@@ -26,6 +27,10 @@ def test_table_schema():
     assert field.type == DataType("long")
     assert field.nullable is True
     assert field.metadata == {}
+
+    json = '{"type":"struct","fields":[{"name":"x","type":{"type":"array","elementType":"long","containsNull":true},"nullable":true,"metadata":{}}]}'
+    schema = Schema.from_json(json)
+    assert schema.fields[0] == Field("x", ArrayType(DataType("long"), True), True, {})
 
 
 def test_table_schema_pyarrow_simple():


### PR DESCRIPTION
In the python library, I noticed that the schemas of nested delta tables are not being built correctly by `Schema.from_json`.  For example this JSON Spark schema with an array field (which is in the test case I've added)
```json
{
    "type": "struct",
    "fields": [
        {
            "name": "x",
            "type": {
                "type": "array",
                "elementType": "long",
                "containsNull": true
            },
            "nullable": true,
            "metadata": {}
        }
    ]
}
```

is translated to this Schema

```python
Schema(Field("x", DataType({"type": "array", "elementType": "long", "containsNull": True}), True, {})
```

When I believe the correct result should be

```python
Schema(Field("x", ArrayType(DataType("long"), True), True, {}))
```