### PR TITLE
Add DeltaTableError in Python binding

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"

--- a/python/deltalake/__init__.py
+++ b/python/deltalake/__init__.py
@@ -1,4 +1,4 @@
 from .data_catalog import DataCatalog
-from .deltalake import RawDeltaTable, rust_core_version
+from .deltalake import PyDeltaTableError, RawDeltaTable, rust_core_version
 from .schema import DataType, Field, Schema
 from .table import DeltaTable, Metadata

--- a/python/deltalake/fs.py
+++ b/python/deltalake/fs.py
@@ -64,7 +64,7 @@ class DeltaStorageHandler(FileSystemHandler):
         Create a directory and subdirectories.
 
         This function succeeds if the directory already exists.
-        
+
         :param path: The path of the new directory.
         :param recursive: Create nested directories as well.
         """

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -74,3 +74,7 @@ addopts = "--cov=deltalake -v -m 'not integration'"
 testpaths = [
     "tests",
 ]
+markers = [
+    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
+    "s3: marks tests as integration tests with S3 (deselect with '-m \"not s3\"')",
+]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -284,6 +284,6 @@ fn deltalake(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<RawDeltaTable>()?;
     m.add_class::<RawDeltaTableMetaData>()?;
     m.add_class::<DeltaStorageFsBackend>()?;
-    m.add("DeltaTableError", py.get_type::<PyDeltaTableError>())?;
+    m.add("PyDeltaTableError", py.get_type::<PyDeltaTableError>())?;
     Ok(())
 }

--- a/python/stubs/deltalake/deltalake.pyi
+++ b/python/stubs/deltalake/deltalake.pyi
@@ -1,5 +1,6 @@
 from typing import Any, Callable
 
 RawDeltaTable: Any
+PyDeltaTableError: Any
 rust_core_version: Callable[[], str]
 DeltaStorageFsBackend: Any

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -261,6 +261,12 @@ def test_delta_table_with_filesystem():
     assert dt.to_pandas(filesystem=filesystem).equals(pd.DataFrame({"id": [5, 7, 9]}))
 
 
+def test_import_delta_table_error():
+    from deltalake import PyDeltaTableError
+
+    PyDeltaTableError()
+
+
 class ExcPassThroughThread(Thread):
     """Wrapper around `threading.Thread` that propagates exceptions."""
 


### PR DESCRIPTION
# Description
- Add PyDeltaTableError in Python binding
- Add markers for pytest
- Bump version to `0.5.4`

# Related Issue(s)
- close https://github.com/delta-io/delta-rs/issues/493
