### PR TITLE
Use `tokio::fs::rename` in `put_obj`.

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1044,7 +1044,7 @@ impl DeltaTable {
         // move temporary commit file to delta log directory
         // rely on storage to fail if the file already exists -
         self.storage
-            .rename_obj(&commit.uri, &self.commit_uri_from_version(version))
+            .rename_obj_noreplace(&commit.uri, &self.commit_uri_from_version(version))
             .await
             .map_err(|e| DeltaTableError::from(DeltaTransactionError::from(e)))?;
 

--- a/rust/src/storage/azure.rs
+++ b/rust/src/storage/azure.rs
@@ -193,8 +193,8 @@ impl StorageBackend for AdlsGen2Backend {
         unimplemented!("put_obj not implemented for azure");
     }
 
-    async fn rename_obj(&self, _src: &str, _dst: &str) -> Result<(), StorageError> {
-        unimplemented!("rename_obj not implemented for azure");
+    async fn rename_obj_noreplace(&self, _src: &str, _dst: &str) -> Result<(), StorageError> {
+        unimplemented!("rename_obj_noreplace not implemented for azure");
     }
 
     async fn delete_obj(&self, _path: &str) -> Result<(), StorageError> {

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -125,8 +125,8 @@ impl StorageBackend for FileStorageBackend {
         }
     }
 
-    async fn rename_obj(&self, src: &str, dst: &str) -> Result<(), StorageError> {
-        rename::rename_if_not_exists(src, dst)
+    async fn rename_obj_noreplace(&self, src: &str, dst: &str) -> Result<(), StorageError> {
+        rename::rename_noreplace(src, dst)
     }
 
     async fn delete_obj(&self, path: &str) -> Result<(), StorageError> {
@@ -152,14 +152,14 @@ mod tests {
 
         // first try should result in successful rename
         backend.put_obj(tmp_file, b"hello").await.unwrap();
-        if let Err(e) = backend.rename_obj(tmp_file, new_file).await {
+        if let Err(e) = backend.rename_obj_noreplace(tmp_file, new_file).await {
             panic!("Expect put_obj to return Ok, got Err: {:#?}", e)
         }
 
         // second try should result in already exists error
         backend.put_obj(tmp_file, b"hello").await.unwrap();
         assert!(matches!(
-            backend.rename_obj(tmp_file, new_file).await,
+            backend.rename_obj_noreplace(tmp_file, new_file).await,
             Err(StorageError::AlreadyExists(s)) if s == new_file_path.to_str().unwrap(),
         ));
     }

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -115,7 +115,6 @@ impl StorageBackend for FileStorageBackend {
         drop(f);
 
         // as temp path is transparent to end user, we could use syscall directly here
-        // path exists check needed by `atomic_rename` might cause a race condition
         match fs::rename(tmp_path, path).await {
             Ok(_) => Ok(()),
             Err(e) => {
@@ -127,7 +126,7 @@ impl StorageBackend for FileStorageBackend {
     }
 
     async fn rename_obj(&self, src: &str, dst: &str) -> Result<(), StorageError> {
-        rename::atomic_rename(src, dst, false)
+        rename::rename_if_not_exists(src, dst)
     }
 
     async fn delete_obj(&self, path: &str) -> Result<(), StorageError> {

--- a/rust/src/storage/gcs/client.rs
+++ b/rust/src/storage/gcs/client.rs
@@ -120,7 +120,7 @@ impl GCSStorageBackend {
         Ok(())
     }
 
-    pub async fn rename<'a>(
+    pub async fn rename_noreplace<'a>(
         &self,
         src: GCSObject<'a>,
         dst: GCSObject<'a>,

--- a/rust/src/storage/gcs/mod.rs
+++ b/rust/src/storage/gcs/mod.rs
@@ -94,7 +94,7 @@ impl StorageBackend for GCSStorageBackend {
     ///
     /// Implementation note:
     ///
-    /// For a multi-writer safe backend, `rename_obj` needs to implement `atomic rename` semantic.
+    /// For a multi-writer safe backend, `rename_obj` needs to implement `rename if not exists` semantic.
     /// In other words, if the destination path already exists, rename should return a
     /// [StorageError::AlreadyExists] error.
     async fn rename_obj(&self, src: &str, dst: &str) -> Result<(), StorageError> {

--- a/rust/src/storage/gcs/mod.rs
+++ b/rust/src/storage/gcs/mod.rs
@@ -97,10 +97,10 @@ impl StorageBackend for GCSStorageBackend {
     /// For a multi-writer safe backend, `rename_obj` needs to implement `rename if not exists` semantic.
     /// In other words, if the destination path already exists, rename should return a
     /// [StorageError::AlreadyExists] error.
-    async fn rename_obj(&self, src: &str, dst: &str) -> Result<(), StorageError> {
+    async fn rename_obj_noreplace(&self, src: &str, dst: &str) -> Result<(), StorageError> {
         let src_uri = parse_uri(src)?.into_gcs_object()?;
         let dst_uri = parse_uri(dst)?.into_gcs_object()?;
-        match self.rename(src_uri, dst_uri).await {
+        match self.rename_noreplace(src_uri, dst_uri).await {
             Err(GCSClientError::PreconditionFailed) => {
                 return Err(StorageError::AlreadyExists(dst.to_string()))
             }

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -504,10 +504,10 @@ pub trait StorageBackend: Send + Sync + Debug {
     ///
     /// Implementation note:
     ///
-    /// For a multi-writer safe backend, `rename_obj` needs to implement `rename if not exists` semantic.
+    /// For a multi-writer safe backend, `rename_obj_noreplace` needs to implement rename if not exists semantic.
     /// In other words, if the destination path already exists, rename should return a
     /// [StorageError::AlreadyExists] error.
-    async fn rename_obj(&self, src: &str, dst: &str) -> Result<(), StorageError>;
+    async fn rename_obj_noreplace(&self, src: &str, dst: &str) -> Result<(), StorageError>;
 
     /// Deletes object by `path`.
     async fn delete_obj(&self, path: &str) -> Result<(), StorageError>;

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -504,7 +504,7 @@ pub trait StorageBackend: Send + Sync + Debug {
     ///
     /// Implementation note:
     ///
-    /// For a multi-writer safe backend, `rename_obj` needs to implement `atomic rename` semantic.
+    /// For a multi-writer safe backend, `rename_obj` needs to implement `rename if not exists` semantic.
     /// In other words, if the destination path already exists, rename should return a
     /// [StorageError::AlreadyExists] error.
     async fn rename_obj(&self, src: &str, dst: &str) -> Result<(), StorageError>;

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -395,7 +395,7 @@ impl StorageBackend for S3StorageBackend {
         Ok(())
     }
 
-    async fn rename_obj(&self, src: &str, dst: &str) -> Result<(), StorageError> {
+    async fn rename_obj_noreplace(&self, src: &str, dst: &str) -> Result<(), StorageError> {
         debug!("rename s3 object: {} -> {}...", src, dst);
 
         let lock_client = match self.lock_client {

--- a/rust/tests/repair_s3_rename_test.rs
+++ b/rust/tests/repair_s3_rename_test.rs
@@ -104,7 +104,7 @@ mod s3 {
     ) -> JoinHandle<Result<(), StorageError>> {
         tokio::spawn(async move {
             println!("rename({}, {}) started", &src, &dst);
-            let result = s3.rename_obj(&src, &dst).await;
+            let result = s3.rename_obj_noreplace(&src, &dst).await;
             println!("rename({}, {}) finished", &src, &dst);
             result
         })


### PR DESCRIPTION
# Description

As a follow up of #367 , use syscall rename in `put_obj` to avoid race conditions.

# Related Issue(s)

- related to #361 
