### PR TITLE
Fix VACUUM by using the URI of the DeltaTable when filtering the files to delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "deltalake-python"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "chrono",
  "deltalake",
@@ -1935,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.14.5"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35100f9347670a566a67aa623369293703322bb9db77d99d7df7313b575ae0c8"
+checksum = "7cf01dbf1c05af0a14c7779ed6f3aa9deac9c3419606ac9de537a2d649005720"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -1951,18 +1951,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.14.5"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12961738cacbd7f91b7c43bc25cfeeaa2698ad07a04b3be0aa88b950865738f"
+checksum = "dbf9e4d128bfbddc898ad3409900080d8d5095c379632fbbfbb9c8cfb1fb852b"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.14.5"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0bc5215d704824dfddddc03f93cb572e1155c68b6761c37005e1c288808ea8"
+checksum = "67701eb32b1f9a9722b4bc54b548ff9d7ebfded011c12daece7b9063be1fd755"
 dependencies = [
  "pyo3-macros-backend",
  "quote",
@@ -1971,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.14.5"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71623fc593224afaab918aa3afcaf86ed2f43d34f6afde7f3922608f253240df"
+checksum = "f44f09e825ee49a105f2c7b23ebee50886a9aee0746f4dd5a704138a64b0218a"
 dependencies = [
  "proc-macro2",
  "pyo3-build-config",

--- a/aws/delta-checkpoint/src/main.rs
+++ b/aws/delta-checkpoint/src/main.rs
@@ -33,7 +33,7 @@ async fn func(event: Value, _: Context) -> Result<(), CheckPointLambdaError> {
 }
 
 async fn process_event(event: &Value) -> Result<(), CheckPointLambdaError> {
-    let (bucket, key) = bucket_and_key_from_event(&event)?;
+    let (bucket, key) = bucket_and_key_from_event(event)?;
     let (path, version) = table_path_and_version_from_key(key.as_str())?;
     let table_uri = table_uri_from_parts(bucket.as_str(), path.as_str())?;
 

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -26,7 +26,7 @@ use super::action::{Action, DeltaOperation};
 use super::partitions::{DeltaTablePartition, PartitionFilter};
 use super::schema::*;
 use super::storage;
-use super::storage::{parse_uri, StorageBackend, StorageError, UriError};
+use super::storage::{StorageBackend, StorageError, UriError};
 use super::table_state::DeltaTableState;
 use crate::delta_config::DeltaConfigError;
 
@@ -1132,16 +1132,9 @@ impl DeltaTable {
         let mut files_to_delete = vec![];
         let mut all_files = self.storage.list_objs(&self.table_uri).await?;
 
-        // TODO: table_path is currently only used in vacuum, consider precalcualte it during table
-        // struct initialization if it ends up being used in other hot paths
-        let table_path = parse_uri(&self.table_uri)?.path();
-
         while let Some(obj_meta) = all_files.next().await {
             let obj_meta = obj_meta?;
-            // We can't use self.table_uri as the prefix to extract relative path because
-            // obj_meta.path is not a URI. For example, for S3 objects, obj_meta.path is just the
-            // object key without `s3://` and bucket name.
-            let rel_path = extract_rel_path(&table_path, &obj_meta.path)?;
+            let rel_path = extract_rel_path(&self.table_uri, &obj_meta.path)?;
 
             if valid_files.contains(rel_path) // file is still being tracked in table
                 || !expired_tombstones.contains(rel_path) // file is not an expired tombstone
@@ -1686,6 +1679,14 @@ mod tests {
         assert!(matches!(
             extract_rel_path("data/delta-0.8.0", "tests/abc.json"),
             Err(DeltaTableError::Generic(_)),
+        ));
+
+        assert!(matches!(
+            extract_rel_path(
+                "s3://bucket/database/table/delta-0.8.0",
+                "s3://bucket/database/table/delta-0.8.0/abc.json"
+            ),
+            Ok("abc.json"),
         ));
     }
 


### PR DESCRIPTION
# Description
- The `obj.meta` is the absolute path of the object on AWS S3 so we could use directly the `table_uri` for comparing the listed files with the valid files of the DeltaTable.

# Related Issue(s)
- closes #549 

# Tested:
- AWS S3
- Local