### PR TITLE
Convert scalar value to correct type based on arrow data type.

### DIFF
--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -229,11 +229,11 @@ impl TableProvider for delta::DeltaTable {
                             max_value: col_states
                                 .max_value
                                 .as_ref()
-                                .map(|scalar| correct_scalar_value_type(scalar.clone(), &dt)),
+                                .and_then(|scalar| correct_scalar_value_type(scalar.clone(), &dt)),
                             min_value: col_states
                                 .min_value
                                 .as_ref()
-                                .map(|scalar| correct_scalar_value_type(scalar.clone(), &dt)),
+                                .and_then(|scalar| correct_scalar_value_type(scalar.clone(), &dt)),
                             distinct_count: col_states.distinct_count,
                         }
                     })
@@ -260,61 +260,57 @@ fn to_scalar_value(stat_val: &serde_json::Value) -> Option<datafusion::scalar::S
 fn correct_scalar_value_type(
     value: datafusion::scalar::ScalarValue,
     field_dt: &ArrowDataType,
-) -> datafusion::scalar::ScalarValue {
+) -> Option<datafusion::scalar::ScalarValue> {
     match field_dt {
         ArrowDataType::Int64 => {
             let raw_value = i64::try_from(value).unwrap();
-            ScalarValue::from(raw_value)
+            Some(ScalarValue::from(raw_value))
         }
         ArrowDataType::Int32 => {
             let raw_value = i64::try_from(value).unwrap() as i32;
-            ScalarValue::from(raw_value)
+            Some(ScalarValue::from(raw_value))
         }
         ArrowDataType::Int16 => {
             let raw_value = i64::try_from(value).unwrap() as i16;
-            ScalarValue::from(raw_value)
+            Some(ScalarValue::from(raw_value))
         }
         ArrowDataType::Int8 => {
             let raw_value = i64::try_from(value).unwrap() as i8;
-            ScalarValue::from(raw_value)
+            Some(ScalarValue::from(raw_value))
         }
         ArrowDataType::Float32 => {
             let raw_value = f64::try_from(value).unwrap() as f32;
-            ScalarValue::from(raw_value)
+            Some(ScalarValue::from(raw_value))
         }
         ArrowDataType::Float64 => {
             let raw_value = f64::try_from(value).unwrap();
-            ScalarValue::from(raw_value)
+            Some(ScalarValue::from(raw_value))
         }
         ArrowDataType::Decimal(_, _) => {
             let raw_value = f64::try_from(value).unwrap();
-            ScalarValue::from(raw_value)
+            Some(ScalarValue::from(raw_value))
         }
         ArrowDataType::Date32 => {
             let raw_value = i64::try_from(value).unwrap() as i32;
-            ScalarValue::Date32(Some(raw_value))
+            Some(ScalarValue::Date32(Some(raw_value)))
         }
         ArrowDataType::Date64 => {
             let raw_value = i64::try_from(value).unwrap();
-            ScalarValue::Date64(Some(raw_value))
+            Some(ScalarValue::Date64(Some(raw_value)))
         }
         ArrowDataType::Timestamp(TimeUnit::Nanosecond, None) => {
             let raw_value = i64::try_from(value).unwrap();
-            ScalarValue::TimestampNanosecond(Some(raw_value))
+            Some(ScalarValue::TimestampNanosecond(Some(raw_value)))
         }
         ArrowDataType::Timestamp(TimeUnit::Microsecond, None) => {
             let raw_value = i64::try_from(value).unwrap();
-            ScalarValue::TimestampMicrosecond(Some(raw_value))
+            Some(ScalarValue::TimestampMicrosecond(Some(raw_value)))
         }
         ArrowDataType::Timestamp(TimeUnit::Millisecond, None) => {
             let raw_value = i64::try_from(value).unwrap();
-            ScalarValue::TimestampMillisecond(Some(raw_value))
+            Some(ScalarValue::TimestampMillisecond(Some(raw_value)))
         }
-        _ => unimplemented!(
-            "Scalar value of arrow type unimplemented for {:?} and {:?}",
-            value,
-            field_dt
-        ),
+        _ => None,
     }
 }
 

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -310,7 +310,14 @@ fn correct_scalar_value_type(
             let raw_value = i64::try_from(value).unwrap();
             Some(ScalarValue::TimestampMillisecond(Some(raw_value)))
         }
-        _ => None,
+        _ => {
+            log::error!(
+                "Scalar value of arrow type unimplemented for {:?} and {:?}",
+                value,
+                field_dt
+            );
+            None
+        }
     }
 }
 

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -24,7 +24,7 @@ use std::any::Any;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use arrow::datatypes::Schema as ArrowSchema;
+use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, TimeUnit};
 use datafusion::datasource::datasource::{ColumnStatistics, Statistics};
 use datafusion::datasource::TableProvider;
 use datafusion::logical_plan::{combine_filters, Expr};
@@ -116,7 +116,8 @@ impl TableProvider for delta::DeltaTable {
     }
 
     fn statistics(&self) -> Statistics {
-        self.get_active_add_actions()
+        let stats = self
+            .get_active_add_actions()
             .iter()
             .fold(
                 Some(Statistics {
@@ -206,7 +207,39 @@ impl TableProvider for delta::DeltaTable {
                     })
                 },
             )
-            .unwrap_or_default()
+            .unwrap_or_default();
+        // Convert column max/min scalar values to correct types based on arrow types.
+        Statistics {
+            num_rows: stats.num_rows,
+            total_byte_size: stats.total_byte_size,
+            column_statistics: stats.column_statistics.map(|col_stats| {
+                let fields = self.schema().unwrap().get_fields();
+                col_stats
+                    .iter()
+                    .zip(fields)
+                    .map(|(col_states, field)| {
+                        let dt = (self as &dyn TableProvider)
+                            .schema()
+                            .field_with_name(field.get_name())
+                            .unwrap()
+                            .data_type()
+                            .clone();
+                        ColumnStatistics {
+                            null_count: col_states.null_count,
+                            max_value: col_states
+                                .max_value
+                                .as_ref()
+                                .map(|scalar| correct_scalar_value_type(scalar.clone(), &dt)),
+                            min_value: col_states
+                                .min_value
+                                .as_ref()
+                                .map(|scalar| correct_scalar_value_type(scalar.clone(), &dt)),
+                            distinct_count: col_states.distinct_count,
+                        }
+                    })
+                    .collect()
+            }),
+        }
     }
 }
 
@@ -221,6 +254,67 @@ fn to_scalar_value(stat_val: &serde_json::Value) -> Option<datafusion::scalar::S
         }
     } else {
         None
+    }
+}
+
+fn correct_scalar_value_type(
+    value: datafusion::scalar::ScalarValue,
+    field_dt: &ArrowDataType,
+) -> datafusion::scalar::ScalarValue {
+    match field_dt {
+        ArrowDataType::Int64 => {
+            let raw_value = i64::try_from(value).unwrap();
+            ScalarValue::from(raw_value)
+        }
+        ArrowDataType::Int32 => {
+            let raw_value = i64::try_from(value).unwrap() as i32;
+            ScalarValue::from(raw_value)
+        }
+        ArrowDataType::Int16 => {
+            let raw_value = i64::try_from(value).unwrap() as i16;
+            ScalarValue::from(raw_value)
+        }
+        ArrowDataType::Int8 => {
+            let raw_value = i64::try_from(value).unwrap() as i8;
+            ScalarValue::from(raw_value)
+        }
+        ArrowDataType::Float32 => {
+            let raw_value = f64::try_from(value).unwrap() as f32;
+            ScalarValue::from(raw_value)
+        }
+        ArrowDataType::Float64 => {
+            let raw_value = f64::try_from(value).unwrap();
+            ScalarValue::from(raw_value)
+        }
+        ArrowDataType::Decimal(_, _) => {
+            let raw_value = f64::try_from(value).unwrap();
+            ScalarValue::from(raw_value)
+        }
+        ArrowDataType::Date32 => {
+            let raw_value = i64::try_from(value).unwrap() as i32;
+            ScalarValue::Date32(Some(raw_value))
+        }
+        ArrowDataType::Date64 => {
+            let raw_value = i64::try_from(value).unwrap();
+            ScalarValue::Date64(Some(raw_value))
+        }
+        ArrowDataType::Timestamp(TimeUnit::Nanosecond, None) => {
+            let raw_value = i64::try_from(value).unwrap();
+            ScalarValue::TimestampNanosecond(Some(raw_value))
+        }
+        ArrowDataType::Timestamp(TimeUnit::Microsecond, None) => {
+            let raw_value = i64::try_from(value).unwrap();
+            ScalarValue::TimestampMicrosecond(Some(raw_value))
+        }
+        ArrowDataType::Timestamp(TimeUnit::Millisecond, None) => {
+            let raw_value = i64::try_from(value).unwrap();
+            ScalarValue::TimestampMillisecond(Some(raw_value))
+        }
+        _ => unimplemented!(
+            "Scalar value of arrow type unimplemented for {:?} and {:?}",
+            value,
+            field_dt
+        ),
     }
 }
 

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -103,7 +103,7 @@ mod datafusion {
                 .iter()
                 .map(|x| x.max_value.as_ref())
                 .collect::<Vec<Option<&ScalarValue>>>(),
-            vec![Some(&ScalarValue::from(4 as i64))],
+            vec![Some(&ScalarValue::from(4 as i32))],
         );
 
         assert_eq!(
@@ -114,7 +114,7 @@ mod datafusion {
                 .iter()
                 .map(|x| x.min_value.as_ref())
                 .collect::<Vec<Option<&ScalarValue>>>(),
-            vec![Some(&ScalarValue::from(0 as i64))],
+            vec![Some(&ScalarValue::from(0 as i32))],
         );
 
         Ok(())


### PR DESCRIPTION
# Description
The description of the main changes of your pull request


This is a follow up of #327 for the comment https://github.com/delta-io/delta-rs/pull/327#discussion_r672030078.
For the max/min column scalar values, we convert it to correct `ScarlarValue` based on arrow datatype.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
