### PR TITLE
Add Metadata in Python bindings

### DIFF
--- a/python/deltalake/__init__.py
+++ b/python/deltalake/__init__.py
@@ -1,3 +1,3 @@
-from .deltalake import RawDeltaTable, rust_core_version
-from .table import DeltaTable
+from .deltalake import RawDeltaTable, RawDeltaTableMetaData, rust_core_version
+from .table import DeltaTable, Metadata
 from .schema import Schema, Field, DataType

--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -85,3 +85,13 @@ PyArrow format
     >>> dt = DeltaTable("../../rust/tests/data/simple_table")
     >>> dt.pyarrow_schema()
     id: int64
+
+Metadata
+-----------
+
+.. code-block:: python
+
+    >>> from deltalake import DeltaTable
+    >>> dt = DeltaTable("../../rust/tests/data/simple_table")
+    >>> dt.metadata()
+    Metadata(id: 5fba94ed-9794-4965-ba6e-6ee3c0d22af9, name: None, description: None, partitionColumns: [], configuration={})

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -2,7 +2,7 @@ from threading import Barrier, Thread
 
 import pytest
 
-from deltalake import DeltaTable
+from deltalake import DeltaTable, Metadata
 
 
 def test_read_simple_table_to_dict():
@@ -15,6 +15,17 @@ def test_read_simple_table_by_version_to_dict():
     table_path = "../rust/tests/data/delta-0.2.0"
     dt = DeltaTable(table_path, version=2)
     assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"value": [1, 2, 3]}
+
+
+def test_read_partitioned_table_metadata():
+    table_path = "../rust/tests/data/delta-0.8.0-partitioned"
+    dt = DeltaTable(table_path)
+    metadata = dt.metadata()
+    assert metadata.id == "fe5a3c11-30d4-4dd7-b115-a1c121e66a4e"
+    assert metadata.name is None
+    assert metadata.description is None
+    assert metadata.partition_columns == ["year", "month", "day"]
+    assert metadata.configuration == {}
 
 
 def test_get_files_partitioned_table():


### PR DESCRIPTION
# Description
Add the metadata in the Python bindings.

Metadata:
- id
- name
- description
- configuration
- partition_columns

# Related Issue(s)
- closes #190 
