### PR TITLE
additional error handling to atomic_rename

### DIFF
--- a/rust/src/storage/file/rename.rs
+++ b/rust/src/storage/file/rename.rs
@@ -44,7 +44,9 @@ mod imp {
             if let libc::EEXIST = e.0 {
                 return Err(StorageError::AlreadyExists(String::from(to)));
             }
-
+            if let libc::EINVAL = e.0 {
+                return Err(StorageError::Generic(format!("atomic_rename failed with message '{}'", e))); 
+            }
             return Err(StorageError::other_std_io_err(format!(
                 "failed to rename {} to {}: {}",
                 from, to, e
@@ -134,7 +136,15 @@ mod tests {
         // successful move A to C
         assert!(a.exists());
         assert!(!c.exists());
-        atomic_rename(a.to_str().unwrap(), c.to_str().unwrap(), false).unwrap();
+        match atomic_rename(a.to_str().unwrap(), c.to_str().unwrap(), false) {
+            Err(StorageError::Generic(e)) if e == "atomic_rename failed with message 'Invalid argument'" => {
+                panic!("expected success, got: {:?}. Note: atomically renaming Windows files from WSL2 is not supported.", e);
+            },
+            Err(e) => {
+                panic!("expected success, got: {:?}", e)
+            },
+            _ => {}
+        }
         assert!(!a.exists());
         assert!(c.exists());
 

--- a/rust/src/storage/file/rename.rs
+++ b/rust/src/storage/file/rename.rs
@@ -45,7 +45,10 @@ mod imp {
                 return Err(StorageError::AlreadyExists(String::from(to)));
             }
             if let libc::EINVAL = e.0 {
-                return Err(StorageError::Generic(format!("atomic_rename failed with message '{}'", e))); 
+                return Err(StorageError::Generic(format!(
+                    "atomic_rename failed with message '{}'",
+                    e
+                )));
             }
             return Err(StorageError::other_std_io_err(format!(
                 "failed to rename {} to {}: {}",
@@ -136,13 +139,10 @@ mod tests {
         // successful move A to C
         assert!(a.exists());
         assert!(!c.exists());
-        match atomic_rename(a.to_str().unwrap(), c.to_str().unwrap()) {
-            Err(StorageError::Generic(e)) if e == "atomic_rename failed with message 'Invalid argument'" => {
-                panic!("expected success, got: {:?}. Note: atomically renaming Windows files from WSL2 is not supported.", e);
-            },
-            Err(e) => {
-                panic!("expected success, got: {:#}", e)
-            },
+        match atomic_rename(a.to_str().unwrap(), c.to_str().unwrap(), false) {
+            Err(StorageError::Generic(e)) if e == "atomic_rename failed with message 'Invalid argument'" =>
+                panic!("expected success, got: {:?}. Note: atomically renaming Windows files from WSL2 is not supported.", e),
+            Err(e) => panic!("expected success, got: {:?}", e),
             _ => {}
         }
         assert!(!a.exists());

--- a/rust/src/storage/file/rename.rs
+++ b/rust/src/storage/file/rename.rs
@@ -136,12 +136,12 @@ mod tests {
         // successful move A to C
         assert!(a.exists());
         assert!(!c.exists());
-        match atomic_rename(a.to_str().unwrap(), c.to_str().unwrap(), false) {
+        match atomic_rename(a.to_str().unwrap(), c.to_str().unwrap()) {
             Err(StorageError::Generic(e)) if e == "atomic_rename failed with message 'Invalid argument'" => {
                 panic!("expected success, got: {:?}. Note: atomically renaming Windows files from WSL2 is not supported.", e);
             },
             Err(e) => {
-                panic!("expected success, got: {:?}", e)
+                panic!("expected success, got: {:#}", e)
             },
             _ => {}
         }


### PR DESCRIPTION
add a specific panic! message when libc::renameat2 returns the EINVAL flag and handle the error message it in the succesful atomic_rename / move A to C test

# Description
After cloning the repo on Windows with VSCode and building it on WSL2, the atomic_rename test failed with a generic "invalid argument" error message. Atomic rename is supported on WSL2, but not when you try to rename files on the Windows mounts. This change adds a error handle for this situation in the atomic_rename function, to make the error much more specific. 

# Related Issue(s)
None as far as I am aware, and I didn't open an issue for it myself. 

# Documentation
N/A

