### PR TITLE
[README] Replace the inactive rust-dataframe with polars

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ This library provides low level access to Delta tables in Rust, which can be
 used with data processing frameworks like
 link:https://github.com/apache/arrow-datafusion[datafusion],
 link:https://github.com/apache/arrow-datafusion/tree/master/ballista[ballista],
-link:https://github.com/nevi-me/rust-dataframe[rust-dataframe],
+link:https://github.com/pola-rs/polars[polars],
 link:https://github.com/rajasekarv/vega[vega], etc. It also provides bindings to other higher level languages such as link:https://delta-io.github.io/delta-rs/python/[Python], Ruby, or Golang.
 
 === Features


### PR DESCRIPTION
It looks like rust-dataframe is inactive while https://github.com/pola-rs/polars is being actively developed and has sponsors too

