### PR TITLE
Optimize remove action apply with early iteration exit #424

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1509,7 +1509,10 @@ fn process_action(state: &mut DeltaTableState, action: Action) -> Result<(), App
             state.files.push(v);
         }
         Action::remove(v) => {
-            state.files.retain(|a| *a.path != v.path);
+            let index = { state.files.iter().position(|a| *a.path == v.path) };
+            if let Some(index) = index {
+                state.files.remove(index);
+            }
             state.tombstones.push(v);
         }
         Action::protocol(v) => {

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1511,7 +1511,7 @@ fn process_action(state: &mut DeltaTableState, action: Action) -> Result<(), App
         Action::remove(v) => {
             let index = { state.files.iter().position(|a| *a.path == v.path) };
             if let Some(index) = index {
-                state.files.remove(index);
+                state.files.swap_remove(index);
             }
             state.tombstones.push(v);
         }

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -15,7 +15,7 @@ async fn read_simple_table() {
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
-        table.get_files(),
+        table.get_files().sort(),
         vec![
             "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
             "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
@@ -23,6 +23,7 @@ async fn read_simple_table() {
             "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
             "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet",
         ]
+        .sort()
     );
     let tombstones = table.get_state().all_tombstones();
     assert_eq!(tombstones.len(), 31);
@@ -38,25 +39,25 @@ async fn read_simple_table() {
     );
     #[cfg(unix)]
     {
-        let paths: Vec<String> = vec![
+        let mut paths: Vec<String> = vec![
                 "./tests/data/simple_table/part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet".to_string(),
                 "./tests/data/simple_table/part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet".to_string(),
                 "./tests/data/simple_table/part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet".to_string(),
                 "./tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet".to_string(),
                 "./tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),
             ];
-        assert_eq!(table.get_file_uris(), paths);
+        assert_eq!(table.get_file_uris().sort(), paths.sort());
     }
     #[cfg(windows)]
     {
-        let paths: Vec<String> = vec![
+        let mut paths: Vec<String> = vec![
                 "./tests/data/simple_table\\part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet".to_string(),
                 "./tests/data/simple_table\\part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet".to_string(),
                 "./tests/data/simple_table\\part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet".to_string(),
                 "./tests/data/simple_table\\part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet".to_string(),
                 "./tests/data/simple_table\\part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),
             ];
-        assert_eq!(table.get_file_uris(), paths);
+        assert_eq!(table.get_file_uris().sort(), paths.sort());
     }
 }
 
@@ -87,7 +88,7 @@ async fn read_simple_table_with_version() {
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
-        table.get_files(),
+        table.get_files().sort(),
         vec![
             "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
             "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
@@ -96,6 +97,7 @@ async fn read_simple_table_with_version() {
             "part-00006-46f2ff20-eb5d-4dda-8498-7bfb2940713b-c000.snappy.parquet",
             "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
         ]
+        .sort()
     );
 
     table = deltalake::open_table_with_version("./tests/data/simple_table", 3)
@@ -105,7 +107,7 @@ async fn read_simple_table_with_version() {
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
-        table.get_files(),
+        table.get_files().sort(),
         vec![
             "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
             "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
@@ -113,7 +115,8 @@ async fn read_simple_table_with_version() {
             "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
             "part-00000-f17fcbf5-e0dc-40ba-adae-ce66d1fcaef6-c000.snappy.parquet",
             "part-00001-bb70d2ba-c196-4df2-9c85-f34969ad3aa9-c000.snappy.parquet",
-        ],
+        ]
+        .sort(),
     );
 }
 


### PR DESCRIPTION
# Description
Right now, we use `Iterator::retain` to remove files from active file list when applying remove actions from the transaction log. This can be optimized by performing an early exit of the iteration when we reach the file that needs to be removed.

1. Find the position of the file.
2. Remove the file from the vector.

# Related Issue(s)
- closes #424 
