### PR TITLE
Throw an error when filter key is not in partitioned columns.

### DIFF
--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -244,7 +244,7 @@ def test_get_files_partitioned_table():
         dt.files_by_partitions(partition_filters=partition_filters)
     assert (
         str(exception.value)
-        == 'Invalid partition filter found: PartitionFilter { key: "unknown", value: Equal("3") }.'
+        == 'Invalid partition filter found: [PartitionFilter { key: "unknown", value: Equal("3") }].'
     )
 
 

--- a/rust/src/partitions.rs
+++ b/rust/src/partitions.rs
@@ -1,7 +1,6 @@
 //! Delta Table partition handling logic.
 
 use crate::DeltaTableError;
-use std::collections::HashSet;
 use std::convert::TryFrom;
 
 /// A Enum used for selecting the partition value operation when filtering a DeltaTable partition.
@@ -44,21 +43,10 @@ impl<'a> PartitionFilter<'a, &str> {
 
     /// Indicates if one of the DeltaTable partition among the list
     /// matches with the partition filter.
-    pub fn match_partitions(
-        &self,
-        partitions: &[DeltaTablePartition<'a>],
-    ) -> Result<bool, DeltaTableError> {
-        let all_partition_keys: HashSet<&str> =
-            partitions.iter().map(|partition| partition.key).collect();
-        if !all_partition_keys.contains(self.key) {
-            Err(DeltaTableError::InvalidPartitionFilter {
-                partition_filter: format!("{:?}", self),
-            })
-        } else {
-            Ok(partitions
-                .iter()
-                .any(|partition| self.match_partition(partition)))
-        }
+    pub fn match_partitions(&self, partitions: &[DeltaTablePartition<'a>]) -> bool {
+        partitions
+            .iter()
+            .any(|partition| self.match_partition(partition))
     }
 }
 

--- a/rust/tests/read_delta_partitions_test.rs
+++ b/rust/tests/read_delta_partitions_test.rs
@@ -93,36 +93,7 @@ fn test_match_filters() {
         value: deltalake::PartitionValue::Equal("2020"),
     };
 
-    assert_eq!(valid_filters.match_partitions(&partitions).unwrap(), true);
-    assert_eq!(
-        valid_filter_month.match_partitions(&partitions).unwrap(),
-        true
-    );
-    assert_eq!(invalid_filter.match_partitions(&partitions).unwrap(), false);
-}
-
-#[test]
-fn test_invalid_filter_key() {
-    let partitions = vec![
-        deltalake::DeltaTablePartition {
-            key: "year",
-            value: "2021",
-        },
-        deltalake::DeltaTablePartition {
-            key: "month",
-            value: "12",
-        },
-    ];
-
-    let invalid_filter = deltalake::PartitionFilter {
-        key: "value",
-        value: deltalake::PartitionValue::Equal("1"),
-    };
-
-    assert!(matches!(
-        invalid_filter.match_partitions(&partitions).unwrap_err(),
-        deltalake::DeltaTableError::InvalidPartitionFilter {
-            partition_filter: _
-        },
-    ));
+    assert_eq!(valid_filters.match_partitions(&partitions), true);
+    assert_eq!(valid_filter_month.match_partitions(&partitions), true);
+    assert_eq!(invalid_filter.match_partitions(&partitions), false);
 }


### PR DESCRIPTION
# Description

Throw an error when filter key is not in partitioned columns.

# Related Issue(s)

- closes #473 

# Documentation
