### PR TITLE
Fix consecutive checkpoints

### DIFF
--- a/rust/src/checkpoints.rs
+++ b/rust/src/checkpoints.rs
@@ -254,7 +254,7 @@ fn checkpoint_add_from_state(
 ) -> Result<Value, ArrowError> {
     let mut v = serde_json::to_value(action::Action::add(add.clone()))?;
 
-    if !add.partition_values.is_empty() && add.partition_values_parsed.is_none() {
+    if !add.partition_values.is_empty() {
         let mut partition_values_parsed: HashMap<String, Value> = HashMap::new();
 
         for (field_name, data_type) in data_types.iter() {

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -102,7 +102,8 @@ impl StorageBackend for FileStorageBackend {
             fs::create_dir_all(parent).await?;
         }
         let mut f = fs::OpenOptions::new()
-            .create_new(true)
+            .create(true)
+            .truncate(true)
             .write(true)
             .open(path)
             .await?;

--- a/rust/tests/checkpoint_writer_test.rs
+++ b/rust/tests/checkpoint_writer_test.rs
@@ -18,7 +18,7 @@ async fn write_simple_checkpoint() {
     cleanup_checkpoint_files(log_path.as_path());
 
     // Load the delta table at version 5
-    let table = deltalake::open_table_with_version(table_location, 5)
+    let mut table = deltalake::open_table_with_version(table_location, 5)
         .await
         .unwrap();
 
@@ -39,27 +39,48 @@ async fn write_simple_checkpoint() {
     // Error("EOF while parsing a value", line: 1, column: 0)'
     std::thread::sleep(std::time::Duration::from_secs(1));
 
-    // _last_checkpoint should exist
-    let last_checkpoint_path = log_path.join("_last_checkpoint");
-    assert!(last_checkpoint_path.as_path().exists());
-
-    // _last_checkpoint should point to the correct version
-    let last_checkpoint_content = fs::read_to_string(last_checkpoint_path.as_path()).unwrap();
-    let last_checkpoint_content: serde_json::Value =
-        serde_json::from_str(last_checkpoint_content.trim()).unwrap();
-
-    let version = last_checkpoint_content
-        .get("version")
-        .unwrap()
-        .as_i64()
-        .unwrap();
+    // _last_checkpoint should exist and point to the correct version
+    let version = get_last_checkpoint_version(&log_path);
     assert_eq!(5, version);
+
+    // Setting table version to 10 for another checkpoint
+    table.load_version(10).await.unwrap();
+    checkpoint_writer
+        .create_checkpoint_from_state(table.version, table.get_state())
+        .await
+        .unwrap();
+
+    // checkpoint should exist
+    let checkpoint_path = log_path.join("00000000000000000010.checkpoint.parquet");
+    assert!(checkpoint_path.as_path().exists());
+
+    // see above
+    std::thread::sleep(std::time::Duration::from_secs(1));
+
+    // _last_checkpoint should exist and point to the correct version
+    let version = get_last_checkpoint_version(&log_path);
+    assert_eq!(10, version);
 
     // delta table should load just fine with the checkpoint in place
     let table_result = deltalake::open_table(table_location).await.unwrap();
     let table = table_result;
     let files = table.get_files();
     assert_eq!(11, files.len());
+}
+
+fn get_last_checkpoint_version(log_path: &PathBuf) -> i64 {
+    let last_checkpoint_path = log_path.join("_last_checkpoint");
+    assert!(last_checkpoint_path.as_path().exists());
+
+    let last_checkpoint_content = fs::read_to_string(last_checkpoint_path.as_path()).unwrap();
+    let last_checkpoint_content: serde_json::Value =
+        serde_json::from_str(last_checkpoint_content.trim()).unwrap();
+
+    last_checkpoint_content
+        .get("version")
+        .unwrap()
+        .as_i64()
+        .unwrap()
 }
 
 fn cleanup_checkpoint_files(log_path: &Path) {

--- a/rust/tests/checkpoint_writer_test.rs
+++ b/rust/tests/checkpoint_writer_test.rs
@@ -43,6 +43,7 @@ async fn write_simple_checkpoint() {
     let version = get_last_checkpoint_version(&log_path);
     assert_eq!(5, version);
 
+    /* uncomment once map support is merged to arrow
     // Setting table version to 10 for another checkpoint
     table.load_version(10).await.unwrap();
     checkpoint_writer
@@ -66,6 +67,7 @@ async fn write_simple_checkpoint() {
     let table = table_result;
     let files = table.get_files();
     assert_eq!(11, files.len());
+    */
 }
 
 fn get_last_checkpoint_version(log_path: &PathBuf) -> i64 {


### PR DESCRIPTION
Some of the code within `checkpoint_add_from_state` is not executed because of excessive check. This PR fixes it.

UPD. This is dependent on map support, so keeping this as DRAFT until the former is merged