### PR TITLE
Add S3StorageOptions to allow configuring S3 backend explicitly

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -76,5 +76,9 @@ pub use self::delta::*;
 pub use self::partitions::*;
 pub use self::schema::*;
 pub use self::storage::{
-    get_backend_for_uri, parse_uri, StorageBackend, StorageError, Uri, UriError,
+    get_backend_for_uri, get_backend_for_uri_with_options, parse_uri, StorageBackend, StorageError,
+    Uri, UriError,
 };
+
+#[cfg(feature = "s3")]
+pub use self::storage::s3::{dynamodb_lock::dynamo_lock_options, s3_storage_options};

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -548,7 +548,7 @@ pub fn get_backend_for_uri(uri: &str) -> Result<Box<dyn StorageBackend>, Storage
 /// Options may be passed in the HashMap or set as environment variables.
 ///
 /// [S3StorageOptions] describes the available options for the S3 backend.
-///
+/// [s3::dynamodb_lock::DynamoDbLockClient] describes additional options for the atomic rename client.
 pub fn get_backend_for_uri_with_options(
     uri: &str,
     // NOTE: prefixing options with "_" to avoid deny warnings error since usage is conditional on s3 and the only usage is with s3 so far
@@ -557,7 +557,7 @@ pub fn get_backend_for_uri_with_options(
     match parse_uri(uri)? {
         #[cfg(any(feature = "s3", feature = "s3-rustls"))]
         Uri::S3Object(_) => Ok(Box::new(s3::S3StorageBackend::new_from_options(
-            S3StorageOptions::from_map(&_options),
+            S3StorageOptions::from_map(_options),
         )?)),
         _ => get_backend_for_uri(uri),
     }

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -638,7 +638,7 @@ fn try_create_lock_client(
 
     match &options.locking_provider {
         Some(p) if p.to_lowercase() == "dynamodb" => {
-            let client = match options.use_web_identity {
+            let dynamodb_client = match options.use_web_identity {
                 true => rusoto_dynamodb::DynamoDbClient::new_with(
                     dispatcher,
                     get_web_identity_provider()?,
@@ -646,11 +646,11 @@ fn try_create_lock_client(
                 ),
                 false => rusoto_dynamodb::DynamoDbClient::new(options.region.clone()),
             };
-            let client = dynamodb_lock::DynamoDbLockClient::new(
-                client,
+            let lock_client = dynamodb_lock::DynamoDbLockClient::new(
+                dynamodb_client,
                 dynamodb_lock::DynamoDbOptions::from_map(&options.extra_opts),
             );
-            Ok(Some(Box::new(client)))
+            Ok(Some(Box::new(lock_client)))
         }
         _ => Ok(None),
     }

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -1,5 +1,6 @@
 //! AWS S3 storage backend. It only supports a single writer and is not multi-writer safe.
 
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::{fmt, pin::Pin};
@@ -22,9 +23,106 @@ use uuid::Uuid;
 
 pub mod dynamodb_lock;
 
-const AWS_S3_ASSUME_ROLE_ARN: &str = "AWS_S3_ASSUME_ROLE_ARN";
-const AWS_S3_ROLE_SESSION_NAME: &str = "AWS_S3_ROLE_SESSION_NAME";
+const AWS_ENDPOINT_URL: &str = "AWS_ENDPOINT_URL";
 const AWS_WEB_IDENTITY_TOKEN_FILE: &str = "AWS_WEB_IDENTITY_TOKEN_FILE";
+
+mod s3_storage_options {
+    pub const AWS_REGION: &str = "AWS_REGION";
+    pub const AWS_S3_ASSUME_ROLE_ARN: &str = "AWS_S3_ASSUME_ROLE_ARN";
+    pub const AWS_S3_LOCKING_PROVIDER: &str = "AWS_S3_LOCKING_PROVIDER";
+    pub const AWS_S3_ROLE_SESSION_NAME: &str = "AWS_S3_ROLE_SESSION_NAME";
+
+    pub const S3_OPTS: &[&str] = &[
+        AWS_REGION,
+        AWS_S3_ASSUME_ROLE_ARN,
+        AWS_S3_LOCKING_PROVIDER,
+        AWS_S3_ROLE_SESSION_NAME,
+    ];
+}
+
+/// Options used to configure the S3StorageBackend.
+///
+/// Available options are described below.
+///
+/// The same key shown in the table below should be used whether passing a key in the hashmap or setting it as an environment variable.
+/// Provided keys may include configuration for the S3 backend and also the optional DynamoDb lock used for atomic rename.
+///
+/// | name/key                 | description                                                                                                                                                    |
+/// | ======================== | ============================================================================================================================================================== |
+/// | AWS_REGION               | The AWS region.                                                                                                                                                |
+/// | AWS_S3_ASSUME_ROLE_ARN   | The role to assume for S3 writes.                                                                                                                              |
+/// | AWS_S3_ROLE_SESSION_NAME | The role session name to use for assume role. If not provided a random session name is generated.                                                              |
+/// | AWS_S3_LOCKING_PROVIDER  | The locking provider to use. For safe atomic rename, this should be `dynamodb`. If empty, no locking provider is used and safe atomic rename is not available. |
+///
+/// Unconsumed `extra_opts` are passed as a `HashMap` to the `dynamodb_lock` module for configuring the dynamodb client used for safe atomic rename.
+///
+/// Two environment variables are not included as options (and not described in the table above).
+/// These must be set as environment variables when desired and are described below:
+///
+/// [dynamodb_lock::DynamoDbOptions] describes the available options.
+///
+/// * AWS_ENDPOINT_URL - This variable is used specifically for testing against localstack and should be specified in the environment.
+/// * AWS_WEB_IDENTITY_TOKEN_FILE - file describing k8s configuration.
+///   env vars to satisfy https://docs.rs/rusoto_sts/0.47.0/rusoto_sts/struct.WebIdentityProvider.html#method.from_k8s_env should be provided
+pub struct S3StorageOptions {
+    region: Region,
+    assume_role_arn: Option<String>,
+    role_session_name: Option<String>,
+    use_web_identity: bool,
+    locking_provider: Option<String>,
+    extra_opts: HashMap<String, String>,
+}
+
+impl S3StorageOptions {
+    /// Creates an instance of S3StorageOptions from environment variables.
+    pub fn from_env() -> S3StorageOptions {
+        let empty_opts = HashMap::new();
+        Self::from_map(&empty_opts)
+    }
+
+    /// Creates an instance of S3StorageOptions from the given HashMap
+    pub fn from_map(options: &HashMap<String, String>) -> S3StorageOptions {
+        fn str_or_default(map: &HashMap<String, String>, key: &str, default: String) -> String {
+            map.get(key)
+                .map(|v| v.to_owned())
+                .unwrap_or_else(|| std::env::var(key).unwrap_or(default))
+        }
+
+        fn str_option(map: &HashMap<String, String>, key: &str) -> Option<String> {
+            map.get(key)
+                .map_or_else(|| std::env::var(key).ok(), |v| Some(v.to_owned()))
+        }
+
+        let extra_opts = options
+            .iter()
+            .filter(|(k, _)| !s3_storage_options::S3_OPTS.contains(&k.as_str()))
+            .map(|(k, v)| (k.to_owned(), v.to_owned()))
+            .collect();
+
+        let endpoint_url = std::env::var(AWS_ENDPOINT_URL).ok();
+        let region = if let Some(endpoint_url) = endpoint_url {
+            Region::Custom {
+                name: str_or_default(
+                    options,
+                    s3_storage_options::AWS_REGION,
+                    "custom".to_string(),
+                ),
+                endpoint: endpoint_url,
+            }
+        } else {
+            Region::default()
+        };
+
+        Self {
+            region,
+            assume_role_arn: str_option(options, s3_storage_options::AWS_S3_ASSUME_ROLE_ARN),
+            role_session_name: str_option(options, s3_storage_options::AWS_S3_ROLE_SESSION_NAME),
+            use_web_identity: std::env::var(AWS_WEB_IDENTITY_TOKEN_FILE).is_ok(),
+            locking_provider: str_option(options, s3_storage_options::AWS_S3_LOCKING_PROVIDER),
+            extra_opts,
+        }
+    }
+}
 
 impl From<RusotoError<rusoto_s3::GetObjectError>> for StorageError {
     fn from(error: RusotoError<rusoto_s3::GetObjectError>) -> Self {
@@ -82,16 +180,18 @@ fn get_web_identity_provider() -> Result<AutoRefreshingProvider<WebIdentityProvi
 }
 
 fn get_sts_assume_role_provider(
-    region: Region,
+    assume_role_arn: String,
+    options: &S3StorageOptions,
 ) -> Result<AutoRefreshingProvider<StsAssumeRoleSessionCredentialsProvider>, StorageError> {
-    let sts_client = StsClient::new(region);
-    let role_arn = std::env::var(AWS_S3_ASSUME_ROLE_ARN)
-        .map_err(|_| StorageError::S3Generic(format!("{} is not set", AWS_S3_ASSUME_ROLE_ARN)))?;
-    let session_name = std::env::var(AWS_S3_ROLE_SESSION_NAME)
-        .unwrap_or_else(|_| format!("delta-rs-{}", Uuid::new_v4()));
+    let sts_client = StsClient::new(options.region.clone());
+    let session_name = options
+        .role_session_name
+        .as_ref()
+        .map(|v| v.to_owned())
+        .unwrap_or_else(|| format!("delta-rs-{}", Uuid::new_v4()));
     let provider = StsAssumeRoleSessionCredentialsProvider::new(
         sts_client,
-        role_arn,
+        assume_role_arn,
         session_name,
         None,
         None,
@@ -101,15 +201,23 @@ fn get_sts_assume_role_provider(
     Ok(AutoRefreshingProvider::new(provider)?)
 }
 
-fn create_s3_client(region: Region) -> Result<S3Client, StorageError> {
-    if std::env::var(AWS_WEB_IDENTITY_TOKEN_FILE).is_ok() {
+fn create_s3_client(options: &S3StorageOptions) -> Result<S3Client, StorageError> {
+    if options.use_web_identity {
         let provider = get_web_identity_provider()?;
-        Ok(S3Client::new_with(HttpClient::new()?, provider, region))
-    } else if std::env::var(AWS_S3_ASSUME_ROLE_ARN).is_ok() {
-        let provider = get_sts_assume_role_provider(region.clone())?;
-        Ok(S3Client::new_with(HttpClient::new()?, provider, region))
+        Ok(S3Client::new_with(
+            HttpClient::new()?,
+            provider,
+            options.region.clone(),
+        ))
+    } else if let Some(assume_role_arn) = &options.assume_role_arn {
+        let provider = get_sts_assume_role_provider(assume_role_arn.to_owned(), options)?;
+        Ok(S3Client::new_with(
+            HttpClient::new()?,
+            provider,
+            options.region.clone(),
+        ))
     } else {
-        Ok(S3Client::new(region))
+        Ok(S3Client::new(options.region.clone()))
     }
 }
 
@@ -186,17 +294,9 @@ pub struct S3StorageBackend {
 impl S3StorageBackend {
     /// Creates a new S3StorageBackend.
     pub fn new() -> Result<Self, StorageError> {
-        let region = if let Ok(url) = std::env::var("AWS_ENDPOINT_URL") {
-            Region::Custom {
-                name: std::env::var("AWS_REGION").unwrap_or_else(|_| "custom".to_string()),
-                endpoint: url,
-            }
-        } else {
-            Region::default()
-        };
-
-        let client = create_s3_client(region.clone())?;
-        let lock_client = try_create_lock_client(region)?;
+        let options = S3StorageOptions::from_env();
+        let client = create_s3_client(&options)?;
+        let lock_client = try_create_lock_client(&options)?;
 
         Ok(Self {
             client,
@@ -204,7 +304,18 @@ impl S3StorageBackend {
         })
     }
 
-    /// Creates a new S3StorageBackend with given s3 and lock clients.
+    /// Creates a new S3StorageBackend from the provided options
+    pub fn new_from_options(options: S3StorageOptions) -> Result<Self, StorageError> {
+        let client = create_s3_client(&options)?;
+        let lock_client = try_create_lock_client(&options)?;
+
+        Ok(Self {
+            client,
+            lock_client,
+        })
+    }
+
+    /// Creates a new S3StorageBackend with given options, s3 client and lock client.
     pub fn new_with(client: rusoto_s3::S3Client, lock_client: Option<Box<dyn LockClient>>) -> Self {
         Self {
             client,
@@ -520,21 +631,25 @@ impl LockData {
     }
 }
 
-fn try_create_lock_client(region: Region) -> Result<Option<Box<dyn LockClient>>, StorageError> {
+fn try_create_lock_client(
+    options: &S3StorageOptions,
+) -> Result<Option<Box<dyn LockClient>>, StorageError> {
     let dispatcher = HttpClient::new()?;
 
-    match std::env::var("AWS_S3_LOCKING_PROVIDER") {
-        Ok(p) if p.to_lowercase() == "dynamodb" => {
-            let client = match std::env::var("AWS_WEB_IDENTITY_TOKEN_FILE") {
-                Ok(_) => rusoto_dynamodb::DynamoDbClient::new_with(
+    match &options.locking_provider {
+        Some(p) if p.to_lowercase() == "dynamodb" => {
+            let client = match options.use_web_identity {
+                true => rusoto_dynamodb::DynamoDbClient::new_with(
                     dispatcher,
                     get_web_identity_provider()?,
-                    region,
+                    options.region.clone(),
                 ),
-                Err(_) => rusoto_dynamodb::DynamoDbClient::new(region),
+                false => rusoto_dynamodb::DynamoDbClient::new(options.region.clone()),
             };
-            let client =
-                dynamodb_lock::DynamoDbLockClient::new(client, dynamodb_lock::Options::default());
+            let client = dynamodb_lock::DynamoDbLockClient::new(
+                client,
+                dynamodb_lock::DynamoDbOptions::from_map(&options.extra_opts),
+            );
             Ok(Some(Box::new(client)))
         }
         _ => Ok(None),

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -56,10 +56,10 @@ mod s3_storage_options {
 ///
 /// Unconsumed `extra_opts` are passed as a `HashMap` to the `dynamodb_lock` module for configuring the dynamodb client used for safe atomic rename.
 ///
+/// [dynamodb_lock::DynamoDbOptions] describes the available options.
+///
 /// Two environment variables are not included as options (and not described in the table above).
 /// These must be set as environment variables when desired and are described below:
-///
-/// [dynamodb_lock::DynamoDbOptions] describes the available options.
 ///
 /// * AWS_ENDPOINT_URL - This variable is used specifically for testing against localstack and should be specified in the environment.
 /// * AWS_WEB_IDENTITY_TOKEN_FILE - file describing k8s configuration.

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -931,7 +931,7 @@ mod tests {
     }
     #[test]
     fn storage_options_web_identity_test() {
-        let options = S3StorageOptions::from_map(hashmap! {
+        let _options = S3StorageOptions::from_map(hashmap! {
             s3_storage_options::AWS_WEB_IDENTITY_TOKEN_FILE.to_string() => "web_identity_token_file".to_string(),
             s3_storage_options::AWS_ROLE_ARN.to_string() => "arn:aws:iam::123456789012:role/web_identity_role".to_string(),
             s3_storage_options::AWS_ROLE_SESSION_NAME.to_string() => "web_identity_session_name".to_string(),

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -23,104 +23,134 @@ use uuid::Uuid;
 
 pub mod dynamodb_lock;
 
-const AWS_ENDPOINT_URL: &str = "AWS_ENDPOINT_URL";
-const AWS_WEB_IDENTITY_TOKEN_FILE: &str = "AWS_WEB_IDENTITY_TOKEN_FILE";
-
-mod s3_storage_options {
+/// Storage option keys to use when creating [crate::storage::s3::S3StorageOptions].
+/// The same key should be used whether passing a key in the hashmap or setting it as an environment variable.
+/// Provided keys may include configuration for the S3 backend and also the optional DynamoDb lock used for atomic rename.
+pub mod s3_storage_options {
+    /// Custom S3 endpoint.
+    pub const AWS_ENDPOINT_URL: &str = "AWS_ENDPOINT_URL";
+    /// The AWS region.
     pub const AWS_REGION: &str = "AWS_REGION";
-    pub const AWS_S3_ASSUME_ROLE_ARN: &str = "AWS_S3_ASSUME_ROLE_ARN";
+    /// Locking provider to use for safe atomic rename.
+    /// `dynamodb` is currently the only supported locking provider.
+    /// If not set, safe atomic rename is not available.
     pub const AWS_S3_LOCKING_PROVIDER: &str = "AWS_S3_LOCKING_PROVIDER";
+    /// The role to assume for S3 writes.
+    pub const AWS_S3_ASSUME_ROLE_ARN: &str = "AWS_S3_ASSUME_ROLE_ARN";
+    /// The role session name to use when a role is assumed. If not provided a random session name is generated.
     pub const AWS_S3_ROLE_SESSION_NAME: &str = "AWS_S3_ROLE_SESSION_NAME";
 
+    /// The web identity token file to use when using a web identity provider.
+    /// NOTE: web identity related options are set in the environment when creating an instance of [crate::storage::s3::S3StorageOptions].
+    /// See also https://docs.rs/rusoto_sts/0.47.0/rusoto_sts/struct.WebIdentityProvider.html#method.from_k8s_env.
+    pub const AWS_WEB_IDENTITY_TOKEN_FILE: &str = "AWS_WEB_IDENTITY_TOKEN_FILE";
+    /// The role name to use for web identity.
+    /// NOTE: web identity related options are set in the environment when creating an instance of [crate::storage::s3::S3StorageOptions].
+    /// See also https://docs.rs/rusoto_sts/0.47.0/rusoto_sts/struct.WebIdentityProvider.html#method.from_k8s_env.
+    pub const AWS_ROLE_ARN: &str = "AWS_ROLE_ARN";
+    /// The role session name to use for web identity.
+    /// NOTE: web identity related options are set in the environment when creating an instance of [crate::storage::s3::S3StorageOptions].
+    /// See also https://docs.rs/rusoto_sts/0.47.0/rusoto_sts/struct.WebIdentityProvider.html#method.from_k8s_env.
+    pub const AWS_ROLE_SESSION_NAME: &str = "AWS_ROLE_SESSION_NAME";
+
+    /// The list of option keys owned by the S3 module.
+    /// Option keys not contained in this list will be added to the `extra_opts` field of [crate::storage::s3::S3StorageOptions].
+    /// `extra_opts` are passed to [crate::storage::s3::dynamodb_lock::DynamoDbOptions] to configure the lock client.
     pub const S3_OPTS: &[&str] = &[
+        AWS_ENDPOINT_URL,
         AWS_REGION,
-        AWS_S3_ASSUME_ROLE_ARN,
         AWS_S3_LOCKING_PROVIDER,
+        AWS_S3_ASSUME_ROLE_ARN,
         AWS_S3_ROLE_SESSION_NAME,
+        AWS_WEB_IDENTITY_TOKEN_FILE,
+        AWS_ROLE_ARN,
+        AWS_ROLE_SESSION_NAME,
     ];
 }
 
 /// Options used to configure the S3StorageBackend.
 ///
-/// Available options are described below.
-///
-/// The same key shown in the table below should be used whether passing a key in the hashmap or setting it as an environment variable.
-/// Provided keys may include configuration for the S3 backend and also the optional DynamoDb lock used for atomic rename.
-///
-/// | name/key                 | description                                                                                                                                                    |
-/// | ======================== | ============================================================================================================================================================== |
-/// | AWS_REGION               | The AWS region.                                                                                                                                                |
-/// | AWS_S3_ASSUME_ROLE_ARN   | The role to assume for S3 writes.                                                                                                                              |
-/// | AWS_S3_ROLE_SESSION_NAME | The role session name to use for assume role. If not provided a random session name is generated.                                                              |
-/// | AWS_S3_LOCKING_PROVIDER  | The locking provider to use. For safe atomic rename, this should be `dynamodb`. If empty, no locking provider is used and safe atomic rename is not available. |
-///
-/// Unconsumed `extra_opts` are passed as a `HashMap` to the `dynamodb_lock` module for configuring the dynamodb client used for safe atomic rename.
-///
-/// [dynamodb_lock::DynamoDbOptions] describes the available options.
-///
-/// Two environment variables are not included as options (and not described in the table above).
-/// These must be set as environment variables when desired and are described below:
-///
-/// * AWS_ENDPOINT_URL - This variable is used specifically for testing against localstack and should be specified in the environment.
-/// * AWS_WEB_IDENTITY_TOKEN_FILE - file describing k8s configuration.
-///   env vars to satisfy https://docs.rs/rusoto_sts/0.47.0/rusoto_sts/struct.WebIdentityProvider.html#method.from_k8s_env should be provided
+/// Available options are described in [s3_storage_options].
+#[derive(Clone, Debug, PartialEq)]
 pub struct S3StorageOptions {
+    _endpoint_url: Option<String>,
     region: Region,
-    assume_role_arn: Option<String>,
-    role_session_name: Option<String>,
-    use_web_identity: bool,
     locking_provider: Option<String>,
+    assume_role_arn: Option<String>,
+    assume_role_session_name: Option<String>,
+    use_web_identity: bool,
     extra_opts: HashMap<String, String>,
 }
 
 impl S3StorageOptions {
-    /// Creates an instance of S3StorageOptions from environment variables.
-    pub fn from_env() -> S3StorageOptions {
-        let empty_opts = HashMap::new();
-        Self::from_map(&empty_opts)
-    }
-
-    /// Creates an instance of S3StorageOptions from the given HashMap
-    pub fn from_map(options: &HashMap<String, String>) -> S3StorageOptions {
-        fn str_or_default(map: &HashMap<String, String>, key: &str, default: String) -> String {
-            map.get(key)
-                .map(|v| v.to_owned())
-                .unwrap_or_else(|| std::env::var(key).unwrap_or(default))
-        }
-
-        fn str_option(map: &HashMap<String, String>, key: &str) -> Option<String> {
-            map.get(key)
-                .map_or_else(|| std::env::var(key).ok(), |v| Some(v.to_owned()))
-        }
-
+    /// Creates an instance of S3StorageOptions from the given HashMap.
+    pub fn from_map(options: HashMap<String, String>) -> S3StorageOptions {
         let extra_opts = options
             .iter()
             .filter(|(k, _)| !s3_storage_options::S3_OPTS.contains(&k.as_str()))
             .map(|(k, v)| (k.to_owned(), v.to_owned()))
             .collect();
 
-        let endpoint_url = std::env::var(AWS_ENDPOINT_URL).ok();
-        let region = if let Some(endpoint_url) = endpoint_url {
+        let endpoint_url = Self::str_option(&options, s3_storage_options::AWS_ENDPOINT_URL);
+        let region = if let Some(endpoint_url) = endpoint_url.as_ref() {
             Region::Custom {
-                name: str_or_default(
-                    options,
+                name: Self::str_or_default(
+                    &options,
                     s3_storage_options::AWS_REGION,
                     "custom".to_string(),
                 ),
-                endpoint: endpoint_url,
+                endpoint: endpoint_url.to_owned(),
             }
         } else {
             Region::default()
         };
 
+        // Copy web identity values provided in options but not the environment into the environment
+        // to get picked up by the `from_k8s_env` call in `get_web_identity_provider`.
+        Self::ensure_env_var(&options, s3_storage_options::AWS_WEB_IDENTITY_TOKEN_FILE);
+        Self::ensure_env_var(&options, s3_storage_options::AWS_ROLE_ARN);
+        Self::ensure_env_var(&options, s3_storage_options::AWS_ROLE_SESSION_NAME);
+
         Self {
+            _endpoint_url: endpoint_url,
             region,
-            assume_role_arn: str_option(options, s3_storage_options::AWS_S3_ASSUME_ROLE_ARN),
-            role_session_name: str_option(options, s3_storage_options::AWS_S3_ROLE_SESSION_NAME),
-            use_web_identity: std::env::var(AWS_WEB_IDENTITY_TOKEN_FILE).is_ok(),
-            locking_provider: str_option(options, s3_storage_options::AWS_S3_LOCKING_PROVIDER),
+            locking_provider: Self::str_option(
+                &options,
+                s3_storage_options::AWS_S3_LOCKING_PROVIDER,
+            ),
+            assume_role_arn: Self::str_option(&options, s3_storage_options::AWS_S3_ASSUME_ROLE_ARN),
+            assume_role_session_name: Self::str_option(
+                &options,
+                s3_storage_options::AWS_S3_ROLE_SESSION_NAME,
+            ),
+            use_web_identity: std::env::var(s3_storage_options::AWS_WEB_IDENTITY_TOKEN_FILE)
+                .is_ok(),
             extra_opts,
         }
+    }
+
+    fn str_or_default(map: &HashMap<String, String>, key: &str, default: String) -> String {
+        map.get(key)
+            .map(|v| v.to_owned())
+            .unwrap_or_else(|| std::env::var(key).unwrap_or(default))
+    }
+
+    fn str_option(map: &HashMap<String, String>, key: &str) -> Option<String> {
+        map.get(key)
+            .map_or_else(|| std::env::var(key).ok(), |v| Some(v.to_owned()))
+    }
+
+    fn ensure_env_var(map: &HashMap<String, String>, key: &str) {
+        if let Some(val) = Self::str_option(map, key) {
+            std::env::set_var(key, val);
+        }
+    }
+}
+
+impl Default for S3StorageOptions {
+    /// Creates an instance of S3StorageOptions from environment variables.
+    fn default() -> S3StorageOptions {
+        Self::from_map(HashMap::new())
     }
 }
 
@@ -185,7 +215,7 @@ fn get_sts_assume_role_provider(
 ) -> Result<AutoRefreshingProvider<StsAssumeRoleSessionCredentialsProvider>, StorageError> {
     let sts_client = StsClient::new(options.region.clone());
     let session_name = options
-        .role_session_name
+        .assume_role_session_name
         .as_ref()
         .map(|v| v.to_owned())
         .unwrap_or_else(|| format!("delta-rs-{}", Uuid::new_v4()));
@@ -294,7 +324,7 @@ pub struct S3StorageBackend {
 impl S3StorageBackend {
     /// Creates a new S3StorageBackend.
     pub fn new() -> Result<Self, StorageError> {
-        let options = S3StorageOptions::from_env();
+        let options = S3StorageOptions::default();
         let client = create_s3_client(&options)?;
         let lock_client = try_create_lock_client(&options)?;
 
@@ -304,7 +334,9 @@ impl S3StorageBackend {
         })
     }
 
-    /// Creates a new S3StorageBackend from the provided options
+    /// Creates a new S3StorageBackend from the provided options.
+    ///
+    /// Options are described in
     pub fn new_from_options(options: S3StorageOptions) -> Result<Self, StorageError> {
         let client = create_s3_client(&options)?;
         let lock_client = try_create_lock_client(&options)?;
@@ -648,7 +680,7 @@ fn try_create_lock_client(
             };
             let lock_client = dynamodb_lock::DynamoDbLockClient::new(
                 dynamodb_client,
-                dynamodb_lock::DynamoDbOptions::from_map(&options.extra_opts),
+                dynamodb_lock::DynamoDbOptions::from_map(options.extra_opts.clone()),
             );
             Ok(Some(Box::new(lock_client)))
         }
@@ -765,6 +797,8 @@ impl dyn LockClient {
 mod tests {
     use super::*;
 
+    use maplit::hashmap;
+
     #[test]
     fn join_multiple_paths() {
         let backend = S3StorageBackend::new().unwrap();
@@ -792,6 +826,130 @@ mod tests {
                 bucket: "foo",
                 key: "bar/baz",
             }
+        );
+    }
+
+    #[test]
+    fn storage_options_default_test() {
+        std::env::set_var(s3_storage_options::AWS_ENDPOINT_URL, "http://localhost");
+        std::env::set_var(s3_storage_options::AWS_REGION, "us-west-1");
+        std::env::set_var(s3_storage_options::AWS_S3_LOCKING_PROVIDER, "dynamodb");
+        std::env::set_var(
+            s3_storage_options::AWS_S3_ASSUME_ROLE_ARN,
+            "arn:aws:iam::123456789012:role/some_role",
+        );
+        std::env::set_var(s3_storage_options::AWS_S3_ROLE_SESSION_NAME, "session_name");
+        std::env::set_var(
+            s3_storage_options::AWS_WEB_IDENTITY_TOKEN_FILE,
+            "token_file",
+        );
+
+        let options = S3StorageOptions::default();
+
+        assert_eq!(
+            S3StorageOptions {
+                _endpoint_url: Some("http://localhost".to_string()),
+                region: Region::Custom {
+                    name: "us-west-1".to_string(),
+                    endpoint: "http://localhost".to_string()
+                },
+                assume_role_arn: Some("arn:aws:iam::123456789012:role/some_role".to_string()),
+                assume_role_session_name: Some("session_name".to_string()),
+                use_web_identity: true,
+                locking_provider: Some("dynamodb".to_string()),
+                extra_opts: HashMap::new(),
+            },
+            options
+        );
+    }
+
+    #[test]
+    fn storage_options_from_map_test() {
+        let options = S3StorageOptions::from_map(hashmap! {
+            s3_storage_options::AWS_ENDPOINT_URL.to_string() => "http://localhost:1234".to_string(),
+            s3_storage_options::AWS_REGION.to_string() => "us-west-2".to_string(),
+            s3_storage_options::AWS_S3_LOCKING_PROVIDER.to_string() => "another_locking_provider".to_string(),
+            s3_storage_options::AWS_S3_ASSUME_ROLE_ARN.to_string() => "arn:aws:iam::123456789012:role/another_role".to_string(),
+            s3_storage_options::AWS_S3_ROLE_SESSION_NAME.to_string() => "another_session_name".to_string(),
+            s3_storage_options::AWS_WEB_IDENTITY_TOKEN_FILE.to_string() => "another_token_file".to_string(),
+        });
+
+        assert_eq!(
+            S3StorageOptions {
+                _endpoint_url: Some("http://localhost:1234".to_string()),
+                region: Region::Custom {
+                    name: "us-west-2".to_string(),
+                    endpoint: "http://localhost:1234".to_string()
+                },
+                assume_role_arn: Some("arn:aws:iam::123456789012:role/another_role".to_string()),
+                assume_role_session_name: Some("another_session_name".to_string()),
+                use_web_identity: true,
+                locking_provider: Some("another_locking_provider".to_string()),
+                extra_opts: HashMap::new(),
+            },
+            options
+        );
+    }
+
+    #[test]
+    fn storage_options_mixed_test() {
+        std::env::set_var(s3_storage_options::AWS_ENDPOINT_URL, "http://localhost");
+        std::env::set_var(s3_storage_options::AWS_REGION, "us-west-1");
+        std::env::set_var(s3_storage_options::AWS_S3_LOCKING_PROVIDER, "dynamodb");
+        std::env::set_var(
+            s3_storage_options::AWS_S3_ASSUME_ROLE_ARN,
+            "arn:aws:iam::123456789012:role/some_role",
+        );
+        std::env::set_var(s3_storage_options::AWS_S3_ROLE_SESSION_NAME, "session_name");
+        std::env::set_var(
+            s3_storage_options::AWS_WEB_IDENTITY_TOKEN_FILE,
+            "token_file",
+        );
+
+        let options = S3StorageOptions::from_map(hashmap! {
+            s3_storage_options::AWS_REGION.to_string() => "us-west-2".to_string(),
+            "DYNAMO_LOCK_PARTITION_KEY_VALUE".to_string() => "my_lock".to_string(),
+        });
+
+        assert_eq!(
+            S3StorageOptions {
+                _endpoint_url: Some("http://localhost".to_string()),
+                region: Region::Custom {
+                    name: "us-west-2".to_string(),
+                    endpoint: "http://localhost".to_string()
+                },
+                assume_role_arn: Some("arn:aws:iam::123456789012:role/some_role".to_string()),
+                assume_role_session_name: Some("session_name".to_string()),
+                use_web_identity: true,
+                locking_provider: Some("dynamodb".to_string()),
+                extra_opts: hashmap! {
+                    "DYNAMO_LOCK_PARTITION_KEY_VALUE".to_string() => "my_lock".to_string(),
+                },
+            },
+            options
+        );
+    }
+    #[test]
+    fn storage_options_web_identity_test() {
+        let options = S3StorageOptions::from_map(hashmap! {
+            s3_storage_options::AWS_WEB_IDENTITY_TOKEN_FILE.to_string() => "web_identity_token_file".to_string(),
+            s3_storage_options::AWS_ROLE_ARN.to_string() => "arn:aws:iam::123456789012:role/web_identity_role".to_string(),
+            s3_storage_options::AWS_ROLE_SESSION_NAME.to_string() => "web_identity_session_name".to_string(),
+        });
+
+        assert_eq!(
+            "web_identity_token_file",
+            std::env::var(s3_storage_options::AWS_WEB_IDENTITY_TOKEN_FILE).unwrap()
+        );
+
+        assert_eq!(
+            "arn:aws:iam::123456789012:role/web_identity_role",
+            std::env::var(s3_storage_options::AWS_ROLE_ARN).unwrap()
+        );
+
+        assert_eq!(
+            "web_identity_session_name",
+            std::env::var(s3_storage_options::AWS_ROLE_SESSION_NAME).unwrap()
         );
     }
 }

--- a/rust/tests/dynamodb_lock_test.rs
+++ b/rust/tests/dynamodb_lock_test.rs
@@ -12,7 +12,7 @@ mod dynamodb {
     const TABLE: &str = "test_table";
 
     async fn create_dynamo_lock(key: &str, owner: &str) -> DynamoDbLockClient {
-        let opts = Options {
+        let opts = DynamoDbOptions {
             partition_key_value: key.to_string(),
             table_name: TABLE.to_string(),
             owner_name: owner.to_string(),
@@ -23,7 +23,7 @@ mod dynamodb {
         create_dynamo_lock_with(key, opts).await
     }
 
-    async fn create_dynamo_lock_with(key: &str, opts: Options) -> DynamoDbLockClient {
+    async fn create_dynamo_lock_with(key: &str, opts: DynamoDbOptions) -> DynamoDbLockClient {
         crate::s3_common::setup();
         let client = DynamoDbClient::new(crate::s3_common::region());
         let _ = client
@@ -142,7 +142,7 @@ mod dynamodb {
     async fn test_non_expirable_lock() {
         let key = "test_non_expirable_lock";
 
-        let opts = |owner: &str| Options {
+        let opts = |owner: &str| DynamoDbOptions {
             partition_key_value: key.to_string(),
             table_name: TABLE.to_string(),
             owner_name: owner.to_string(),

--- a/rust/tests/repair_s3_rename_test.rs
+++ b/rust/tests/repair_s3_rename_test.rs
@@ -128,7 +128,7 @@ mod s3 {
         let client = S3Client::new_with(dispatcher, ChainProvider::new(), s3_common::region());
         let lock_client = dynamodb_lock::DynamoDbLockClient::new(
             rusoto_dynamodb::DynamoDbClient::new(s3_common::region()),
-            dynamodb_lock::Options::default(),
+            dynamodb_lock::DynamoDbOptions::default(),
         );
 
         (

--- a/rust/tests/s3_test.rs
+++ b/rust/tests/s3_test.rs
@@ -6,6 +6,7 @@ mod s3_common;
 mod s3 {
     use crate::s3_common::setup;
     use deltalake::storage;
+    use deltalake::{dynamo_lock_options, s3_storage_options};
     use maplit::hashmap;
     use serial_test::serial;
 
@@ -27,11 +28,12 @@ mod s3 {
         let storage = storage::get_backend_for_uri_with_options(
             table_uri,
             hashmap! {
-                storage::s3_storage_options::AWS_REGION.to_string() => "us-east-2".to_string(),
+                s3_storage_options::AWS_REGION.to_string() => "us-east-2".to_string(),
+                dynamo_lock_options::DYNAMO_LOCK_OWNER_NAME.to_string() => "s3::deltars/simple".to_string(),
             },
         )
         .unwrap();
-        let table = deltalake::DeltaTable::new(table_uri, storage).unwrap();
+        let mut table = deltalake::DeltaTable::new(table_uri, storage).unwrap();
         table.load().await.unwrap();
         println!("{}", table);
 


### PR DESCRIPTION
# Description

Add S3StorageOptions to allow configuring S3 backend explicitly (rather than through env).

This enables different backend configuration for two different delta tables (which is a need in kafka-delta-ingest for dead lettering to delta). With this change, we can configure two different storage backends with different parameters (specifically DynamoDb lock name difference is needed for our use case) and use the `DeltaTable::new` factory (https://github.com/delta-io/delta-rs/blob/main/rust/src/delta.rs#L1038).

# Related Issue(s)

Does not reference an existing delta-rs issue, but required for dead lettering to delta in kafka-delta-ingest - https://github.com/delta-io/kafka-delta-ingest/pull/69
