### PR TITLE
rename get_actions to get_active_add_actions

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -790,8 +790,8 @@ impl DeltaTable {
             .collect())
     }
 
-    /// Return a refernece to the "add" actions present in the loaded state
-    pub fn get_actions(&self) -> &Vec<action::Add> {
+    /// Return a refernece to all active "add" actions present in the loaded state
+    pub fn get_active_add_actions(&self) -> &Vec<action::Add> {
         &self.state.files
     }
 

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -59,7 +59,7 @@ impl TableProvider for delta::DeltaTable {
 
         let partitions = filenames
             .into_iter()
-            .zip(self.get_actions())
+            .zip(self.get_active_add_actions())
             .map(|(fname, action)| {
                 let statistics = if let Ok(Some(statistics)) = action.get_stats() {
                     Statistics {
@@ -109,7 +109,7 @@ impl TableProvider for delta::DeltaTable {
     }
 
     fn statistics(&self) -> Statistics {
-        self.get_actions()
+        self.get_active_add_actions()
             .iter()
             .fold(
                 Some(Statistics {


### PR DESCRIPTION
# Description

`get_actions` might give reader the wrong impression that it will return all action variants.

Follow up on https://github.com/delta-io/delta-rs/pull/321.