### PR TITLE
Make Format.options to be required field

### DIFF
--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -362,12 +362,13 @@ pub struct Format {
     /// Name of the encoding for files in this table.
     provider: String,
     /// A map containing configuration options for the format.
-    options: Option<HashMap<String, Option<String>>>,
+    options: HashMap<String, Option<String>>,
 }
 
 impl Format {
     /// Allows creation of a new action::Format
     pub fn new(provider: String, options: Option<HashMap<String, Option<String>>>) -> Self {
+        let options = options.unwrap_or_default();
         Self { provider, options }
     }
 
@@ -501,10 +502,10 @@ impl MetaData {
                                     estr,
                                 ))
                             })?;
-                            re.format.options = Some(options);
+                            re.format.options = options;
                         }
                         _ => {
-                            re.format.options = None;
+                            re.format.options = HashMap::new();
                         }
                     }
                 }


### PR DESCRIPTION
# Description
Format.options is required field, see https://github.com/delta-io/delta/blob/eab445a15f478ed2454cf152edb795e9fece91f6/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala#L358-L360

