### PR TITLE
Bump Python bindings version to v0.4.6

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"


### PR DESCRIPTION
# Description
Bump Python bindings version to v0.4.6

