### PR TITLE
Adding a primitive and high-level writer interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,7 @@ dependencies = [
  "log",
  "maplit",
  "parquet",
+ "parquet-format",
  "pretty_assertions",
  "regex",
  "reqwest",
@@ -635,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "deltalake-python"
-version = "0.4.9"
+version = "0.4.8"
 dependencies = [
  "arrow",
  "deltalake",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "deltalake-python"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "arrow",
  "deltalake",

--- a/rust/.ignore
+++ b/rust/.ignore
@@ -1,0 +1,2 @@
+tests/data
+test_atomic*

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -40,6 +40,9 @@ rusoto_sts = { version = "0.46", optional = true }
 rusoto_dynamodb = { version = "0.46", optional = true }
 maplit = { version = "1", optional = true }
 
+# High-level writer
+parquet-format = "~2.6.1"
+
 arrow  = { version = "4" }
 datafusion = { version = "4", optional = true }
 parquet = { version = "4" }

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -816,17 +816,19 @@ impl DeltaTable {
         DeltaTransaction::new(self, options)
     }
 
-
     /// Create a new add action and write the given bytes to the storage backend as a fully formed
     /// Parquet file
-    pub async fn add_file(&mut self, bytes: &Vec<u8>, partitions: Option<Vec<WritablePartitionValue>>) -> Result<i64, DeltaTransactionError> {
+    pub async fn add_file(
+        &mut self,
+        bytes: &Vec<u8>,
+        partitions: Option<Vec<WritablePartitionValue>>,
+    ) -> Result<i64, DeltaTransactionError> {
         let path = self.generate_parquet_filename(partitions);
-        let storage_path = self
-            .storage
-            .join_path(&self.table_path, &path);
+        let storage_path = self.storage.join_path(&self.table_path, &path);
 
         debug!("Writing a parquet file to {}", &storage_path);
-        self.storage.put_obj(&storage_path, &bytes)
+        self.storage
+            .put_obj(&storage_path, &bytes)
             .await
             .map_err(|source| DeltaTransactionError::Storage { source })?;
 
@@ -871,7 +873,8 @@ impl DeltaTable {
             }
         }
 
-        self.storage.join_paths(&path_parts.iter().map(|s| s.as_str()).collect::<Vec<&str>>())
+        self.storage
+            .join_paths(&path_parts.iter().map(|s| s.as_str()).collect::<Vec<&str>>())
     }
 
     /// Create a new Delta Table struct without loading any data from backing storage.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -52,6 +52,8 @@ extern crate lazy_static;
 extern crate parquet;
 extern crate regex;
 extern crate serde;
+#[cfg(test)]
+#[macro_use]
 extern crate serde_json;
 extern crate thiserror;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -61,6 +61,7 @@ pub mod delta_arrow;
 pub mod partitions;
 mod schema;
 pub mod storage;
+pub mod writer;
 
 #[cfg(feature = "datafusion-ext")]
 pub mod delta_datafusion;

--- a/rust/src/writer.rs
+++ b/rust/src/writer.rs
@@ -4,162 +4,23 @@
 //! Unlike the transaction API on DeltaTable, this higher level writer will also write out the
 //! parquet files
 
-use crate::{
-    action::{Add, ColumnCountStat, ColumnValueStat, Stats},
-    DeltaDataTypeVersion, DeltaTable, DeltaTableError, DeltaTransactionError, Schema,
-    StorageBackend, StorageError, UriError,
-};
-use arrow::{
-    array::{as_boolean_array, as_primitive_array, make_array, Array, ArrayData},
-    buffer::MutableBuffer,
-    datatypes::Schema as ArrowSchema,
-    datatypes::*,
-    error::ArrowError,
-    json::reader::Decoder,
-    record_batch::RecordBatch,
-};
-use log::*;
-use parquet::{
-    arrow::ArrowWriter,
-    basic::{Compression, LogicalType},
-    errors::ParquetError,
-    file::{
-        metadata::RowGroupMetaData, properties::WriterProperties, statistics::Statistics,
-        writer::InMemoryWriteableCursor,
-    },
-    schema::types::{ColumnDescriptor, SchemaDescriptor},
-};
-use parquet_format::FileMetaData;
-use serde_json::{Number, Value};
-use std::collections::HashMap;
+use arrow::record_batch::RecordBatch;
+use crate::{DeltaTableError, DeltaTransactionError};
+use parquet::basic::Compression;
+use parquet::file::properties::WriterProperties;
+use parquet::file::writer::InMemoryWriteableCursor;
+use parquet::arrow::ArrowWriter;
+use serde_json::Value;
 use std::convert::TryFrom;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-use uuid::Uuid;
 
-/**
- * Errors which can be returned when attempting to write a parquet file or Delta transaction
- */
-#[derive(thiserror::Error, Debug)]
-pub enum DeltaWriterError {
-    /// Missing partition column
-    #[error("Missing partition column: {col_name}")]
-    MissingPartitionColumn {
-        /// The name of the column missing the partition
-        col_name: String,
-    },
-
-    /// The Arrow RecordBatch schema doesn't match the expected schema
-    #[error("Arrow RecordBatch schema does not match: RecordBatch schema: {record_batch_schema}, {expected_schema}")]
-    SchemaMismatch {
-        /// TODO
-        record_batch_schema: SchemaRef,
-        /// TODO
-        expected_schema: Arc<arrow::datatypes::Schema>,
-    },
-
-    /// Missing metadata
-    #[error("{0}")]
-    MissingMetadata(String),
-
-    /// RecordBatch created from a JSON string turned out to be a None
-    #[error("Arrow RecordBatch created from JSON buffer is a None value")]
-    EmptyRecordBatch,
-
-    /// Deserialization of the Delta per-file statistics failed
-    #[error("Serialization of delta log statistics failed")]
-    StatsSerializationFailed {
-        /// TODO
-        stats: Stats,
-    },
-
-    /// Invalid table path
-    #[error("Invalid table path: {}", .source)]
-    UriError {
-        /// The source UriError
-        #[from]
-        source: UriError,
-    },
-
-    /// Delta Lake storage interaction failed
-    #[error("Storage interaction failed: {source}")]
-    Storage {
-        /// Source error
-        #[from]
-        source: StorageError,
-    },
-
-    /// DeltaTable interaction failed
-    #[error("DeltaTable interaction failed: {source}")]
-    DeltaTable {
-        /// The source error from the DeltaTable
-        #[from]
-        source: DeltaTableError,
-    },
-
-    /// Arrow interaction failed
-    #[error("Arrow interaction failed: {source}")]
-    Arrow {
-        /// The source ArrowError from the arrow crate
-        #[from]
-        source: ArrowError,
-    },
-
-    /// Parquet write failed
-    #[error("Parquet write failed: {source}")]
-    Parquet {
-        /// The source ParquetError from the parquet crate
-        #[from]
-        source: ParquetError,
-    },
-
-    /// Delta transaction commit failed
-    #[error("Delta transaction commit failed: {source}")]
-    DeltaTransactionError {
-        /// The source error from the DeltaTable on writing the transaction
-        #[from]
-        source: DeltaTransactionError,
-    },
-}
-
-/**
- * The DeltaWriter struct provides a high--level API for writing parquet files and their
- * transactions to the given DeltaTable
- */
-pub struct DeltaWriter {
-    /// The DeltaTable this writer is affiliated with
-    table: DeltaTable,
-    /// The DeltaTable's storage backend
-    storage: Box<dyn StorageBackend>,
-    /// TODD
-    arrow_schema_ref: Arc<arrow::datatypes::Schema>,
-    /// TODD
-    writer_properties: WriterProperties,
-    /// TODD
+struct ParquetBuffer {
+    writer: ArrowWriter<InMemoryWriteableCursor>,
     cursor: InMemoryWriteableCursor,
-    /// TODD
-    arrow_writer: ArrowWriter<InMemoryWriteableCursor>,
-    /// TODD
-    partition_columns: Vec<String>,
-    /// TODD
-    partition_values: HashMap<String, String>,
-    /// TODD
-    buffered_record_batch_count: usize,
 }
 
-impl DeltaWriter {
-    /// Initialize the writer from the given table path and delta schema
-    pub async fn for_table_path(table_path: &str) -> Result<DeltaWriter, DeltaWriterError> {
-        let table = crate::open_table(&table_path).await?;
-        let storage = crate::get_backend_for_uri(table_path)?;
-
-        // Initialize an arrow schema ref from the delta table schema
-        let metadata = table.get_metadata()?.clone();
-        let schema = metadata.schema.clone();
-        let arrow_schema = <ArrowSchema as TryFrom<&Schema>>::try_from(&schema).unwrap();
-        let arrow_schema_ref = Arc::new(arrow_schema);
-        let partition_columns = metadata.partition_columns;
-
+impl ParquetBuffer {
+    fn try_new(schema: arrow::datatypes::SchemaRef) -> Result<Self, DeltaTableError> {
         // Initialize writer properties for the underlying arrow writer
         let writer_properties = WriterProperties::builder()
             // NOTE: Consider extracting config for writer properties and setting more than just compression
@@ -167,511 +28,110 @@ impl DeltaWriter {
             .build();
 
         let cursor = InMemoryWriteableCursor::default();
-        let arrow_writer = ArrowWriter::try_new(
+        let writer = ArrowWriter::try_new(
             cursor.clone(),
-            arrow_schema_ref.clone(),
-            Some(writer_properties.clone()),
+            schema,
+            Some(writer_properties),
         )?;
+
+        Ok(Self { writer, cursor })
+    }
+
+    fn write_batch(&mut self, batch: &RecordBatch) -> Result<(), DeltaTableError> {
+        self.writer.write(batch).map_err(|source| DeltaTableError::ParquetError { source })
+    }
+
+    fn data(&self) -> Vec<u8> {
+        self.cursor.data()
+    }
+
+    fn close(&mut self) -> Result<parquet_format::FileMetaData, DeltaTableError> {
+        self.writer.close().map_err(|source| DeltaTableError::ParquetError { source })
+    }
+}
+
+struct BufferedJSONWriter {
+    table: crate::DeltaTable,
+    buffer: Vec<serde_json::Value>,
+    schema: arrow::datatypes::SchemaRef,
+}
+
+impl BufferedJSONWriter {
+    fn try_new(table: crate::DeltaTable) -> Result<Self, DeltaTableError> {
+        let metadata = table.get_metadata()?.clone();
+        let schema = metadata.schema;
+        let arrow_schema = <arrow::datatypes::Schema as TryFrom<&crate::Schema>>::try_from(&schema).unwrap();
+        let schema = Arc::new(arrow_schema);
+        let partition_columns = metadata.partition_columns;
 
         Ok(Self {
             table,
-            storage,
-            arrow_schema_ref,
-            writer_properties,
-            cursor,
-            arrow_writer,
-            partition_columns,
-            partition_values: HashMap::new(),
-            buffered_record_batch_count: 0,
+            schema,
+            buffer: vec![],
         })
     }
 
-    /// TODO
-    pub async fn last_transaction_version(
-        &self,
-        app_id: &str,
-    ) -> Result<Option<DeltaDataTypeVersion>, DeltaWriterError> {
-        let tx_versions = self.table.get_app_transaction_version();
-
-        let v = tx_versions.get(app_id).map(|v| v.to_owned());
-
-        debug!("Transaction version is {:?}", v);
-
-        Ok(v)
+    /**
+     * Return the total Values pending in the buffer
+     */
+    fn count(&self) -> usize {
+        self.buffer.len()
     }
 
-    /// Writes the record batch in-memory and updates internal state accordingly.
-    /// This method buffers the write stream internally so it can be invoked for many record batches and flushed after the appropriate number of bytes has been written.
-    pub async fn write_record_batch(
-        &mut self,
-        record_batch: &RecordBatch,
-    ) -> Result<(), DeltaWriterError> {
-        let partition_values = extract_partition_values(&self.partition_columns, record_batch)?;
-
-        // Verify record batch schema matches the expected schema
-        let schemas_match = record_batch.schema() == self.arrow_schema_ref;
-
-        if !schemas_match {
-            return Err(DeltaWriterError::SchemaMismatch {
-                record_batch_schema: record_batch.schema(),
-                expected_schema: self.arrow_schema_ref.clone(),
-            });
-        }
-
-        // TODO: Verify that this RecordBatch contains partition values that agree with previous partition values (if any) for the current writer context
-        self.partition_values = partition_values;
-
-        // write the record batch to the held arrow writer
-        self.arrow_writer.write(record_batch)?;
-
-        self.buffered_record_batch_count += 1;
-
+    /**
+     * Write a new Value into the buffer
+     */
+    fn write(&mut self, value: Value) -> std::io::Result<()> {
+        self.buffer.push(value);
         Ok(())
     }
 
-    /// Returns the current byte length of the in memory buffer.
-    /// This may be used by the caller to decide when to finalize the file write.
-    pub fn buffer_len(&self) -> usize {
-        self.cursor.data().len()
-    }
+    async fn flush(&mut self) -> Result<(), DeltaTransactionError> {
+        use arrow::json::reader::Decoder;
 
-    /// Writes the existing parquet bytes to storage and resets internal state to handle another file.
-    pub async fn write_file(&mut self) -> Result<DeltaDataTypeVersion, DeltaWriterError> {
-        debug!("Writing parquet file.");
-        let obj_bytes = self.cursor.data();
+        let mut value_iter = InMemValueIter::from_vec(&self.buffer);
+        let decoder = Decoder::new(self.schema.clone(), self.count(), None);
+        let record_batch = decoder
+            .next_batch(&mut value_iter)
+            .map_err(|source| DeltaTableError::ArrowError { source })?;
 
-        // TODO: support partitions on the write
-        let version = self.table.add_file(&obj_bytes, None, None).await?;
+        if record_batch.is_none() {
+            return Ok(());
+        }
 
-        // After data is written, re-initialize internal state to handle another file
-        self.reset()?;
-        Ok(version)
-    }
+        let mut pb = ParquetBuffer::try_new(self.schema.clone())?;
+        pb.write_batch(&record_batch.unwrap())?;
+        let _metadata = pb.close();
 
-    /// TODO
-    pub fn buffered_record_batch_count(&self) -> usize {
-        self.buffered_record_batch_count
-    }
+        self.table.add_file(&pb.data(), None, None).await?;
 
-    fn reset(&mut self) -> Result<(), DeltaWriterError> {
-        // Reset the internal cursor for the next file.
-        self.cursor = InMemoryWriteableCursor::default();
-        // Reset buffered record batch count to 0.
-        self.buffered_record_batch_count = 0;
-        // Reset the internal arrow writer for the next file.
-        self.arrow_writer = ArrowWriter::try_new(
-            self.cursor.clone(),
-            self.arrow_schema_ref.clone(),
-            Some(self.writer_properties.clone()),
-        )?;
-
+        self.buffer.clear();
         Ok(())
     }
-
-    // TODO: parquet files have a 5 digit zero-padded prefix and a "c\d{3}" suffix that I have not been able to find documentation for yet.
-    fn next_data_path(
-        &self,
-        partition_cols: &Vec<String>,
-        partition_values: &HashMap<String, String>,
-    ) -> Result<String, DeltaWriterError> {
-        // TODO: what does 00000 mean?
-        let first_part = "00000";
-        let uuid_part = Uuid::new_v4();
-        // TODO: what does c000 mean?
-        let last_part = "c000";
-
-        // NOTE: If we add a non-snappy option, file name must change
-        let file_name = format!(
-            "part-{}-{}-{}.snappy.parquet",
-            first_part, uuid_part, last_part
-        );
-
-        let data_path = if partition_cols.len() > 0 {
-            let mut path_parts = vec![];
-
-            for k in partition_cols.iter() {
-                let partition_value =
-                    partition_values
-                        .get(k)
-                        .ok_or(DeltaWriterError::MissingPartitionColumn {
-                            col_name: k.to_string(),
-                        })?;
-
-                let part = format!("{}={}", k, partition_value);
-
-                path_parts.push(part);
-            }
-            path_parts.push(file_name);
-            path_parts.join("/")
-        } else {
-            file_name
-        };
-
-        Ok(data_path)
-    }
-
-    /// TODO
-    pub fn arrow_schema(&self) -> Arc<arrow::datatypes::Schema> {
-        self.arrow_schema_ref.clone()
-    }
 }
 
-/// TODD
-fn delta_stats_from_file_metadata(file_metadata: &FileMetaData) -> Result<Stats, ParquetError> {
-    let type_ptr = parquet::schema::types::from_thrift(file_metadata.schema.as_slice());
-    let schema_descriptor = type_ptr.map(|type_| Arc::new(SchemaDescriptor::new(type_)))?;
-
-    let mut min_values: HashMap<String, ColumnValueStat> = HashMap::new();
-    let mut max_values: HashMap<String, ColumnValueStat> = HashMap::new();
-    let mut null_counts: HashMap<String, ColumnCountStat> = HashMap::new();
-
-    let row_group_metadata: Result<Vec<RowGroupMetaData>, ParquetError> = file_metadata
-        .row_groups
-        .iter()
-        .map(|rg| RowGroupMetaData::from_thrift(schema_descriptor.clone(), rg.clone()))
-        .collect();
-    let row_group_metadata = row_group_metadata?;
-
-    for i in 0..schema_descriptor.num_columns() {
-        let column_descr = schema_descriptor.column(i);
-        let column_path = column_descr.path();
-
-        // TODO: skip stats for lists and structs for now as these are missing in parquet crate column chunks
-        if column_path.parts().len() > 1 {
-            continue;
-        }
-
-        let statistics: Vec<&Statistics> = row_group_metadata
-            .iter()
-            .filter_map(|g| g.column(i).statistics())
-            .collect();
-
-        let (min, max) = stats_min_and_max(&statistics, column_descr.clone())?;
-
-        if let Some(min) = min {
-            let min = ColumnValueStat::Value(min);
-            min_values.insert(column_descr.name().to_string(), min);
-        }
-
-        if let Some(max) = max {
-            let max = ColumnValueStat::Value(max);
-            max_values.insert(column_descr.name().to_string(), max);
-        }
-
-        let null_count: u64 = statistics.iter().map(|s| s.null_count()).sum();
-        let null_count = ColumnCountStat::Value(null_count as i64);
-        null_counts.insert(column_descr.name().to_string(), null_count);
-    }
-
-    Ok(Stats {
-        numRecords: file_metadata.num_rows,
-        maxValues: max_values,
-        minValues: min_values,
-        nullCount: null_counts,
-    })
-}
-
-/// TODD
-fn stats_min_and_max(
-    statistics: &[&Statistics],
-    column_descr: Arc<ColumnDescriptor>,
-) -> Result<(Option<Value>, Option<Value>), ParquetError> {
-    let stats_with_min_max: Vec<&Statistics> = statistics
-        .iter()
-        .filter(|s| s.has_min_max_set())
-        .map(|s| *s)
-        .collect();
-
-    if stats_with_min_max.len() == 0 {
-        return Ok((None, None));
-    }
-
-    let (data_size, data_type) = match stats_with_min_max.first() {
-        Some(Statistics::Boolean(_)) => (std::mem::size_of::<bool>(), DataType::Boolean),
-        Some(Statistics::Int32(_)) => (std::mem::size_of::<i32>(), DataType::Int32),
-        Some(Statistics::Int64(_)) => (std::mem::size_of::<i64>(), DataType::Int64),
-        Some(Statistics::Float(_)) => (std::mem::size_of::<f32>(), DataType::Float32),
-        Some(Statistics::Double(_)) => (std::mem::size_of::<f64>(), DataType::Float64),
-        Some(Statistics::ByteArray(_)) if is_utf8(column_descr.logical_type()) => {
-            (0, DataType::Utf8)
-        }
-        _ => {
-            // NOTE: Skips
-            // Statistics::Int96(_)
-            // Statistics::ByteArray(_)
-            // Statistics::FixedLenByteArray(_)
-
-            return Ok((None, None));
-        }
-    };
-
-    if data_type == DataType::Utf8 {
-        return Ok(min_max_strings_from_stats(&stats_with_min_max));
-    }
-
-    let arrow_buffer_capacity = stats_with_min_max.len() * data_size;
-
-    let min_array = arrow_array_from_bytes(
-        data_type.clone(),
-        arrow_buffer_capacity,
-        stats_with_min_max.iter().map(|s| s.min_bytes()).collect(),
-    );
-
-    let max_array = arrow_array_from_bytes(
-        data_type.clone(),
-        arrow_buffer_capacity,
-        stats_with_min_max.iter().map(|s| s.max_bytes()).collect(),
-    );
-
-    match data_type {
-        DataType::Boolean => {
-            let min = arrow::compute::min_boolean(as_boolean_array(&min_array));
-            let min = min.map(|b| Value::Bool(b));
-
-            let max = arrow::compute::max_boolean(as_boolean_array(&max_array));
-            let max = max.map(|b| Value::Bool(b));
-
-            Ok((min, max))
-        }
-        DataType::Int32 => {
-            let min_array = as_primitive_array::<arrow::datatypes::Int32Type>(&min_array);
-            let min = arrow::compute::min(min_array);
-            let min = min.map(|i| Value::Number(Number::from(i)));
-
-            let max_array = as_primitive_array::<arrow::datatypes::Int32Type>(&max_array);
-            let max = arrow::compute::max(max_array);
-            let max = max.map(|i| Value::Number(Number::from(i)));
-
-            Ok((min, max))
-        }
-        DataType::Int64 => {
-            let min_array = as_primitive_array::<arrow::datatypes::Int64Type>(&min_array);
-            let min = arrow::compute::min(min_array);
-            let min = min.map(|i| Value::Number(Number::from(i)));
-
-            let max_array = as_primitive_array::<arrow::datatypes::Int64Type>(&max_array);
-            let max = arrow::compute::max(max_array);
-            let max = max.map(|i| Value::Number(Number::from(i)));
-
-            Ok((min, max))
-        }
-        DataType::Float32 => {
-            let min_array = as_primitive_array::<arrow::datatypes::Float32Type>(&min_array);
-            let min = arrow::compute::min(min_array);
-            let min = min
-                .map(|f| Number::from_f64(f as f64).map(|n| Value::Number(n)))
-                .flatten();
-
-            let max_array = as_primitive_array::<arrow::datatypes::Float32Type>(&max_array);
-            let max = arrow::compute::max(max_array);
-            let max = max
-                .map(|f| Number::from_f64(f as f64).map(|n| Value::Number(n)))
-                .flatten();
-
-            Ok((min, max))
-        }
-        DataType::Float64 => {
-            let min_array = as_primitive_array::<arrow::datatypes::Float64Type>(&min_array);
-            let min = arrow::compute::min(min_array);
-            let min = min
-                .map(|f| Number::from_f64(f).map(|n| Value::Number(n)))
-                .flatten();
-
-            let max_array = as_primitive_array::<arrow::datatypes::Float64Type>(&max_array);
-            let max = arrow::compute::max(max_array);
-            let max = max
-                .map(|f| Number::from_f64(f).map(|n| Value::Number(n)))
-                .flatten();
-
-            Ok((min, max))
-        }
-        _ => Ok((None, None)),
-    }
-}
-
-/// TODD
-fn arrow_array_from_bytes(
-    data_type: DataType,
-    capacity: usize,
-    byte_arrays: Vec<&[u8]>,
-) -> Arc<dyn Array> {
-    let mut buffer = MutableBuffer::new(capacity);
-
-    for arr in byte_arrays.iter() {
-        buffer.extend_from_slice(arr);
-    }
-
-    let builder = ArrayData::builder(data_type)
-        .len(byte_arrays.len())
-        .add_buffer(buffer.into());
-
-    let data = builder.build();
-
-    make_array(data)
-}
-
-/// TODD
-fn min_max_strings_from_stats(
-    stats_with_min_max: &Vec<&Statistics>,
-) -> (Option<Value>, Option<Value>) {
-    let min_string_candidates = stats_with_min_max
-        .iter()
-        .filter_map(|s| str_opt_from_bytes(s.min_bytes()));
-
-    let min_value = min_string_candidates
-        .min()
-        .map(|s| Value::String(s.to_string()));
-
-    let max_string_candidates = stats_with_min_max
-        .iter()
-        .filter_map(|s| str_opt_from_bytes(s.max_bytes()));
-
-    let max_value = max_string_candidates
-        .max()
-        .map(|s| Value::String(s.to_string()));
-
-    return (min_value, max_value);
-}
-
-/// TODD
-#[inline]
-fn is_utf8(opt: Option<LogicalType>) -> bool {
-    match opt.as_ref() {
-        Some(LogicalType::STRING(_)) => true,
-        _ => false,
-    }
-}
-
-/// TODD
-fn str_opt_from_bytes(bytes: &[u8]) -> Option<&str> {
-    std::str::from_utf8(bytes).ok()
-}
-
-/// TODD
 struct InMemValueIter<'a> {
-    /// TODD
     buffer: &'a [Value],
-    /// TODD
     current_index: usize,
 }
 
 impl<'a> InMemValueIter<'a> {
-    fn from_vec(v: &'a [Value]) -> Self {
+    fn from_vec(buffer: &'a [Value]) -> Self {
         Self {
-            buffer: v,
+            buffer,
             current_index: 0,
         }
     }
 }
 
 impl<'a> Iterator for InMemValueIter<'a> {
-    type Item = Result<Value, ArrowError>;
+    type Item = Result<Value, arrow::error::ArrowError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let item = self.buffer.get(self.current_index);
-
         self.current_index += 1;
-
         item.map(|v| Ok(v.to_owned()))
     }
-}
-
-/// Creates an Arrow RecordBatch from the passed JSON buffer.
-pub fn record_batch_from_json(
-    arrow_schema_ref: Arc<ArrowSchema>,
-    json_buffer: &[Value],
-) -> Result<RecordBatch, DeltaWriterError> {
-    let row_count = json_buffer.len();
-    let mut value_iter = InMemValueIter::from_vec(json_buffer);
-    let decoder = Decoder::new(arrow_schema_ref.clone(), row_count, None);
-
-    decoder
-        .next_batch(&mut value_iter)?
-        .ok_or(DeltaWriterError::EmptyRecordBatch)
-}
-
-fn extract_partition_values(
-    partition_cols: &Vec<String>,
-    record_batch: &RecordBatch,
-) -> Result<HashMap<String, String>, DeltaWriterError> {
-    let mut partition_values = HashMap::new();
-
-    for col_name in partition_cols.iter() {
-        let arrow_schema = record_batch.schema();
-
-        let i = arrow_schema.index_of(col_name)?;
-        let col = record_batch.column(i);
-
-        let partition_string = stringified_partition_value(col)?;
-
-        partition_values.insert(col_name.clone(), partition_string);
-    }
-
-    Ok(partition_values)
-}
-
-fn create_add(
-    partition_values: &HashMap<String, String>,
-    path: String,
-    size: i64,
-    file_metadata: &FileMetaData,
-) -> Result<Add, DeltaWriterError> {
-    let stats = delta_stats_from_file_metadata(file_metadata)?;
-    let stats_string = serde_json::to_string(&stats)
-        .or(Err(DeltaWriterError::StatsSerializationFailed { stats }))?;
-
-    // Determine the modification timestamp to include in the add action - milliseconds since epoch
-    // Err should be impossible in this case since `SystemTime::now()` is always greater than `UNIX_EPOCH`
-    let modification_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-    let modification_time = modification_time.as_millis() as i64;
-
-    Ok(Add {
-        path,
-        size,
-
-        partitionValues: partition_values.to_owned(),
-        partitionValues_parsed: None,
-
-        modificationTime: modification_time,
-        dataChange: true,
-
-        stats: Some(stats_string),
-        stats_parsed: None,
-        // ?
-        tags: None,
-    })
-}
-
-// very naive implementation for plucking the partition value from the first element of a column array.
-// ideally, we would do some validation to ensure the record batch containing the passed partition column contains only distinct values.
-// if we calculate stats _first_, we can avoid the extra iteration by ensuring max and min match for the column.
-// however, stats are optional and can be added later with `dataChange` false log entries, and it may be more appropriate to add stats _later_ to speed up the initial write.
-// a happy middle-road might be to compute stats for partition columns only on the initial write since we should validate partition values anyway, and compute additional stats later (at checkpoint time perhaps?).
-// also this does not currently support nested partition columns and many other data types.
-fn stringified_partition_value(arr: &Arc<dyn Array>) -> Result<String, DeltaWriterError> {
-    let data_type = arr.data_type();
-
-    let s = match data_type {
-        DataType::Int8 => as_primitive_array::<Int8Type>(arr).value(0).to_string(),
-        DataType::Int16 => as_primitive_array::<Int16Type>(arr).value(0).to_string(),
-        DataType::Int32 => as_primitive_array::<Int32Type>(arr).value(0).to_string(),
-        DataType::Int64 => as_primitive_array::<Int64Type>(arr).value(0).to_string(),
-        DataType::UInt8 => as_primitive_array::<UInt8Type>(arr).value(0).to_string(),
-        DataType::UInt16 => as_primitive_array::<UInt16Type>(arr).value(0).to_string(),
-        DataType::UInt32 => as_primitive_array::<UInt32Type>(arr).value(0).to_string(),
-        DataType::UInt64 => as_primitive_array::<UInt64Type>(arr).value(0).to_string(),
-        DataType::Utf8 => {
-            let data = arrow::array::as_string_array(arr);
-
-            data.value(0).to_string()
-        }
-        // TODO: handle more types
-        _ => {
-            unimplemented!("Unimplemented data type: {:?}", data_type);
-        }
-    };
-
-    Ok(s)
 }
 
 #[cfg(test)]
@@ -679,16 +139,8 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_nonexistent_table() {
-        let res = DeltaWriter::for_table_path("/nonexistent/table").await;
-        assert!(res.is_err());
-        if let Err(err) = res {
-            match err {
-                DeltaWriterError::DeltaTable { source: _ } => {}
-                other => {
-                    assert!(false, "Expected a DeltaTable error, got `{}`", other);
-                }
-            }
-        }
+    async fn test_simple() {
+        let table = crate::open_table("./tests/data/delta-0.8.0").await.unwrap();
+        let writer = BufferedJSONWriter::try_new(table).unwrap();
     }
 }

--- a/rust/src/writer.rs
+++ b/rust/src/writer.rs
@@ -241,7 +241,7 @@ impl DeltaWriter {
         let obj_bytes = self.cursor.data();
 
         // TODO: support partitions on the write
-        let version = self.table.add_file(&obj_bytes, None).await?;
+        let version = self.table.add_file(&obj_bytes, None, None).await?;
 
         // After data is written, re-initialize internal state to handle another file
         self.reset()?;

--- a/rust/src/writer.rs
+++ b/rust/src/writer.rs
@@ -1,0 +1,709 @@
+//! The writer module contains the DeltaWriter and DeltaWriterError definitions and provides a
+//! higher level API for performing Delta transaction writes to a given Delta Table.
+//!
+//! Unlike the transaction API on DeltaTable, this higher level writer will also write out the
+//! parquet files
+
+
+use arrow::{
+    array::{as_boolean_array, as_primitive_array, make_array, Array, ArrayData},
+    buffer::MutableBuffer,
+    datatypes::Schema as ArrowSchema,
+    datatypes::*,
+    error::ArrowError,
+    json::reader::Decoder,
+    record_batch::RecordBatch,
+};
+use crate::{
+    action::{Action, Add, ColumnCountStat, ColumnValueStat, Stats},
+    DeltaDataTypeVersion, DeltaTable, DeltaTableError, DeltaTransactionError, Schema,
+    StorageBackend, StorageError, UriError,
+};
+use log::{debug, info};
+use parquet::{
+    arrow::ArrowWriter,
+    basic::{Compression, LogicalType},
+    errors::ParquetError,
+    file::{
+        metadata::RowGroupMetaData, properties::WriterProperties, statistics::Statistics,
+        writer::InMemoryWriteableCursor,
+    },
+    schema::types::{ColumnDescriptor, SchemaDescriptor},
+};
+use parquet_format::FileMetaData;
+use serde_json::{Number, Value};
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+/**
+ * Errors which can be returned when attempting to write a parquet file or Delta transaction
+ */
+#[derive(thiserror::Error, Debug)]
+pub enum DeltaWriterError {
+    /// Missing partition column
+    #[error("Missing partition column: {col_name}")]
+    MissingPartitionColumn {
+        /// The name of the column missing the partition
+        col_name: String
+    },
+
+    /// The Arrow RecordBatch schema doesn't match the expected schema
+    #[error("Arrow RecordBatch schema does not match: RecordBatch schema: {record_batch_schema}, {expected_schema}")]
+    SchemaMismatch {
+        /// TODO
+        record_batch_schema: SchemaRef,
+        /// TODO
+        expected_schema: Arc<arrow::datatypes::Schema>,
+    },
+
+    /// Missing metadata
+    #[error("{0}")]
+    MissingMetadata(String),
+
+    /// RecordBatch created from a JSON string turned out to be a None
+    #[error("Arrow RecordBatch created from JSON buffer is a None value")]
+    EmptyRecordBatch,
+
+    /// Deserialization of the Delta per-file statistics failed
+    #[error("Serialization of delta log statistics failed")]
+    StatsSerializationFailed {
+        /// TODO
+        stats: Stats
+    },
+
+    /// Invalid table path
+    #[error("Invalid table path: {}", .source)]
+    UriError {
+        /// The source UriError
+        #[from]
+        source: UriError,
+    },
+
+    /// Delta Lake storage interaction failed
+    #[error("Storage interaction failed: {source}")]
+    Storage {
+        /// Source error
+        #[from]
+        source: StorageError,
+    },
+
+    /// DeltaTable interaction failed
+    #[error("DeltaTable interaction failed: {source}")]
+    DeltaTable {
+        /// The source error from the DeltaTable
+        #[from]
+        source: DeltaTableError,
+    },
+
+    /// Arrow interaction failed
+    #[error("Arrow interaction failed: {source}")]
+    Arrow {
+        /// The source ArrowError from the arrow crate
+        #[from]
+        source: ArrowError,
+    },
+
+    /// Parquet write failed
+    #[error("Parquet write failed: {source}")]
+    Parquet {
+        /// The source ParquetError from the parquet crate
+        #[from]
+        source: ParquetError,
+    },
+
+    /// Delta transaction commit failed
+    #[error("Delta transaction commit failed: {source}")]
+    DeltaTransactionError {
+        /// The source error from the DeltaTable on writing the transaction
+        #[from]
+        source: DeltaTransactionError,
+    },
+}
+
+/**
+ * The DeltaWriter struct provides a high--level API for writing parquet files and their
+ * transactions to the given DeltaTable
+ */
+pub struct DeltaWriter {
+    /// The DeltaTable this writer is affiliated with
+    table: DeltaTable,
+    /// The DeltaTable's storage backend
+    storage: Box<dyn StorageBackend>,
+    /// TODD
+    arrow_schema_ref: Arc<arrow::datatypes::Schema>,
+    /// TODD
+    writer_properties: WriterProperties,
+    /// TODD
+    cursor: InMemoryWriteableCursor,
+    /// TODD
+    arrow_writer: ArrowWriter<InMemoryWriteableCursor>,
+    /// TODD
+    partition_columns: Vec<String>,
+    /// TODD
+    partition_values: HashMap<String, String>,
+    /// TODD
+    buffered_record_batch_count: usize,
+}
+
+impl DeltaWriter {
+    /// Initialize the writer from the given table path and delta schema
+    pub async fn for_table_path(table_path: String) -> Result<DeltaWriter, DeltaWriterError> {
+        let table = crate::open_table(&table_path.as_str()).await?;
+        let storage = crate::get_backend_for_uri(table_path.as_str())?;
+
+        // Initialize an arrow schema ref from the delta table schema
+        let metadata = table.get_metadata()?.clone();
+        let schema = metadata.schema.clone();
+        let arrow_schema = <ArrowSchema as TryFrom<&Schema>>::try_from(&schema).unwrap();
+        let arrow_schema_ref = Arc::new(arrow_schema);
+        let partition_columns = metadata.partition_columns;
+
+        // Initialize writer properties for the underlying arrow writer
+        let writer_properties = WriterProperties::builder()
+            // NOTE: Consider extracting config for writer properties and setting more than just compression
+            .set_compression(Compression::SNAPPY)
+            .build();
+
+        let cursor = InMemoryWriteableCursor::default();
+        let arrow_writer = ArrowWriter::try_new(
+            cursor.clone(),
+            arrow_schema_ref.clone(),
+            Some(writer_properties.clone()),
+        )?;
+
+        Ok(Self {
+            table,
+            storage,
+            arrow_schema_ref,
+            writer_properties,
+            cursor,
+            arrow_writer,
+            partition_columns,
+            partition_values: HashMap::new(),
+            buffered_record_batch_count: 0,
+        })
+    }
+
+    /// TODO
+    pub async fn last_transaction_version(
+        &self,
+        app_id: &str,
+    ) -> Result<Option<DeltaDataTypeVersion>, DeltaWriterError> {
+        let tx_versions = self.table.get_app_transaction_version();
+
+        let v = tx_versions.get(app_id).map(|v| v.to_owned());
+
+        debug!("Transaction version is {:?}", v);
+
+        Ok(v)
+    }
+
+    /// Writes the record batch in-memory and updates internal state accordingly.
+    /// This method buffers the write stream internally so it can be invoked for many record batches and flushed after the appropriate number of bytes has been written.
+    pub async fn write_record_batch(
+        &mut self,
+        record_batch: &RecordBatch,
+    ) -> Result<(), DeltaWriterError> {
+        let partition_values = extract_partition_values(&self.partition_columns, record_batch)?;
+
+        // Verify record batch schema matches the expected schema
+        let schemas_match = record_batch.schema() == self.arrow_schema_ref;
+
+        if !schemas_match {
+            return Err(DeltaWriterError::SchemaMismatch {
+                record_batch_schema: record_batch.schema(),
+                expected_schema: self.arrow_schema_ref.clone(),
+            });
+        }
+
+        // TODO: Verify that this RecordBatch contains partition values that agree with previous partition values (if any) for the current writer context
+        self.partition_values = partition_values;
+
+        // write the record batch to the held arrow writer
+        self.arrow_writer.write(record_batch)?;
+
+        self.buffered_record_batch_count += 1;
+
+        Ok(())
+    }
+
+    /// Returns the current byte length of the in memory buffer.
+    /// This may be used by the caller to decide when to finalize the file write.
+    pub fn buffer_len(&self) -> usize {
+        self.cursor.data().len()
+    }
+
+    /// Writes the existing parquet bytes to storage and resets internal state to handle another file.
+    pub async fn write_file(
+        &mut self,
+        actions: &mut Vec<Action>,
+    ) -> Result<DeltaDataTypeVersion, DeltaWriterError> {
+        info!("Writing parquet file.");
+
+        let metadata = self.arrow_writer.close()?;
+
+        let path = self.next_data_path(&self.partition_columns, &self.partition_values)?;
+
+        let obj_bytes = self.cursor.data();
+        let file_size = obj_bytes.len() as i64;
+
+        let storage_path = self
+            .storage
+            .join_path(self.table.table_path.as_str(), path.as_str());
+
+        //
+        // TODO: Wrap in retry loop to handle temporary network errors
+        //
+
+        self.storage
+            .put_obj(storage_path.as_str(), obj_bytes.as_slice())
+            .await?;
+
+        info!("Parquet file written.");
+
+        // After data is written, re-initialize internal state to handle another file
+        self.reset()?;
+
+        info!("Writing Delta transaction.");
+
+        let add = create_add(&self.partition_values, path, file_size, &metadata)?;
+
+        actions.push(Action::add(add));
+
+        // TODO: Pass StreamingUpdate operation
+        let mut tx = self.table.create_transaction(None);
+        let version = tx.commit_with(actions.as_slice(), None).await?;
+
+        info!("Committed Delta version {}", version);
+
+        Ok(version)
+    }
+
+    /// TODO
+    pub fn buffered_record_batch_count(&self) -> usize {
+        self.buffered_record_batch_count
+    }
+
+    fn reset(&mut self) -> Result<(), DeltaWriterError> {
+        // Reset the internal cursor for the next file.
+        self.cursor = InMemoryWriteableCursor::default();
+        // Reset buffered record batch count to 0.
+        self.buffered_record_batch_count = 0;
+        // Reset the internal arrow writer for the next file.
+        self.arrow_writer = ArrowWriter::try_new(
+            self.cursor.clone(),
+            self.arrow_schema_ref.clone(),
+            Some(self.writer_properties.clone()),
+        )?;
+
+        Ok(())
+    }
+
+    // TODO: parquet files have a 5 digit zero-padded prefix and a "c\d{3}" suffix that I have not been able to find documentation for yet.
+    fn next_data_path(
+        &self,
+        partition_cols: &Vec<String>,
+        partition_values: &HashMap<String, String>,
+    ) -> Result<String, DeltaWriterError> {
+        // TODO: what does 00000 mean?
+        let first_part = "00000";
+        let uuid_part = Uuid::new_v4();
+        // TODO: what does c000 mean?
+        let last_part = "c000";
+
+        // NOTE: If we add a non-snappy option, file name must change
+        let file_name = format!(
+            "part-{}-{}-{}.snappy.parquet",
+            first_part, uuid_part, last_part
+        );
+
+        let data_path = if partition_cols.len() > 0 {
+            let mut path_parts = vec![];
+
+            for k in partition_cols.iter() {
+                let partition_value =
+                    partition_values
+                        .get(k)
+                        .ok_or(DeltaWriterError::MissingPartitionColumn {
+                            col_name: k.to_string(),
+                        })?;
+
+                let part = format!("{}={}", k, partition_value);
+
+                path_parts.push(part);
+            }
+            path_parts.push(file_name);
+            path_parts.join("/")
+        } else {
+            file_name
+        };
+
+        Ok(data_path)
+    }
+
+    /// TODO
+    pub fn arrow_schema(&self) -> Arc<arrow::datatypes::Schema> {
+        self.arrow_schema_ref.clone()
+    }
+}
+
+/// TODD
+fn delta_stats_from_file_metadata(file_metadata: &FileMetaData) -> Result<Stats, ParquetError> {
+    let type_ptr = parquet::schema::types::from_thrift(file_metadata.schema.as_slice());
+    let schema_descriptor = type_ptr.map(|type_| Arc::new(SchemaDescriptor::new(type_)))?;
+
+    let mut min_values: HashMap<String, ColumnValueStat> = HashMap::new();
+    let mut max_values: HashMap<String, ColumnValueStat> = HashMap::new();
+    let mut null_counts: HashMap<String, ColumnCountStat> = HashMap::new();
+
+    let row_group_metadata: Result<Vec<RowGroupMetaData>, ParquetError> = file_metadata
+        .row_groups
+        .iter()
+        .map(|rg| RowGroupMetaData::from_thrift(schema_descriptor.clone(), rg.clone()))
+        .collect();
+    let row_group_metadata = row_group_metadata?;
+
+    for i in 0..schema_descriptor.num_columns() {
+        let column_descr = schema_descriptor.column(i);
+        let column_path = column_descr.path();
+
+        // TODO: skip stats for lists and structs for now as these are missing in parquet crate column chunks
+        if column_path.parts().len() > 1 {
+            continue;
+        }
+
+        let statistics: Vec<&Statistics> = row_group_metadata
+            .iter()
+            .filter_map(|g| g.column(i).statistics())
+            .collect();
+
+        let (min, max) = stats_min_and_max(&statistics, column_descr.clone())?;
+
+        if let Some(min) = min {
+            let min = ColumnValueStat::Value(min);
+            min_values.insert(column_descr.name().to_string(), min);
+        }
+
+        if let Some(max) = max {
+            let max = ColumnValueStat::Value(max);
+            max_values.insert(column_descr.name().to_string(), max);
+        }
+
+        let null_count: u64 = statistics.iter().map(|s| s.null_count()).sum();
+        let null_count = ColumnCountStat::Value(null_count as i64);
+        null_counts.insert(column_descr.name().to_string(), null_count);
+    }
+
+    Ok(Stats {
+        numRecords: file_metadata.num_rows,
+        maxValues: max_values,
+        minValues: min_values,
+        nullCount: null_counts,
+    })
+}
+
+/// TODD
+fn stats_min_and_max(
+    statistics: &[&Statistics],
+    column_descr: Arc<ColumnDescriptor>,
+) -> Result<(Option<Value>, Option<Value>), ParquetError> {
+    let stats_with_min_max: Vec<&Statistics> = statistics
+        .iter()
+        .filter(|s| s.has_min_max_set())
+        .map(|s| *s)
+        .collect();
+
+    if stats_with_min_max.len() == 0 {
+        return Ok((None, None));
+    }
+
+    let (data_size, data_type) = match stats_with_min_max.first() {
+        Some(Statistics::Boolean(_)) => (std::mem::size_of::<bool>(), DataType::Boolean),
+        Some(Statistics::Int32(_)) => (std::mem::size_of::<i32>(), DataType::Int32),
+        Some(Statistics::Int64(_)) => (std::mem::size_of::<i64>(), DataType::Int64),
+        Some(Statistics::Float(_)) => (std::mem::size_of::<f32>(), DataType::Float32),
+        Some(Statistics::Double(_)) => (std::mem::size_of::<f64>(), DataType::Float64),
+        Some(Statistics::ByteArray(_)) if is_utf8(column_descr.logical_type()) => {
+            (0, DataType::Utf8)
+        }
+        _ => {
+            // NOTE: Skips
+            // Statistics::Int96(_)
+            // Statistics::ByteArray(_)
+            // Statistics::FixedLenByteArray(_)
+
+            return Ok((None, None));
+        }
+    };
+
+    if data_type == DataType::Utf8 {
+        return Ok(min_max_strings_from_stats(&stats_with_min_max));
+    }
+
+    let arrow_buffer_capacity = stats_with_min_max.len() * data_size;
+
+    let min_array = arrow_array_from_bytes(
+        data_type.clone(),
+        arrow_buffer_capacity,
+        stats_with_min_max.iter().map(|s| s.min_bytes()).collect(),
+    );
+
+    let max_array = arrow_array_from_bytes(
+        data_type.clone(),
+        arrow_buffer_capacity,
+        stats_with_min_max.iter().map(|s| s.max_bytes()).collect(),
+    );
+
+    match data_type {
+        DataType::Boolean => {
+            let min = arrow::compute::min_boolean(as_boolean_array(&min_array));
+            let min = min.map(|b| Value::Bool(b));
+
+            let max = arrow::compute::max_boolean(as_boolean_array(&max_array));
+            let max = max.map(|b| Value::Bool(b));
+
+            Ok((min, max))
+        }
+        DataType::Int32 => {
+            let min_array = as_primitive_array::<arrow::datatypes::Int32Type>(&min_array);
+            let min = arrow::compute::min(min_array);
+            let min = min.map(|i| Value::Number(Number::from(i)));
+
+            let max_array = as_primitive_array::<arrow::datatypes::Int32Type>(&max_array);
+            let max = arrow::compute::max(max_array);
+            let max = max.map(|i| Value::Number(Number::from(i)));
+
+            Ok((min, max))
+        }
+        DataType::Int64 => {
+            let min_array = as_primitive_array::<arrow::datatypes::Int64Type>(&min_array);
+            let min = arrow::compute::min(min_array);
+            let min = min.map(|i| Value::Number(Number::from(i)));
+
+            let max_array = as_primitive_array::<arrow::datatypes::Int64Type>(&max_array);
+            let max = arrow::compute::max(max_array);
+            let max = max.map(|i| Value::Number(Number::from(i)));
+
+            Ok((min, max))
+        }
+        DataType::Float32 => {
+            let min_array = as_primitive_array::<arrow::datatypes::Float32Type>(&min_array);
+            let min = arrow::compute::min(min_array);
+            let min = min
+                .map(|f| Number::from_f64(f as f64).map(|n| Value::Number(n)))
+                .flatten();
+
+            let max_array = as_primitive_array::<arrow::datatypes::Float32Type>(&max_array);
+            let max = arrow::compute::max(max_array);
+            let max = max
+                .map(|f| Number::from_f64(f as f64).map(|n| Value::Number(n)))
+                .flatten();
+
+            Ok((min, max))
+        }
+        DataType::Float64 => {
+            let min_array = as_primitive_array::<arrow::datatypes::Float64Type>(&min_array);
+            let min = arrow::compute::min(min_array);
+            let min = min
+                .map(|f| Number::from_f64(f).map(|n| Value::Number(n)))
+                .flatten();
+
+            let max_array = as_primitive_array::<arrow::datatypes::Float64Type>(&max_array);
+            let max = arrow::compute::max(max_array);
+            let max = max
+                .map(|f| Number::from_f64(f).map(|n| Value::Number(n)))
+                .flatten();
+
+            Ok((min, max))
+        }
+        _ => Ok((None, None)),
+    }
+}
+
+/// TODD
+fn arrow_array_from_bytes(
+    data_type: DataType,
+    capacity: usize,
+    byte_arrays: Vec<&[u8]>,
+) -> Arc<dyn Array> {
+    let mut buffer = MutableBuffer::new(capacity);
+
+    for arr in byte_arrays.iter() {
+        buffer.extend_from_slice(arr);
+    }
+
+    let builder = ArrayData::builder(data_type)
+        .len(byte_arrays.len())
+        .add_buffer(buffer.into());
+
+    let data = builder.build();
+
+    make_array(data)
+}
+
+/// TODD
+fn min_max_strings_from_stats(
+    stats_with_min_max: &Vec<&Statistics>,
+) -> (Option<Value>, Option<Value>) {
+    let min_string_candidates = stats_with_min_max
+        .iter()
+        .filter_map(|s| str_opt_from_bytes(s.min_bytes()));
+
+    let min_value = min_string_candidates
+        .min()
+        .map(|s| Value::String(s.to_string()));
+
+    let max_string_candidates = stats_with_min_max
+        .iter()
+        .filter_map(|s| str_opt_from_bytes(s.max_bytes()));
+
+    let max_value = max_string_candidates
+        .max()
+        .map(|s| Value::String(s.to_string()));
+
+    return (min_value, max_value);
+}
+
+/// TODD
+#[inline]
+fn is_utf8(opt: Option<LogicalType>) -> bool {
+    match opt.as_ref() {
+        Some(LogicalType::STRING(_)) => true,
+        _ => false,
+    }
+}
+
+/// TODD
+fn str_opt_from_bytes(bytes: &[u8]) -> Option<&str> {
+    std::str::from_utf8(bytes).ok()
+}
+
+/// TODD
+struct InMemValueIter<'a> {
+    /// TODD
+    buffer: &'a [Value],
+    /// TODD
+    current_index: usize,
+}
+
+impl<'a> InMemValueIter<'a> {
+    fn from_vec(v: &'a [Value]) -> Self {
+        Self {
+            buffer: v,
+            current_index: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for InMemValueIter<'a> {
+    type Item = Result<Value, ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self.buffer.get(self.current_index);
+
+        self.current_index += 1;
+
+        item.map(|v| Ok(v.to_owned()))
+    }
+}
+
+/// Creates an Arrow RecordBatch from the passed JSON buffer.
+pub fn record_batch_from_json(
+    arrow_schema_ref: Arc<ArrowSchema>,
+    json_buffer: &[Value],
+) -> Result<RecordBatch, DeltaWriterError> {
+    let row_count = json_buffer.len();
+    let mut value_iter = InMemValueIter::from_vec(json_buffer);
+    let decoder = Decoder::new(arrow_schema_ref.clone(), row_count, None);
+
+    decoder
+        .next_batch(&mut value_iter)?
+        .ok_or(DeltaWriterError::EmptyRecordBatch)
+}
+
+fn extract_partition_values(
+    partition_cols: &Vec<String>,
+    record_batch: &RecordBatch,
+) -> Result<HashMap<String, String>, DeltaWriterError> {
+    let mut partition_values = HashMap::new();
+
+    for col_name in partition_cols.iter() {
+        let arrow_schema = record_batch.schema();
+
+        let i = arrow_schema.index_of(col_name)?;
+        let col = record_batch.column(i);
+
+        let partition_string = stringified_partition_value(col)?;
+
+        partition_values.insert(col_name.clone(), partition_string);
+    }
+
+    Ok(partition_values)
+}
+
+fn create_add(
+    partition_values: &HashMap<String, String>,
+    path: String,
+    size: i64,
+    file_metadata: &FileMetaData,
+) -> Result<Add, DeltaWriterError> {
+    let stats = delta_stats_from_file_metadata(file_metadata)?;
+    let stats_string = serde_json::to_string(&stats)
+        .or(Err(DeltaWriterError::StatsSerializationFailed { stats }))?;
+
+    // Determine the modification timestamp to include in the add action - milliseconds since epoch
+    // Err should be impossible in this case since `SystemTime::now()` is always greater than `UNIX_EPOCH`
+    let modification_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    let modification_time = modification_time.as_millis() as i64;
+
+    Ok(Add {
+        path,
+        size,
+
+        partitionValues: partition_values.to_owned(),
+        partitionValues_parsed: None,
+
+        modificationTime: modification_time,
+        dataChange: true,
+
+        stats: Some(stats_string),
+        stats_parsed: None,
+        // ?
+        tags: None,
+    })
+}
+
+// very naive implementation for plucking the partition value from the first element of a column array.
+// ideally, we would do some validation to ensure the record batch containing the passed partition column contains only distinct values.
+// if we calculate stats _first_, we can avoid the extra iteration by ensuring max and min match for the column.
+// however, stats are optional and can be added later with `dataChange` false log entries, and it may be more appropriate to add stats _later_ to speed up the initial write.
+// a happy middle-road might be to compute stats for partition columns only on the initial write since we should validate partition values anyway, and compute additional stats later (at checkpoint time perhaps?).
+// also this does not currently support nested partition columns and many other data types.
+fn stringified_partition_value(arr: &Arc<dyn Array>) -> Result<String, DeltaWriterError> {
+    let data_type = arr.data_type();
+
+    let s = match data_type {
+        DataType::Int8 => as_primitive_array::<Int8Type>(arr).value(0).to_string(),
+        DataType::Int16 => as_primitive_array::<Int16Type>(arr).value(0).to_string(),
+        DataType::Int32 => as_primitive_array::<Int32Type>(arr).value(0).to_string(),
+        DataType::Int64 => as_primitive_array::<Int64Type>(arr).value(0).to_string(),
+        DataType::UInt8 => as_primitive_array::<UInt8Type>(arr).value(0).to_string(),
+        DataType::UInt16 => as_primitive_array::<UInt16Type>(arr).value(0).to_string(),
+        DataType::UInt32 => as_primitive_array::<UInt32Type>(arr).value(0).to_string(),
+        DataType::UInt64 => as_primitive_array::<UInt64Type>(arr).value(0).to_string(),
+        DataType::Utf8 => {
+            let data = arrow::array::as_string_array(arr);
+
+            data.value(0).to_string()
+        }
+        // TODO: handle more types
+        _ => {
+            unimplemented!("Unimplemented data type: {:?}", data_type);
+        }
+    };
+
+    Ok(s)
+}

--- a/rust/src/writer.rs
+++ b/rust/src/writer.rs
@@ -4,15 +4,141 @@
 //! Unlike the transaction API on DeltaTable, this higher level writer will also write out the
 //! parquet files
 
-use arrow::record_batch::RecordBatch;
+use crate::action::Txn;
 use crate::{DeltaTableError, DeltaTransactionError};
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use parquet::file::writer::InMemoryWriteableCursor;
-use parquet::arrow::ArrowWriter;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
+
+/**
+ * BufferedJSONWriter allows for buffering serde_json::Value rows before flushing to parquet files
+ * and a Delta transaction
+ */
+pub struct BufferedJSONWriter {
+    table: crate::DeltaTable,
+    buffer: HashMap<WriterPartition, Vec<Value>>,
+    schema: arrow::datatypes::SchemaRef,
+    partitions: Vec<String>,
+    txns: Vec<Txn>,
+}
+
+impl BufferedJSONWriter {
+    /**
+     * Attempt to construct the BufferedJSONWriter, will fail if the table's metadata is not
+     * present
+     */
+    pub fn try_new(table: crate::DeltaTable) -> Result<Self, DeltaTableError> {
+        let metadata = table.get_metadata()?.clone();
+        let schema = metadata.schema;
+        let arrow_schema =
+            <arrow::datatypes::Schema as TryFrom<&crate::Schema>>::try_from(&schema).unwrap();
+        let schema = Arc::new(arrow_schema);
+
+        Ok(Self {
+            table,
+            schema,
+            buffer: HashMap::new(),
+            partitions: metadata.partition_columns,
+            txns: vec![],
+        })
+    }
+
+    /**
+     * Return the total Values pending in the buffer
+     */
+    pub fn count(&self, partitions: &WriterPartition) -> Option<usize> {
+        self.buffer.get(&partitions).map(|b| b.len())
+    }
+
+    /**
+     * Add a txn action to the buffer
+     */
+    pub fn record_txn(&mut self, txn: Txn) {
+        self.txns.push(txn);
+    }
+
+    /**
+     * Write a new Value into the buffer
+     */
+    pub fn write(
+        &mut self,
+        value: Value,
+        partitions: WriterPartition,
+    ) -> Result<(), DeltaTableError> {
+        match partitions {
+            WriterPartition::NoPartitions => {
+                if self.partitions.len() > 0 {
+                    return Err(DeltaTableError::SchemaMismatch {
+                        msg: "Table has partitions but noone were supplied on write".to_string(),
+                    });
+                }
+            }
+            WriterPartition::KeyValues { .. } => {
+                if self.partitions.len() == 0 {
+                    return Err(DeltaTableError::SchemaMismatch {
+                        msg: "Table has no partitions yet they were supplied on write".to_string(),
+                    });
+                }
+            }
+        }
+
+        if let Some(buffer) = self.buffer.get_mut(&partitions) {
+            buffer.push(value);
+        } else {
+            self.buffer.insert(partitions, vec![value]);
+        }
+        Ok(())
+    }
+
+    /**
+     * Flush the buffer, causing a write of parquet files for each set of partitioned information
+     * as well as any buffered txn actions
+     *
+     * This will create a single transaction in the delta transaction log
+     */
+    pub async fn flush(&mut self) -> Result<(), DeltaTransactionError> {
+        use arrow::json::reader::Decoder;
+
+        let mut parquet_bufs = vec![];
+
+        for (partitions, values) in self.buffer.iter() {
+            let count = self.count(&partitions).unwrap_or(0);
+            let mut value_iter = InMemValueIter::from_vec(&values);
+            let decoder = Decoder::new(self.schema.clone(), count, None);
+
+            let record_batch = decoder
+                .next_batch(&mut value_iter)
+                .map_err(|source| DeltaTableError::ArrowError { source })?;
+
+            if record_batch.is_none() {
+                return Ok(());
+            }
+
+            let mut pb = ParquetBuffer::try_new(self.schema.clone())?;
+            pb.write_batch(&record_batch.unwrap())?;
+            let _metadata = pb.close();
+            parquet_bufs.push(pb.data());
+        }
+
+        let mut dtx = self.table.create_transaction(None);
+        dtx.add_actions(
+            self.txns
+                .drain(0..)
+                .map(|t| crate::action::Action::txn(t))
+                .collect(),
+        );
+
+        dtx.commit(None).await?;
+        self.buffer.clear();
+        Ok(())
+    }
+}
 
 struct ParquetBuffer {
     writer: ArrowWriter<InMemoryWriteableCursor>,
@@ -28,17 +154,15 @@ impl ParquetBuffer {
             .build();
 
         let cursor = InMemoryWriteableCursor::default();
-        let writer = ArrowWriter::try_new(
-            cursor.clone(),
-            schema,
-            Some(writer_properties),
-        )?;
+        let writer = ArrowWriter::try_new(cursor.clone(), schema, Some(writer_properties))?;
 
         Ok(Self { writer, cursor })
     }
 
     fn write_batch(&mut self, batch: &RecordBatch) -> Result<(), DeltaTableError> {
-        self.writer.write(batch).map_err(|source| DeltaTableError::ParquetError { source })
+        self.writer
+            .write(batch)
+            .map_err(|source| DeltaTableError::ParquetError { source })
     }
 
     fn data(&self) -> Vec<u8> {
@@ -46,67 +170,9 @@ impl ParquetBuffer {
     }
 
     fn close(&mut self) -> Result<parquet_format::FileMetaData, DeltaTableError> {
-        self.writer.close().map_err(|source| DeltaTableError::ParquetError { source })
-    }
-}
-
-struct BufferedJSONWriter {
-    table: crate::DeltaTable,
-    buffer: Vec<serde_json::Value>,
-    schema: arrow::datatypes::SchemaRef,
-}
-
-impl BufferedJSONWriter {
-    fn try_new(table: crate::DeltaTable) -> Result<Self, DeltaTableError> {
-        let metadata = table.get_metadata()?.clone();
-        let schema = metadata.schema;
-        let arrow_schema = <arrow::datatypes::Schema as TryFrom<&crate::Schema>>::try_from(&schema).unwrap();
-        let schema = Arc::new(arrow_schema);
-        let partition_columns = metadata.partition_columns;
-
-        Ok(Self {
-            table,
-            schema,
-            buffer: vec![],
-        })
-    }
-
-    /**
-     * Return the total Values pending in the buffer
-     */
-    fn count(&self) -> usize {
-        self.buffer.len()
-    }
-
-    /**
-     * Write a new Value into the buffer
-     */
-    fn write(&mut self, value: Value) -> std::io::Result<()> {
-        self.buffer.push(value);
-        Ok(())
-    }
-
-    async fn flush(&mut self) -> Result<(), DeltaTransactionError> {
-        use arrow::json::reader::Decoder;
-
-        let mut value_iter = InMemValueIter::from_vec(&self.buffer);
-        let decoder = Decoder::new(self.schema.clone(), self.count(), None);
-        let record_batch = decoder
-            .next_batch(&mut value_iter)
-            .map_err(|source| DeltaTableError::ArrowError { source })?;
-
-        if record_batch.is_none() {
-            return Ok(());
-        }
-
-        let mut pb = ParquetBuffer::try_new(self.schema.clone())?;
-        pb.write_batch(&record_batch.unwrap())?;
-        let _metadata = pb.close();
-
-        self.table.add_file(&pb.data(), None, None).await?;
-
-        self.buffer.clear();
-        Ok(())
+        self.writer
+            .close()
+            .map_err(|source| DeltaTableError::ParquetError { source })
     }
 }
 
@@ -134,13 +200,52 @@ impl<'a> Iterator for InMemValueIter<'a> {
     }
 }
 
+/**
+ * The type of partition for a row being written to a writer
+ */
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum WriterPartition {
+    /// The row is not partitioned
+    NoPartitions,
+    /// The row is partitioned with the following sets of key=value partition strings
+    KeyValues {
+        /// Each entry in the vec should be a key=value pair
+        partitions: Vec<(String, String)>,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_simple() {
+    async fn test_writer_buffer_nopartition() {
         let table = crate::open_table("./tests/data/delta-0.8.0").await.unwrap();
-        let writer = BufferedJSONWriter::try_new(table).unwrap();
+        let mut writer = BufferedJSONWriter::try_new(table).unwrap();
+        assert_eq!(writer.count(&WriterPartition::NoPartitions), None);
+        let res = writer.write(json!({"hello":"world"}), WriterPartition::NoPartitions);
+        assert!(res.is_ok());
+        assert_eq!(writer.count(&WriterPartition::NoPartitions), Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_writer_write_partition_mismatch() {
+        let table = crate::open_table("./tests/data/delta-0.8.0-partitioned")
+            .await
+            .unwrap();
+        let mut writer = BufferedJSONWriter::try_new(table).unwrap();
+        let res = writer.write(json!({"hello":"world"}), WriterPartition::NoPartitions);
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_writer_write_partitions_to_nopartition() {
+        let table = crate::open_table("./tests/data/delta-0.8.0").await.unwrap();
+        let mut writer = BufferedJSONWriter::try_new(table).unwrap();
+        let partitions = WriterPartition::KeyValues {
+            partitions: vec![("year".to_string(), "2021".to_string())],
+        };
+        let res = writer.write(json!({"hello":"world"}), partitions);
+        assert!(res.is_err());
     }
 }

--- a/rust/tests/concurrent_writes_test.rs
+++ b/rust/tests/concurrent_writes_test.rs
@@ -15,7 +15,12 @@ use std::time::Duration;
 #[tokio::test]
 #[cfg(all(feature = "s3", feature = "dynamodb"))]
 async fn concurrent_writes_s3() {
-    prepare_s3().await;
+    s3_common::setup_dynamodb("concurrent_writes");
+    s3_common::cleanup_dir_except(
+        "s3://deltars/concurrent_workers/_delta_log",
+        vec!["00000000000000000000.json".to_string()],
+    )
+    .await;
     run_test(|name| Worker::new("s3://deltars/concurrent_workers", name)).await;
 }
 
@@ -115,14 +120,4 @@ fn prepare_fs() {
         "./tests/data/concurrent_workers/_delta_log",
         vec!["00000000000000000000.json".to_string()],
     );
-}
-
-#[cfg(feature = "s3")]
-async fn prepare_s3() {
-    s3_common::setup_dynamodb("concurrent_writes");
-    s3_common::cleanup_dir_except(
-        "s3://deltars/concurrent_workers/_delta_log",
-        vec!["00000000000000000000.json".to_string()],
-    )
-    .await;
 }

--- a/rust/tests/concurrent_writes_test.rs
+++ b/rust/tests/concurrent_writes_test.rs
@@ -94,7 +94,8 @@ impl Worker {
     }
 
     async fn commit_file(&mut self, name: &str) -> i64 {
-        let actions = [action::Action::add(action::Add {
+        let mut tx = self.table.create_transaction(None);
+        tx.add_action(action::Action::add(action::Add {
             path: format!("{}.parquet", name),
             size: 396,
             partitionValues: HashMap::new(),
@@ -104,9 +105,8 @@ impl Worker {
             stats: None,
             stats_parsed: None,
             tags: None,
-        })];
-        let mut tx = self.table.create_transaction(None);
-        tx.commit_with(&actions, None).await.unwrap()
+        }));
+        tx.commit(None).await.unwrap()
     }
 }
 

--- a/rust/tests/write_exploration.rs
+++ b/rust/tests/write_exploration.rs
@@ -401,11 +401,9 @@ async fn smoke_test() {
     // HACK: cloning the add path to remove later in test. Ultimately, an "UpdateCommmand" will need to handle this differently
     let remove_path = add.path.clone();
 
+    transaction.add_action(Action::add(add));
     // commit the transaction
-    transaction
-        .commit_with(&[Action::add(add)], None)
-        .await
-        .unwrap();
+    transaction.commit(None).await.unwrap();
 
     //
     // ---
@@ -455,11 +453,9 @@ async fn smoke_test() {
     // TODO: removes should be calculated based on files containing a match for the update key.
     let remove = create_remove(remove_path);
 
+    transaction.add_actions(vec![Action::add(add), Action::remove(remove)]);
     // commit the transaction
-    transaction
-        .commit_with(&[Action::add(add), Action::remove(remove)], None)
-        .await
-        .unwrap();
+    transaction.commit(None).await.unwrap();
 
     // A notable thing to mention:
     // This implementation treats the DeltaTable instance as a single snapshot of the current log.


### PR DESCRIPTION
# Description

This pull request is a work in progress, pending more complete riffing on the [deltalake_ext.rs](https://github.com/delta-io/kafka-delta-ingest/blob/main/src/deltalake_ext.rs).

The objective here is that the primitive API will just handle writing some bytes to storage and the subsequent `add` transaction, whereas the high-level writer API will manage buffering of rows for a parquet file.
