### PR TITLE
Ensures that all table schemas are of StructType

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1638,23 +1638,20 @@ mod tests {
     #[tokio::test]
     async fn test_create_delta_table() {
         // Setup
-        let test_schema = Schema::new(
-            "test".to_string(),
-            vec![
-                SchemaField::new(
-                    "Id".to_string(),
-                    SchemaDataType::primitive("integer".to_string()),
-                    true,
-                    HashMap::new(),
-                ),
-                SchemaField::new(
-                    "Name".to_string(),
-                    SchemaDataType::primitive("string".to_string()),
-                    true,
-                    HashMap::new(),
-                ),
-            ],
-        );
+        let test_schema = Schema::new(vec![
+            SchemaField::new(
+                "Id".to_string(),
+                SchemaDataType::primitive("integer".to_string()),
+                true,
+                HashMap::new(),
+            ),
+            SchemaField::new(
+                "Name".to_string(),
+                SchemaDataType::primitive("string".to_string()),
+                true,
+                HashMap::new(),
+            ),
+        ]);
 
         let delta_md = DeltaTableMetaData::new(
             Some("Test Table Create".to_string()),

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types)]
 
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// Type alias for a string expected to match a GUID/UUID format
@@ -14,16 +15,25 @@ pub type DeltaDataTypeTimestamp = DeltaDataTypeLong;
 /// Type alias for i32/Delta int
 pub type DeltaDataTypeInt = i32;
 
+static STRUCT_TAG: &'static str = "struct";
 /// Represents a struct field defined in the Delta table schema.
 // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#Schema-Serialization-Format
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]
 pub struct SchemaTypeStruct {
-    // type field is always the string "struct", so we are ignoring it here
-    r#type: String,
+    r#type: Cow<'static, str>,
     fields: Vec<SchemaField>,
 }
 
 impl SchemaTypeStruct {
+    /// Create a new Schema using a vector of SchemaFields
+    pub fn new(fields: Vec<SchemaField>) -> Self {
+        let tag = Cow::Borrowed(STRUCT_TAG);
+        Self {
+            r#type: tag,
+            fields,
+        }
+    }
+
     /// Returns the list of fields contained within the column struct.
     pub fn get_fields(&self) -> &Vec<SchemaField> {
         &self.fields
@@ -162,20 +172,4 @@ pub enum SchemaDataType {
 }
 
 /// Represents the schema of the delta table.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct Schema {
-    r#type: String,
-    fields: Vec<SchemaField>,
-}
-
-impl Schema {
-    /// Returns the list of fields that make up the schema definition of the table.
-    pub fn get_fields(&self) -> &Vec<SchemaField> {
-        &self.fields
-    }
-
-    /// Create a new Schema using a vector of SchemaFields
-    pub fn new(r#type: String, fields: Vec<SchemaField>) -> Self {
-        Self { r#type, fields }
-    }
-}
+pub type Schema = SchemaTypeStruct;

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -15,7 +15,7 @@ pub type DeltaDataTypeTimestamp = DeltaDataTypeLong;
 /// Type alias for i32/Delta int
 pub type DeltaDataTypeInt = i32;
 
-static STRUCT_TAG: &'static str = "struct";
+static STRUCT_TAG: &str = "struct";
 /// Represents a struct field defined in the Delta table schema.
 // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#Schema-Serialization-Format
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default, Clone)]


### PR DESCRIPTION
# Description
This change makes the table `Schema` type an alias to the `SchemaTypeStruct` thus ensuring that all tables are properly created with the correct schema type.

# Related Issue(s)
closes #409

# Documentation
The related issue #409 details this a bit more. But as required in other delta implementations -  spark -
the create table must use a struct type as the schema definition. 

https://jaceklaskowski.github.io/mastering-spark-sql-book/logical-operators/CreateTableStatement/?h=createtable
https://jaceklaskowski.github.io/mastering-spark-sql-book/types/StructType/