### PR TITLE
pin arrow to major version

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,8 +55,8 @@ async-stream = { version = "0.3.2", default-features = true, optional = true }
 # High-level writer
 parquet-format = "~2.6.1"
 
-arrow = "6.1.0"
-parquet = "6.1.0"
+arrow = "6"
+parquet = "6"
 datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "e62cb455955e120cfe9d8935aa3ebc8726369d15", optional = true }
 
 crossbeam = { version = "0", optional = true }


### PR DESCRIPTION
# Description

Makes it more flexible for downstream consumers. We can expect no breaking api changes in arrow within the same major version releases.