### PR TITLE
Add common setup envs code for S3 tests

### DIFF
--- a/rust/tests/dynamodb_test.rs
+++ b/rust/tests/dynamodb_test.rs
@@ -2,21 +2,19 @@
 #[macro_use]
 extern crate maplit;
 
+#[cfg(feature = "s3")]
+mod s3_common;
+
 #[cfg(feature = "dynamodb")]
 mod dynamodb {
     use deltalake::s3::dynamodb_lock::{attr, DynamoDbLockClient, Options, PARTITION_KEY_NAME};
-    use rusoto_core::Region;
     use rusoto_dynamodb::*;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     async fn create_dynamo_lock(key: &str, owner: &str) -> DynamoDbLockClient {
+        crate::s3_common::setup();
         let table_name = "test_table";
-        std::env::set_var("AWS_ACCESS_KEY_ID", "test");
-        std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
-        let client = DynamoDbClient::new(Region::Custom {
-            name: "custom".to_string(),
-            endpoint: "http://localhost:4566".to_string(),
-        });
+        let client = DynamoDbClient::new(crate::s3_common::region());
         let opts = Options {
             partition_key_value: key.to_string(),
             table_name: table_name.to_string(),

--- a/rust/tests/s3_common/mod.rs
+++ b/rust/tests/s3_common/mod.rs
@@ -1,0 +1,19 @@
+use rusoto_core::Region;
+
+pub const ENDPOINT: &str = "http://localhost:4566";
+
+#[allow(dead_code)]
+pub fn setup() {
+    std::env::set_var("AWS_REGION", "us-east-2");
+    std::env::set_var("AWS_ACCESS_KEY_ID", "test");
+    std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+    std::env::set_var("AWS_ENDPOINT_URL", ENDPOINT);
+}
+
+#[allow(dead_code)]
+pub fn region() -> Region {
+    Region::Custom {
+        name: "custom".to_string(),
+        endpoint: ENDPOINT.to_string(),
+    }
+}

--- a/rust/tests/s3_test.rs
+++ b/rust/tests/s3_test.rs
@@ -1,5 +1,9 @@
 #[cfg(feature = "s3")]
+mod s3_common;
+
+#[cfg(feature = "s3")]
 mod s3 {
+    use crate::s3_common::setup;
     use serial_test::serial;
 
     /*
@@ -9,13 +13,6 @@ mod s3 {
      * know
      */
     use deltalake::StorageError;
-
-    fn setup() {
-        std::env::set_var("AWS_REGION", "us-east-2");
-        std::env::set_var("AWS_ACCESS_KEY_ID", "test");
-        std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
-        std::env::set_var("AWS_ENDPOINT_URL", "http://localhost:4566");
-    }
 
     #[tokio::test]
     #[serial]

--- a/rust/tests/simple_commit_test.rs
+++ b/rust/tests/simple_commit_test.rs
@@ -2,6 +2,9 @@ extern crate chrono;
 extern crate deltalake;
 extern crate utime;
 
+#[cfg(feature = "s3")]
+mod s3_common;
+
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -124,18 +127,11 @@ fn cleanup_log_dir_fs() {
 
 #[cfg(feature = "s3")]
 mod s3_ops {
-    use rusoto_core::Region;
     use rusoto_s3::{DeleteObjectRequest, S3Client, S3};
 
     pub async fn cleanup_log_dir_s3() {
-        let endpoint = "http://localhost:4566";
-        std::env::set_var("AWS_ACCESS_KEY_ID", "test");
-        std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
-        std::env::set_var("AWS_ENDPOINT_URL", &endpoint);
-        let client = S3Client::new(Region::Custom {
-            name: "custom".to_string(),
-            endpoint: endpoint.to_string(),
-        });
+        crate::s3_common::setup();
+        let client = S3Client::new(crate::s3_common::region());
         delete_obj(&client, "00000000000000000001.json").await;
         delete_obj(&client, "00000000000000000002.json").await;
     }


### PR DESCRIPTION
# Description
Fixes #176

For integration tests, cargo executes each test file within its own crate, so in order to declare common code which has to be used among different test one should create it under directory with mod.rs file. This will not be acknowledged as test file and hence could be reused in other tests.

# Documentation

More here https://doc.rust-lang.org/book/ch11-03-test-organization.html#submodules-in-integration-tests.
