### PR TITLE
Add initial Rust release CI 

### DIFF
--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -1,0 +1,46 @@
+name: Release to Cargo
+
+on:
+  push:
+    tags: [ 'rust-v*' ]
+
+defaults:
+  run:
+    working-directory: ./rust
+
+jobs:
+  validate-release-tag:
+    name: Validate git tag
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: compare git tag with cargo metadata
+        run: |
+          PUSHED_TAG=${GITHUB_REF##*/}
+          CURR_VER=$( grep version Cargo.toml | head -n 1 | awk '{print $3}' | tr -d '"' )
+          if [[ "${PUSHED_TAG}" != "rust-v${CURR_VER}" ]]; then
+            echo "Cargo metadata has version set to ${CURR_VER}, but got pushed tag ${PUSHED_TAG}."
+            exit 1
+          fi
+
+  release-crate:
+    needs: validate-release-tag
+    name: Release crate
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: actions-rs/cargo@v1
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        with:
+          command: publish
+          args: --manifest-path ./rust/Cargo.toml


### PR DESCRIPTION
# Description

Whenever a tag `rust-vx.y.z` (like `rust-v0.4.0`) is pushed, this workflow will publish via `cargo publish`.

GitHub Secrets configuration:
- `CARGO_REPOSITORY_TOKEN` - Token used in `cargo login`

**BLOCKER: Since `cargo publish` requires all dependencies to be published, this will fail until [azure-sdk-for-rust](https://github.com/Azure/azure-sdk-for-rust) is stable or released.**

Also, I noticed in the `rust-v3.0.0/rust/Cargo.lock` file that `azure_core` and `azure_storage` is commented so this seems acknowledged:

```toml
# Azure
# reqwest = { version = "0", optional = true }
# azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust", optional = true, rev = "536da42ebefd411feff8ba6a0965865e2741267e" }
# azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust", optional = true, rev = "536da42ebefd411feff8ba6a0965865e2741267e", features = ["blob", "account", "adls_gen2"] }
```

We could create another `Cargo.release.toml` to hide the `azure` dependencies for the meantime but seems unfulfilling.

# Related Issue(s)

- closes #238 

# Documentation

Links:
- https://doc.rust-lang.org/cargo/reference/publishing.html#github-permissions
- https://github.com/katyo/publish-crates 