### PR TITLE
avoid wildcard dependency constraint to unblock crates.io release

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -63,6 +63,6 @@ glibc_version = "0"
 
 [dev-dependencies]
 utime = "0.3"
-serial_test = "*"
+serial_test = "0"
 pretty_assertions = "0"
 tempdir = "0"


### PR DESCRIPTION
# Description

Fix the follow publish error:

```
error: api errors (status 200 OK): wildcard (`*`) dependency constraints are not allowed on crates.io. See https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies for more information
```