### PR TITLE
Retry S3 get request on 500 Internal Server Error

### DIFF
--- a/rust/tests/repair_s3_rename_test.rs
+++ b/rust/tests/repair_s3_rename_test.rs
@@ -6,7 +6,7 @@ mod s3_common;
 mod s3 {
 
     use crate::s3_common;
-    use deltalake::storage::s3::{dynamodb_lock, S3StorageBackend};
+    use deltalake::storage::s3::{dynamodb_lock, S3StorageBackend, S3StorageOptions};
     use deltalake::{StorageBackend, StorageError};
     use rusoto_core::credential::ChainProvider;
     use rusoto_core::request::DispatchSignedRequestFuture;
@@ -132,7 +132,11 @@ mod s3 {
         );
 
         (
-            S3StorageBackend::new_with(client, Some(Box::new(lock_client))),
+            S3StorageBackend::new_with(
+                client,
+                Some(Box::new(lock_client)),
+                S3StorageOptions::default(),
+            ),
             pause_until_true,
         )
     }


### PR DESCRIPTION
# Description
We're getting 500 errors in kafka-delta-ingest on get requests (especially with several workers), which is expected and such requests have to be retried
```
<Error><Code>InternalError</Code><Message>We encountered an internal error. Please try again.</Message>
```
 
We've already tested this in high load environments and this fix helped us avoid unnecessary restarts https://github.com/delta-io/delta-rs/tree/kdi-partition-values-quick-fix.

I've tried to find some universal approach to retry every s3 requests, but couldn't figure out one due to rusoto restrictions 