### PR TITLE
Fix S3 list_objs and cleanup_metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "arrow"
-version = "6.1.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a900a6164aa0abf26d7a6dfea727116a3619456decfbf573e60c7615bf49e84c"
+checksum = "46cb449d481a6b13ea4e82e9fc662ea3e29cb5dc0a310fc42e27592cef3cb611"
 dependencies = [
  "bitflags",
  "chrono",
@@ -397,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "4.1.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e95a3e867422fd8d04049041f5671f94d53c32a9dcd82e2be268714942f3f3"
+checksum = "c42350b81f044f576ff88ac750419f914abb46a03831bb1747134344ee7a4e64"
 dependencies = [
  "strum",
  "strum_macros",
@@ -584,7 +584,8 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "6.0.0"
-source = "git+https://github.com/apache/arrow-datafusion?rev=e62cb455955e120cfe9d8935aa3ebc8726369d15#e62cb455955e120cfe9d8935aa3ebc8726369d15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e4a8a1f1ee057b2c27a01f050b9dffe56e8d43605d0201234b353a3cc1eb2f"
 dependencies = [
  "ahash",
  "arrow",
@@ -668,7 +669,7 @@ version = "0.5.4"
 dependencies = [
  "chrono",
  "deltalake",
- "env_logger 0.7.1",
+ "env_logger 0.9.0",
  "pyo3",
  "reqwest",
  "serde_json",
@@ -1767,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "6.1.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a30c6117ed7e42e115887483c0b81277f4c2e3c17cc10c6c4244c1113e6e611"
+checksum = "479de475fbb7abf51e39cde69da3cc902d13a6fcb9259993f98688325e6a1ee7"
 dependencies = [
  "arrow",
  "base64",
@@ -2679,15 +2680,15 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
 
 [[package]]
 name = "strum_macros"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/aws/delta-checkpoint/src/main.rs
+++ b/aws/delta-checkpoint/src/main.rs
@@ -46,7 +46,8 @@ async fn process_event(event: &Value) -> Result<(), CheckPointLambdaError> {
             table_uri, version
         );
 
-        checkpoints::create_checkpoint_from_table_uri(&table_uri, version).await?;
+        checkpoints::create_checkpoint_from_table_uri_and_cleanup(&table_uri, version, None)
+            .await?;
     } else {
         info!(
             "Not writing checkpoint for table uri {} at delta version {}.",

--- a/rust/src/delta_arrow.rs
+++ b/rust/src/delta_arrow.rs
@@ -16,7 +16,7 @@ impl TryFrom<&schema::Schema> for ArrowSchema {
         let fields = s
             .get_fields()
             .iter()
-            .map(|field| <ArrowField as TryFrom<&schema::SchemaField>>::try_from(field))
+            .map(<ArrowField as TryFrom<&schema::SchemaField>>::try_from)
             .collect::<Result<Vec<ArrowField>, ArrowError>>()?;
 
         Ok(ArrowSchema::new(fields))
@@ -125,7 +125,7 @@ impl TryFrom<&schema::SchemaDataType> for ArrowDataType {
             schema::SchemaDataType::r#struct(s) => Ok(ArrowDataType::Struct(
                 s.get_fields()
                     .iter()
-                    .map(|f| <ArrowField as TryFrom<&schema::SchemaField>>::try_from(f))
+                    .map(<ArrowField as TryFrom<&schema::SchemaField>>::try_from)
                     .collect::<Result<Vec<ArrowField>, ArrowError>>()?,
             )),
             schema::SchemaDataType::array(a) => {

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -466,6 +466,7 @@ impl From<AzureError> for StorageError {
 }
 
 /// Describes metadata of a storage object.
+#[derive(Debug)]
 pub struct ObjectMeta {
     /// The path where the object is stored. This is the path component of the object URI.
     ///

--- a/rust/tests/read_delta_partitions_test.rs
+++ b/rust/tests/read_delta_partitions_test.rs
@@ -151,7 +151,7 @@ async fn read_null_partitions_from_checkpoint() {
 
     fs_common::commit_add(&mut table, &add(Some("red".to_string()))).await;
     fs_common::commit_add(&mut table, &add(None)).await;
-    deltalake::checkpoints::create_checkpoint_from_table(&table)
+    deltalake::checkpoints::create_checkpoint(&table)
         .await
         .unwrap();
 

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -8,6 +8,7 @@ use pretty_assertions::assert_eq;
 use std::collections::HashMap;
 use std::time::SystemTime;
 
+#[allow(dead_code)]
 mod fs_common;
 
 #[tokio::test]


### PR DESCRIPTION
The `list_objs` for s3 returned a list of `ObjectMeta` with a `path` as `key` instead of `s3_path`. E.g.
`ObjectMeta { path: 'table/_delta_log' }` instead of `ObjectMeta { path: 's3://bucket/table/_delta_log' }`. However, the `head_obj` for example returns expected s3 uri.

This was found when running `cleanup_metadata` on S3, since it uses `list_objs` to list objects. So primary testing are done within a scope of this feature. I've also replicated tests with fs to be consistent. Also note that there's no workaround to pauses as S3 doesnt allow you to change object modified metadata.  