### PR TITLE
Disable default features for rusoto

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
         override: true
     - name: build and lint with clippy
       run: cargo clippy --features azure,datafusion-ext,s3
+    - name: Spot-check build for rustls features
+      run: cargo clippy --features s3-rustls
 
   test:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,6 +2205,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "lazy_static",
  "log",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -28,7 +28,7 @@ features = ["extension-module", "abi3", "abi3-py36"]
 [dependencies.deltalake]
 path = "../rust"
 version = "0"
-features = ["s3", "azure"]
+features = ["s3-native-tls", "azure"]
 
 [package.metadata.maturin]
 name = "deltalake"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -28,7 +28,7 @@ features = ["extension-module", "abi3", "abi3-py36"]
 [dependencies.deltalake]
 path = "../rust"
 version = "0"
-features = ["s3-native-tls", "azure"]
+features = ["s3", "azure"]
 
 [package.metadata.maturin]
 name = "deltalake"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -57,7 +57,7 @@ async-trait = "0.1"
 rust-dataframe-ext = []
 datafusion-ext = ["datafusion", "crossbeam"]
 azure = ["azure_core", "azure_storage", "reqwest"]
-s3-native-tls = ["rusoto_core/native-tls", "rusoto_credential", "rusoto_s3/native-tls", "rusoto_sts/native-tls", "rusoto_dynamodb/native-tls", "maplit"]
+s3 = ["rusoto_core/native-tls", "rusoto_credential", "rusoto_s3/native-tls", "rusoto_sts/native-tls", "rusoto_dynamodb/native-tls", "maplit"]
 s3-rustls = ["rusoto_core/rustls", "rusoto_credential", "rusoto_s3/rustls", "rusoto_sts/rustls", "rusoto_dynamodb/rustls", "maplit"]
 
 [build-dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,11 +33,11 @@ azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust", optional = t
 azure_storage = { git = "https://github.com/Azure/azure-sdk-for-rust", optional = true, rev = "536da42ebefd411feff8ba6a0965865e2741267e", features = ["blob", "account", "adls_gen2"] }
 
 # S3
-rusoto_core = { version = "0.46", optional = true }
+rusoto_core = { version = "0.46", default-features = false, optional = true }
 rusoto_credential = { version = "0.46", optional = true }
-rusoto_s3 = { version = "0.46", optional = true }
-rusoto_sts = { version = "0.46", optional = true }
-rusoto_dynamodb = { version = "0.46", optional = true }
+rusoto_s3 = { version = "0.46", default-features = false, optional = true }
+rusoto_sts = { version = "0.46", default-features = false, optional = true }
+rusoto_dynamodb = { version = "0.46", default-features = false, optional = true }
 maplit = { version = "1", optional = true }
 
 # High-level writer
@@ -57,7 +57,8 @@ async-trait = "0.1"
 rust-dataframe-ext = []
 datafusion-ext = ["datafusion", "crossbeam"]
 azure = ["azure_core", "azure_storage", "reqwest"]
-s3 = ["rusoto_core", "rusoto_credential", "rusoto_s3", "rusoto_sts", "rusoto_dynamodb", "maplit"]
+s3-native-tls = ["rusoto_core/native-tls", "rusoto_credential", "rusoto_s3/native-tls", "rusoto_sts/native-tls", "rusoto_dynamodb/native-tls", "maplit"]
+s3-rustls = ["rusoto_core/rustls", "rusoto_credential", "rusoto_s3/rustls", "rusoto_sts/rustls", "rusoto_dynamodb/rustls", "maplit"]
 
 [build-dependencies]
 glibc_version = "0"

--- a/rust/README.md
+++ b/rust/README.md
@@ -37,6 +37,7 @@ Optional cargo package features
 -----------------------
 
 - `s3` - enable the S3 storage backend to work with Delta Tables in AWS S3.
+- `s3-rustls` - enable the S3 storage backend but rely on [rustls](https://github.com/ctz/rustls) rather than OpenSSL (`native-tls`).
 - `azure` - enable the Azure storage backend to work with Delta Tables in Azure Data Lake Storage Gen2 accounts.
 - `datafusion-ext` - enable the `datafusion::datasource::TableProvider` trait implementation for Delta Tables, allowing them to be queried using [DataFusion](https://github.com/apache/arrow/tree/master/rust/datafusion).
 


### PR DESCRIPTION
This allows clients to use rustls or native-tls. In my case I need to use rustls
so that I can build Lambdas more easily
