### PR TITLE
Introduce update_incremental

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -635,8 +635,7 @@ impl DeltaTable {
     /// incrementally applying each version since current.
     pub async fn update_incremental(&mut self) -> Result<(), DeltaTableError> {
         self.version += 1;
-        self.apply_logs_from_current_version().await?;
-        Ok(())
+        self.apply_logs_from_current_version().await
     }
 
     async fn apply_logs_from_current_version(&mut self) -> Result<(), DeltaTableError> {

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -602,12 +602,13 @@ impl DeltaTable {
             }
         }
 
-        self.apply_logs_after_current_version().await?;
+        self.apply_logs_from_current_version().await?;
 
         Ok(())
     }
 
-    /// Updates the DeltaTable to the most recent state committed to the transaction log.
+    /// Updates the DeltaTable to the most recent state committed to the transaction log by
+    /// loading the last checkpoint and incrementally applying each version since.
     pub async fn update(&mut self) -> Result<(), DeltaTableError> {
         match self.get_last_checkpoint().await {
             Ok(last_check_point) => {
@@ -625,12 +626,20 @@ impl DeltaTable {
             }
         }
 
-        self.apply_logs_after_current_version().await?;
+        self.apply_logs_from_current_version().await?;
 
         Ok(())
     }
 
-    async fn apply_logs_after_current_version(&mut self) -> Result<(), DeltaTableError> {
+    /// Updates the DeltaTable to the most recent state committed to the transaction by
+    /// incrementally applying each version since current.
+    pub async fn update_incremental(&mut self) -> Result<(), DeltaTableError> {
+        self.version += 1;
+        self.apply_logs_from_current_version().await?;
+        Ok(())
+    }
+
+    async fn apply_logs_from_current_version(&mut self) -> Result<(), DeltaTableError> {
         // replay logs after checkpoint
         loop {
             match self.apply_log(self.version).await {
@@ -1355,7 +1364,9 @@ impl<'a> DeltaTransaction<'a> {
     ) -> Result<DeltaDataTypeVersion, DeltaTransactionError> {
         let mut attempt_number: u32 = 0;
         loop {
-            let version = self.next_attempt_version().await?;
+            self.delta_table.update_incremental().await?;
+
+            let version = self.delta_table.version + 1;
 
             match self
                 .delta_table
@@ -1385,13 +1396,6 @@ impl<'a> DeltaTransaction<'a> {
                 }
             }
         }
-    }
-
-    async fn next_attempt_version(
-        &mut self,
-    ) -> Result<DeltaDataTypeVersion, DeltaTransactionError> {
-        self.delta_table.update().await?;
-        Ok(self.delta_table.version + 1)
     }
 }
 


### PR DESCRIPTION
Not sure that that fully "fixes" the #128, but that's still the improvement, especially for writes, as you don't load checkpoints on each write/retry.

Also note attention to the function rename `apply_logs_after_current_version` -> `apply_logs_from_current_version`. I found after misleading as it's first applies the current version and then increments. That was not acceptable for update_incremental function since the current version is already applied. Hence, without creating any new wheels I figured to reuse that function but then, within update_incremental, I'm incrementing the table version so the next one will be applied. There's the case when  there's no new version after current, but `apply_logs_from_current_version` already handles that by reverting the version to one back so we're good there.

upd. Closes #128.