### PR TITLE
Accommodate AWS_ENDPOINT_URL in the python binding to allow alternatives to S3

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"

--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -76,7 +76,7 @@ class DataType:
 
 
 class MapType(DataType):
-    """ Concrete class for map data types. """
+    """Concrete class for map data types."""
 
     def __init__(self, key_type: str, value_type: str, value_contains_null: bool):
         super().__init__("map")
@@ -97,7 +97,7 @@ class MapType(DataType):
 
 
 class ArrayType(DataType):
-    """ Concrete class for array data types. """
+    """Concrete class for array data types."""
 
     def __init__(self, element_type: DataType, contains_null: bool):
         super().__init__("array")
@@ -116,7 +116,7 @@ class ArrayType(DataType):
 
 
 class StructType(DataType):
-    """ Concrete class for struct data types. """
+    """Concrete class for struct data types."""
 
     def __init__(self, fields: List["Field"]):
         super().__init__("struct")
@@ -131,7 +131,7 @@ class StructType(DataType):
 
 
 class Field:
-    """ Create a DeltaTable Field instance."""
+    """Create a DeltaTable Field instance."""
 
     def __init__(
         self,
@@ -158,7 +158,7 @@ class Field:
 
 
 class Schema:
-    """ Create a DeltaTable Schema instance."""
+    """Create a DeltaTable Schema instance."""
 
     def __init__(self, fields: List[Field], json_value: Dict[str, Any]):
         self.fields = fields

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -10,29 +10,29 @@ from .schema import Schema, pyarrow_schema_from_json
 
 
 class Metadata:
-    """ Create a Metadata instance. """
+    """Create a Metadata instance."""
 
     def __init__(self, table: RawDeltaTable):
         self._metadata = table.metadata()
 
     @property
     def id(self):
-        """ Return the unique identifier of the DeltaTable. """
+        """Return the unique identifier of the DeltaTable."""
         return self._metadata.id
 
     @property
     def name(self):
-        """ Return the user-provided identifier of the DeltaTable. """
+        """Return the user-provided identifier of the DeltaTable."""
         return self._metadata.name
 
     @property
     def description(self):
-        """ Return the user-provided description of the DeltaTable. """
+        """Return the user-provided description of the DeltaTable."""
         return self._metadata.description
 
     @property
     def partition_columns(self):
-        """ Return an array containing the names of the partitioned columns of the DeltaTable. """
+        """Return an array containing the names of the partitioned columns of the DeltaTable."""
         return self._metadata.partition_columns
 
     @property
@@ -44,7 +44,7 @@ class Metadata:
 
     @property
     def configuration(self):
-        """ Return the DeltaTable properties. """
+        """Return the DeltaTable properties."""
         return self._metadata.configuration
 
     def __str__(self) -> str:
@@ -70,7 +70,7 @@ class Metadata:
 
 
 class DeltaTable:
-    """ Create a DeltaTable instance."""
+    """Create a DeltaTable instance."""
 
     def __init__(self, table_path: str, version: Optional[int] = None):
         """
@@ -194,16 +194,18 @@ class DeltaTable:
 
         # Decide based on the first file, if the file is on cloud storage or local
         if paths[0].netloc:
-            query_str = ''
+            query_str = ""
             # pyarrow doesn't properly support the AWS_ENDPOINT_URL environment vartiable
             # for non-AWS S3 like resources. This is a slight hack until such a
             # point when pyarrow learns about AWS_ENDPOINT_URL
-            endpoint_url = os.environ.get('AWS_ENDPOINT_URL')
+            endpoint_url = os.environ.get("AWS_ENDPOINT_URL")
             if endpoint_url is not None:
                 endpoint = urlparse(endpoint_url)
                 # This format specific to the URL schema inference done inside
                 # of pyarrow, consult their tests/dataset.py for examples
-                query_str += f'?scheme={endpoint.scheme}&endpoint_override={endpoint.netloc}'
+                query_str += (
+                    f"?scheme={endpoint.scheme}&endpoint_override={endpoint.netloc}"
+                )
 
             keys = [curr_file.path for curr_file in paths]
             return dataset(

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Tuple
 from urllib.parse import urlparse
 
+import os
 import pyarrow
 from pyarrow.dataset import dataset
 
@@ -193,11 +194,22 @@ class DeltaTable:
 
         # Decide based on the first file, if the file is on cloud storage or local
         if paths[0].netloc:
+            query_str = ''
+            # pyarrow doesn't properly support the AWS_ENDPOINT_URL environment vartiable
+            # for non-AWS S3 like resources. This is a slight hack until such a
+            # point when pyarrow learns about AWS_ENDPOINT_URL
+            endpoint_url = os.environ.get('AWS_ENDPOINT_URL')
+            if endpoint_url is not None:
+                endpoint = urlparse(endpoint_url)
+                # This format specific to the URL schema inference done inside
+                # of pyarrow, consult their tests/dataset.py for examples
+                query_str += f'?scheme={endpoint.scheme}&endpoint_override={endpoint.netloc}'
+
             keys = [curr_file.path for curr_file in paths]
             return dataset(
                 keys,
                 schema=self.pyarrow_schema(),
-                filesystem=f"{paths[0].scheme}://{paths[0].netloc}",
+                filesystem=f"{paths[0].scheme}://{paths[0].netloc}{query_str}",
             )
         else:
             return dataset(file_paths, schema=self.pyarrow_schema(), format="parquet")

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -195,7 +195,7 @@ class DeltaTable:
         # Decide based on the first file, if the file is on cloud storage or local
         if paths[0].netloc:
             query_str = ""
-            # pyarrow doesn't properly support the AWS_ENDPOINT_URL environment vartiable
+            # pyarrow doesn't properly support the AWS_ENDPOINT_URL environment variable
             # for non-AWS S3 like resources. This is a slight hack until such a
             # point when pyarrow learns about AWS_ENDPOINT_URL
             endpoint_url = os.environ.get("AWS_ENDPOINT_URL")


### PR DESCRIPTION
# Description

This allows the use of minio or localstack for the Python bindings

Reviewed live via Jitsi with @houqp


# Related Issue(s)
<!---
For example:

- closes #106
--->

None filed yet

# Documentation

<!---
Share links to useful documentation
--->


The use of `AWS_ENDPOINT_URL` is not [yet conventional](https://github.com/aws/aws-cli/issues/1270#issuecomment-301625262) by the `aws` CLI, but we're already relying on this in the Rust code specifically. :shrug: 
