### PR TITLE
Add commit_version method to DeltaTransaction

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1212,9 +1212,7 @@ fn log_bytes_from_actions(actions: &[Action]) -> Result<String, serde_json::Erro
         jsons.push(json);
     }
 
-    let log_entry = jsons.join("\n");
-
-    Ok(log_entry)
+    Ok(jsons.join("\n"))
 }
 
 fn process_action(

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1080,7 +1080,7 @@ impl<'a> DeltaTransaction<'a> {
         // TODO: create a CommitInfo action and prepend it to actions.
 
         // Serialize all actions that are part of this log entry.
-        let log_entry = log_bytes_from_actions(additional_actions)?;
+        let log_entry = log_entry_from_actions(additional_actions)?;
 
         // try to commit in a loop in case other writers write the next version first
         let version = self.try_commit_loop(log_entry.as_bytes()).await?;
@@ -1102,7 +1102,7 @@ impl<'a> DeltaTransaction<'a> {
     ) -> Result<DeltaDataTypeVersion, DeltaTransactionError> {
         // TODO: create a CommitInfo action and prepend it to actions.
 
-        let log_entry = log_bytes_from_actions(additional_actions)?;
+        let log_entry = log_entry_from_actions(additional_actions)?;
         let tmp_log_path = self.prepare_commit(log_entry.as_bytes()).await?;
         let version = self.try_commit(&tmp_log_path, version).await?;
 
@@ -1189,7 +1189,7 @@ impl<'a> DeltaTransaction<'a> {
     }
 }
 
-fn log_bytes_from_actions(actions: &[Action]) -> Result<String, serde_json::Error> {
+fn log_entry_from_actions(actions: &[Action]) -> Result<String, serde_json::Error> {
     let mut jsons = Vec::<String>::new();
 
     for action in actions {

--- a/rust/tests/simple_commit_test.rs
+++ b/rust/tests/simple_commit_test.rs
@@ -13,45 +13,121 @@ use std::collections::HashMap;
 
 use deltalake::{action, DeltaTransactionError};
 
-#[tokio::test]
-async fn test_two_commits_fs() {
-    prepare_fs();
-    test_two_commits("./tests/data/simple_commit")
-        .await
-        .unwrap();
-}
+mod simple_commit_s3 {
+    use super::*;
 
-#[cfg(all(feature = "s3", feature = "dynamodb"))]
-#[tokio::test]
-async fn test_two_commits_s3() {
-    let path = "s3://deltars/simple_commit_rw1";
-    s3_common::setup_dynamodb("concurrent_writes");
-    prepare_s3(path).await;
+    #[cfg(all(feature = "s3", feature = "dynamodb"))]
+    #[tokio::test]
+    async fn test_two_commits_s3() {
+        let path = "s3://deltars/simple_commit_rw1";
+        s3_common::setup_dynamodb("concurrent_writes");
+        prepare_s3(path).await;
 
-    test_two_commits(path).await.unwrap();
-}
-
-#[cfg(all(feature = "s3", not(feature = "dynamodb")))]
-#[tokio::test]
-async fn test_two_commits_s3_fails_with_no_lock() {
-    use deltalake::{StorageError, TransactionCommitAttemptError};
-
-    let path = "s3://deltars/simple_commit_rw2";
-    prepare_s3(path).await;
-
-    let result = test_two_commits(path).await;
-    if let Err(DeltaTransactionError::CommitRetriesExceeded { ref inner }) = result {
-        if let TransactionCommitAttemptError::Storage { source } = inner {
-            if let StorageError::S3Generic(err) = source {
-                assert_eq!(err, "dynamodb locking is not enabled");
-                return;
-            }
-        }
+        test_two_commits(path).await.unwrap();
     }
 
-    result.unwrap();
+    #[cfg(all(feature = "s3", not(feature = "dynamodb")))]
+    #[tokio::test]
+    async fn test_two_commits_s3_fails_with_no_lock() {
+        use deltalake::{StorageError, TransactionCommitAttemptError};
 
-    panic!("S3 commit without dynamodb locking is expected to fail")
+        let path = "s3://deltars/simple_commit_rw2";
+        prepare_s3(path).await;
+
+        let result = test_two_commits(path).await;
+        if let Err(DeltaTransactionError::TransactionCommitAttempt { ref inner }) = result {
+            if let TransactionCommitAttemptError::Storage { source } = inner {
+                if let StorageError::S3Generic(err) = source {
+                    assert_eq!(err, "dynamodb locking is not enabled");
+                    return;
+                }
+            }
+        }
+
+        result.unwrap();
+
+        panic!("S3 commit without dynamodb locking is expected to fail")
+    }
+}
+
+mod simple_commit_fs {
+    // Tests are run serially to allow usage of the same local fs directory.
+    use serial_test::serial;
+
+    use super::*;
+
+    #[tokio::test]
+    #[serial]
+    async fn test_two_commits_fs() {
+        prepare_fs();
+        test_two_commits("./tests/data/simple_commit")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_commit_version_succeeds_if_version_does_not_exist() {
+        prepare_fs();
+
+        let table_path = "./tests/data/simple_commit";
+        let mut table = deltalake::open_table(table_path).await.unwrap();
+
+        assert_eq!(0, table.version);
+        assert_eq!(0, table.get_files().len());
+
+        let tx1_actions = tx1_actions();
+
+        let mut tx1 = table.create_transaction(None);
+        let result = tx1
+            .commit_version(1, tx1_actions.as_slice(), None)
+            .await
+            .unwrap();
+
+        assert_eq!((), result);
+        assert_eq!(1, table.version);
+        assert_eq!(2, table.get_files().len());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_commit_version_fails_if_version_exists() {
+        prepare_fs();
+
+        let table_path = "./tests/data/simple_commit";
+        let mut table = deltalake::open_table(table_path).await.unwrap();
+
+        assert_eq!(0, table.version);
+        assert_eq!(0, table.get_files().len());
+
+        let tx1_actions = tx1_actions();
+
+        let mut tx1 = table.create_transaction(None);
+        let _ = tx1
+            .commit_version(1, tx1_actions.as_slice(), None)
+            .await
+            .unwrap();
+
+        let tx2_actions = tx2_actions();
+
+        let mut tx2 = table.create_transaction(None);
+
+        // we already committed version 1 - this should fail and return error for caller to handle.
+        let result = tx2.commit_version(1, tx2_actions.as_slice(), None).await;
+
+        match result {
+            Err(deltalake::DeltaTransactionError::VersionAlreadyExists { .. }) => {
+                assert!(true, "Delta version already exists.");
+            }
+            _ => {
+                assert!(false, "Delta version should already exist.");
+            }
+        }
+
+        assert!(result.is_err());
+        assert_eq!(1, table.version);
+        assert_eq!(2, table.get_files().len());
+    }
 }
 
 async fn test_two_commits(table_path: &str) -> Result<(), DeltaTransactionError> {
@@ -60,7 +136,28 @@ async fn test_two_commits(table_path: &str) -> Result<(), DeltaTransactionError>
     assert_eq!(0, table.version);
     assert_eq!(0, table.get_files().len());
 
-    let tx1_actions = vec![
+    let tx1_actions = tx1_actions();
+
+    let mut tx1 = table.create_transaction(None);
+    let version = tx1.commit_with(tx1_actions.as_slice(), None).await?;
+
+    assert_eq!(1, version);
+    assert_eq!(version, table.version);
+    assert_eq!(2, table.get_files().len());
+
+    let tx2_actions = tx2_actions();
+
+    let mut tx2 = table.create_transaction(None);
+    let version = tx2.commit_with(tx2_actions.as_slice(), None).await.unwrap();
+
+    assert_eq!(2, version);
+    assert_eq!(version, table.version);
+    assert_eq!(4, table.get_files().len());
+    Ok(())
+}
+
+fn tx1_actions() -> Vec<action::Action> {
+    vec![
         action::Action::add(action::Add {
             path: String::from(
                 "part-00000-b44fcdb0-8b06-4f3a-8606-f8311a96f6dc-c000.snappy.parquet",
@@ -87,16 +184,11 @@ async fn test_two_commits(table_path: &str) -> Result<(), DeltaTransactionError>
             stats_parsed: None,
             tags: None,
         }),
-    ];
+    ]
+}
 
-    let mut tx1 = table.create_transaction(None);
-    let version = tx1.commit_with(tx1_actions.as_slice(), None).await?;
-
-    assert_eq!(1, version);
-    assert_eq!(version, table.version);
-    assert_eq!(2, table.get_files().len());
-
-    let tx2_actions = vec![
+fn tx2_actions() -> Vec<action::Action> {
+    vec![
         action::Action::add(action::Add {
             path: String::from(
                 "part-00000-512e1537-8aaa-4193-b8b4-bef3de0de409-c000.snappy.parquet",
@@ -123,15 +215,7 @@ async fn test_two_commits(table_path: &str) -> Result<(), DeltaTransactionError>
             stats_parsed: None,
             tags: None,
         }),
-    ];
-
-    let mut tx2 = table.create_transaction(None);
-    let version = tx2.commit_with(tx2_actions.as_slice(), None).await.unwrap();
-
-    assert_eq!(2, version);
-    assert_eq!(version, table.version);
-    assert_eq!(4, table.get_files().len());
-    Ok(())
+    ]
 }
 
 fn prepare_fs() {

--- a/rust/tests/simple_commit_test.rs
+++ b/rust/tests/simple_commit_test.rs
@@ -84,7 +84,7 @@ mod simple_commit_fs {
             .await
             .unwrap();
 
-        assert_eq!((), result);
+        assert_eq!(1, result);
         assert_eq!(1, table.version);
         assert_eq!(2, table.get_files().len());
     }


### PR DESCRIPTION
# Description

This PR adds a `commit_version` method to `DeltaTransaction` which takes a version parameter from the caller. 

Some clients (i.e. https://github.com/delta-io/kafka-delta-ingest) include `txn` actions when creating delta log entries that may require additional conflict resolution with external systems before incrementing the delta log version. The `commit_version` method propagates version conflict errors back to the caller immediately so they may apply conflict resolution steps before attempting another commit.

This PR is complete - but leaving it in a draft status per @rtyler's [notice](https://delta-users.slack.com/archives/C013LCAEB98/p1621350036003900) that we may preemptively avoid some conflicts by incorporating this into [his PR](https://github.com/delta-io/delta-rs/pull/248).



