### PR TITLE
Update app tx version when processing action

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -319,7 +319,7 @@ impl DeltaTable {
     ) -> Result<(), ApplyLogError> {
         for line in reader.lines() {
             let action: Action = serde_json::from_str(line?.as_str())?;
-            DeltaTable::process_action(&mut self.state, &action)?;
+            process_action(&mut self.state, &action)?;
         }
 
         Ok(())
@@ -347,7 +347,7 @@ impl DeltaTable {
                 )));
             }
             for record in preader.get_row_iter(None)? {
-                DeltaTable::process_action(
+                process_action(
                     &mut self.state,
                     &Action::from_parquet_record(&schema, &record)?,
                 )?;

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -998,9 +998,6 @@ mod tests {
             app_transaction_version,
         };
 
-        let app_transaction_version = HashMap::new();
-        app_transaction_version.insert("abc", 3);
-
         let txn_action = Action::txn(action::Txn {
             appId: "abc".to_string(),
             version: 2,

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -282,10 +282,10 @@ impl DeltaTable {
                 });
             }
             Action::txn(v) => {
-                state
+                *state
                     .app_transaction_version
                     .entry(v.appId.clone())
-                    .or_insert(v.version);
+                    .or_insert(v.version) = v.version;
             }
             Action::commitInfo(v) => {
                 state.commit_infos.push(v.clone());

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1007,7 +1007,7 @@ mod tests {
             lastUpdated: 0,
         });
 
-        process_action(&mut state, &txn_action);
+        let _ = process_action(&mut state, &txn_action).unwrap();
 
         assert_eq!(2, *state.app_transaction_version.get("abc").unwrap());
         assert_eq!(1, *state.app_transaction_version.get("xyz").unwrap());

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -984,7 +984,7 @@ mod tests {
 
     #[test]
     fn state_records_new_txn_version() {
-        let app_transaction_version = HashMap::new();
+        let mut app_transaction_version = HashMap::new();
         app_transaction_version.insert("abc".to_string(), 1);
         app_transaction_version.insert("xyz".to_string(), 1);
 


### PR DESCRIPTION
# Description

This is a drive-by fix.

I encountered a bug when using the delta txn version from kafka-delta-ingest. The prior `process_action` implementation does not update the existing map entry for tx version when re-processing actions. This change resolves that.

