### PR TITLE
fix sleep workaround in checkpoint test

### DIFF
--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -109,6 +109,7 @@ impl StorageBackend for FileStorageBackend {
             .await?;
 
         f.write_all(obj_bytes).await?;
+        f.flush().await?;
 
         Ok(())
     }

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -411,6 +411,12 @@ pub trait StorageBackend: Send + Sync + Debug {
     >;
 
     /// Create new object with `obj_bytes` as content.
+    ///
+    /// Implementation note:
+    ///
+    /// To support safe concurrent read, if `path` already exists, `put_obj` needs to update object
+    /// content in backing store atomically, i.e. reader of the object should never read a partial
+    /// write.
     async fn put_obj(&self, path: &str, obj_bytes: &[u8]) -> Result<(), StorageError>;
 
     /// Moves object from `src` to `dst`.

--- a/rust/tests/checkpoint_writer_test.rs
+++ b/rust/tests/checkpoint_writer_test.rs
@@ -34,11 +34,6 @@ async fn write_simple_checkpoint() {
     let checkpoint_path = log_path.join("00000000000000000005.checkpoint.parquet");
     assert!(checkpoint_path.as_path().exists());
 
-    // HACK: seems like a race condition exists reading the file back in.
-    // Without the sleep, frequently fails with:
-    // Error("EOF while parsing a value", line: 1, column: 0)'
-    std::thread::sleep(std::time::Duration::from_secs(1));
-
     // _last_checkpoint should exist and point to the correct version
     let version = get_last_checkpoint_version(&log_path);
     assert_eq!(5, version);
@@ -54,9 +49,6 @@ async fn write_simple_checkpoint() {
     // checkpoint should exist
     let checkpoint_path = log_path.join("00000000000000000010.checkpoint.parquet");
     assert!(checkpoint_path.as_path().exists());
-
-    // see above
-    std::thread::sleep(std::time::Duration::from_secs(1));
 
     // _last_checkpoint should exist and point to the correct version
     let version = get_last_checkpoint_version(&log_path);


### PR DESCRIPTION
# Description

Our file storage backend `put_obj` implementation is not correct because it could result in partial write being visible to readers.

This change fixes partial read for non-concurrent readers. To properly support concurrent readers, we need to write to a temp location first, then follow by an atomic rename. Filed https://github.com/delta-io/delta-rs/issues/361 as follow up.
