### PR TITLE
Add filesystem argument for reading DeltaTable in Python binding

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -191,7 +191,7 @@ class DeltaTable:
         return pyarrow_schema_from_json(self._table.arrow_schema_json())
 
     def to_pyarrow_dataset(
-        self, partitions: Optional[List[Tuple[str, str, Any]]] = None, filesystem: FileSystem = None
+        self, partitions: Optional[List[Tuple[str, str, Any]]] = None, filesystem: Optional[FileSystem] = None
     ) -> pyarrow.dataset.Dataset:
         """
         Build a PyArrow Dataset using data from the DeltaTable.
@@ -251,7 +251,7 @@ class DeltaTable:
         self,
         partitions: Optional[List[Tuple[str, str, Any]]] = None,
         columns: Optional[List[str]] = None,
-        filesystem: FileSystem = None
+        filesystem: Optional[FileSystem] = None
     ) -> pyarrow.Table:
         """
         Build a PyArrow Table using data from the DeltaTable.
@@ -267,7 +267,7 @@ class DeltaTable:
         self,
         partitions: Optional[List[Tuple[str, str, Any]]] = None,
         columns: Optional[List[str]] = None,
-        filesystem: FileSystem = None
+        filesystem: Optional[FileSystem] = None
     ) -> "pandas.DataFrame":
         """
         Build a pandas dataframe using data from the DeltaTable.

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 import pyarrow
 from pyarrow.dataset import dataset, partitioning
+from pyarrow.fs import FileSystem
 
 if TYPE_CHECKING:
     import pandas
@@ -190,15 +191,16 @@ class DeltaTable:
         return pyarrow_schema_from_json(self._table.arrow_schema_json())
 
     def to_pyarrow_dataset(
-        self, partitions: Optional[List[Tuple[str, str, Any]]] = None
+        self, partitions: Optional[List[Tuple[str, str, Any]]] = None, filesystem: FileSystem = None
     ) -> pyarrow.dataset.Dataset:
         """
         Build a PyArrow Dataset using data from the DeltaTable.
 
         :param partitions: A list of partition filters, see help(DeltaTable.files_by_partitions) for filter syntax
+        :param filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
         :return: the PyArrow dataset in PyArrow
         """
-        if partitions is None:
+        if not partitions:
             file_paths = self._table.file_uris()
         else:
             file_paths = self._table.files_by_partitions(partitions)
@@ -219,19 +221,21 @@ class DeltaTable:
             # for non-AWS S3 like resources. This is a slight hack until such a
             # point when pyarrow learns about AWS_ENDPOINT_URL
             endpoint_url = os.environ.get("AWS_ENDPOINT_URL")
-            if endpoint_url is not None:
+            if endpoint_url:
                 endpoint = urlparse(endpoint_url)
                 # This format specific to the URL schema inference done inside
                 # of pyarrow, consult their tests/dataset.py for examples
                 query_str += (
                     f"?scheme={endpoint.scheme}&endpoint_override={endpoint.netloc}"
                 )
+            if not filesystem:
+                filesystem = f"{paths[0].scheme}://{paths[0].netloc}{query_str}"
 
             keys = [curr_file.path for curr_file in paths]
             return dataset(
                 keys,
                 schema=self.pyarrow_schema(),
-                filesystem=f"{paths[0].scheme}://{paths[0].netloc}{query_str}",
+                filesystem=filesystem,
                 partitioning=partitioning(flavor="hive"),
             )
         else:
@@ -239,6 +243,7 @@ class DeltaTable:
                 file_paths,
                 schema=self.pyarrow_schema(),
                 format="parquet",
+                filesystem=filesystem,
                 partitioning=partitioning(flavor="hive"),
             )
 
@@ -246,29 +251,33 @@ class DeltaTable:
         self,
         partitions: Optional[List[Tuple[str, str, Any]]] = None,
         columns: Optional[List[str]] = None,
+        filesystem: FileSystem = None
     ) -> pyarrow.Table:
         """
         Build a PyArrow Table using data from the DeltaTable.
 
         :param partitions: A list of partition filters, see help(DeltaTable.files_by_partitions) for filter syntax
         :param columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
+        :param filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
         :return: the PyArrow table
         """
-        return self.to_pyarrow_dataset(partitions).to_table(columns=columns)
+        return self.to_pyarrow_dataset(partitions=partitions, filesystem=filesystem).to_table(columns=columns)
 
     def to_pandas(
         self,
         partitions: Optional[List[Tuple[str, str, Any]]] = None,
         columns: Optional[List[str]] = None,
+        filesystem: FileSystem = None
     ) -> "pandas.DataFrame":
         """
         Build a pandas dataframe using data from the DeltaTable.
 
         :param partitions: A list of partition filters, see help(DeltaTable.files_by_partitions) for filter syntax
         :param columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
+        :param filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
         :return: a pandas dataframe
         """
-        return self.to_pyarrow_table(partitions, columns).to_pandas()
+        return self.to_pyarrow_table(partitions=partitions, columns=columns, filesystem=filesystem).to_pandas()
 
     def update_incremental(self) -> None:
         """

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -51,6 +51,7 @@ nitpick_ignore = [
     ("py:class", "pyarrow.lib.Table"),
     ("py:class", "pyarrow.lib.DataType"),
     ("py:class", "pyarrow.lib.Field"),
+    ("py:class", "pyarrow._fs.FileSystem"),
     ("py:class", "RawDeltaTable"),
     ("py:class", "pandas.DataFrame"),
 ]

--- a/python/stubs/pyarrow/fs.pyi
+++ b/python/stubs/pyarrow/fs.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+FileSystem: Any

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -2,6 +2,7 @@ from threading import Barrier, Thread
 
 import pandas as pd
 import pytest
+from pyarrow.fs import LocalFileSystem
 
 from deltalake import DeltaTable, Metadata
 
@@ -11,12 +12,10 @@ def test_read_simple_table_to_dict():
     dt = DeltaTable(table_path)
     assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"id": [5, 7, 9]}
 
-
 def test_read_simple_table_by_version_to_dict():
     table_path = "../rust/tests/data/delta-0.2.0"
     dt = DeltaTable(table_path, version=2)
     assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"value": [1, 2, 3]}
-
 
 def test_read_simple_table_update_incremental():
     table_path = "../rust/tests/data/simple_table"
@@ -177,6 +176,12 @@ def test_delta_table_to_pandas():
     dt = DeltaTable(table_path)
     assert dt.to_pandas().equals(pd.DataFrame({"id": [5, 7, 9]}))
 
+
+def test_delta_table_with_filesystem():
+    table_path = "../rust/tests/data/simple_table"
+    dt = DeltaTable(table_path)
+    filesystem = LocalFileSystem()
+    assert dt.to_pandas(filesystem=filesystem).equals(pd.DataFrame({"id": [5, 7, 9]}))
 
 class ExcPassThroughThread(Thread):
     """Wrapper around `threading.Thread` that propagates exceptions."""


### PR DESCRIPTION
# Description
- Expose `filesystem` argument for reading DeltaTable with Pyarrow in the Python binding

# Related Issue(s)
#392 
