### PR TITLE
Added .to_pandas to deltalake python

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1,10 +1,11 @@
 import os
 import warnings
 from dataclasses import dataclass
-from typing import Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 from urllib.parse import urlparse
 
-import pandas as pd
+if TYPE_CHECKING:
+    import pandas as pd
 import pyarrow
 from pyarrow.dataset import dataset, partitioning
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, List, Optional, Tuple
 from urllib.parse import urlparse
 
+import pandas as pd
 import pyarrow
 from pyarrow.dataset import dataset, partitioning
 
@@ -252,3 +253,18 @@ class DeltaTable:
         :return: the PyArrow table
         """
         return self.to_pyarrow_dataset(partitions).to_table(columns=columns)
+
+    def to_pandas(
+        self,
+        partitions: Optional[List[Tuple[str, str, Any]]] = None,
+        columns: Optional[List[str]] = None
+    ) -> pd.DataFrame:
+        """
+        Build a pandas dataframe using data from the DeltaTable.
+
+        :param partitions: A list of partition filters, see help(DeltaTable.files_by_partitions) for filter syntax
+        :param columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
+        :return: a pandas dataframe
+        """
+        return self.to_pyarrow_table(partitions, columns).to_pandas()
+

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1,11 +1,9 @@
 import os
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 from urllib.parse import urlparse
 
-if TYPE_CHECKING:
-    import pandas as pd
 import pyarrow
 from pyarrow.dataset import dataset, partitioning
 
@@ -259,7 +257,7 @@ class DeltaTable:
         self,
         partitions: Optional[List[Tuple[str, str, Any]]] = None,
         columns: Optional[List[str]] = None,
-    ) -> pd.DataFrame:
+    ) -> "pd.DataFrame":  # type: ignore
         """
         Build a pandas dataframe using data from the DeltaTable.
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -257,7 +257,7 @@ class DeltaTable:
     def to_pandas(
         self,
         partitions: Optional[List[Tuple[str, str, Any]]] = None,
-        columns: Optional[List[str]] = None
+        columns: Optional[List[str]] = None,
     ) -> pd.DataFrame:
         """
         Build a pandas dataframe using data from the DeltaTable.
@@ -267,4 +267,3 @@ class DeltaTable:
         :return: a pandas dataframe
         """
         return self.to_pyarrow_table(partitions, columns).to_pandas()
-

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1,5 +1,6 @@
 from threading import Barrier, Thread
 
+import pandas as pd
 import pytest
 
 from deltalake import DeltaTable, Metadata
@@ -161,6 +162,12 @@ def test_get_files_partitioned_table():
 
     partition_filters = [("unknown", "=", "3")]
     assert dt.files_by_partitions(partition_filters=partition_filters) == []
+
+
+def test_delta_table_to_pandas():
+    table_path = "../rust/tests/data/simple_table"
+    dt = DeltaTable(table_path)
+    assert dt.to_pandas().equals(pd.DataFrame({"id": [5, 7, 9]}))
 
 
 class ExcPassThroughThread(Thread):


### PR DESCRIPTION
# Description
Many users that work in Python use pandas in their daily work. Adding a `.to_pandas` method makes it super easy for users to read in a Delta table into a pandas dataframe. 

# Related Issue(s)
-

# Documentation
- Added documentation to the `.to_pandas` method. Will update the docs if the proposed change looks fine.
