### PR TITLE
separate integration tests from the rest of CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,19 @@ defaults:
     working-directory: ./rust
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install minimal stable with clippy and rustfmt
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: default
+        toolchain: stable
+        override: true
+    - name: Format
+      run: cargo fmt -- --check
+
   build:
     strategy:
       fail-fast: false
@@ -19,37 +32,54 @@ jobs:
           - ubuntu-latest
           - macOS-10.15
           - windows-2019
-
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    # the whole target dir is over 400MB cache limit, so we have to split up
-    # the cache step to avoid caching deps dir
-    - name: Cache Rust build
-      uses: actions/cache@v1.0.1
-      with:
-        path: target/debug/build
-        key: ${{ runner.OS }}-target-build-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.OS }}-target-build-
-    - name: Cache Rust incremental build
-      uses: actions/cache@v1.0.1
-      with:
-        path: target/debug/incremental
-        key: ${{ runner.OS }}-target-incremental-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.OS }}-target-incremental-
     - name: Install minimal stable with clippy and rustfmt
       uses: actions-rs/toolchain@v1
       with:
         profile: default
         toolchain: stable
         override: true
-    - name: Check
+    - name: build and lint with clippy
       run: cargo clippy --features azure,datafusion-ext,s3
-    - name: Build
-      run: cargo build --features azure,datafusion-ext,s3
-    - name: Format
-      run: cargo fmt -- --check
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-10.15
+          - windows-2019
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install minimal stable with clippy and rustfmt
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: default
+        toolchain: stable
+        override: true
     - name: Run tests
-      run: cargo test --verbose --features azure,datafusion-ext,s3
+      run: cargo test --verbose --features datafusion-ext
+
+  integration_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-10.15
+          - windows-2019
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install minimal stable with clippy and rustfmt
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: default
+        toolchain: stable
+        override: true
+    - name: Run tests
+      run: cargo test --verbose --features azure,s3

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -60,11 +60,18 @@ jobs:
     - name: Install matruin
       run: pip install maturin==0.9.0
 
-    - name: Run Python tests
+    - name: Build and install deltalake
       run: |
         # disable manylinux audit checks for test builds
         maturin build --manylinux off
         ls -lh ../target/wheels
         PY_MINOR_VER=$(python -V | cut -d. -f 2)
         pip install $(printf ../target/wheels/deltalake-*-cp36-abi3-*.whl)'[devel,pandas]'
-        py.test tests
+
+    - name: Run tests
+      run: |
+        py.test tests -m 'not integration'
+
+    - name: Run Integration tests
+      run: |
+        py.test tests -m integration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
  "env_logger",
  "errno",
  "futures",
- "glibc_version",
+ "glibc_version 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "libc",
  "log",
@@ -1004,6 +1004,15 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 [[package]]
 name = "glibc_version"
 version = "0.1.2"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "glibc_version"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803ff7635f1ab4e2c064b68a0c60da917d3d18dc8d086130f689d62ce4f1c33e"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "python",
     "glibc_version",
 ]
+
+[profile.dev]
+split-debuginfo = "unpacked"

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -119,6 +119,8 @@ class ExcPassThroughThread(Thread):
             raise self.exc
 
 
+@pytest.mark.s3
+@pytest.mark.integration
 @pytest.mark.timeout(timeout=5, method="thread")
 def test_read_multiple_tables_from_s3(s3cred):
     """
@@ -136,6 +138,8 @@ def test_read_multiple_tables_from_s3(s3cred):
         ]
 
 
+@pytest.mark.s3
+@pytest.mark.integration
 @pytest.mark.timeout(timeout=10, method="thread")
 def test_read_multiple_tables_from_s3_multi_threaded(s3cred):
     thread_count = 10

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,6 +1,7 @@
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 mod platform_cfg {
     fn detect_glibc_renameat2() {
+        // we should never fail on version parsing when the target is linux + glibc
         let ver = glibc_version::get_version().unwrap();
         if ver.major >= 2 && ver.minor >= 28 {
             println!("cargo:rustc-cfg=glibc_renameat2");


### PR DESCRIPTION
# Description

This should make non-integration test related CI failure easier to catch. Breaking up CI into finer grain parallel jobs should also speed up the pipeline.