### PR TITLE
support partition value string deserialization for float/double/date

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -105,7 +105,7 @@ class DeltaTable:
         Each tuple has format: (key, op, value) and compares the key with the value.
         The supported op are: `=`, `!=`, `in`, and `not in`.
         If the op is in or not in, the value must be a collection such as a list, a set or a tuple.
-        The supported type for value is str.
+        The supported type for value is str. Use empty string `''` for Null partition value.
 
         Examples:
         ("x", "=", "a")

--- a/rust/src/delta_arrow.rs
+++ b/rust/src/delta_arrow.rs
@@ -90,7 +90,7 @@ impl TryFrom<&schema::SchemaDataType> for ArrowDataType {
                     }
                     "date" => {
                         // A calendar date, represented as a year-month-day triple without a
-                        // timezone.
+                        // timezone. Stored as 4 bytes integer representing days sinece 1970-01-01
                         Ok(ArrowDataType::Date32)
                     }
                     "timestamp" => {


### PR DESCRIPTION
# Description

support partition value string deserialization for float/double/date

# Related Issue(s)

related to https://github.com/delta-io/delta-rs/issues/357

# Documentation

https://github.com/delta-io/delta/blob/master/PROTOCOL.md#partition-value-serialization
