### PR TITLE
Exposing file stats

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -128,7 +128,7 @@ impl RawDeltaTable {
     }
 
     pub fn files(&self) -> PyResult<Vec<String>> {
-        Ok(self._table.get_files().to_vec())
+        Ok(self._table.get_files())
     }
 
     pub fn file_paths(&self) -> PyResult<Vec<String>> {

--- a/ruby/src/lib.rs
+++ b/ruby/src/lib.rs
@@ -36,8 +36,8 @@ impl TableData {
         self.actual.version
     }
 
-    fn files(&self) -> &[String] {
-        self.actual.get_files().as_slice()
+    fn files(&self) -> Vec<String> {
+        self.actual.get_files()
     }
 }
 
@@ -69,7 +69,7 @@ methods!(
         let mut array = Array::with_capacity(files.len());
 
         for file in files {
-            array.push(RString::new_utf8(file));
+            array.push(RString::new_utf8(&file));
         }
 
         array

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta.rs"
 license = "Apache-2.0"

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -141,7 +141,7 @@ pub struct StatsParsed {
 }
 
 /// Delta log action that describes a parquet data file that is part of the table.
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Add {
     /// A relative path, from the root of the table, to a file that should be added to the table
     pub path: String,

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -655,7 +655,12 @@ impl DeltaTable {
             .collect())
     }
 
-    /// Returns a reference to the file list present in the loaded state.
+    /// Return a refernece to the "add" actions present in the loaded state
+    pub fn get_actions(&self) -> &Vec<action::Add> {
+        &self.state.files
+    }
+
+    /// Returns a collection of file names present in the loaded state
     pub fn get_files(&self) -> Vec<String> {
         self.state
             .files

--- a/rust/tests/azure_test.rs
+++ b/rust/tests/azure_test.rs
@@ -20,7 +20,7 @@ mod azure {
         assert_eq!(table.get_min_reader_version(), 1);
         assert_eq!(
             table.get_files(),
-            &vec![
+            vec![
                 "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
                 "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
                 "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -16,7 +16,7 @@ async fn read_delta_2_0_table_without_version() {
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
         table.get_files(),
-        &vec![
+        vec![
             "part-00000-cb6b150b-30b8-4662-ad28-ff32ddab96d2-c000.snappy.parquet",
             "part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet",
             "part-00001-c373a5bd-85f0-4758-815e-7eb62007a15c-c000.snappy.parquet",
@@ -58,7 +58,7 @@ async fn read_delta_2_0_table_with_version() {
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
         table.get_files(),
-        &vec![
+        vec![
             "part-00000-b44fcdb0-8b06-4f3a-8606-f8311a96f6dc-c000.snappy.parquet",
             "part-00001-185eca06-e017-4dea-ae49-fc48b973e37e-c000.snappy.parquet",
         ],
@@ -72,7 +72,7 @@ async fn read_delta_2_0_table_with_version() {
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
         table.get_files(),
-        &vec![
+        vec![
             "part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet",
             "part-00001-c373a5bd-85f0-4758-815e-7eb62007a15c-c000.snappy.parquet",
         ]
@@ -86,7 +86,7 @@ async fn read_delta_2_0_table_with_version() {
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
         table.get_files(),
-        &vec![
+        vec![
             "part-00000-cb6b150b-30b8-4662-ad28-ff32ddab96d2-c000.snappy.parquet",
             "part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet",
             "part-00001-c373a5bd-85f0-4758-815e-7eb62007a15c-c000.snappy.parquet",
@@ -104,7 +104,7 @@ async fn read_delta_8_0_table_without_version() {
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
         table.get_files(),
-        &vec![
+        vec![
             "part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet",
             "part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet"
         ]

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -16,7 +16,7 @@ async fn read_simple_table() {
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
         table.get_files(),
-        &vec![
+        vec![
             "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
             "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
             "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
@@ -69,7 +69,7 @@ async fn read_simple_table_with_version() {
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
         table.get_files(),
-        &vec![
+        vec![
             "part-00000-a72b1fb3-f2df-41fe-a8f0-e65b746382dd-c000.snappy.parquet",
             "part-00001-c506e79a-0bf8-4e2b-a42b-9731b2e490ae-c000.snappy.parquet",
             "part-00003-508ae4aa-801c-4c2c-a923-f6f89930a5c1-c000.snappy.parquet",
@@ -87,7 +87,7 @@ async fn read_simple_table_with_version() {
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
         table.get_files(),
-        &vec![
+        vec![
             "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
             "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
             "part-00003-53f42606-6cda-4f13-8d07-599a21197296-c000.snappy.parquet",
@@ -105,7 +105,7 @@ async fn read_simple_table_with_version() {
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
         table.get_files(),
-        &vec![
+        vec![
             "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
             "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
             "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",

--- a/rust/tests/s3_test.rs
+++ b/rust/tests/s3_test.rs
@@ -26,7 +26,7 @@ mod s3 {
         assert_eq!(table.get_min_reader_version(), 1);
         assert_eq!(
             table.get_files(),
-            &vec![
+            vec![
                 "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
                 "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
                 "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
@@ -61,7 +61,7 @@ mod s3 {
         assert_eq!(table.get_min_reader_version(), 1);
         assert_eq!(
             table.get_files(),
-            &vec![
+            vec![
                 "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
                 "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
                 "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",


### PR DESCRIPTION
# Description

This change will refactors `DeltaTableState` to carry out the `Add` struct from the action module, this will allow the `DeltaTable` or `DeltaTableState` structs to expose stats more readily to their consumers.


# Related Issue(s)

Todo #45 
