### PR TITLE
[Python] Create PyArrow dataset fragments from delta log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+**/target
 *.sw*
 tlaplus/*.toolbox/*_SnapShot_*/
 tlaplus/*.toolbox/*_SnapShot_*.launch

--- a/python/.cargo/config
+++ b/python/.cargo/config
@@ -3,3 +3,9 @@ rustflags = [
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -264,6 +264,8 @@ class DeltaTable:
             filesystem = pa_fs.PyFileSystem(
                 DeltaStorageHandler(self._table.table_uri())
             )
+        
+        format = ParquetFileFormat()
 
         files = self._table.files_with_stats()
         if partitions:
@@ -273,7 +275,7 @@ class DeltaTable:
         # TODO: Add partition values
 
         fragments = (
-            ParquetFileFormat.make_fragment(
+            format.make_fragment(
                 file.path,
                 filesystem=filesystem,
                 partition_expression=_stats_to_pyarrow_expression(file),
@@ -282,7 +284,7 @@ class DeltaTable:
         )
 
         return FileSystemDataset(
-            fragments, self.pyarrow_schema(), ParquetFileFormat, filesystem
+            fragments, self.pyarrow_schema(), format, filesystem
         )
 
     def to_pyarrow_table(

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -342,6 +342,13 @@ def _stats_to_pyarrow_expression(stats: FileStats) -> Expression:
     for column, maximum in stats.max_values.items():
         expressions.append(field(column) <= maximum)
 
+    for column, null_count in stats.null_counts.items():
+        if null_count == stats.num_records:
+            expressions.append(field(column).is_null())
+
+        if null_count == 0:
+            expressions.append(~field(column).is_null())
+
     if len(expressions) > 0:
         return reduce(lambda a, b: a & b, expressions)
     else:

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -273,8 +273,6 @@ class DeltaTable:
             filter_set = set(self._table.files_by_partitions(partitions))
             files = [stat for stat in files if stat.path in filter_set]
 
-        # TODO: Add partition values
-
         fragments = (
             format.make_fragment(
                 file.path,
@@ -334,8 +332,15 @@ class DeltaTable:
 
 def _stats_to_pyarrow_expression(stats: FileStats) -> Expression:
     expressions = []
+
     for partition_column, partition_value in stats.partition_values.items():
         expressions.append(field(partition_column) == partition_value)
+
+    for column, minimum in stats.min_values.items():
+        expressions.append(field(column) >= minimum)
+
+    for column, maximum in stats.max_values.items():
+        expressions.append(field(column) <= maximum)
 
     if len(expressions) > 0:
         return reduce(lambda a, b: a & b, expressions)

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -239,14 +239,14 @@ impl RawDeltaTable {
             .map(|res| {
                 let result = match res {
                     Ok((path, Some(stats))) => FileStats {
-                        file_path: path.to_string(),
+                        path: path.to_string(),
                         num_records: stats.num_records,
                         min_values: HashMap::new(),
                         max_values: HashMap::new(),
                         null_counts: HashMap::new(),
                     },
                     Ok((path, None)) => FileStats {
-                        file_path: path.to_string(),
+                        path: path.to_string(),
                         num_records: 0,
                         min_values: HashMap::new(),
                         max_values: HashMap::new(),
@@ -263,7 +263,7 @@ impl RawDeltaTable {
 #[pyclass]
 pub struct FileStats {
     #[pyo3(get)]
-    file_path: String,
+    path: String,
     #[pyo3(get)]
     num_records: i64,
     #[pyo3(get)]
@@ -324,7 +324,7 @@ fn deltalake(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<RawDeltaTable>()?;
     m.add_class::<RawDeltaTableMetaData>()?;
     m.add_class::<DeltaStorageFsBackend>()?;
-    m.add_class::<FileStats>()?;
+    // m.add_class::<FileStats>()?;
     m.add("PyDeltaTableError", py.get_type::<PyDeltaTableError>())?;
     Ok(())
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -238,15 +238,17 @@ impl RawDeltaTable {
             .get_stats_iter()
             .map(|res| {
                 let result = match res {
-                    Ok((path, Some(stats))) => FileStats {
-                        path: path,
+                    Ok((path, partition_values, Some(stats))) => FileStats {
+                        path,
+                        partition_values: partition_values.clone(),
                         num_records: stats.num_records,
                         min_values: HashMap::new(),
                         max_values: HashMap::new(),
                         null_counts: HashMap::new(),
                     },
-                    Ok((path, None)) => FileStats {
-                        path: path,
+                    Ok((path, partition_values, None)) => FileStats {
+                        path,
+                        partition_values: partition_values.clone(),
                         num_records: 0,
                         min_values: HashMap::new(),
                         max_values: HashMap::new(),
@@ -264,6 +266,8 @@ impl RawDeltaTable {
 pub struct FileStats {
     #[pyo3(get)]
     path: String,
+    #[pyo3(get)]
+    partition_values: HashMap<String, Option<String>>,
     #[pyo3(get)]
     num_records: i64,
     #[pyo3(get)]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -41,10 +41,7 @@ impl PyDeltaTableError {
     }
 
     fn from_chrono(err: chrono::ParseError) -> pyo3::PyErr {
-        PyDeltaTableError::new_err(format!(
-            "Parse date and time string failed: {}",
-            err.to_string()
-        ))
+        PyDeltaTableError::new_err(format!("Parse date and time string failed: {}", err))
     }
 }
 
@@ -257,7 +254,7 @@ impl RawDeltaTable {
                 None => true,
             })
             .map(|((path, partition_values), stats)| {
-                let stats = stats.map_err(|err| PyDeltaTableError::from_raw(err))?;
+                let stats = stats.map_err(PyDeltaTableError::from_raw)?;
                 let expression = filestats_to_expression(py, partition_values, stats)?;
                 Ok((path, expression))
             })
@@ -271,11 +268,11 @@ fn json_value_to_py(value: &serde_json::Value, py: Python) -> PyObject {
         serde_json::Value::Bool(val) => val.to_object(py),
         serde_json::Value::Number(val) => {
             if val.is_f64() {
-                return val.as_f64().expect("not an f64").to_object(py);
+                val.as_f64().expect("not an f64").to_object(py)
             } else if val.is_i64() {
-                return val.as_i64().expect("not an i64").to_object(py);
+                val.as_i64().expect("not an i64").to_object(py)
             } else {
-                return val.as_u64().expect("not an u64").to_object(py);
+                val.as_u64().expect("not an u64").to_object(py)
             }
         }
         serde_json::Value::String(val) => val.to_object(py),
@@ -337,13 +334,13 @@ fn filestats_to_expression<'py>(
         }
     }
 
-    if expressions.len() == 0 {
-        return Ok(None);
+    if expressions.is_empty() {
+        Ok(None)
     } else {
-        return expressions
+        expressions
             .into_iter()
             .reduce(|accum, item| accum?.getattr("__and__")?.call1((item?,)))
-            .transpose();
+            .transpose()
     }
 }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -234,28 +234,25 @@ impl RawDeltaTable {
     }
 
     pub fn files_with_stats(&mut self) -> PyResult<Vec<FileStats>> {
-        self._table.get_stats_iter()
+        self._table
+            .get_stats_iter()
             .map(|res| {
                 let result = match res {
-                    Ok((path, Some(stats))) => {
-                        FileStats {
-                            file_path: path.to_string(),
-                            num_records: stats.num_records,
-                            min_values: HashMap::new(),
-                            max_values: HashMap::new(),
-                            null_counts: HashMap::new()
-                        }
+                    Ok((path, Some(stats))) => FileStats {
+                        file_path: path.to_string(),
+                        num_records: stats.num_records,
+                        min_values: HashMap::new(),
+                        max_values: HashMap::new(),
+                        null_counts: HashMap::new(),
                     },
-                    Ok((path, None)) => {
-                        FileStats {
-                            file_path: path.to_string(),
-                            num_records: 0,
-                            min_values: HashMap::new(),
-                            max_values: HashMap::new(),
-                            null_counts: HashMap::new()
-                        }
+                    Ok((path, None)) => FileStats {
+                        file_path: path.to_string(),
+                        num_records: 0,
+                        min_values: HashMap::new(),
+                        max_values: HashMap::new(),
+                        null_counts: HashMap::new(),
                     },
-                    Err(err) => return Err(PyDeltaTableError::from_raw(err))
+                    Err(err) => return Err(PyDeltaTableError::from_raw(err)),
                 };
                 Ok(result)
             })

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -310,14 +310,14 @@ fn filestats_to_expression<'py>(
             // Blocked on https://issues.apache.org/jira/browse/ARROW-11259
             _ => None,
         }) {
-            expressions.push(field.call1((column,))?.call_method1("__gt__", (minimum,)));
+            expressions.push(field.call1((column,))?.call_method1("__ge__", (minimum,)));
         }
 
         for (column, maximum) in stats.max_values.iter().filter_map(|(k, v)| match v {
             ColumnValueStat::Value(val) => Some((k.clone(), json_value_to_py(val, py))),
             _ => None,
         }) {
-            expressions.push(field.call1((column,))?.call_method1("__lt__", (maximum,)));
+            expressions.push(field.call1((column,))?.call_method1("__le__", (maximum,)));
         }
 
         for (column, null_count) in stats.null_count.iter().filter_map(|(k, v)| match v {

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -239,14 +239,14 @@ impl RawDeltaTable {
             .map(|res| {
                 let result = match res {
                     Ok((path, Some(stats))) => FileStats {
-                        path: path.to_string(),
+                        path: path,
                         num_records: stats.num_records,
                         min_values: HashMap::new(),
                         max_values: HashMap::new(),
                         null_counts: HashMap::new(),
                     },
                     Ok((path, None)) => FileStats {
-                        path: path.to_string(),
+                        path: path,
                         num_records: 0,
                         min_values: HashMap::new(),
                         max_values: HashMap::new(),
@@ -324,7 +324,7 @@ fn deltalake(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<RawDeltaTable>()?;
     m.add_class::<RawDeltaTableMetaData>()?;
     m.add_class::<DeltaStorageFsBackend>()?;
-    // m.add_class::<FileStats>()?;
+    m.add_class::<FileStats>()?;
     m.add("PyDeltaTableError", py.get_type::<PyDeltaTableError>())?;
     Ok(())
 }

--- a/python/stubs/deltalake/deltalake.pyi
+++ b/python/stubs/deltalake/deltalake.pyi
@@ -1,6 +1,5 @@
 from typing import Any, Callable
 
-FileStats: Any
 RawDeltaTable: Any
 PyDeltaTableError: Any
 rust_core_version: Callable[[], str]

--- a/python/stubs/deltalake/deltalake.pyi
+++ b/python/stubs/deltalake/deltalake.pyi
@@ -1,5 +1,6 @@
 from typing import Any, Callable
 
+FileStats: Any
 RawDeltaTable: Any
 PyDeltaTableError: Any
 rust_core_version: Callable[[], str]

--- a/python/stubs/pyarrow/dataset.pyi
+++ b/python/stubs/pyarrow/dataset.pyi
@@ -3,3 +3,5 @@ from typing import Any
 Dataset: Any
 dataset: Any
 partitioning: Any
+FileSystemDataset: Any
+ParquetFileFormat: Any

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -131,7 +131,7 @@ def test_read_table_with_filter():
         "month": ["12", "12", "12"],
         "day": ["20", "20", "4"],
     }
-    filter_expr = (ds.field("year") == 2021) and (ds.field("month") == 12)
+    filter_expr = (ds.field("year") == 2021) & (ds.field("month") == 12)
 
     assert dt.to_pyarrow_dataset().to_table(filter=filter_expr).to_pydict() == expected
 

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -158,7 +158,9 @@ def test_read_table_with_stats():
     data = dataset.to_table(filter=filter_expr)
     assert data.num_rows == 0
 
-    # This does not currently work, but should in the future.
+    # TODO(wjones127): Enable these tests once C++ Arrow implements is_null and is_valid
+    # simplification. Blocked on: https://issues.apache.org/jira/browse/ARROW-12659
+
     # filter_expr = ds.field("cases").is_null()
     # assert len(list(dataset.get_fragments(filter=filter_expr))) == 0
 

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -144,15 +144,26 @@ def test_read_table_with_filter():
 def test_read_table_with_stats():
     table_path = "../rust/tests/data/COVID-19_NYT"
     dt = DeltaTable(table_path)
-    expected = {}
-    filter_expr = ds.field("date") > "2021-02-20"
-
     dataset = dt.to_pyarrow_dataset()
 
+    filter_expr = ds.field("date") > "2021-02-20"
     assert len(list(dataset.get_fragments(filter=filter_expr))) == 2
 
     data = dataset.to_table(filter=filter_expr)
     assert data.num_rows < 147181 + 47559
+
+    filter_expr = ds.field("cases") < 0
+    assert len(list(dataset.get_fragments(filter=filter_expr))) == 0
+
+    data = dataset.to_table(filter=filter_expr)
+    assert data.num_rows == 0
+
+    # This does not currently work, but should in the future.
+    # filter_expr = ds.field("cases").is_null()
+    # assert len(list(dataset.get_fragments(filter=filter_expr))) == 0
+
+    # data = dataset.to_table(filter=filter_expr)
+    # assert data.num_rows == 0
 
 
 def test_vacuum_dry_run_simple_table():

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -18,7 +18,8 @@ def test_read_simple_table_to_dict():
 def test_read_simple_table_by_version_to_dict():
     table_path = "../rust/tests/data/delta-0.2.0"
     dt = DeltaTable(table_path, version=2)
-    assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"value": [1, 2, 3]}
+    assert dt.to_pyarrow_dataset().to_table().to_pydict() == {
+        "value": [1, 2, 3]}
 
 
 def test_load_with_datetime():
@@ -70,7 +71,8 @@ def test_load_with_datetime_bad_format():
 def test_read_simple_table_update_incremental():
     table_path = "../rust/tests/data/simple_table"
     dt = DeltaTable(table_path, version=0)
-    assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"id": [0, 1, 2, 3, 4]}
+    assert dt.to_pyarrow_dataset().to_table().to_pydict() == {
+        "id": [0, 1, 2, 3, 4]}
     dt.update_incremental()
     assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"id": [5, 7, 9]}
 
@@ -131,9 +133,10 @@ def test_read_table_with_filter():
         "month": ["12", "12", "12"],
         "day": ["20", "20", "4"],
     }
-    filter_expr = (ds.field("year") == 2021) & (ds.field("month") == 12)
+    filter_expr = (ds.field("year") == "2021") & (ds.field("month") == "12")
 
-    assert dt.to_pyarrow_dataset().to_table(filter=filter_expr).to_pydict() == expected
+    assert dt.to_pyarrow_dataset().to_table(
+        filter=filter_expr).to_pydict() == expected
 
 
 def test_read_table_with_stats():
@@ -284,7 +287,8 @@ def test_delta_table_with_filesystem():
     table_path = "../rust/tests/data/simple_table"
     dt = DeltaTable(table_path)
     filesystem = LocalFileSystem()
-    assert dt.to_pandas(filesystem=filesystem).equals(pd.DataFrame({"id": [5, 7, 9]}))
+    assert dt.to_pandas(filesystem=filesystem).equals(
+        pd.DataFrame({"id": [5, 7, 9]}))
 
 
 def test_import_delta_table_error():
@@ -373,7 +377,8 @@ def test_read_multiple_tables_from_s3_multi_threaded(s3_localstack):
             "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet",
         ]
 
-    threads = [ExcPassThroughThread(target=read_table) for _ in range(thread_count)]
+    threads = [ExcPassThroughThread(target=read_table)
+               for _ in range(thread_count)]
     for t in threads:
         t.start()
     for t in threads:

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -135,8 +135,10 @@ def test_read_table_with_filter():
     }
     filter_expr = (ds.field("year") == "2021") & (ds.field("month") == "12")
 
-    assert dt.to_pyarrow_dataset().to_table(
-        filter=filter_expr).to_pydict() == expected
+    dataset = dt.to_pyarrow_dataset()
+
+    assert len(list(dataset.get_fragments(filter=filter_expr))) == 2
+    assert dataset.to_table(filter=filter_expr).to_pydict() == expected
 
 
 def test_read_table_with_stats():
@@ -145,8 +147,11 @@ def test_read_table_with_stats():
     expected = {}
     filter_expr = ds.field("date") > "2021-02-20"
 
-    data = dt.to_pyarrow_dataset().to_table(filter=filter_expr)
+    dataset = dt.to_pyarrow_dataset()
 
+    assert len(list(dataset.get_fragments(filter=filter_expr))) == 2
+
+    data = dataset.to_table(filter=filter_expr)
     assert data.num_rows < 147181 + 47559
 
 

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -55,9 +55,7 @@ fn decode_path(raw_path: &str) -> Result<String, ActionError> {
     percent_decode(raw_path.as_bytes())
         .decode_utf8()
         .map(|c| c.to_string())
-        .map_err(|e| {
-            ActionError::InvalidField(format!("Decode path failed for action: {}", e.to_string(),))
-        })
+        .map_err(|e| ActionError::InvalidField(format!("Decode path failed for action: {}", e,)))
 }
 
 /// Struct used to represent minValues and maxValues in add action statistics.

--- a/rust/src/bin/delta-inspect.rs
+++ b/rust/src/bin/delta-inspect.rs
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
             };
 
             if files_matches.is_present("full_uri") {
-                table.get_file_uris().iter().for_each(|f| println!("{}", f));
+                table.get_file_uris().for_each(|f| println!("{}", f));
             } else {
                 table.get_files_iter().for_each(|f| println!("{}", f));
             };

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -974,10 +974,16 @@ impl DeltaTable {
     /// Returns iterator over file statistics
     pub fn get_stats_iter(
         &self,
-    ) -> impl Iterator<Item = Result<(String, Option<Stats>), DeltaTableError>> + '_ {
+    ) -> impl Iterator<
+        Item = Result<(String, &HashMap<String, Option<String>>, Option<Stats>), DeltaTableError>,
+    > + '_ {
         self.state.files().iter().map(|add| {
             let stats = add.get_stats().map_err(DeltaTableError::from)?;
-            Ok((self.storage.join_path(&self.table_uri, &add.path), stats))
+            Ok((
+                self.storage.join_path(&self.table_uri, &add.path),
+                &add.partition_values,
+                stats,
+            ))
         })
     }
 

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -972,14 +972,13 @@ impl DeltaTable {
     }
 
     /// Returns iterator over file statistics
-    pub fn get_stats_iter(&self) -> impl Iterator<Item = Result<(&str, Option<Stats>), DeltaTableError>> + '_ {
-        self.state
-            .files()
-            .iter()
-            .map(|add| {
-                let stats = add.get_stats().map_err(DeltaTableError::from)?;
-                Ok((add.path.as_ref(), stats))
-            })
+    pub fn get_stats_iter(
+        &self,
+    ) -> impl Iterator<Item = Result<(String, Option<Stats>), DeltaTableError>> + '_ {
+        self.state.files().iter().map(|add| {
+            let stats = add.get_stats().map_err(DeltaTableError::from)?;
+            Ok((self.storage.join_path(&self.table_uri, &add.path), stats))
+        })
     }
 
     /// Returns the currently loaded state snapshot.

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -971,6 +971,17 @@ impl DeltaTable {
             .collect()
     }
 
+    /// Returns iterator over file statistics
+    pub fn get_stats_iter(&self) -> impl Iterator<Item = Result<(&str, Option<Stats>), DeltaTableError>> + '_ {
+        self.state
+            .files()
+            .iter()
+            .map(|add| {
+                let stats = add.get_stats().map_err(DeltaTableError::from)?;
+                Ok((add.path.as_ref(), stats))
+            })
+    }
+
     /// Returns the currently loaded state snapshot.
     pub fn get_state(&self) -> &DeltaTableState {
         &self.state

--- a/rust/src/delta_arrow.rs
+++ b/rust/src/delta_arrow.rs
@@ -90,7 +90,7 @@ impl TryFrom<&schema::SchemaDataType> for ArrowDataType {
                         let extract = DECIMAL_REGEX.captures(decimal).ok_or_else(|| {
                             ArrowError::SchemaError(format!(
                                 "Invalid decimal type for Arrow: {}",
-                                decimal.to_string()
+                                decimal
                             ))
                         })?;
                         let precision = extract
@@ -103,7 +103,7 @@ impl TryFrom<&schema::SchemaDataType> for ArrowDataType {
                             (Some(p), Some(s)) => Ok(ArrowDataType::Decimal(p, s)),
                             _ => Err(ArrowError::SchemaError(format!(
                                 "Invalid precision or scale decimal type for Arrow: {}",
-                                decimal.to_string()
+                                decimal
                             ))),
                         }
                     }
@@ -118,7 +118,7 @@ impl TryFrom<&schema::SchemaDataType> for ArrowDataType {
                     }
                     s => Err(ArrowError::SchemaError(format!(
                         "Invalid data type for Arrow: {}",
-                        s.to_string()
+                        s
                     ))),
                 }
             }

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -103,7 +103,7 @@ impl StorageBackend for FileStorageBackend {
         if let Some(parent) = Path::new(path).parent() {
             fs::create_dir_all(parent).await?;
         }
-        let tmp_path = &format!("{}_{}", path, Uuid::new_v4().to_string());
+        let tmp_path = &format!("{}_{}", path, Uuid::new_v4());
         let mut f = fs::OpenOptions::new()
             .create(true)
             .truncate(true)

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -137,12 +137,11 @@ async fn read_delta_8_0_table_without_version() {
             "part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet"
         ]
     );
-    assert_eq!(table.get_stats().len(), 2);
+    assert_eq!(table.get_stats().count(), 2);
 
     assert_eq!(
         table
             .get_stats()
-            .into_iter()
             .map(|x| x.unwrap().unwrap().num_records)
             .sum::<i64>(),
         4
@@ -151,7 +150,6 @@ async fn read_delta_8_0_table_without_version() {
     assert_eq!(
         table
             .get_stats()
-            .into_iter()
             .map(|x| x.unwrap().unwrap().null_count["value"].as_value().unwrap())
             .collect::<Vec<i64>>(),
         vec![0, 0]

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -50,7 +50,7 @@ async fn read_simple_table() {
     }
     #[cfg(windows)]
     {
-        let mut paths = table.get_file_uris();
+        let mut paths: Vec<String> = table.get_file_uris().collect();
         paths.sort();
         let mut expected_paths: Vec<String> = vec![
                 "./tests/data/simple_table\\part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -37,7 +37,7 @@ async fn read_simple_table() {
     }));
     #[cfg(unix)]
     {
-        let mut paths = table.get_file_uris();
+        let mut paths: Vec<String> = table.get_file_uris().collect();
         paths.sort();
         let expected_paths: Vec<String> = vec![
                 "./tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),


### PR DESCRIPTION
# Description

As currently written, `DeltaTable.to_pyarrow_dataset()` will start the dataset discovery process, requiring additional IO to discover partitions and read schemas. This PR changes the implementation to populate the dataset fragments based on the delta log, which will avoid some discovery IO and also allow the datasets API to benefit from the file statistics in the log.

In detail:

 * Changed `get_file_uris()` and `get_stats()` public methods to return iterators instead of materialized vectors.
 * Added new `get_partition_values()` method that returns iterator over the partition values of each file.
 * Created new `dataset_partitions()` method in Rust `RawDeltaTable` impl, which returns the list of files and an associated partition expression (one that is guaranteed to be true for all rows in the file). Constructing this in Rust is a little more verbose in than in Python, but allows us to avoid creating intermediate objects for the Rust-Python interface. 

# Related Issue(s)

I started prototyping this based on discussion in https://issues.apache.org/jira/browse/ARROW-14730. If this is successful, I'll create issues on this repo to gradually improve the dataset functionality.
