### PR TITLE
Update file storage backend to write _all_ bytes from the passed buffer.

### DIFF
--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -107,7 +107,7 @@ impl StorageBackend for FileStorageBackend {
             .open(path)
             .await?;
 
-        f.write(obj_bytes).await?;
+        f.write_all(obj_bytes).await?;
 
         Ok(())
     }


### PR DESCRIPTION
# Description
This PR addresses a bug I discovered in the FileStorageBackend. The `put_obj` implementation was calling `File::write` which does not write the full byte buffer. Changed to call `write_all`.

# Related Issue(s)
N/A

# Documentation
* https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
* https://doc.rust-lang.org/std/io/trait.Write.html#tymethod.write
