### PR TITLE
Prototype support for Delta Sharing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,6 +2144,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "serde",
+ "serde_json",
  "serde_urlencoded 0.7.0",
  "tokio",
  "tokio-native-tls",

--- a/README.adoc
+++ b/README.adoc
@@ -30,6 +30,7 @@ link:https://github.com/rajasekarv/vega[vega], etc. It also provides bindings to
 * Local file system
 * AWS S3
 * Azure Data Lake Storage Gen 2
+* link:https://delta.io/sharing[Delta Sharing]
 * :x: Google Cloud Storage see link:https://github.com/delta-io/delta-rs/issues/56[#56]
 
 .Support features

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -28,7 +28,7 @@ features = ["extension-module", "abi3", "abi3-py36"]
 [dependencies.deltalake]
 path = "../rust"
 version = "0"
-features = ["s3", "azure"]
+features = ["s3", "azure", "delta-sharing"]
 
 [package.metadata.maturin]
 name = "deltalake"
@@ -41,6 +41,8 @@ classifier = [
 project-url = { Repo = "https://github.com/delta-io/delta-rs" }
 requires-dist = [
     "pyarrow>=4",
+    "fsspec>=0.7.4",
+    "aiohttp",
     'numpy<1.20.0;python_version<="3.6"',
     "pandas; extra =='pandas'",
     "mypy; extra == 'devel'",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -56,6 +56,7 @@ async-trait = "0.1"
 [features]
 rust-dataframe-ext = []
 datafusion-ext = ["datafusion", "crossbeam"]
+delta-sharing = ["reqwest"]
 azure = ["azure_core", "azure_storage", "reqwest"]
 s3 = ["rusoto_core", "rusoto_credential", "rusoto_s3", "rusoto_sts", "rusoto_dynamodb", "maplit"]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,7 +28,7 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 lazy_static = "1"
 
 # Azure
-reqwest = { version = "0", optional = true }
+reqwest = { version = "0", features = ["json"], optional = true }
 azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust", optional = true, rev = "536da42ebefd411feff8ba6a0965865e2741267e" }
 azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust", optional = true, rev = "536da42ebefd411feff8ba6a0965865e2741267e", features = ["blob", "account", "adls_gen2"] }
 

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -765,7 +765,6 @@ pub enum Action {
     file(File),
 }
 
-
 impl Action {
     /// Returns an action from the given parquet Row. Used when deserializing delta log parquet
     /// checkpoints.

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -663,6 +663,10 @@ pub struct Protocol {
     pub min_reader_version: DeltaDataTypeInt,
     /// Minimum version of the Delta write protocol a client must implement to correctly read the
     /// table.
+    ///
+    /// If the table is not writeable the value of the min_writer_version will be i32::MAX to
+    /// ensure that no client computes that it can write to the table
+    #[serde(default="max_int32")]
     pub min_writer_version: DeltaDataTypeInt,
 }
 
@@ -696,6 +700,11 @@ impl Protocol {
 
         Ok(re)
     }
+}
+
+/// Return i32::MAX for serde defaults
+fn max_int32() -> DeltaDataTypeInt {
+    i32::MAX
 }
 
 /// Represents an action in the Delta log. The Delta log is an aggregate of all actions performed

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -28,9 +28,9 @@ use super::action::{Action, DeltaOperation};
 use super::partitions::{DeltaTablePartition, PartitionFilter};
 use super::schema::*;
 use super::storage;
-use super::storage::{StorageBackend, StorageError, UriError};
 #[cfg(feature = "delta-sharing")]
 use super::storage::StorageBackendType;
+use super::storage::{StorageBackend, StorageError, UriError};
 use uuid::Uuid;
 
 /// Metadata for a checkpoint file
@@ -494,11 +494,11 @@ impl DeltaTable {
     #[cfg(feature = "delta-sharing")]
     async fn deltasharing_load(&mut self) -> Result<(), DeltaTableError> {
         let response = reqwest::Client::new()
-                        .post(format!("{}/query", self.table_path))
-                        .bearer_auth(std::env::var("BEARER_TOKEN").unwrap_or("".to_string()))
-                        .json(&json!({"predicateHints": [], "limitHint": 1000}))
-                        .send()
-                        .await?;
+            .post(format!("{}/query", self.table_path))
+            .bearer_auth(std::env::var("BEARER_TOKEN").unwrap_or("".to_string()))
+            .json(&json!({"predicateHints": [], "limitHint": 1000}))
+            .send()
+            .await?;
         let version_header = response.headers().get("Delta-Table-Version").unwrap();
         self.version = version_header.to_str().unwrap().parse::<i64>().unwrap();
 

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -28,7 +28,7 @@ use super::action::{Action, DeltaOperation};
 use super::partitions::{DeltaTablePartition, PartitionFilter};
 use super::schema::*;
 use super::storage;
-use super::storage::{StorageBackend, StorageError, UriError};
+use super::storage::{StorageBackend, StorageBackendType, StorageError, UriError};
 use uuid::Uuid;
 
 /// Metadata for a checkpoint file

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -52,7 +52,7 @@ extern crate lazy_static;
 extern crate parquet;
 extern crate regex;
 extern crate serde;
-#[cfg(test)]
+#[cfg(any(feature = "delta-sharing", test))]
 #[macro_use]
 extern crate serde_json;
 extern crate thiserror;

--- a/rust/src/storage/azure.rs
+++ b/rust/src/storage/azure.rs
@@ -16,7 +16,7 @@ use azure_storage::clients::{
 use futures::stream::{Stream, TryStreamExt};
 use log::debug;
 
-use super::{parse_uri, ObjectMeta, StorageBackend, StorageError, UriError};
+use super::{parse_uri, ObjectMeta, StorageBackend, StorageBackendType, StorageError, UriError};
 
 /// An object on an Azure Data Lake Storage Gen2 account.
 #[derive(Debug, PartialEq)]
@@ -113,6 +113,10 @@ fn to_storage_err(err: Box<dyn Error + Sync + std::marker::Send>) -> StorageErro
 
 #[async_trait::async_trait]
 impl StorageBackend for AdlsGen2Backend {
+    fn backend_type(&self) -> StorageBackendType {
+        StorageBackendType::Azure
+    }
+
     async fn head_obj(&self, path: &str) -> Result<ObjectMeta, StorageError> {
         debug!("Getting properties for {}", path);
         let obj = parse_uri(path)?.into_adlsgen2_object()?;

--- a/rust/src/storage/deltashare.rs
+++ b/rust/src/storage/deltashare.rs
@@ -5,7 +5,7 @@
 use futures::Stream;
 use std::pin::Pin;
 
-use super::{ObjectMeta, StorageBackend, StorageError};
+use super::{ObjectMeta, StorageBackend, StorageBackendType, StorageError};
 
 /// An object to encapsulate the Delta Share's URL
 #[derive(Debug, PartialEq)]
@@ -20,27 +20,30 @@ impl<'a> std::fmt::Display for DeltaShareObject<'a>{
     }
 }
 
-/// The DeltaShareBackend implements read-only behaviors for the Delta Sharing API
+/// The DeltaShareBackend is an empty shell since Delta Sharing is integrated directly into DeltaTable
 #[derive(Debug)]
 pub struct DeltaShareBackend {
-    url: String,
 }
 
 impl DeltaShareBackend {
     /// Instantiate a new backend
-    pub fn new(obj: DeltaShareObject<'_>) -> Self {
-        Self { url: String::from(obj.url) }
+    pub fn new() -> Self {
+        Self {}
     }
 }
 
 #[async_trait::async_trait]
 impl StorageBackend for DeltaShareBackend {
+    fn backend_type(&self) -> StorageBackendType {
+        StorageBackendType::DeltaSharing
+    }
+
     async fn head_obj(&self, _path: &str) -> Result<ObjectMeta, StorageError> {
-        Err(StorageError::UnsupportedOperation("head_obj will not work against a read-only Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation("head_obj will not work directly against a Delta Share".to_string()))
     }
 
     async fn get_obj(&self, _path: &str) -> Result<Vec<u8>, StorageError> {
-        Err(StorageError::UnsupportedOperation("get_obj will not work against a read-only Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation("get_obj will not work directly against a Delta Share".to_string()))
     }
 
     async fn list_objs<'a>(
@@ -50,18 +53,18 @@ impl StorageBackend for DeltaShareBackend {
         Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + Send + 'a>>,
         StorageError,
     > {
-        Err(StorageError::UnsupportedOperation("list_obj will not work against a read-only Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation("list_obj will not work directly against a Delta Share".to_string()))
     }
 
     async fn put_obj(&self, _path: &str, _obj_bytes: &[u8]) -> Result<(), StorageError> {
-        Err(StorageError::UnsupportedOperation("put_obj will not work against a read-only Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation("put_obj will not work directly against a Delta Share".to_string()))
     }
 
     async fn rename_obj(&self, _src: &str, _dst: &str) -> Result<(), StorageError> {
-        Err(StorageError::UnsupportedOperation("rename_obj will not work against a read-only Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation("rename_obj will not work directly against a Delta Share".to_string()))
     }
 
     async fn delete_obj(&self, _path: &str) -> Result<(), StorageError> {
-        Err(StorageError::UnsupportedOperation("delete_obj will not work against a read-only Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation("delete_obj will not work directly against a Delta Share".to_string()))
     }
 }

--- a/rust/src/storage/deltashare.rs
+++ b/rust/src/storage/deltashare.rs
@@ -1,4 +1,4 @@
-//! The Delta Share backend encapsulates the functionality necessary for using a 
+//! The Delta Share backend encapsulates the functionality necessary for using a
 //! Delta Sharing server (https://delta.io/sharing/) API as the DeltaTable storage
 //! backend
 
@@ -14,7 +14,7 @@ pub struct DeltaShareObject<'a> {
     pub url: &'a str,
 }
 
-impl<'a> std::fmt::Display for DeltaShareObject<'a>{
+impl<'a> std::fmt::Display for DeltaShareObject<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.url)
     }
@@ -22,8 +22,7 @@ impl<'a> std::fmt::Display for DeltaShareObject<'a>{
 
 /// The DeltaShareBackend is an empty shell since Delta Sharing is integrated directly into DeltaTable
 #[derive(Debug)]
-pub struct DeltaShareBackend {
-}
+pub struct DeltaShareBackend {}
 
 impl DeltaShareBackend {
     /// Instantiate a new backend
@@ -39,11 +38,15 @@ impl StorageBackend for DeltaShareBackend {
     }
 
     async fn head_obj(&self, _path: &str) -> Result<ObjectMeta, StorageError> {
-        Err(StorageError::UnsupportedOperation("head_obj will not work directly against a Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation(
+            "head_obj will not work directly against a Delta Share".to_string(),
+        ))
     }
 
     async fn get_obj(&self, _path: &str) -> Result<Vec<u8>, StorageError> {
-        Err(StorageError::UnsupportedOperation("get_obj will not work directly against a Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation(
+            "get_obj will not work directly against a Delta Share".to_string(),
+        ))
     }
 
     async fn list_objs<'a>(
@@ -53,18 +56,26 @@ impl StorageBackend for DeltaShareBackend {
         Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + Send + 'a>>,
         StorageError,
     > {
-        Err(StorageError::UnsupportedOperation("list_obj will not work directly against a Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation(
+            "list_obj will not work directly against a Delta Share".to_string(),
+        ))
     }
 
     async fn put_obj(&self, _path: &str, _obj_bytes: &[u8]) -> Result<(), StorageError> {
-        Err(StorageError::UnsupportedOperation("put_obj will not work directly against a Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation(
+            "put_obj will not work directly against a Delta Share".to_string(),
+        ))
     }
 
     async fn rename_obj(&self, _src: &str, _dst: &str) -> Result<(), StorageError> {
-        Err(StorageError::UnsupportedOperation("rename_obj will not work directly against a Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation(
+            "rename_obj will not work directly against a Delta Share".to_string(),
+        ))
     }
 
     async fn delete_obj(&self, _path: &str) -> Result<(), StorageError> {
-        Err(StorageError::UnsupportedOperation("delete_obj will not work directly against a Delta Share".to_string()))
+        Err(StorageError::UnsupportedOperation(
+            "delete_obj will not work directly against a Delta Share".to_string(),
+        ))
     }
 }

--- a/rust/src/storage/deltashare.rs
+++ b/rust/src/storage/deltashare.rs
@@ -37,6 +37,12 @@ impl StorageBackend for DeltaShareBackend {
         StorageBackendType::DeltaSharing
     }
 
+    /// Delta Sharing file paths are already fully formed, no need for this helper
+    /// to do any actual joining
+    fn join_path(&self, _path: &str, path_to_join: &str) -> String {
+        path_to_join.to_string()
+    }
+
     async fn head_obj(&self, _path: &str) -> Result<ObjectMeta, StorageError> {
         Err(StorageError::UnsupportedOperation(
             "head_obj will not work directly against a Delta Share".to_string(),

--- a/rust/src/storage/deltashare.rs
+++ b/rust/src/storage/deltashare.rs
@@ -1,0 +1,67 @@
+//! The Delta Share backend encapsulates the functionality necessary for using a 
+//! Delta Sharing server (https://delta.io/sharing/) API as the DeltaTable storage
+//! backend
+
+use futures::Stream;
+use std::pin::Pin;
+
+use super::{ObjectMeta, StorageBackend, StorageError};
+
+/// An object to encapsulate the Delta Share's URL
+#[derive(Debug, PartialEq)]
+pub struct DeltaShareObject<'a> {
+    /// The URL of the share
+    pub url: &'a str,
+}
+
+impl<'a> std::fmt::Display for DeltaShareObject<'a>{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.url)
+    }
+}
+
+/// The DeltaShareBackend implements read-only behaviors for the Delta Sharing API
+#[derive(Debug)]
+pub struct DeltaShareBackend {
+    url: String,
+}
+
+impl DeltaShareBackend {
+    /// Instantiate a new backend
+    pub fn new(obj: DeltaShareObject<'_>) -> Self {
+        Self { url: String::from(obj.url) }
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageBackend for DeltaShareBackend {
+    async fn head_obj(&self, _path: &str) -> Result<ObjectMeta, StorageError> {
+        Err(StorageError::UnsupportedOperation("head_obj will not work against a read-only Delta Share".to_string()))
+    }
+
+    async fn get_obj(&self, _path: &str) -> Result<Vec<u8>, StorageError> {
+        Err(StorageError::UnsupportedOperation("get_obj will not work against a read-only Delta Share".to_string()))
+    }
+
+    async fn list_objs<'a>(
+        &'a self,
+        _path: &'a str,
+    ) -> Result<
+        Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + Send + 'a>>,
+        StorageError,
+    > {
+        Err(StorageError::UnsupportedOperation("list_obj will not work against a read-only Delta Share".to_string()))
+    }
+
+    async fn put_obj(&self, _path: &str, _obj_bytes: &[u8]) -> Result<(), StorageError> {
+        Err(StorageError::UnsupportedOperation("put_obj will not work against a read-only Delta Share".to_string()))
+    }
+
+    async fn rename_obj(&self, _src: &str, _dst: &str) -> Result<(), StorageError> {
+        Err(StorageError::UnsupportedOperation("rename_obj will not work against a read-only Delta Share".to_string()))
+    }
+
+    async fn delete_obj(&self, _path: &str) -> Result<(), StorageError> {
+        Err(StorageError::UnsupportedOperation("delete_obj will not work against a read-only Delta Share".to_string()))
+    }
+}

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -11,7 +11,7 @@ use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use tokio_stream::wrappers::ReadDirStream;
 
-use super::{ObjectMeta, StorageBackend, StorageError};
+use super::{ObjectMeta, StorageBackend, StorageBackendType, StorageError};
 
 mod rename;
 
@@ -44,6 +44,10 @@ impl FileStorageBackend {
 
 #[async_trait::async_trait]
 impl StorageBackend for FileStorageBackend {
+    fn backend_type(&self) -> StorageBackendType {
+        StorageBackendType::FileSystem
+    }
+
     fn join_path(&self, path: &str, path_to_join: &str) -> String {
         let new_path = Path::new(path);
         new_path

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -18,7 +18,7 @@ use rusoto_sts::WebIdentityProvider;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncReadExt;
 
-use super::{parse_uri, ObjectMeta, StorageBackend, StorageError};
+use super::{parse_uri, ObjectMeta, StorageBackend, StorageBackendType, StorageError};
 
 pub mod dynamodb_lock;
 
@@ -240,6 +240,10 @@ impl std::fmt::Debug for S3StorageBackend {
 
 #[async_trait::async_trait]
 impl StorageBackend for S3StorageBackend {
+    fn backend_type(&self) -> StorageBackendType {
+        StorageBackendType::S3
+    }
+
     async fn head_obj(&self, path: &str) -> Result<ObjectMeta, StorageError> {
         let uri = parse_uri(path)?.into_s3object()?;
 

--- a/rust/tests/delta_sharing_test.rs
+++ b/rust/tests/delta_sharing_test.rs
@@ -2,10 +2,12 @@ extern crate deltalake;
 
 #[cfg(feature = "delta-sharing")]
 #[tokio::test]
-async fn read_simple_table() {
-    let table = deltalake::open_table("http://localhost:8000/api/v1/shares/rtyler/schemas/samples/tables/covid19-nyt")
-        .await
-        .unwrap();
+async fn read_simple_delta_sharing_table() {
+    let table = deltalake::open_table(
+        "https://sharing.delta.io/delta-sharing/shares/delta_sharing/schemas/default/tables/COVID_19_NYT"
+    )
+    .await
+    .unwrap();
     assert_eq!(table.version, 0);
     assert_eq!(table.get_min_reader_version(), 1);
     let files = table.get_files();

--- a/rust/tests/delta_sharing_test.rs
+++ b/rust/tests/delta_sharing_test.rs
@@ -1,0 +1,13 @@
+extern crate deltalake;
+
+#[cfg(feature = "delta-sharing")]
+#[tokio::test]
+async fn read_simple_table() {
+    let table = deltalake::open_table("http://localhost:8000/api/v1/shares/rtyler/schemas/samples/tables/covid19-nyt")
+        .await
+        .unwrap();
+    assert_eq!(table.version, 0);
+    assert_eq!(table.get_min_reader_version(), 1);
+    let files = table.get_files();
+    assert_eq!(8, files.len());
+}


### PR DESCRIPTION
See [Delta Sharing](https://delta.io/sharing) for more information.

Delta Sharing throws our `StorageBackend` concept out the window a bit since it doesn't act like a primitive storage backend but rather it's almost like the `_delta_log` data is served directly over HTTP.

I think the right place to bring this in is within `DeltaTable`, I'm not expecting we're going to have multiple "things" like this, contrasted to multiple object stores.