### PR TITLE
Add bool config enableExpiredLogCleanup

### DIFF
--- a/rust/src/checkpoints.rs
+++ b/rust/src/checkpoints.rs
@@ -97,7 +97,7 @@ pub async fn create_checkpoint_from_table_uri(
     )
     .await?;
 
-    if table.version >= 0 {
+    if table.version >= 0 && table.get_state().enable_expired_log_cleanup() {
         let deleted_log_num = cleanup_expired_logs(
             table.version + 1,
             table.storage.as_ref(),
@@ -121,7 +121,7 @@ pub async fn create_checkpoint_from_table(table: &DeltaTable) -> Result<(), Chec
     )
     .await?;
 
-    if table.version >= 0 {
+    if table.version >= 0 && table.get_state().enable_expired_log_cleanup() {
         let deleted_log_num = cleanup_expired_logs(
             table.version + 1,
             table.storage.as_ref(),

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -31,6 +31,7 @@ mod rename;
 /// * Support for other platforms are not implemented at the moment.
 #[derive(Default, Debug)]
 pub struct FileStorageBackend {
+    #[allow(dead_code)]
     root: String,
 }
 


### PR DESCRIPTION
# Description

This is the follow up work of #484. This patch adds one bool config `enableExpiredLogCleanup` which is also documented in official delta lake implementation. The config controls whether to clean up expired checkpoints and logs.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
