### PR TITLE
Refresh Python usage documentation

### DIFF
--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -31,7 +31,7 @@ To load the current version, use the constructor:
 Alternatively, if you have a data catalog you can load it by reference to a 
 database and table name. Currently only AWS Glue is supported.
 
-.. TODO: auth to data catalog?
+For AWS Glue catalog, use AWS environment variables to authenticate.
 
 .. code-block:: python
 

--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -257,7 +257,7 @@ PyArrow datasets may also be passed to compatible query engines, such as DuckDB_
     5
 
 Finally, you can always pass the list of file paths to an engine. For example,
-you can pass them to :py:meth:`dask.dataframe.read_parquet`:
+you can pass them to ``dask.dataframe.read_parquet``:
 
 .. code-block:: python
 

--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -73,8 +73,10 @@ number or datetime string:
     >>> dt.load_version(1)
     >>> dt.load_with_timestamp("2021-11-04 00:05:23.283+00:00")
 
-.. TODO: What guarantees are there about being able to find versions? Are old ones
-   cleaned up? Are we able to see before the latest checkpoint?
+.. warning::
+
+    Previous table versions may not exist if they have been vacuumed, in which
+    case an exception will be thrown. See `Vacuuming tables`_ for more information.
 
 Examining a Table
 -----------------
@@ -138,9 +140,15 @@ History
 ~~~~~~~
 
 Depending on what system wrote the table, the delta table may have provenance
-information describing what operations were performed on the table and when. 
-This information is not written by all writers and different writers may use
-different schemas to encode the actions.
+information describing what operations were performed on the table, when, and 
+by whom. This information is retained for 30 days by default, unless otherwise
+specified by the table configuration ``delta.logRetentionDuration``.
+
+.. note::
+
+    This information is not written by all writers and different writers may use 
+    different schemas to encode the actions. For Spark's format, see: 
+    https://docs.delta.io/latest/delta-utility.html#history-schema
 
 To view the available history, use :meth:`DeltaTable.history`:
 


### PR DESCRIPTION
# Description

I rewrote most of the Python usage documentation.

 * Reflowed the usage documentation to start with loading, then look at log introspection, and finally querying tables. At the end I created a placeholder for writing, noting that it's not yet supported.
 * Added info about supported backends and data catalogs.
 * Added more examples and guidance on how to query Delta tables. Note: I'd like to include DataFusion here, but from what I've seen that's not yet possible, right?

By rewriting this I broke any links to sections *within* the page, but not to the page itself.

# Related Issue(s)

None

# Documentation

<!---
Share links to useful documentation
--->
