### PR TITLE
Gcs writer bugs

### DIFF
--- a/rust/src/storage/gcs/client.rs
+++ b/rust/src/storage/gcs/client.rs
@@ -150,7 +150,7 @@ impl GCSStorageBackend {
             }
         }
 
-        Ok(())
+        self.delete(src).await
     }
 
     pub async fn delete<'a>(&self, uri: GCSObject<'a>) -> Result<(), GCSClientError> {

--- a/rust/src/storage/gcs/client.rs
+++ b/rust/src/storage/gcs/client.rs
@@ -150,7 +150,7 @@ impl GCSStorageBackend {
             }
         }
 
-        self.delete(src).await
+        Ok(())
     }
 
     pub async fn delete<'a>(&self, uri: GCSObject<'a>) -> Result<(), GCSClientError> {

--- a/rust/src/storage/gcs/util.rs
+++ b/rust/src/storage/gcs/util.rs
@@ -66,6 +66,7 @@ where
     }
 
     Ok(builder
+        .header(reqwest::header::CONTENT_LENGTH, content_len)
         .headers(parts.headers)
         .body(buffer.freeze())
         .build()?)


### PR DESCRIPTION
# Description
After putting together some code to actually write into gcs, I had encountered a few issues.
- Content Length header must be included on POST requests, else a 411 status is returned
- ~The storage backend rename method was attempting to cleanup the src file, but it turns out this is unnecessary`~
EDIT: nope that delete in rename is needed

