### PR TITLE
Update schema.rs for metadata json parsing

### DIFF
--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -54,7 +54,9 @@ pub struct SchemaField {
     nullable: bool,
     // A JSON map containing information about this column. Keys prefixed with Delta are reserved
     // for the implementation.
-    metadata: HashMap<String, String>,
+    metadata: HashMap<String, serde_json::Value>,
+    // bug fix for issue 457, 524. This will enable
+    // to read metadata containing numerical value
 }
 
 impl SchemaField {


### PR DESCRIPTION
bugfix for issue 457, 524. This will enable to read metadata containing a numerical value
For more detail, please refer 
https://github.com/delta-io/delta-rs/issues/524
https://github.com/delta-io/delta-rs/issues/457

# Description
Users were facing an issue while reading delta table using delta-rs library when there was a numerical value present in the metadata column of delta transaction log. Users used to get `Failed to apply transaction log: Invalid JSON in log record error` error

# Related Issue(s)
https://github.com/delta-io/delta-rs/issues/524
https://github.com/delta-io/delta-rs/issues/457

- closes #106
--->

# Documentation
Replaced `HashMap<String, String>` with `HashMap<String, serde_json::Value>` in 
https://github.com/delta-io/delta-rs/blob/57133e161e03a34d8902abd210dca80731ce00d1/rust/src/schema.rs#L57

<!---
Share links to useful documentation
https://github.com/delta-io/delta-rs/issues/524
https://github.com/delta-io/delta-rs/issues/457
