### PR TITLE
fix python doc release

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -96,6 +96,8 @@ jobs:
 
   release-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write 
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
# Description

Grant commit access to `release-docs` job

# Documentation

https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token
https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-contents
