### PR TITLE
Expose delta statistics as utility function

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -24,6 +24,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{cmp::Ordering, collections::HashSet};
 use uuid::Uuid;
 
+use crate::action::Stats;
+
 use super::action;
 use super::action::{Action, DeltaOperation};
 use super::partitions::{DeltaTablePartition, PartitionFilter};
@@ -821,6 +823,15 @@ impl DeltaTable {
             .files
             .iter()
             .map(|add| self.storage.join_path(&self.table_uri, &add.path))
+            .collect()
+    }
+
+    /// Returns statistics for files, in order
+    pub fn get_stats(&self) -> Result<Vec<Option<Stats>>, DeltaTableError> {
+        self.state
+            .files
+            .iter()
+            .map(|add| add.get_stats().map_err(DeltaTableError::from))
             .collect()
     }
 

--- a/rust/tests/data/delta-0.8.0/_delta_log/00000000000000000000.json
+++ b/rust/tests/data/delta-0.8.0/_delta_log/00000000000000000000.json
@@ -1,5 +1,5 @@
 {"commitInfo":{"timestamp":1615043767813,"operation":"WRITE","operationParameters":{"mode":"Overwrite","partitionBy":"[]"},"isBlindAppend":false,"operationMetrics":{"numFiles":"2","numOutputBytes":"885","numOutputRows":"5"}}}
 {"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
 {"metaData":{"id":"c48a3abf-ea47-498b-b173-52ce534e8dab","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1615043767476}}
-{"add":{"path":"part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet","partitionValues":{},"size":440,"modificationTime":1615043767000,"dataChange":true}}
-{"add":{"path":"part-00001-911a94a2-43f6-4acb-8620-5e68c2654989-c000.snappy.parquet","partitionValues":{},"size":445,"modificationTime":1615043767000,"dataChange":true}}
+{"add":{"path":"part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet","partitionValues":{},"size":440,"modificationTime":1615043767000,"dataChange":true, "stats":"{\"numRecords\":2,\"nullCount\":{\"value\":0},\"minValues\":{\"value\": 0},\"maxValues\":{\"value\":2}}"}}
+{"add":{"path":"part-00001-911a94a2-43f6-4acb-8620-5e68c2654989-c000.snappy.parquet","partitionValues":{},"size":445,"modificationTime":1615043767000,"dataChange":true, "stats":"{\"numRecords\":3,\"nullCount\":{\"value\":0},\"minValues\":{\"value\": 2},\"maxValues\":{\"value\":4}}"}}

--- a/rust/tests/data/delta-0.8.0/_delta_log/00000000000000000001.json
+++ b/rust/tests/data/delta-0.8.0/_delta_log/00000000000000000001.json
@@ -1,3 +1,3 @@
 {"commitInfo":{"timestamp":1615043776199,"operation":"DELETE","operationParameters":{"predicate":"[\"(`value` = 3)\"]"},"readVersion":0,"isBlindAppend":false,"operationMetrics":{"numRemovedFiles":"1","numDeletedRows":"1","numAddedFiles":"1","numCopiedRows":"2"}}}
 {"remove":{"path":"part-00001-911a94a2-43f6-4acb-8620-5e68c2654989-c000.snappy.parquet","deletionTimestamp":1615043776198,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":445}}
-{"add":{"path":"part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet","partitionValues":{},"size":440,"modificationTime":1615043776000,"dataChange":true}}
+{"add":{"path":"part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet","partitionValues":{},"size":440,"modificationTime":1615043776000,"dataChange":true,"stats":"{\"numRecords\":2,\"nullCount\":{\"value\":0},\"minValues\":{\"value\": 2},\"maxValues\":{\"value\":4}}"}}

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -109,6 +109,27 @@ async fn read_delta_8_0_table_without_version() {
             "part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet"
         ]
     );
+    assert_eq!(table.get_stats().unwrap().len(), 2);
+
+    assert_eq!(
+        table
+            .get_stats()
+            .unwrap()
+            .into_iter()
+            .map(|x| x.unwrap().num_records)
+            .sum::<i64>(),
+        4
+    );
+
+    assert_eq!(
+        table
+            .get_stats()
+            .unwrap()
+            .into_iter()
+            .map(|x| x.unwrap().null_count["value"].as_value().unwrap())
+            .collect::<Vec<i64>>(),
+        vec![0, 0]
+    );
     let tombstones = table.get_tombstones();
     assert_eq!(tombstones.len(), 1);
     assert_eq!(


### PR DESCRIPTION
# Description
This exposes the file statistics of the files in a table.

This also adds some integration testing against a delta dataset.

# Related Issue(s)
<!---
For example:


--->
Closes #247


# Documentation

<!---
Share links to useful documentation
--->

https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-file-and-remove-file