### PR TITLE
added warning message if the detected glibc version is < 2.28

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -8,7 +8,7 @@ mod platform_cfg {
         } else {
             let more_info = "https://docs.rs/deltalake/latest/deltalake/storage/file/struct.FileStorageBackend.html";
             println!(
-                "cargo:warning=glibc versions < 2.28 are currently unsupported, glibc version found {}.{}. For more information: {}", 
+                "cargo:warning=glibc version >= 2.28 is required for performing commits to local file system, glibc version found {}.{}. For more information: {}", 
                 ver.major, ver.minor, more_info
             );
         }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -5,6 +5,12 @@ mod platform_cfg {
         let ver = glibc_version::get_version().unwrap();
         if ver.major >= 2 && ver.minor >= 28 {
             println!("cargo:rustc-cfg=glibc_renameat2");
+        } else {
+            let more_info = "https://docs.rs/deltalake/0.4.0/deltalake/storage/file/struct.FileStorageBackend.html";
+            println!(
+                "cargo:warning=glibc versions < 2.28 are currently unsupported, glibc version found {}.{}. For more information: {}", 
+                ver.major, ver.minor, more_info
+            );
         }
     }
 

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -6,7 +6,7 @@ mod platform_cfg {
         if ver.major >= 2 && ver.minor >= 28 {
             println!("cargo:rustc-cfg=glibc_renameat2");
         } else {
-            let more_info = "https://docs.rs/deltalake/0.4.0/deltalake/storage/file/struct.FileStorageBackend.html";
+            let more_info = "https://docs.rs/deltalake/latest/deltalake/storage/file/struct.FileStorageBackend.html";
             println!(
                 "cargo:warning=glibc versions < 2.28 are currently unsupported, glibc version found {}.{}. For more information: {}", 
                 ver.major, ver.minor, more_info


### PR DESCRIPTION
# Description
Added a warning message to assist in debugging since atomic renames has only been implemented for glibc version >= 2.28


## Example output
![image](https://user-images.githubusercontent.com/37084994/126856077-3c7406ae-e9c0-4d59-877c-933baa152cf3.png)
