### PR TITLE
Add a simple error message for NotATable

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -141,8 +141,9 @@ pub enum DeltaTableError {
         source: action::ActionError,
     },
     /// Error returned when it is not a DeltaTable.
-    #[error("Not a Delta table")]
-    NotATable,
+    #[error("Not a Delta table: {0}")]
+    NotATable(String),
+
     /// Error returned when no metadata was found in the DeltaTable.
     #[error("No metadata found, please make sure table is loaded.")]
     NoMetadata,
@@ -646,7 +647,7 @@ impl DeltaTable {
                             if self.version == -1 {
                                 // no snapshot found, no 0 version found.  this is not a delta
                                 // table, possibly an empty directroy.
-                                return Err(DeltaTableError::NotATable);
+                                return Err(DeltaTableError::NotATable("No snapshot  or version 0 found, perhaps this is an empty directory?".to_string()));
                             }
                         }
                         _ => {

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -645,9 +645,11 @@ impl DeltaTable {
                         ApplyLogError::EndOfLog => {
                             self.version -= 1;
                             if self.version == -1 {
-                                // no snapshot found, no 0 version found.  this is not a delta
-                                // table, possibly an empty directroy.
-                                return Err(DeltaTableError::NotATable("No snapshot  or version 0 found, perhaps this is an empty directory?".to_string()));
+                                let err = format!(
+                                    "No snapshot or version 0 found, perhaps {} is an empty dir?",
+                                    self.table_uri
+                                );
+                                return Err(DeltaTableError::NotATable(err));
                             }
                         }
                         _ => {

--- a/rust/tests/read_error_test.rs
+++ b/rust/tests/read_error_test.rs
@@ -9,6 +9,6 @@ async fn read_empty_folder() {
 
     assert!(matches!(
         result.unwrap_err(),
-        deltalake::DeltaTableError::NotATable,
+        deltalake::DeltaTableError::NotATable(_),
     ));
 }


### PR DESCRIPTION
# Description

This commit updates NotATable to provide some more useful user-facing error
information.


# Related Issue(s)

* #267
