### PR TITLE
Make dynamodb lease_duration optional to support non-expirable locks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,6 @@ jobs:
         # Using `cargo test s3` requires tests to include _s3_ part in a name which is easily human error prone.
         run: |
          cargo test s3 --test simple_commit_test --features s3
-         cargo test s3 --test dynamodb_lock_test --features s3
          cargo test s3 --test concurrent_writes_test --features s3
-         cargo test s3 --test repair_s3_rename_test --features s3
+         cargo test --test dynamodb_lock_test --features s3
+         cargo test --test repair_s3_rename_test --features s3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:0.12.11
     ports:
       - "4566:4566"
       - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
@@ -16,7 +16,7 @@ services:
       test: [ "CMD", "curl", "-f", "http://localhost:4566/health" ]
 
   setup:
-    image: localstack/localstack
+    image: localstack/localstack:0.12.11
     depends_on:
       - localstack
     entrypoint: "/bin/bash"

--- a/rust/src/storage/s3/dynamodb_lock.rs
+++ b/rust/src/storage/s3/dynamodb_lock.rs
@@ -501,7 +501,7 @@ impl<'a> AcquireLockState<'a> {
                     // rvn doesn't match, meaning that other worker acquire it before us
                     // let's change cached lock with new one and extend timeout period
                     self.cached_lock = Some(existing);
-                    return Err(DynamoError::ConditionalCheckFailed);
+                    Err(DynamoError::ConditionalCheckFailed)
                 }
             }
         }

--- a/rust/src/storage/s3/dynamodb_lock.rs
+++ b/rust/src/storage/s3/dynamodb_lock.rs
@@ -466,9 +466,12 @@ impl<'a> AcquireLockState<'a> {
     /// then this function returns `true` if the elapsed time sine `started` is reached `timeout_in`.
     fn has_timed_out(&self) -> bool {
         self.started.elapsed() > self.timeout_in && {
-            let is_non_expirable = self.cached_lock.is_some()
-                && self.cached_lock.as_ref().unwrap().lease_duration.is_none();
-            !(self.client.opts.do_not_timeout_on_non_expirable_locks && is_non_expirable)
+            let non_expirable = if let Some(ref cached_lock) = self.cached_lock {
+                cached_lock.lease_duration.is_none()
+            } else {
+                false
+            };
+            !(self.client.opts.do_not_timeout_on_non_expirable_locks && non_expirable)
         }
     }
 

--- a/rust/src/storage/s3/dynamodb_lock.rs
+++ b/rust/src/storage/s3/dynamodb_lock.rs
@@ -23,9 +23,6 @@ mod options {
     pub const REFRESH_PERIOD_MILLIS: &str = "DYNAMO_LOCK_REFRESH_PERIOD_MILLIS";
     /// Environment variable for `additional_time_to_wait_for_lock` option.
     pub const ADDITIONAL_TIME_TO_WAIT_MILLIS: &str = "DYNAMO_LOCK_ADDITIONAL_TIME_TO_WAIT_MILLIS";
-    /// Environment variable for `do_not_timeout_on_non_expirable_locks` option.
-    pub const DO_NOT_TIMEOUT_ON_NON_EXPIRABLE_LOCKS: &str =
-        "DYNAMO_DO_NOT_TIMEOUT_ON_NON_EXPIRABLE_LOCKS";
 }
 
 /// Configuration options for [`DynamoDbLockClient`].
@@ -45,8 +42,6 @@ pub struct Options {
     pub refresh_period: Duration,
     /// The amount of time to wait in addition to `lease_duration`.
     pub additional_time_to_wait_for_lock: Duration,
-    /// If set, then `try_acquire_lock` will not fail with timeout if the active lock is non expirable.
-    pub do_not_timeout_on_non_expirable_locks: bool,
 }
 
 impl Default for Options {
@@ -66,12 +61,6 @@ impl Default for Options {
         let additional_time_to_wait_for_lock =
             Duration::from_millis(u64_env(options::ADDITIONAL_TIME_TO_WAIT_MILLIS, 1000));
 
-        let do_not_timeout_on_non_expirable_locks = "true"
-            == str_env(
-                options::DO_NOT_TIMEOUT_ON_NON_EXPIRABLE_LOCKS,
-                "true".to_string(),
-            );
-
         Self {
             partition_key_value: str_env(options::PARTITION_KEY_VALUE, "delta-rs".to_string()),
             table_name: str_env(options::TABLE_NAME, "delta_rs_lock_table".to_string()),
@@ -79,7 +68,6 @@ impl Default for Options {
             lease_duration: u64_env(options::LEASE_DURATION, 20),
             refresh_period,
             additional_time_to_wait_for_lock,
-            do_not_timeout_on_non_expirable_locks,
         }
     }
 }
@@ -462,8 +450,8 @@ struct AcquireLockState<'a> {
 }
 
 impl<'a> AcquireLockState<'a> {
-    /// If lock is expirable (lease_duration is set) and is do_not_timeout_on_non_expirable_locks
-    /// then this function returns `true` if the elapsed time sine `started` is reached `timeout_in`.
+    /// If lock is expirable (lease_duration is set) then this function returns `true`
+    /// if the elapsed time sine `started` is reached `timeout_in`.
     fn has_timed_out(&self) -> bool {
         self.started.elapsed() > self.timeout_in && {
             let non_expirable = if let Some(ref cached_lock) = self.cached_lock {
@@ -471,7 +459,7 @@ impl<'a> AcquireLockState<'a> {
             } else {
                 false
             };
-            !(self.client.opts.do_not_timeout_on_non_expirable_locks && non_expirable)
+            !non_expirable
         }
     }
 

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -416,7 +416,8 @@ pub struct LockItem {
     /// when the lock is stale.
     pub record_version_number: String,
     /// The amount of time (in seconds) that the owner has this lock for.
-    pub lease_duration: u64,
+    /// If lease_duration is None then the lock is non-expirable.
+    pub lease_duration: Option<u64>,
     /// Tells whether or not the lock was marked as released when loaded from DynamoDB.
     pub is_released: bool,
     /// Optional data associated with this lock.

--- a/rust/tests/dynamodb_lock_test.rs
+++ b/rust/tests/dynamodb_lock_test.rs
@@ -43,7 +43,7 @@ mod dynamodb {
         let data = "data".to_string();
         let item = lock.acquire_lock(Some(&data)).await.unwrap();
         assert_eq!(item.owner_name, "worker");
-        assert_eq!(item.lease_duration, 3);
+        assert_eq!(item.lease_duration, Some(3));
         assert_eq!(item.data.as_ref(), Some(&data));
         assert_eq!(item.is_released, false);
         assert_eq!(

--- a/rust/tests/dynamodb_lock_test.rs
+++ b/rust/tests/dynamodb_lock_test.rs
@@ -4,23 +4,29 @@ mod s3_common;
 
 #[cfg(feature = "s3")]
 mod dynamodb {
-    use deltalake::storage::s3::dynamodb_lock::{DynamoDbLockClient, Options, PARTITION_KEY_NAME};
+    use deltalake::storage::s3::dynamodb_lock::*;
     use maplit::hashmap;
     use rusoto_dynamodb::*;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+    const TABLE: &str = "test_table";
+
     async fn create_dynamo_lock(key: &str, owner: &str) -> DynamoDbLockClient {
-        crate::s3_common::setup();
-        let table_name = "test_table";
-        let client = DynamoDbClient::new(crate::s3_common::region());
         let opts = Options {
             partition_key_value: key.to_string(),
-            table_name: table_name.to_string(),
+            table_name: TABLE.to_string(),
             owner_name: owner.to_string(),
             lease_duration: 3,
             refresh_period: Duration::from_millis(500),
             additional_time_to_wait_for_lock: Duration::from_millis(500),
+            do_not_timeout_on_non_expirable_locks: true,
         };
+        create_dynamo_lock_with(key, opts).await
+    }
+
+    async fn create_dynamo_lock_with(key: &str, opts: Options) -> DynamoDbLockClient {
+        crate::s3_common::setup();
+        let client = DynamoDbClient::new(crate::s3_common::region());
         let _ = client
             .delete_item(DeleteItemInput {
                 key: hashmap! {
@@ -29,11 +35,18 @@ mod dynamodb {
                         ..Default::default()
                     }
                 },
-                table_name: table_name.to_string(),
+                table_name: TABLE.to_string(),
                 ..Default::default()
             })
             .await;
         DynamoDbLockClient::new(client, opts)
+    }
+
+    fn attr_val<T: ToString>(s: T) -> AttributeValue {
+        AttributeValue {
+            s: Some(s.to_string()),
+            ..Default::default()
+        }
     }
 
     #[tokio::test]
@@ -72,8 +85,9 @@ mod dynamodb {
 
     #[tokio::test]
     async fn test_acquire_expired_lock() {
-        let c1 = create_dynamo_lock("test_acquire_expired_lock", "w1").await;
-        let c2 = create_dynamo_lock("test_acquire_expired_lock", "w2").await;
+        let key = "test_acquire_expired_lock";
+        let c1 = create_dynamo_lock(key, "w1").await;
+        let c2 = create_dynamo_lock(key, "w2").await;
 
         let l1 = c1.acquire_lock(None).await.unwrap();
 
@@ -92,9 +106,10 @@ mod dynamodb {
 
     #[tokio::test]
     async fn test_acquire_expired_lock_multiple_workers() {
-        let origin = create_dynamo_lock("test_acquire_expired_lock_multiple_workers", "o").await;
-        let c1 = create_dynamo_lock("test_acquire_expired_lock_multiple_workers", "w1").await;
-        let c2 = create_dynamo_lock("test_acquire_expired_lock_multiple_workers", "w2").await;
+        let key = "test_acquire_expired_lock_multiple_workers";
+        let origin = create_dynamo_lock(key, "o").await;
+        let c1 = create_dynamo_lock(key, "w1").await;
+        let c2 = create_dynamo_lock(key, "w2").await;
 
         let _ = origin.acquire_lock(None).await.unwrap();
         let f1 = tokio::spawn(async move { c1.try_acquire_lock(None).await });
@@ -122,5 +137,80 @@ mod dynamodb {
             acquired.record_version_number,
             current.record_version_number
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_non_expirable_lock() {
+        non_expirable_lock_test_case("test_non_expirable_lock", true)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_non_expirable_lock_timedout() {
+        let result = non_expirable_lock_test_case("test_non_expirable_lock_timedout", false).await;
+        match result {
+            Err(DynamoError::TimedOut(v)) => assert_eq!(v, 1),
+            _ => panic!("unexpected {:?}", result),
+        }
+    }
+
+    async fn non_expirable_lock_test_case(
+        key: &str,
+        do_not_timeout_on_non_expirable_locks: bool,
+    ) -> Result<(), DynamoError> {
+        let opts = |owner: &str| Options {
+            partition_key_value: key.to_string(),
+            table_name: TABLE.to_string(),
+            owner_name: owner.to_string(),
+            lease_duration: 1,
+            refresh_period: Duration::from_millis(100),
+            additional_time_to_wait_for_lock: Duration::from_millis(100),
+            do_not_timeout_on_non_expirable_locks,
+        };
+
+        let w1 = create_dynamo_lock_with(key, opts("w1")).await;
+        let w2 = create_dynamo_lock_with(key, opts("w2")).await;
+
+        let dynamodb_client = DynamoDbClient::new(crate::s3_common::region());
+
+        // manual acquire without setting lease_duration so it's considered as non-expirable
+        let w1_rnv = "rvn_w1";
+        dynamodb_client
+            .put_item(PutItemInput {
+                table_name: TABLE.to_string(),
+                item: hashmap! {
+                    PARTITION_KEY_NAME.to_string() => attr_val(key),
+                    OWNER_NAME.to_string() => attr_val("w1"),
+                    RECORD_VERSION_NUMBER.to_string() => attr_val(w1_rnv),
+                },
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let current = w1.get_lock().await.unwrap().unwrap();
+        assert_eq!(current.lease_duration, None);
+
+        // start w2 to try to acquire the lock
+        let acquire_lock = tokio::spawn(async move { w2.acquire_lock(None).await });
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let current = w1.get_lock().await.unwrap().unwrap();
+        // verify that event after 2 sec (2x than lease_duration) that the non expirable lock
+        // is still in dynamo and not expired
+        assert_eq!(current.owner_name, "w1");
+        assert_eq!(current.record_version_number, w1_rnv);
+
+        // release w1, so w2 will acquire it
+        assert!(w1.release_lock(&current).await.unwrap());
+        let lock_w2 = acquire_lock.await.unwrap()?;
+
+        // check that it's actually another/new lock in dynamo
+        let current = w1.get_lock().await.unwrap().unwrap();
+        assert_ne!(w1_rnv, lock_w2.record_version_number);
+        assert_eq!(current.record_version_number, lock_w2.record_version_number);
+        Ok(())
     }
 }


### PR DESCRIPTION
# Description
This PR brings the support of non-expirable locks. Such behaviour might be desired by external systems which interact with concurrent writer, e.g. in order to pause them etc. However there's the risk of delta-rs writer might expire such lock. With these changes, when the active lock has lease_duration as None, then the lock client treats such lock as non expirable and will not expire it. 

I've also introduced an optional `do_not_timeout_on_non_expirable_locks` config with default to `true`. If `true` then the acquire lock function will not fail with timeout when its reached so (the timeout is config's `lease_duration` + `additional_time_to_wait_for_lock`)
