### PR TITLE
add "element" as the arrow list field name

### DIFF
--- a/rust/src/delta_arrow.rs
+++ b/rust/src/delta_arrow.rs
@@ -40,7 +40,7 @@ impl TryFrom<&schema::SchemaTypeArray> for ArrowField {
 
     fn try_from(a: &schema::SchemaTypeArray) -> Result<Self, ArrowError> {
         Ok(ArrowField::new(
-            "",
+            "element",
             ArrowDataType::try_from(a.get_element_type())?,
             a.contains_null(),
         ))


### PR DESCRIPTION
# Description

When converting delta array type to arrow list, the arrow list should have a name in its field.
Spark and Parquet use "element" as the field name, thus I have used that.

# Related Issue(s)

None

# Documentation

"element" comes from https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#nested-types
