### PR TITLE
Unify s3 and fs try_commit behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "deltalake-python"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "arrow",
  "deltalake",

--- a/build/setup_localstack.sh
+++ b/build/setup_localstack.sh
@@ -25,7 +25,8 @@ wait_for "S3" "aws s3api list-buckets --endpoint-url=$ENDPOINT"
 echo "Uploading S3 test delta tables..."
 aws s3api create-bucket --bucket deltars --endpoint-url=$ENDPOINT > /dev/null 2>&1
 aws s3 sync /data/golden s3://deltars/golden/ --delete --endpoint-url=$ENDPOINT > /dev/null
-aws s3 sync /data/simple s3://deltars/simple/ --delete --endpoint-url=$ENDPOINT > /dev/null
+aws s3 sync /data/simple_table s3://deltars/simple/ --delete --endpoint-url=$ENDPOINT > /dev/null
+aws s3 sync /data/simple_commit s3://deltars/simple_commit_rw/ --delete --endpoint-url=$ENDPOINT > /dev/null
 
 wait_for "DynamoDB" "aws dynamodb list-tables --endpoint-url=$ENDPOINT"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,4 +25,5 @@ services:
     volumes:
       - "./build/setup_localstack.sh:/setup_localstack.sh"
       - "./rust/tests/data/golden:/data/golden"
-      - "./rust/tests/data/simple_table:/data/simple"
+      - "./rust/tests/data/simple_table:/data/simple_table"
+      - "./rust/tests/data/simple_commit:/data/simple_commit"

--- a/rust/src/storage/azure.rs
+++ b/rust/src/storage/azure.rs
@@ -189,4 +189,8 @@ impl StorageBackend for AdlsGen2Backend {
     async fn put_obj(&self, _path: &str, _obj_bytes: &[u8]) -> Result<(), StorageError> {
         unimplemented!("put_obj not implemented for azure");
     }
+
+    async fn rename_obj(&self, _src: &str, _dst: &str) -> Result<(), StorageError> {
+        unimplemented!("rename_obj not implemented for azure");
+    }
 }

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -8,7 +8,6 @@ use tokio::io::AsyncWriteExt;
 use tokio_stream::wrappers::ReadDirStream;
 
 use super::{ObjectMeta, StorageBackend, StorageError};
-use uuid::Uuid;
 
 mod rename;
 
@@ -85,52 +84,23 @@ impl StorageBackend for FileStorageBackend {
     }
 
     async fn put_obj(&self, path: &str, obj_bytes: &[u8]) -> Result<(), StorageError> {
-        let tmp_path = create_tmp_file_with_retry(self, path, obj_bytes).await?;
-
-        if let Err(e) = rename::atomic_rename(&tmp_path, path) {
-            fs::remove_file(tmp_path).await.unwrap_or(());
-            return Err(e);
+        if let Some(parent) = Path::new(path).parent() {
+            fs::create_dir_all(parent).await?;
         }
+        let mut f = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(path)
+            .await?;
+
+        f.write(obj_bytes).await?;
 
         Ok(())
     }
-}
 
-const CREATE_TEMPORARY_FILE_MAX_TRIES: i32 = 5;
-
-async fn create_tmp_file_with_retry(
-    backend: &FileStorageBackend,
-    path: &str,
-    obj_bytes: &[u8],
-) -> Result<String, StorageError> {
-    let mut i = 0;
-
-    while i < CREATE_TEMPORARY_FILE_MAX_TRIES {
-        let tmp_file_name = format!("{}.temporary", Uuid::new_v4().to_string());
-        let tmp_path = backend.join_path(&backend.root, &tmp_file_name);
-        let rf = fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&tmp_path)
-            .await;
-
-        match rf {
-            Ok(mut f) => {
-                f.write(obj_bytes).await?;
-                return Ok(tmp_path);
-            }
-            Err(e) => {
-                std::fs::remove_file(&tmp_path).unwrap_or(());
-                if e.kind() != std::io::ErrorKind::AlreadyExists {
-                    return Err(StorageError::Io { source: e });
-                }
-            }
-        }
-
-        i += 1;
+    async fn rename_obj(&self, src: &str, dst: &str) -> Result<(), StorageError> {
+        rename::atomic_rename(src, dst)
     }
-
-    Err(StorageError::AlreadyExists(String::from(path)))
 }
 
 #[cfg(test)]
@@ -138,31 +108,28 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn put_obj() {
+    async fn put_and_rename() {
         let tmp_dir = tempdir::TempDir::new("rename_test").unwrap();
         let backend = FileStorageBackend::new(tmp_dir.path().to_str().unwrap());
-        let tmp_dir_path = tmp_dir.path();
-        let new_file_path = tmp_dir_path.join("new_file");
 
-        if let Err(e) = backend
-            .put_obj(new_file_path.to_str().unwrap(), b"hello")
-            .await
-        {
+        let tmp_file_path = tmp_dir.path().join("tmp_file");
+        let new_file_path = tmp_dir.path().join("new_file");
+
+        let tmp_file = tmp_file_path.to_str().unwrap();
+        let new_file = new_file_path.to_str().unwrap();
+
+        // first try should result in successful rename
+        backend.put_obj(tmp_file, b"hello").await.unwrap();
+        if let Err(e) = backend.rename_obj(tmp_file, new_file).await {
             panic!("Expect put_obj to return Ok, got Err: {:#?}", e)
         }
 
         // second try should result in already exists error
+        backend.put_obj(tmp_file, b"hello").await.unwrap();
         assert!(matches!(
-            backend.put_obj(new_file_path.to_str().unwrap(), b"hello").await,
+            backend.rename_obj(tmp_file, new_file).await,
             Err(StorageError::AlreadyExists(s)) if s == new_file_path.to_str().unwrap(),
         ));
-
-        // make sure rename failure doesn't leave any dangling temp file
-        let paths = std::fs::read_dir(tmp_dir_path)
-            .unwrap()
-            .map(|entry| entry.unwrap().path())
-            .collect::<Vec<_>>();
-        assert_eq!(paths, [new_file_path]);
     }
 
     #[test]

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -181,10 +181,16 @@ pub enum StorageError {
     },
     #[cfg(feature = "s3")]
     #[error("Failed to delete S3 object: {0}")]
-    S3Delete(#[from] rusoto_core::RusotoError<rusoto_s3::DeleteObjectError>),
+    S3Delete {
+        #[from]
+        source: rusoto_core::RusotoError<rusoto_s3::DeleteObjectError>,
+    },
     #[cfg(feature = "s3")]
     #[error("Failed to copy S3 object: {0}")]
-    S3Copy(#[from] rusoto_core::RusotoError<rusoto_s3::CopyObjectError>),
+    S3Copy {
+        #[from]
+        source: rusoto_core::RusotoError<rusoto_s3::CopyObjectError>,
+    },
     #[cfg(feature = "s3")]
     #[error("S3 Object missing body content: {0}")]
     S3MissingObjectBody(String),

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -180,6 +180,12 @@ pub enum StorageError {
         source: rusoto_core::RusotoError<rusoto_s3::PutObjectError>,
     },
     #[cfg(feature = "s3")]
+    #[error("Failed to delete S3 object: {0}")]
+    S3Delete(#[from] rusoto_core::RusotoError<rusoto_s3::DeleteObjectError>),
+    #[cfg(feature = "s3")]
+    #[error("Failed to copy S3 object: {0}")]
+    S3Copy(#[from] rusoto_core::RusotoError<rusoto_s3::CopyObjectError>),
+    #[cfg(feature = "s3")]
     #[error("S3 Object missing body content: {0}")]
     S3MissingObjectBody(String),
     #[cfg(feature = "s3")]
@@ -275,6 +281,11 @@ pub trait StorageBackend: Send + Sync + Debug {
     ///
     /// For a multi-writer safe backend, put_obj needs to implement create if not exists semantic.
     async fn put_obj(&self, path: &str, obj_bytes: &[u8]) -> Result<(), StorageError>;
+
+    /// Moves object `src` to `dst`.
+    ///
+    /// This operation may or may not be the atomic, depending on the underlying backend.
+    async fn rename_obj(&self, src: &str, dst: &str) -> Result<(), StorageError>;
 }
 
 pub fn get_backend_for_uri(uri: &str) -> Result<Box<dyn StorageBackend>, StorageError> {

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -180,13 +180,13 @@ pub enum StorageError {
         source: rusoto_core::RusotoError<rusoto_s3::PutObjectError>,
     },
     #[cfg(feature = "s3")]
-    #[error("Failed to delete S3 object: {0}")]
+    #[error("Failed to delete S3 object: {source}")]
     S3Delete {
         #[from]
         source: rusoto_core::RusotoError<rusoto_s3::DeleteObjectError>,
     },
     #[cfg(feature = "s3")]
-    #[error("Failed to copy S3 object: {0}")]
+    #[error("Failed to copy S3 object: {source}")]
     S3Copy {
         #[from]
         source: rusoto_core::RusotoError<rusoto_s3::CopyObjectError>,

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -8,7 +8,8 @@ use rusoto_core::credential::ChainProvider;
 use rusoto_core::{HttpClient, Region, RusotoError};
 use rusoto_credential::AutoRefreshingProvider;
 use rusoto_s3::{
-    GetObjectRequest, HeadObjectRequest, ListObjectsV2Request, PutObjectRequest, S3Client, S3,
+    CopyObjectRequest, DeleteObjectRequest, GetObjectRequest, HeadObjectRequest,
+    ListObjectsV2Request, PutObjectRequest, S3Client, S3,
 };
 use rusoto_sts::WebIdentityProvider;
 use tokio::io::AsyncReadExt;
@@ -293,12 +294,6 @@ impl StorageBackend for S3StorageBackend {
     async fn put_obj(&self, path: &str, obj_bytes: &[u8]) -> Result<(), StorageError> {
         debug!("put s3 object: {}...", path);
 
-        match self.head_obj(path).await {
-            Ok(_) => return Err(StorageError::AlreadyExists(path.to_string())),
-            Err(StorageError::NotFound) => (),
-            Err(e) => return Err(e),
-        }
-
         let uri = parse_uri(path)?.into_s3object()?;
         let put_req = PutObjectRequest {
             bucket: uri.bucket.to_string(),
@@ -308,6 +303,38 @@ impl StorageBackend for S3StorageBackend {
         };
 
         self.client.put_object(put_req).await?;
+
+        Ok(())
+    }
+
+    async fn rename_obj(&self, src: &str, dst: &str) -> Result<(), StorageError> {
+        debug!("rename s3 object: {} to {}...", src, dst);
+
+        match self.head_obj(dst).await {
+            Ok(_) => return Err(StorageError::AlreadyExists(dst.to_string())),
+            Err(StorageError::NotFound) => (),
+            Err(e) => return Err(e),
+        }
+
+        let src = parse_uri(src)?.into_s3object()?;
+        let dst = parse_uri(dst)?.into_s3object()?;
+
+        self.client
+            .copy_object(CopyObjectRequest {
+                bucket: dst.bucket.to_string(),
+                key: dst.key.to_string(),
+                copy_source: format!("{}/{}", src.bucket, src.key),
+                ..Default::default()
+            })
+            .await?;
+
+        self.client
+            .delete_object(DeleteObjectRequest {
+                bucket: src.bucket.to_string(),
+                key: src.key.to_string(),
+                ..Default::default()
+            })
+            .await?;
 
         Ok(())
     }

--- a/rust/tests/simple_commit_test.rs
+++ b/rust/tests/simple_commit_test.rs
@@ -2,18 +2,30 @@ extern crate chrono;
 extern crate deltalake;
 extern crate utime;
 
-use deltalake::action;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-#[tokio::test]
-async fn test_two_commits() {
-    cleanup_log_dir();
+use rusoto_core::Region;
+use rusoto_s3::{DeleteObjectRequest, S3Client, S3};
 
-    let mut table = deltalake::open_table("./tests/data/simple_commit")
-        .await
-        .unwrap();
+use deltalake::action;
+
+#[tokio::test]
+async fn test_two_commits_fs() {
+    cleanup_log_dir_fs();
+    test_two_commits("./tests/data/simple_commit").await;
+}
+
+#[cfg(feature = "s3")]
+#[tokio::test]
+async fn test_two_commits_s3() {
+    cleanup_log_dir_s3().await;
+    test_two_commits("s3://deltars/simple_commit_rw").await;
+}
+
+async fn test_two_commits(table_path: &str) {
+    let mut table = deltalake::open_table(table_path).await.unwrap();
 
     assert_eq!(0, table.version);
     assert_eq!(0, table.get_files().len());
@@ -91,7 +103,7 @@ async fn test_two_commits() {
     assert_eq!(4, table.get_files().len());
 }
 
-fn cleanup_log_dir() {
+fn cleanup_log_dir_fs() {
     let log_dir = PathBuf::from("./tests/data/simple_commit/_delta_log");
     let paths = fs::read_dir(log_dir.as_path()).unwrap();
 
@@ -111,4 +123,26 @@ fn cleanup_log_dir() {
             _ => {}
         }
     }
+}
+
+async fn cleanup_log_dir_s3() {
+    let endpoint = "http://localhost:4566";
+    std::env::set_var("AWS_ACCESS_KEY_ID", "test");
+    std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+    std::env::set_var("AWS_ENDPOINT_URL", &endpoint);
+    let client = S3Client::new(Region::Custom {
+        name: "custom".to_string(),
+        endpoint: endpoint.to_string(),
+    });
+    delete_obj(&client, "00000000000000000001.json").await;
+    delete_obj(&client, "00000000000000000002.json").await;
+}
+
+async fn delete_obj(client: &S3Client, name: &str) {
+    let req = DeleteObjectRequest {
+        bucket: "deltars".to_string(),
+        key: format!("simple_commit_rw/_delta_log/{}", name),
+        ..Default::default()
+    };
+    client.delete_object(req).await.unwrap();
 }


### PR DESCRIPTION
# Description
Before introducing S3 locking we need to match its behaviour with filesystem backend. 
Also, temporary files are now created before commit loop, to avoid unnecessary creation of tmp files at each try. 

I've also made simple_commit to be tested against s3 backend, so with these we have first s3 writer test