### PR TITLE
Use renameat2 symbol exported from official libc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "lock_api"

--- a/rust/src/storage/file/rename.rs
+++ b/rust/src/storage/file/rename.rs
@@ -50,19 +50,7 @@ mod imp {
             if #[cfg(all(target_os = "linux", target_env = "gnu"))] {
                 cfg_if::cfg_if! {
                     if #[cfg(glibc_renameat2)] {
-                        const RENAME_NOREPLACE: libc::c_uint = 1;
-
-                        extern "C" {
-                            fn renameat2(
-                                olddirfd: libc::c_int,
-                                oldpath: *const libc::c_char,
-                                newdirfd: libc::c_int,
-                                newpath: *const libc::c_char,
-                                flags: libc::c_uint,
-                            ) -> libc::c_int;
-                        }
-
-                        renameat2(libc::AT_FDCWD, from, libc::AT_FDCWD, to, RENAME_NOREPLACE)
+                        libc::renameat2(libc::AT_FDCWD, from, libc::AT_FDCWD, to, libc::RENAME_NOREPLACE)
                     } else {
                         // target has old glibc (< 2.28), we would need to invoke syscall manually
                         unimplemented!()


### PR DESCRIPTION
# Description

Tries to use renameat2 exported from latest libc crate fixed in [rust-lang/libc#2116](https://github.com/rust-lang/libc/pull/2116/files) (as mentioned in [comment](https://github.com/delta-io/delta-rs/pull/140/files/98c1d9181249f83790719ad28ccb33ecbdb4cd74#r598330852)).

# Related Issue(s)

closes #143