### PR TITLE
Use WebIdentityProvider for DynamoDb client in k8s

### DIFF
--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -275,6 +275,22 @@ pub enum StorageError {
         #[from]
         source: s3::dynamodb_lock::DynamoError,
     },
+    /// Error representing a failure to retrieve AWS credentials.
+    #[cfg(any(feature = "s3", feature = "s3-rustls"))]
+    #[error("Failed to retrieve AWS credentials: {source}")]
+    AWSCredentials {
+        /// The underlying Rusoto CredentialsError
+        #[from]
+        source: rusoto_credential::CredentialsError,
+    },
+    /// Error caused by the http request dispatcher not being able to be created.
+    #[cfg(any(feature = "s3", feature = "s3-rustls"))]
+    #[error("Failed to create request dispatcher: {source}")]
+    AWSHttpClient {
+        /// The underlying Rusoto TlsError
+        #[from]
+        source: rusoto_core::request::TlsError,
+    },
 
     /// Azure error
     #[cfg(feature = "azure")]


### PR DESCRIPTION
# Description
Thank you for all the awesome work on this crate!

This is a small fix for getting `WebIdentityProvider` credentials for the DynamoDb lock client via service account in k8s. Essentially just a copy of what was already being done for the S3 client, but I have folded the logic into a separate function for code reuse. I have successfully tested this in cluster as well.

# Related Issue(s)
Essentially #132 for DynamoDb

# Documentation
`WebIdentityProvider`: https://docs.rs/rusoto_sts/0.45.0/rusoto_sts/struct.WebIdentityProvider.html
