### PR TITLE
Bump the version of pyarrow needed for Python bindings

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -39,7 +39,7 @@ classifier = [
 ]
 project-url = { Repo = "https://github.com/delta-io/delta-rs" }
 requires-dist = [
-    "pyarrow>=2",
+    "pyarrow>=4",
     'numpy<1.20.0;python_version<="3.6"',
     "pandas; extra =='pandas'",
     "pytest; extra == 'devel'",


### PR DESCRIPTION
# Description
The version of pyarrow must be >= 4 for the Python bindings

# Related Issue(s)
#218