### PR TITLE
Fix duplicates on update call

### DIFF
--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -40,6 +40,9 @@ async fn read_delta_table_with_update() {
     let path = "./tests/data/simple_table_with_checkpoint/";
     let table_newest_version = deltalake::open_table(path).await.unwrap();
     let mut table_to_update = deltalake::open_table_with_version(path, 0).await.unwrap();
+    // calling update several times should not produce any duplicates
+    table_to_update.update().await.unwrap();
+    table_to_update.update().await.unwrap();
     table_to_update.update().await.unwrap();
 
     assert_eq!(


### PR DESCRIPTION
# Description
Every time the `update` is called, the `Add` action from the latest checkpoints are being applied once more, leading into duplicates. 
As it turned out, it's a regression from https://github.com/delta-io/delta-rs/pull/124 changes.

First commit shows the repro steps, second revers mention changes and resolves the issue
