### PR TITLE
Add dry_run vacuum command

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -159,6 +159,21 @@ class DeltaTable:
         """
         return self._metadata
 
+    def vacuum(self, retention_hours: int, dry_run: bool = True) -> List[str]:
+        """
+        Run the Vacuum command on the Delta Table: lists files no longer referenced by the Delta table and are older than the retention threshold.
+
+        :param retention_hours: the retention threshold in hours
+        :param dry_run: when activated, lists only the files, removed otherwise
+        :return: the list of files no longer referenced by the Delta Table and are older than the retention threshold.
+        """
+        if retention_hours < 0:
+            raise ValueError("The retention periods should be positive.")
+
+        if not dry_run:
+            raise NotImplementedError("Only Vacuum with dry_run is available.")
+        return self._table.vacuum(dry_run, retention_hours)
+
     def pyarrow_schema(self) -> pyarrow.Schema:
         """
         Get the current schema of the DeltaTable with the Parquet PyArrow format.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -144,6 +144,17 @@ impl RawDeltaTable {
             .map_err(|_| PyDeltaTableError::new_err("Got invalid table schema"))
     }
 
+    /// Run the Vacuum command on the Delta Table: lists and removes files no longer referenced by the Delta table and are older than the retention threshold.
+    pub fn vacuum(&self, dry_run: bool, retention_hours: u64) -> PyResult<Vec<String>> {
+        match dry_run {
+            true => Ok(self
+                ._table
+                .vacuum_dry_run(retention_hours)
+                .map_err(PyDeltaTableError::from_raw)?),
+            false => unimplemented!("Only Vacuum with dry_run is available."),
+        }
+    }
+
     pub fn arrow_schema_json(&self) -> PyResult<String> {
         let schema = self
             ._table

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -17,6 +17,36 @@ def test_read_simple_table_by_version_to_dict():
     assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"value": [1, 2, 3]}
 
 
+def test_vacuum_dry_run_simple_table():
+    table_path = "../rust/tests/data/delta-0.2.0"
+    dt = DeltaTable(table_path)
+    retention_periods = 169
+    assert dt.vacuum(retention_periods) == [
+        "../rust/tests/data/delta-0.2.0/part-00000-512e1537-8aaa-4193-b8b4-bef3de0de409-c000.snappy.parquet",
+        "../rust/tests/data/delta-0.2.0/part-00000-b44fcdb0-8b06-4f3a-8606-f8311a96f6dc-c000.snappy.parquet",
+        "../rust/tests/data/delta-0.2.0/part-00001-185eca06-e017-4dea-ae49-fc48b973e37e-c000.snappy.parquet",
+        "../rust/tests/data/delta-0.2.0/part-00001-4327c977-2734-4477-9507-7ccf67924649-c000.snappy.parquet",
+    ]
+
+    retention_periods = -1
+    with pytest.raises(Exception) as exception:
+        dt.vacuum(retention_periods)
+    assert str(exception.value) == "The retention periods should be positive."
+
+    retention_periods = 167
+    with pytest.raises(Exception) as exception:
+        dt.vacuum(retention_periods)
+    assert (
+        str(exception.value)
+        == "Invalid retention period, retention for Vacuum must be greater than 1 week (168 hours)"
+    )
+
+    retention_periods = 167
+    with pytest.raises(Exception) as exception:
+        dt.vacuum(retention_periods, dry_run=False)
+    assert str(exception.value) == "Only Vacuum with dry_run is available."
+
+
 def test_read_partitioned_table_metadata():
     table_path = "../rust/tests/data/delta-0.8.0-partitioned"
     dt = DeltaTable(table_path)


### PR DESCRIPTION
# Description
Add a Vacuum dry run command for listing files no longer referenced by a Delta table and are older than the retention threshold.

# Documentation
https://docs.delta.io/0.8.0/delta-utility.html#remove-files-no-longer-referenced-by-a-delta-table
