### PR TITLE
Low level create table

### DIFF
--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -364,11 +364,8 @@ pub struct Format {
 
 impl Format {
     /// Allows creation of a new action::Format
-    pub fn new(provider: String, options: Option<HashMap<String,String>>) -> Self {
-        Self {
-            provider,
-            options
-        }
+    pub fn new(provider: String, options: Option<HashMap<String, String>>) -> Self {
+        Self { provider, options }
     }
 
     /// Return the Format provider
@@ -382,7 +379,7 @@ impl Default for Format {
     fn default() -> Self {
         Self {
             provider: "parquet".to_string(),
-            options: Default::default()
+            options: Default::default(),
         }
     }
 }

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -363,6 +363,7 @@ pub struct Format {
 }
 
 impl Format {
+    /// Allows creation of a new action::Format
     pub fn new(provider: String, options: Option<HashMap<String,String>>) -> Self {
         Self {
             provider,
@@ -370,6 +371,7 @@ impl Format {
         }
     }
 }
+
 /// Action that describes the metadata of the table.
 /// This is a top-level action in Delta log entries.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -614,7 +614,7 @@ impl Remove {
 
 /// Action used by streaming systems to track progress using application-specific versions to
 /// enable idempotency.
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Txn {
     /// A unique identifier for the application performing the transaction.
@@ -667,7 +667,7 @@ impl Txn {
 
 /// Action used to increase the version of the Delta protocol required to read or write to the
 /// table.
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Protocol {
     /// Minimum version of the Delta read protocol a client must implement to correctly read the
@@ -712,7 +712,7 @@ impl Protocol {
 
 /// Represents an action in the Delta log. The Delta log is an aggregate of all actions performed
 /// on the table, so the full list of actions is required to properly read a table.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Action {
     /// Changes the current metadata of the table. Must be present in the first version of a table.
     /// Subsequent `metaData` actions completely overwrite previous metadata.

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -370,6 +370,11 @@ impl Format {
             options
         }
     }
+
+    /// Return the Format provider
+    pub fn get_provider(self) -> String {
+        self.provider
+    }
 }
 
 /// Action that describes the metadata of the table.

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -354,7 +354,7 @@ impl Add {
 }
 
 /// Describes the data format of files in the table.
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Format {
     /// Name of the encoding for files in this table.
     provider: String,
@@ -374,6 +374,16 @@ impl Format {
     /// Return the Format provider
     pub fn get_provider(self) -> String {
         self.provider
+    }
+}
+
+// Assuming this is a more appropriate default than derived Default
+impl Default for Format {
+    fn default() -> Self {
+        Self {
+            provider: "parquet".to_string(),
+            options: Default::default()
+        }
     }
 }
 

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -362,6 +362,14 @@ pub struct Format {
     options: Option<HashMap<String, String>>,
 }
 
+impl Format {
+    pub fn new(provider: String, options: Option<HashMap<String,String>>) -> Self {
+        Self {
+            provider,
+            options
+        }
+    }
+}
 /// Action that describes the metadata of the table.
 /// This is a top-level action in Delta log entries.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -354,7 +354,7 @@ impl Add {
 }
 
 /// Describes the data format of files in the table.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Format {
     /// Name of the encoding for files in this table.
     provider: String,
@@ -679,7 +679,7 @@ impl Txn {
 
 /// Action used to increase the version of the Delta protocol required to read or write to the
 /// table.
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Protocol {
     /// Minimum version of the Delta read protocol a client must implement to correctly read the

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -207,6 +207,29 @@ pub struct DeltaTableMetaData {
     pub configuration: HashMap<String, String>,
 }
 
+impl DeltaTableMetaData {
+    fn new(
+        name: Option<String>, 
+        description: Option<String>, 
+        schema: Schema, 
+        partition: Vec<String>, 
+        config: HashMap<String, String>
+    ) -> Self {
+        //use inputs
+        
+        Self {
+            id: Uuid::new_v4().to_string(), //create a new GUID
+            name: name,
+            description: description,
+            format: action::Format::new("parquet".to_string(), None),
+            schema: schema,
+            partition_columns: partition,
+            created_time: Utc::now().timestamp(),  //create a timestamp for current timestamp
+            configuration: config
+        }
+    }
+}
+
 impl fmt::Display for DeltaTableMetaData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -384,6 +407,17 @@ fn extract_rel_path<'a, 'b>(
         )))
     }
 }
+
+
+// TODO
+pub fn create_delta_table(table_uri: String, metadata: DeltaTableMetaData) {
+    // create a new table at the target location with the given DeltaTableMetaData
+    // need commit info, version 0
+    println!("{}", table_uri);
+    let meta = action::MetaData::try_from(metadata).unwrap();
+    println!("{:?}", meta);
+}
+
 
 /// In memory representation of a Delta Table
 pub struct DeltaTable {
@@ -1576,5 +1610,38 @@ mod tests {
         } else {
             assert!(parquet_filename.contains("col1=a/col2=b/part-00000-"));
         }
+    }
+
+    #[test]
+    fn test_create_delta_table() {
+
+        let test_schema = Schema::new(
+            "test".to_string(),
+            vec![
+                SchemaField::new(
+                    "Id".to_string(), 
+                    SchemaDataType::primitive("integer".to_string()),
+                    true,
+                    HashMap::new()
+                ),
+                SchemaField::new(
+                    "Name".to_string(), 
+                    SchemaDataType::primitive("string".to_string()),
+                    true,
+                    HashMap::new()
+                )
+            ]
+        );
+
+        let deltamd = DeltaTableMetaData::new(
+            None, 
+            None, 
+            test_schema, 
+            vec![], 
+            HashMap::new()
+        );
+
+        let _new_delta_table = create_delta_table("new_table".to_string(), deltamd);
+
     }
 }

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1074,7 +1074,7 @@ impl DeltaTable {
         ];
         
         let mut transaction = self.create_transaction(None);
-        transaction.add_actions(actions);
+        transaction.add_actions(actions.clone());
 
         // Need better error handling here
         let prepared_commit = transaction.prepare_commit(None).await.unwrap();
@@ -1082,7 +1082,10 @@ impl DeltaTable {
 
         // Can we mutate the DeltaTable's state using process_action()
         // in order to get most up-to-date state based on the commit above
-        
+        for action in actions {
+            let _ = process_action(&mut self.state, action)?;
+        }
+
         Ok(())
     }
 
@@ -1680,7 +1683,7 @@ mod tests {
         ).unwrap();
 
         dt.create(delta_md, protocol).await.unwrap();
-
+        println!("{}", dt);
         // assert new log file created before deletion
         // assert DeltaTable version is now 0
         assert_eq!(dt.version, 0);

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -217,6 +217,7 @@ impl DeltaTableMetaData {
         partition: Vec<String>, 
         config: HashMap<String, String>
     ) -> Self {
+        // Reference implementation uses uuid v4 to create GUID:
         // https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala#L350
         
         Self {

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1064,7 +1064,7 @@ impl DeltaTable {
     ) -> Result<(), DeltaTableError> {
         // need to check if table already exists so that protocal and metaData arent overwritten on second create
         
-        let meta = action::MetaData::try_from(metadata).unwrap();
+        let meta = action::MetaData::try_from(metadata)?;
 
         let mut transaction = self.create_transaction(None);
 
@@ -1075,7 +1075,9 @@ impl DeltaTable {
                 Action::metaData(meta)
             ]
         );
-        transaction.commit(None).await.unwrap();
+
+        let prepared_commit = transaction.prepare_commit(None).await?;
+        self.try_commit_transaction(prepared_commit, 0);
 
         //possible need to refresh state to give an accurate DeltaTable reference back at the end of creation
         Ok(())

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -224,7 +224,7 @@ impl DeltaTableMetaData {
             format: action::Format::new("parquet".to_string(), None),
             schema: schema,
             partition_columns: partition,
-            created_time: Utc::now().timestamp(),  //create a timestamp for current timestamp
+            created_time: Utc::now().timestamp_millis(),  //create a timestamp for current timestamp
             configuration: config
         }
     }

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1694,7 +1694,8 @@ mod tests {
 
         // assert DeltaTableState metadata matches fields in above DeltaTableMetaData
         // assert metadata name
-        // assert partitions is none
-        // assert no configs
+        let current_metadata = dt.get_metadata().unwrap();
+        assert!(current_metadata.partition_columns.is_empty());
+        assert!(current_metadata.configuration.is_empty());
     }
 }

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -45,6 +45,7 @@ pub struct SchemaField {
 
 impl SchemaField {
 
+    /// Create a new SchemaField from scratch
     pub fn new(
         name: String, 
         r#type: SchemaDataType,
@@ -174,6 +175,7 @@ impl Schema {
         &self.fields
     }
 
+    /// Create a new Schema using a vector of SchemaFields
     pub fn new(r#type: String, fields: Vec<SchemaField>) -> Self {
         Self {
             r#type,

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -44,19 +44,18 @@ pub struct SchemaField {
 }
 
 impl SchemaField {
-
     /// Create a new SchemaField from scratch
     pub fn new(
-        name: String, 
+        name: String,
         r#type: SchemaDataType,
-        nullable: bool, 
-        metadata: HashMap<String, String>
+        nullable: bool,
+        metadata: HashMap<String, String>,
     ) -> Self {
         Self {
             name,
             r#type,
             nullable,
-            metadata
+            metadata,
         }
     }
 
@@ -177,9 +176,6 @@ impl Schema {
 
     /// Create a new Schema using a vector of SchemaFields
     pub fn new(r#type: String, fields: Vec<SchemaField>) -> Self {
-        Self {
-            r#type,
-            fields
-        }
+        Self { r#type, fields }
     }
 }

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -44,6 +44,21 @@ pub struct SchemaField {
 }
 
 impl SchemaField {
+
+    pub fn new(
+        name: String, 
+        r#type: SchemaDataType,
+        nullable: bool, 
+        metadata: HashMap<String, String>
+    ) -> Self {
+        Self {
+            name,
+            r#type,
+            nullable,
+            metadata
+        }
+    }
+
     /// The column name of the schema field.
     pub fn get_name(&self) -> &str {
         &self.name
@@ -157,5 +172,12 @@ impl Schema {
     /// Returns the list of fields that make up the schema definition of the table.
     pub fn get_fields(&self) -> &Vec<SchemaField> {
         &self.fields
+    }
+
+    pub fn new(r#type: String, fields: Vec<SchemaField>) -> Self {
+        Self {
+            r#type,
+            fields
+        }
     }
 }

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -162,7 +162,7 @@ pub enum SchemaDataType {
 }
 
 /// Represents the schema of the delta table.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Schema {
     r#type: String,
     fields: Vec<SchemaField>,


### PR DESCRIPTION
# Description
This is the current implementation for a low level create table api

# Looking for feedback
- I think the new() method for DeltaTableMetaData needs to take in format (just defaulted to parquet to get things working)
- I think the create() method should return an updated version of the DeltaTable instead of nothing at the moment