### PR TITLE
Fix path check of parquet_filename

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1607,6 +1607,10 @@ mod tests {
             (String::from("col2"), String::from("b")),
         ];
         let parquet_filename = txn.generate_parquet_filename(Some(partitions));
-        assert!(parquet_filename.contains("col1=a/col2=b/part-00000-"));
+        if cfg!(windows) {
+            assert!(parquet_filename.contains("col1=a\\col2=b\\part-00000-"));
+        } else {
+            assert!(parquet_filename.contains("col1=a/col2=b/part-00000-"));
+        }
     }
 }


### PR DESCRIPTION
# Description

Newly added test `parquet_filename` failed on windows-2019 CI:

---- delta::tests::parquet_filename stdout ----
thread 'delta::tests::parquet_filename' panicked at 'assertion failed: parquet_filename.contains(\"col1=a/col2=b/part-00000-\")', rust\src\delta.rs:1610:9

This tries to fix it.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
