### PR TITLE
Make streams impl send

### DIFF
--- a/rust/src/storage/azure.rs
+++ b/rust/src/storage/azure.rs
@@ -153,8 +153,10 @@ impl StorageBackend for AdlsGen2Backend {
     async fn list_objs<'a>(
         &'a self,
         path: &'a str,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + 'a>>, StorageError>
-    {
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + Send + 'a>>,
+        StorageError,
+    > {
         debug!("Listing objects under {}", path);
         let obj = parse_uri(path)?.into_adlsgen2_object()?;
         self.validate_container(&obj)?;

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -76,8 +76,10 @@ impl StorageBackend for FileStorageBackend {
     async fn list_objs<'a>(
         &'a self,
         path: &'a str,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + 'a>>, StorageError>
-    {
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + Send + 'a>>,
+        StorageError,
+    > {
         let readdir = ReadDirStream::new(fs::read_dir(path).await?);
 
         Ok(Box::pin(readdir.err_into().and_then(|entry| async move {

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -356,7 +356,10 @@ pub trait StorageBackend: Send + Sync + Debug {
     async fn list_objs<'a>(
         &'a self,
         path: &'a str,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + 'a>>, StorageError>;
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + Send + 'a>>,
+        StorageError,
+    >;
 
     /// Create new object with `obj_bytes` as content.
     async fn put_obj(&self, path: &str, obj_bytes: &[u8]) -> Result<(), StorageError>;

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -232,8 +232,10 @@ impl StorageBackend for S3StorageBackend {
     async fn list_objs<'a>(
         &'a self,
         path: &'a str,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + 'a>>, StorageError>
-    {
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + Send + 'a>>,
+        StorageError,
+    > {
         let uri = parse_uri(path)?.into_s3object()?;
 
         /// This enum is used to represent 3 states in our object metadata streaming logic:


### PR DESCRIPTION
# Description

This makes `BackendStorage::list_objs` to be `Send + Sync` so that `BackendStorage` can play nice with other tokio streams.

# Related Issue(s)

Closes #230

# Documentation

None
