### PR TITLE
Remove coupling of DynamoDbLockClient from S3 storage

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,1 +1,8 @@
 target/
+tests/data/action_reconciliation/
+tests/data/checkpoints_tombstones/expired/
+tests/data/checkpoints_tombstones/metadata_broken/
+tests/data/checkpoints_tombstones/metadata_false/
+tests/data/checkpoints_tombstones/metadata_true/
+tests/data/checkpoints_with_expired_logs/
+tests/data/read_null_partitions_from_checkpoint/

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -26,9 +26,7 @@ use serde::Serialize;
 use std::time::Duration;
 use uuid::Uuid;
 
-use dynamodb_lock::{
-    LockClient, LockItem, DEFAULT_MAX_RETRY_ACQUIRE_LOCK_ATTEMPTS,
-};
+use dynamodb_lock::{LockClient, LockItem, DEFAULT_MAX_RETRY_ACQUIRE_LOCK_ATTEMPTS};
 
 /// Lock data which stores an attempt to rename `source` into `destination`
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -55,7 +53,7 @@ impl LockData {
 
 /// Uses a `LockClient` to support additional features required by S3 Storage.
 pub struct S3LockClient {
-    lock_client: Box<dyn LockClient>
+    lock_client: Box<dyn LockClient>,
 }
 
 impl S3LockClient {
@@ -540,9 +538,7 @@ impl S3StorageBackend {
         lock_client: Option<Box<dyn LockClient>>,
         options: S3StorageOptions,
     ) -> Self {
-	let s3_lock_client = lock_client.map(|lc| S3LockClient {
-	    lock_client: lc
-	});
+        let s3_lock_client = lock_client.map(|lc| S3LockClient { lock_client: lc });
         Self {
             client,
             s3_lock_client,
@@ -833,11 +829,9 @@ fn try_create_lock_client(
                 dynamodb_client,
                 dynamodb_lock::DynamoDbOptions::from_map(options.extra_opts.clone()),
             );
-            Ok(Some(
-		S3LockClient {
-		    lock_client: Box::new(lock_client)
-		}
-	    ))
+            Ok(Some(S3LockClient {
+                lock_client: Box::new(lock_client),
+            }))
         }
         _ => Ok(None),
     }

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -1,4 +1,4 @@
- //! AWS S3 storage backend. It only supports a single writer and is not multi-writer safe.
+//! AWS S3 storage backend. It only supports a single writer and is not multi-writer safe.
 
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -53,7 +53,7 @@ impl LockData {
     }
 }
 
-/// A kind of `LockClient` specified for Deltalake S3 Storage Backend
+/// Uses a `LockClient` to support additional features required by S3 Storage.
 pub struct S3LockClient {
     lock_client: Box<dyn LockClient>
 }


### PR DESCRIPTION
# Description
As part of the refactoring done by https://github.com/delta-io/delta-rs/pull/508, the `LockClient` used by the S3 storage implementation got coupled to a specific implementation of the `LockClient`, i.e. `DynamoDbLockClient`.  That doesn't look to be necessary and this PR addresses that by removing that coupling and let the S3 storage support any `LockClient`. 

This is useful in cases where we may not be using S3 in AWS.  For example, one could be using MinIO, Hitachi HCP etc which implement the S3 protocol and can be used just like S3.  In these cases, a DynamoDb based lock is not required and some other implementation can be used.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
