### PR TITLE
Fix incorrect latest version

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -547,7 +547,7 @@ impl DeltaTable {
 
     async fn get_latest_version(&mut self) -> Result<DeltaDataTypeVersion, DeltaTableError> {
         let mut version = match self.get_last_checkpoint().await {
-            Ok(last_check_point) => last_check_point.version,
+            Ok(last_check_point) => last_check_point.version + 1,
             Err(LoadCheckpointError::NotFound) => {
                 // no checkpoint, start with version 0
                 0


### PR DESCRIPTION
# Description
The `get_latest_version` method looks incorrect to me, by comparing with the logic in other latest version related methods.

The correct logic looks like to be: 1. get last check point version from `get_last_checkpoint`. 2. try to load log with `version = version + 1` until failing to load one and the the latest version is `version = version - 1`.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
