### PR TITLE
Add storage options for backends

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -67,15 +67,24 @@ class Metadata:
 class DeltaTable:
     """Create a DeltaTable instance."""
 
-    def __init__(self, table_uri: str, version: Optional[int] = None):
+    def __init__(
+        self,
+        table_uri: str,
+        version: Optional[int] = None,
+        storage_options: Optional[Dict[str, str]] = None,
+    ):
         """
         Create the Delta Table from a path with an optional version.
         Multiple StorageBackends are currently supported: AWS S3, Azure Data Lake Storage Gen2, Google Cloud Storage (GCS) and local URI.
+        Depending on the storage backend used, you could provide options values using the ``storage_options`` parameter.
 
         :param table_uri: the path of the DeltaTable
         :param version: version of the DeltaTable
+        :param storage_options: a dictionary of the options to use for the storage backend
         """
-        self._table = RawDeltaTable(table_uri, version=version)
+        self._table = RawDeltaTable(
+            table_uri, version=version, storage_options=storage_options
+        )
         self._metadata = Metadata(self._table)
 
     @classmethod
@@ -275,9 +284,7 @@ class DeltaTable:
             for file, part_expression in self._table.dataset_partitions(partitions)
         ]
 
-        return FileSystemDataset(
-            fragments, self.pyarrow_schema(), format, filesystem
-        )
+        return FileSystemDataset(fragments, self.pyarrow_schema(), format, filesystem)
 
     def to_pyarrow_table(
         self,

--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -28,6 +28,14 @@ To load the current version, use the constructor:
 
     >>> dt = DeltaTable("../rust/tests/data/delta-0.2.0")
 
+Depending on your storage backend, you could use the ``storage_options`` parameter to provide some configuration.
+Currently only AWS S3 is supported.
+
+.. code-block:: python
+
+    >>> storage_options = {"AWS_ACCESS_KEY_ID": "THE_AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY":"THE_AWS_SECRET_ACCESS_KEY"}
+    >>> dt = DeltaTable("../rust/tests/data/delta-0.2.0", storage_options=storage_options)
+
 Alternatively, if you have a data catalog you can load it by reference to a 
 database and table name. Currently only AWS Glue is supported.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin==0.11.5"]
+requires = ["maturin==0.12.6"]
 build-backend = "maturin"
 
 [project]

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -18,8 +18,13 @@ def test_read_simple_table_to_dict():
 def test_read_simple_table_by_version_to_dict():
     table_path = "../rust/tests/data/delta-0.2.0"
     dt = DeltaTable(table_path, version=2)
-    assert dt.to_pyarrow_dataset().to_table().to_pydict() == {
-        "value": [1, 2, 3]}
+    assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"value": [1, 2, 3]}
+
+
+def test_read_simple_table_using_options_to_dict():
+    table_path = "../rust/tests/data/delta-0.2.0"
+    dt = DeltaTable(table_path, version=2, storage_options={})
+    assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"value": [1, 2, 3]}
 
 
 def test_load_with_datetime():
@@ -71,8 +76,7 @@ def test_load_with_datetime_bad_format():
 def test_read_simple_table_update_incremental():
     table_path = "../rust/tests/data/simple_table"
     dt = DeltaTable(table_path, version=0)
-    assert dt.to_pyarrow_dataset().to_table().to_pydict() == {
-        "id": [0, 1, 2, 3, 4]}
+    assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"id": [0, 1, 2, 3, 4]}
     dt.update_incremental()
     assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"id": [5, 7, 9]}
 
@@ -305,8 +309,7 @@ def test_delta_table_with_filesystem():
     table_path = "../rust/tests/data/simple_table"
     dt = DeltaTable(table_path)
     filesystem = LocalFileSystem()
-    assert dt.to_pandas(filesystem=filesystem).equals(
-        pd.DataFrame({"id": [5, 7, 9]}))
+    assert dt.to_pandas(filesystem=filesystem).equals(pd.DataFrame({"id": [5, 7, 9]}))
 
 
 def test_import_delta_table_error():
@@ -395,8 +398,7 @@ def test_read_multiple_tables_from_s3_multi_threaded(s3_localstack):
             "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet",
         ]
 
-    threads = [ExcPassThroughThread(target=read_table)
-               for _ in range(thread_count)]
+    threads = [ExcPassThroughThread(target=read_table) for _ in range(thread_count)]
     for t in threads:
         t.start()
     for t in threads:

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -146,6 +146,12 @@ pub mod s3_storage_options {
     pub const AWS_ENDPOINT_URL: &str = "AWS_ENDPOINT_URL";
     /// The AWS region.
     pub const AWS_REGION: &str = "AWS_REGION";
+    /// The AWS_ACCESS_KEY_ID to use for S3.
+    pub const AWS_ACCESS_KEY_ID: &str = "AWS_ACCESS_KEY_ID";
+    /// The AWS_SECRET_ACCESS_ID to use for S3.
+    pub const AWS_SECRET_ACCESS_KEY: &str = "AWS_SECRET_ACCESS_KEY";
+    /// The AWS_SESSION_TOKEN to use for S3.
+    pub const AWS_SESSION_TOKEN: &str = "AWS_SESSION_TOKEN";
     /// Locking provider to use for safe atomic rename.
     /// `dynamodb` is currently the only supported locking provider.
     /// If not set, safe atomic rename is not available.
@@ -184,6 +190,9 @@ pub mod s3_storage_options {
     pub const S3_OPTS: &[&str] = &[
         AWS_ENDPOINT_URL,
         AWS_REGION,
+        AWS_ACCESS_KEY_ID,
+        AWS_SECRET_ACCESS_KEY,
+        AWS_SESSION_TOKEN,
         AWS_S3_LOCKING_PROVIDER,
         AWS_S3_ASSUME_ROLE_ARN,
         AWS_S3_ROLE_SESSION_NAME,
@@ -203,6 +212,9 @@ pub mod s3_storage_options {
 pub struct S3StorageOptions {
     _endpoint_url: Option<String>,
     region: Region,
+    aws_access_key_id: Option<String>,
+    aws_secret_access_key: Option<String>,
+    aws_session_token: Option<String>,
     locking_provider: Option<String>,
     assume_role_arn: Option<String>,
     assume_role_session_name: Option<String>,
@@ -238,6 +250,9 @@ impl S3StorageOptions {
 
         // Copy web identity values provided in options but not the environment into the environment
         // to get picked up by the `from_k8s_env` call in `get_web_identity_provider`.
+        Self::ensure_env_var(&options, s3_storage_options::AWS_ACCESS_KEY_ID);
+        Self::ensure_env_var(&options, s3_storage_options::AWS_SECRET_ACCESS_KEY);
+        Self::ensure_env_var(&options, s3_storage_options::AWS_SESSION_TOKEN);
         Self::ensure_env_var(&options, s3_storage_options::AWS_WEB_IDENTITY_TOKEN_FILE);
         Self::ensure_env_var(&options, s3_storage_options::AWS_ROLE_ARN);
         Self::ensure_env_var(&options, s3_storage_options::AWS_ROLE_SESSION_NAME);
@@ -262,6 +277,12 @@ impl S3StorageOptions {
         Self {
             _endpoint_url: endpoint_url,
             region,
+            aws_access_key_id: Self::str_option(&options, s3_storage_options::AWS_ACCESS_KEY_ID),
+            aws_secret_access_key: Self::str_option(
+                &options,
+                s3_storage_options::AWS_SECRET_ACCESS_KEY,
+            ),
+            aws_session_token: Self::str_option(&options, s3_storage_options::AWS_SESSION_TOKEN),
             locking_provider: Self::str_option(
                 &options,
                 s3_storage_options::AWS_S3_LOCKING_PROVIDER,
@@ -930,6 +951,9 @@ mod tests {
                     name: "us-west-1".to_string(),
                     endpoint: "http://localhost".to_string()
                 },
+                aws_access_key_id: Some("test".to_string()),
+                aws_secret_access_key: Some("test".to_string()),
+                aws_session_token: None,
                 assume_role_arn: Some("arn:aws:iam::123456789012:role/some_role".to_string()),
                 assume_role_session_name: Some("session_name".to_string()),
                 use_web_identity: true,
@@ -965,6 +989,9 @@ mod tests {
                     name: "us-west-2".to_string(),
                     endpoint: "http://localhost:1234".to_string()
                 },
+                aws_access_key_id: Some("test".to_string()),
+                aws_secret_access_key: Some("test".to_string()),
+                aws_session_token: None,
                 assume_role_arn: Some("arn:aws:iam::123456789012:role/another_role".to_string()),
                 assume_role_session_name: Some("another_session_name".to_string()),
                 use_web_identity: true,
@@ -1014,6 +1041,9 @@ mod tests {
                     name: "us-west-2".to_string(),
                     endpoint: "http://localhost".to_string()
                 },
+                aws_access_key_id: Some("test".to_string()),
+                aws_secret_access_key: Some("test".to_string()),
+                aws_session_token: None,
                 assume_role_arn: Some("arn:aws:iam::123456789012:role/some_role".to_string()),
                 assume_role_session_name: Some("session_name".to_string()),
                 use_web_identity: true,


### PR DESCRIPTION
# Description
- Add `storage_options` parameters to the `DeltaTable` constructor to provide options for the backend storage in the Python binding
- Refactoring of the alternate constructors for the `DeltaTable`
- Bump version of `maturin` to `0.12.6`
- Add options in the S3 backend storage 

# Related Issue(s)
- closes #477 
- closes #278 