### PR TITLE
[feat] optional lock when creating custom S3 backend

### DIFF
--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -184,10 +184,10 @@ impl S3StorageBackend {
     }
 
     /// Creates a new S3StorageBackend with given s3 and lock clients.
-    pub fn new_with(client: rusoto_s3::S3Client, lock_client: Box<dyn LockClient>) -> Self {
+    pub fn new_with(client: rusoto_s3::S3Client, lock_client: Option<Box<dyn LockClient>>) -> Self {
         Self {
             client,
-            lock_client: Some(lock_client),
+            lock_client,
         }
     }
 

--- a/rust/tests/repair_s3_rename_test.rs
+++ b/rust/tests/repair_s3_rename_test.rs
@@ -132,7 +132,7 @@ mod s3 {
         );
 
         (
-            S3StorageBackend::new_with(client, Box::new(lock_client)),
+            S3StorageBackend::new_with(client, Some(Box::new(lock_client))),
             pause_until_true,
         )
     }


### PR DESCRIPTION
# Description
Make `LockClient` optional in `S3StorageBackend::new_with(S3Client,Box<dyn LockClient>)`

# Related Issue(s)
None

