### PR TITLE
fix libc constraints to pull in renameat2 symbol

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ description = "Native Delta Lake implementation in Rust"
 edition = "2018"
 
 [dependencies]
-libc = "0.2"
+libc = ">=0.2.90,<1"
 errno = "0.2"
 clap = { version = ">=3.0.0-beta.2,<4", features = ["color"] }
 anyhow = "1"


### PR DESCRIPTION
# Description
renameat2 is only available starting in libc 0.2.90

