### PR TITLE
[Fix] Python table to_pyarrow_dataset: add support for hive style par…

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 
 import os
 import pyarrow
-from pyarrow.dataset import dataset
+from pyarrow.dataset import dataset, partitioning
 
 from .deltalake import RawDeltaTable, RawDeltaTableMetaData
 from .schema import Schema, pyarrow_schema_from_json
@@ -212,9 +212,15 @@ class DeltaTable:
                 keys,
                 schema=self.pyarrow_schema(),
                 filesystem=f"{paths[0].scheme}://{paths[0].netloc}{query_str}",
+                partitioning=partitioning(flavor="hive"),
             )
         else:
-            return dataset(file_paths, schema=self.pyarrow_schema(), format="parquet")
+            return dataset(
+                file_paths,
+                schema=self.pyarrow_schema(),
+                format="parquet",
+                partitioning=partitioning(flavor="hive"),
+            )
 
     def to_pyarrow_table(self) -> pyarrow.Table:
         """

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -17,6 +17,18 @@ def test_read_simple_table_by_version_to_dict():
     assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"value": [1, 2, 3]}
 
 
+def test_read_partitioned_table_to_dict():
+    table_path = "../rust/tests/data/delta-0.8.0-partitioned"
+    dt = DeltaTable(table_path)
+    expected = {
+        "value": ["1", "2", "3", "6", "7", "5", "4"],
+        "year": ["2020", "2020", "2020", "2021", "2021", "2021", "2021"],
+        "month": ["1", "2", "2", "12", "12", "12", "4"],
+        "day": ["1", "3", "5", "20", "20", "4", "5"],
+    }
+    assert dt.to_pyarrow_dataset().to_table().to_pydict() == expected
+
+
 def test_vacuum_dry_run_simple_table():
     table_path = "../rust/tests/data/delta-0.2.0"
     dt = DeltaTable(table_path)


### PR DESCRIPTION
…titionning when reading a table

# Description
When reading a partitioned table with `.to_pyarrow_dataset()` method, the partition columns are always set to `null`.

For example, if my table has one parquet file with one row `{value: 14}`: 
`s3://my-bucket/my-database/my-table/year=2020/month=11/day=23/part-1234.parquet`

The following: `DeltaTable("s3://my-bucket/my-database/my-table/").to_pyarrow_dataset()` will return one row with content:
`{ value: 14, year: null, month: null, day: null }`

The current fix makes pyarrow handle the partitioning when creating a dataset.