### PR TITLE
fix python binding black lint

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -20,9 +20,9 @@ jobs:
       with:
         python-version: 3.6
     - name: Format Python code with Black
-      uses: psf/black@stable
-      with:
-        args: ". --check"
+      run: |
+        pip install black
+        black . --check
     - name: Install minimal stable with clippy and rustfmt
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
# Description

The upstream action is not well maintained and implemented, it's better/faster to just install black from pip manually.