### PR TITLE
added initial commit info on create method for a DeltaTable

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1741,6 +1741,20 @@ mod tests {
                 Action::metaData(action) => {
                     assert_eq!(DeltaTableMetaData::try_from(action).unwrap(), delta_md);
                 }
+                Action::commitInfo(mut action) => {
+                    let modified_action = if action.is_object() {
+                        let temp = action.as_object_mut().unwrap();
+                        temp["timestamp"] = Value::String("".to_string());
+                        Some(Value::Object(temp.clone()))
+                    } else {
+                        None
+                    };
+
+                    assert_eq!(
+                        modified_action.unwrap(),
+                        json!({"operation": "CREATE TABLE", "userName": "test user", "delta-rs": crate_version().to_string(), "timestamp": "".to_string()})
+                    )
+                }
                 _ => (),
             }
         }

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1093,7 +1093,9 @@ impl DeltaTable {
         // delta-rs commit info will include the delta-rs version and timestamp as of now
         let mut enriched_commit_info = match commit_info {
             Some(Value::Object(map)) => Ok(map),
-            Some(_) => Err(DeltaTableError::Generic(format!("Expected a json object"))),
+            Some(_) => Err(DeltaTableError::Generic(
+                "Expected a json object".to_string(),
+            )),
             None => Ok(serde_json::Map::new()),
         }?;
         enriched_commit_info.insert(


### PR DESCRIPTION
# Description
Adding commitInfo data for the create method for DeltaTable

# Related Issue(s)
closes #350

Looking for input on the field names for json provided by delta-rs
"delta-rs": version of delta-rs
"timestamp": unix time in milliseconds 
