### PR TITLE
Implement get_file_paths_by_partitions

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -642,6 +642,18 @@ impl DeltaTable {
         Ok(files)
     }
 
+    /// Return the full file paths as strings for the partition(s)
+    pub fn get_file_paths_by_partitions(
+        &self,
+        filters: &[PartitionFilter<&str>],
+    ) -> Result<Vec<String>, DeltaTableError> {
+        let files = self.get_files_by_partitions(filters)?;
+        Ok(files
+            .iter()
+            .map(|fname| self.storage.join_path(&self.table_path, fname))
+            .collect())
+    }
+
     /// Returns a reference to the file list present in the loaded state.
     pub fn get_files(&self) -> &Vec<String> {
         &self.state.files

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -149,11 +149,21 @@ async fn read_delta_8_0_table_with_partitions() {
             "year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet".to_string()
         ]
     );
+
+    #[cfg(unix)]
     assert_eq!(
         table.get_file_paths_by_partitions(&filters).unwrap(),
         vec![
             "./tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet".to_string(),
             "./tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet".to_string()
+        ]
+    );
+    #[cfg(windows)]
+    assert_eq!(
+        table.get_file_paths_by_partitions(&filters).unwrap(),
+        vec![
+            "./tests/data/delta-0.8.0-partitioned\\year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet".to_string(),
+            "./tests/data/delta-0.8.0-partitioned\\year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet".to_string()
         ]
     );
 

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -149,6 +149,13 @@ async fn read_delta_8_0_table_with_partitions() {
             "year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet".to_string()
         ]
     );
+    assert_eq!(
+        table.get_file_paths_by_partitions(&filters).unwrap(),
+        vec![
+            "./tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet".to_string(),
+            "./tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet".to_string()
+        ]
+    );
 
     let filters = vec![deltalake::PartitionFilter {
         key: "month",

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -42,8 +42,7 @@ async fn read_simple_table() {
             "./tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet".to_string(),
             "./tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),
         ];
-    assert_eq!(
-        table.get_file_paths(), paths);
+    assert_eq!(table.get_file_paths(), paths);
 }
 
 #[tokio::test]

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -35,6 +35,15 @@ async fn read_simple_table() {
             ..Default::default()
         }
     );
+    let paths: Vec<String> = vec![
+            "./tests/data/simple_table/part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet".to_string(),
+            "./tests/data/simple_table/part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet".to_string(),
+            "./tests/data/simple_table/part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet".to_string(),
+            "./tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet".to_string(),
+            "./tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),
+        ];
+    assert_eq!(
+        table.get_file_paths(), paths);
 }
 
 #[tokio::test]

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -35,14 +35,28 @@ async fn read_simple_table() {
             ..Default::default()
         }
     );
-    let paths: Vec<String> = vec![
-            "./tests/data/simple_table/part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet".to_string(),
-            "./tests/data/simple_table/part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet".to_string(),
-            "./tests/data/simple_table/part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet".to_string(),
-            "./tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet".to_string(),
-            "./tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),
-        ];
-    assert_eq!(table.get_file_paths(), paths);
+    #[cfg(unix)]
+    {
+        let paths: Vec<String> = vec![
+                "./tests/data/simple_table/part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet".to_string(),
+                "./tests/data/simple_table/part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet".to_string(),
+                "./tests/data/simple_table/part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet".to_string(),
+                "./tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet".to_string(),
+                "./tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),
+            ];
+        assert_eq!(table.get_file_paths(), paths);
+    }
+    #[cfg(windows)]
+    {
+        let paths: Vec<String> = vec![
+                "./tests/data/simple_table\\part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet".to_string(),
+                "./tests/data/simple_table\\part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet".to_string(),
+                "./tests/data/simple_table\\part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet".to_string(),
+                "./tests/data/simple_table\\part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet".to_string(),
+                "./tests/data/simple_table\\part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),
+            ];
+        assert_eq!(table.get_file_paths(), paths);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description

Fairly straightforward implementation and integration test to allow Rust binding users to get fully-qualified file paths for the specified partitions.

# Related Issue(s)

Fixes #222
