### PR TITLE
Fix the Python release Github action workflow for macos11

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -36,6 +36,8 @@ jobs:
         include:
           - target: x86_64-apple-darwin
             os: macOS-10.15
+          - target: aarch64-apple-darwin
+            os: macOS-11
           - target: x86_64-pc-windows-msvc
             os: windows-2019
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# Description
- Add the target in the Python release workflow of Github Action

More info: https://github.com/delta-io/delta-rs/runs/4925831645?check_suite_focus=true