### PR TITLE
Add pyarrow floatingpoint in Python bindings

### DIFF
--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -220,7 +220,7 @@ def pyarrow_datatype_from_dict(json_dict: Dict[str, Any]) -> pyarrow.DataType:
     elif type_class == "struct":
         fields = [pyarrow_field_from_dict(field) for field in json_dict["children"]]
         return pyarrow.struct(fields)
-    elif type_class == "int" or type_class == "float" or type_class == "date":
+    elif type_class == "int" or type_class == "date":
         return pyarrow.type_for_alias(f'{type_class}{json_dict["type"]["bitWidth"]}')
     elif type_class == "time":
         type_info = json_dict["type"]
@@ -252,6 +252,14 @@ def pyarrow_datatype_from_dict(json_dict: Dict[str, Any]) -> pyarrow.DataType:
         return pyarrow.decimal128(
             precision=type_info["precision"], scale=type_info["scale"]
         )
+    elif type_class.startswith("floatingpoint"):
+        type_info = json_dict["type"]
+        if type_info["precision"] == "HALF":
+            return pyarrow.float16()
+        elif type_info["precision"] == "SINGLE":
+            return pyarrow.float32()
+        elif type_info["precision"] == "DOUBLE":
+            return pyarrow.float64()
     else:
         return pyarrow.type_for_alias(type_class)
 

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -57,7 +57,7 @@ def test_table_schema_pyarrow_020():
     assert field.metadata is None
 
 
-def test_schema_pyarrow_from_decimal_type():
+def test_schema_pyarrow_from_decimal_and_floating_types():
     field_name = "decimal_test"
     metadata = {b"metadata_k": b"metadata_v"}
     precision = 20
@@ -72,6 +72,21 @@ def test_schema_pyarrow_from_decimal_type():
     )
     assert pyarrow_field.name == field_name
     assert pyarrow_field.type == pyarrow.decimal128(precision=precision, scale=scale)
+    assert dict(pyarrow_field.metadata) == metadata
+    assert pyarrow_field.nullable is False
+
+    field_name = "floating_test"
+    metadata = {b"metadata_k": b"metadata_v"}
+    pyarrow_field = pyarrow_field_from_dict(
+        {
+            "name": field_name,
+            "nullable": False,
+            "metadata": metadata,
+            "type": {"name": "floatingpoint", "precision": "HALF"},
+        }
+    )
+    assert pyarrow_field.name == field_name
+    assert pyarrow_field.type == pyarrow.float16()
     assert dict(pyarrow_field.metadata) == metadata
     assert pyarrow_field.nullable is False
 


### PR DESCRIPTION
# Description
Add the missing `floatingpoint` pyarrow data type inside the Python bindings

# Related Issue(s)
- closes #192 
