### PR TITLE
DataFusion: Expose, calculate number of records in TableProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,64 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,7 +567,6 @@ dependencies = [
  "cfg-if",
  "chrono",
  "clap 3.0.0-beta.2",
- "crossbeam",
  "datafusion",
  "env_logger 0.8.3",
  "errno",
@@ -1476,15 +1417,6 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
-
-[[package]]
-name = "memoffset"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,6 @@ keywords = ["deltalake", "delta", "datalake"]
 description = "Native Delta Lake implementation in Rust"
 edition = "2018"
 
-
 [dependencies]
 libc = ">=0.2.90,<1"
 errno = "0.2"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["deltalake", "delta", "datalake"]
 description = "Native Delta Lake implementation in Rust"
 edition = "2018"
 
+
 [dependencies]
 libc = ">=0.2.90,<1"
 errno = "0.2"
@@ -46,7 +47,6 @@ parquet-format = "~2.6.1"
 arrow  = { version = "4" }
 datafusion = { version = "4", optional = true }
 parquet = { version = "4" }
-crossbeam = { version = "0", optional = true }
 cfg-if = "1"
 async-trait = "0.1"
 # NOTE: disable rust-dataframe integration since it currently doesn't have a
@@ -55,7 +55,7 @@ async-trait = "0.1"
 
 [features]
 rust-dataframe-ext = []
-datafusion-ext = ["datafusion", "crossbeam"]
+datafusion-ext = ["datafusion"]
 azure = ["azure_core", "azure_storage", "reqwest"]
 s3 = ["rusoto_core/native-tls", "rusoto_credential", "rusoto_s3/native-tls", "rusoto_sts/native-tls", "rusoto_dynamodb/native-tls", "maplit"]
 s3-rustls = ["rusoto_core/rustls", "rusoto_credential", "rusoto_s3/rustls", "rusoto_sts/rustls", "rusoto_dynamodb/rustls", "maplit"]

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -110,7 +110,7 @@ impl TableProvider for delta::DeltaTable {
                             .num_rows
                             .map(|rows| rows + new_stats.num_records as usize),
                         total_byte_size: None,
-                        column_statistics: None,
+                        column_statistics: None, // TODO: add column statistics
                     })
                 },
             )

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -94,8 +94,26 @@ impl TableProvider for delta::DeltaTable {
     }
 
     fn statistics(&self) -> Statistics {
-        // TODO: proxy delta table stats after https://github.com/delta-io/delta.rs/issues/45 has
-        // been completed
-        Statistics::default()
+        self.get_stats()
+            .into_iter()
+            .fold(
+                Some(Statistics {
+                    num_rows: Some(0),
+                    total_byte_size: None,
+                    column_statistics: None,
+                }),
+                |acc, stats| {
+                    let acc = acc?;
+                    let new_stats = stats.unwrap_or(None)?;
+                    Some(Statistics {
+                        num_rows: acc
+                            .num_rows
+                            .map(|rows| rows + new_stats.num_records as usize),
+                        total_byte_size: None,
+                        column_statistics: None,
+                    })
+                },
+            )
+            .unwrap_or_default()
     }
 }

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -59,10 +59,7 @@ mod datafusion {
             .unwrap();
         let statistics = table.statistics();
 
-        assert_eq!(
-            statistics.num_rows,
-            Some(4),
-        );
+        assert_eq!(statistics.num_rows, Some(4),);
 
         Ok(())
     }

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -3,6 +3,7 @@ mod datafusion {
     use std::sync::Arc;
 
     use arrow::array::*;
+    use datafusion::datasource::TableProvider;
     use datafusion::error::Result;
     use datafusion::execution::context::ExecutionContext;
 
@@ -46,6 +47,21 @@ mod datafusion {
         assert_eq!(
             batches[0].column(0).as_ref(),
             Arc::new(Date32Array::from(vec![18629])).as_ref(),
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_datafusion_stats() -> Result<()> {
+        let table = deltalake::open_table("./tests/data/delta-0.8.0")
+            .await
+            .unwrap();
+        let statistics = table.statistics();
+
+        assert_eq!(
+            statistics.num_rows,
+            Some(4),
         );
 
         Ok(())


### PR DESCRIPTION
# Description
Adds implementation of `statistics` to table provider to return total number of rows.

This helps in applying cost-based optimization (join reordering), and optimization with a direct  `COUNT(*)`.
I also removed the unneeded crossbeam dependency.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
