### PR TITLE
support custom endpoint url for S3 backend

### DIFF
--- a/rust/src/storage/s3.rs
+++ b/rust/src/storage/s3.rs
@@ -143,7 +143,16 @@ pub struct S3StorageBackend {
 
 impl S3StorageBackend {
     pub fn new() -> Self {
-        let client = create_s3_client(Region::default()).unwrap();
+        let region = if let Ok(url) = std::env::var("AWS_ENDPOINT_URL") {
+            Region::Custom {
+                name: "custom".to_string(),
+                endpoint: url.clone(),
+            }
+        } else {
+            Region::default()
+        };
+
+        let client = create_s3_client(region).unwrap();
         Self { client }
     }
 }

--- a/rust/src/storage/s3.rs
+++ b/rust/src/storage/s3.rs
@@ -146,7 +146,7 @@ impl S3StorageBackend {
         let region = if let Ok(url) = std::env::var("AWS_ENDPOINT_URL") {
             Region::Custom {
                 name: "custom".to_string(),
-                endpoint: url.clone(),
+                endpoint: url,
             }
         } else {
             Region::default()


### PR DESCRIPTION
# Description

S3 compatible services like minio and localstack need to be accessed by setting a custom endpoint url. This PR adds support for setting the endpoint url through `AWS_ENDPOINT_URL` env var. The env var name is picked based on aws cli argument `--endpoint-url`.

# Related Issue(s)

- closes #163
