### PR TITLE
Fix nullable partition values

### DIFF
--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -38,12 +38,7 @@ fn populate_hashmap_with_option_from_parquet_map(
                 .map_err(|_| "key for HashMap in parquet has to be a string")?
                 .clone(),
         )
-        .or_insert(Some(
-            values
-                .get_string(j)
-                .map_err(|_| "value for HashMap in parquet has to be a string")?
-                .clone(),
-        ));
+        .or_insert_with(|| values.get_string(j).ok().cloned());
     }
 
     Ok(())

--- a/rust/tests/read_delta_partitions_test.rs
+++ b/rust/tests/read_delta_partitions_test.rs
@@ -1,8 +1,14 @@
 extern crate deltalake;
 
+use deltalake::action::Add;
 use deltalake::schema::SchemaDataType;
+use maplit::hashmap;
+use serde_json::json;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+
+#[allow(dead_code)]
+mod fs_common;
 
 #[test]
 fn test_create_delta_table_partition() {
@@ -114,4 +120,50 @@ fn test_match_filters() {
         invalid_filter.match_partitions(&partitions, &partition_data_types),
         false
     );
+}
+
+#[tokio::test]
+async fn read_null_partitions_from_checkpoint() {
+    let mut table = fs_common::create_table_from_json(
+        "./tests/data/read_null_partitions_from_checkpoint",
+        json!({
+            "type": "struct",
+            "fields": [
+                {"name":"id","type":"integer","metadata":{},"nullable":true},
+                {"name":"color","type":"string","metadata":{},"nullable":true},
+            ]
+        }),
+        vec!["color"],
+        json!({}),
+    )
+    .await;
+
+    println!("{}", table.table_uri);
+
+    let delta_log = std::path::Path::new(&table.table_uri).join("_delta_log");
+
+    let add = |partition: Option<String>| Add {
+        partition_values: hashmap! {
+            "color".to_string() => partition
+        },
+        ..fs_common::add(0)
+    };
+
+    fs_common::commit_add(&mut table, &add(Some("red".to_string()))).await;
+    fs_common::commit_add(&mut table, &add(None)).await;
+    deltalake::checkpoints::create_checkpoint_from_table(&table)
+        .await
+        .unwrap();
+
+    // remove 0 version log to explicitly show that metadata is read from cp
+    std::fs::remove_file(delta_log.clone().join("00000000000000000000.json")).unwrap();
+
+    let cp = delta_log
+        .clone()
+        .join("00000000000000000002.checkpoint.parquet");
+    assert!(cp.exists());
+
+    // verify that table loads from checkpoint and handles null partitions
+    let table = deltalake::open_table(&table.table_uri).await.unwrap();
+    assert_eq!(table.version, 2);
 }


### PR DESCRIPTION
If checkpoint contains the partition with null value, the `populate_hashmap_with_option_from_parquet_map` will fail to read it because it expects the value to be present, despite the map being `HashMap<String, Option<String>>`