### PR TITLE
Add pytest coverage plugin

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -70,8 +70,8 @@ jobs:
 
     - name: Run tests
       run: |
-        py.test tests -m 'not integration'
+        py.test --cov tests -m 'not integration'
 
     # - name: Run Integration tests
     #   run: |
-    #     py.test tests -m integration
+    #     py.test --cov tests -m integration

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -43,6 +43,7 @@ requires-dist = [
     "pandas; extra =='pandas'",
     "pytest; extra == 'devel'",
     "pytest-mock; extra == 'devel'",
+    "pytest-cov; extra == 'devel'",
     "pytest-timeout; extra == 'devel'",
 ]
 provides-extra = ["pandas", "devel"]


### PR DESCRIPTION
# Description
Add a coverage report for the CI on the test coverage 

# Documentation

```
---------- coverage: platform linux, python 3.6.12-final-0 -----------
Name                       Stmts   Miss  Cover
----------------------------------------------
tests/conftest.py              6      3    50%
tests/test_schema.py         109      0   100%
tests/test_table_read.py      71     23    68%
tests/test_version.py          4      0   100%
----------------------------------------------
> TOTAL                        190     26    86%
```