### PR TITLE
Fix fs parent dir creation and tx version log update

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -282,10 +282,10 @@ impl DeltaTable {
                 });
             }
             Action::txn(v) => {
-                state
+                *state
                     .app_transaction_version
                     .entry(v.appId.clone())
-                    .or_insert(v.version);
+                    .or_insert(v.version) = v.version;
             }
             Action::commitInfo(v) => {
                 state.commit_infos.push(v.clone());

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -87,6 +87,12 @@ impl StorageBackend for FileStorageBackend {
     async fn put_obj(&self, path: &str, obj_bytes: &[u8]) -> Result<(), StorageError> {
         let tmp_path = create_tmp_file_with_retry(self, path, obj_bytes).await?;
 
+        let dir = std::path::Path::new(path);
+
+        if let Some(d) = dir.parent() {
+            fs::create_dir_all(d).await?;
+        }
+
         if let Err(e) = rename::atomic_rename(&tmp_path, path) {
             fs::remove_file(tmp_path).await.unwrap_or(());
             return Err(e);


### PR DESCRIPTION
# Description

This commit contains two drive by bug fixes I encountered when upgrading to the latest delta-rs commit.

1. Ensure parent dir exists within fs backend put_obj
2. Update the latest tx version for txn commits when reading log entries.

The behavior I observed that led to these two bug fixes:

1. For partitioned tables, file backend failed on rename since partition folder does not exist on first write.
2. The delta metadata did not contain the latest txn version after calling update on the delta table. So log always contained txn version of 1.
