### PR TITLE
Add is_non_acquirable field to the dynamodb lock

### DIFF
--- a/rust/src/storage/s3/dynamodb_lock.rs
+++ b/rust/src/storage/s3/dynamodb_lock.rs
@@ -157,6 +157,13 @@ pub enum DynamoError {
     /// Error returned by [`DynamoDbLockClient::acquire_lock`] which indicates that the lock could
     /// not be acquired because the `is_non_acquirable` is set to `true`.
     /// Usually this is done intentionally outside of [`DynamoDbLockClient`].
+    ///
+    /// The example could be the dropping of a table. For example external service acquires the lock
+    /// to drop (or drop/create etc., something that modifies the delta log completely) a table.
+    /// The dangerous part here is that the concurrent delta workers will still perform the write
+    /// whenever the lock is available, because it effectively locks the rename operation. However
+    /// if the `is_non_acquirable` is set, then the `NonAcquirableLock` is returned which prohibits
+    /// the delta-rs to continue the write.
     #[error("The existing lock in dynamodb is non-acquirable")]
     NonAcquirableLock,
 

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -636,8 +636,10 @@ pub struct LockItem {
     pub data: Option<String>,
     /// The last time this lock was updated or retrieved.
     pub lookup_time: u128,
-    /// Tells whether this lock was acquired by expiring existing one
+    /// Tells whether this lock was acquired by expiring existing one.
     pub acquired_expired_lock: bool,
+    /// If true then this lock could not be acquired.
+    pub is_non_acquirable: bool,
 }
 
 /// Lock data which stores an attempt to rename `source` into `destination`


### PR DESCRIPTION
# Description
If there's any outside of delta-rs writes to the table that are done with s3 backend and dynamodb lock, we want the mechanism to immediately stop delta-rs writes if required. 

The example could be the dropping of a table. For example you acquire a lock and then try drop (or drop/create etc., something that modifies the delta log completely) a table. The dangerous part here is that the concurrent delta workers will still perform the write whenever the lock is available, because we effectively lock the `rename` operation. 

To prevent that, this PR introduces a `is_non_acquirable` that will cause delta-rs writer to fail immediately (or to be precise return the specific error) when the remote lock has this field set. For this to work, the outside of delta-rs writer, which performs the dangerous operation, has to set this field by itself once the lock is acquired.