### PR TITLE
[Python] Test in minimal and latest Python environments

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Enable manylinux Python targets
       env:
         PY_VER: ${{ matrix.config.python_version }}
-      run:
+      run: |
         if (( ${PYARROW_VER} > 37 )); then
           VERSION_STRING=cp${PY_VER}-cp${PY_VER}
         else

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -36,7 +36,7 @@ jobs:
     name: Python Build (Python ${{ matrix.config.python_version }} PyArrow ${{ matrix.config.pyarrow_version }})
     runs-on: ubuntu-latest
     # use the same environment we have for python release
-    container: quay.io/pypa/manylinux2010_x86_64:2020-12-31-4928808
+    container: quay.io/pypa/manylinux2010_x86_64:2022-03-14-b2cd80b
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -36,6 +36,13 @@ jobs:
     runs-on: ubuntu-latest
     # use the same environment we have for python release
     container: quay.io/pypa/manylinux2010_x86_64:2020-12-31-4928808
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # test on oldest supported Python + PyArrow versions
+          - { python_version: "36", pyarrow_version: "4.0.0" }
+          - { python_version: "310", pyarrow_version: "latest" }
     steps:
     # actions/checkout@v2 is a node action, which runs on a fairly new
     # version of node. however, manylinux environment's glibc is too old for
@@ -57,13 +64,23 @@ jobs:
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
     - name: Enable manylinux Python targets
-      run: echo "/opt/python/cp36-cp36m/bin" >> $GITHUB_PATH
+      env:
+        PY_VER: ${{ matrix.config.python_version }}
+      run: echo "/opt/python/cp${PY_VER}-cp${PY_VER}m/bin" >> $GITHUB_PATH
 
     - name: Build and install deltalake
+      env:
+        PYARROW_VER: ${{ matrix.config.pyarrow_version }}
       run: |
         pip install virtualenv
         virtualenv venv
         source venv/bin/activate
+        make setup
+        if ${PYARROW_VER} = "latest"; then
+          pip install pyarrow
+        else
+          pip install pyarrow==${PYARROW_VER}
+        fi
         make develop
 
     - name: Run tests
@@ -76,6 +93,8 @@ jobs:
     #     py.test --cov tests -m integration
 
     - name: Build Sphinx documentation
+      # Sphinx support for typehints before 3.8 aren't great.
+      if: matrix.config.python_version >= 38
       run: |
         source venv/bin/activate
         make build-documentation

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -84,7 +84,7 @@ jobs:
         virtualenv venv
         source venv/bin/activate
         make setup
-        if ${PYARROW_VER} = "latest"; then
+        if [ "${PYARROW_VER}" = "latest" ]; then
           pip install pyarrow
         else
           pip install pyarrow==${PYARROW_VER}

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -90,10 +90,6 @@ jobs:
     # docker based action.
     - uses: actions/checkout@v1
 
-    # Require for building openssl-sys
-    - name: Install perl-IPC/Cmd
-      run: yum install -y perl-IPC-Cmd
-
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -84,11 +84,7 @@ jobs:
     name: Python Build (Python 3.10 PyArrow latest)
     runs-on: ubuntu-latest
     steps:
-    # actions/checkout@v2 is a node action, which runs on a fairly new
-    # version of node. however, manylinux environment's glibc is too old for
-    # that version of the node. so we will have to use v1 instead, which is a
-    # docker based action.
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -32,18 +32,11 @@ jobs:
     - name: Check Rust
       run: make check-rust
 
-  test:
-    name: Python Build (Python ${{ matrix.config.python_version }} PyArrow ${{ matrix.config.pyarrow_version }})
+  test-minimal:
+    name: Python Build (Python 3.6 PyArrow 4.0.0)
     runs-on: ubuntu-latest
     # use the same environment we have for python release
     container: quay.io/pypa/manylinux2010_x86_64:2022-03-14-b2cd80b
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          # test on oldest supported Python + PyArrow versions
-          - { python_version: "36", pyarrow_version: "4.0.0" }
-          - { python_version: "310", pyarrow_version: "latest" }
     steps:
     # actions/checkout@v2 is a node action, which runs on a fairly new
     # version of node. however, manylinux environment's glibc is too old for
@@ -65,30 +58,16 @@ jobs:
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
     - name: Enable manylinux Python targets
-      env:
-        PY_VER: ${{ matrix.config.python_version }}
-      run: |
-        if (( $PY_VER > 37 )); then
-          VERSION_STRING=cp${PY_VER}-cp${PY_VER}
-        else
-          # "m" is for pymalloc, which doesn't seem to be used after 3.7
-          VERSION_STRING=cp${PY_VER}-cp${PY_VER}m
-        fi
-        echo "/opt/python/${VERSION_STRING}/bin" >> $GITHUB_PATH
+      run: echo "/opt/python/cp36-cp36m/bin" >> $GITHUB_PATH
 
     - name: Build and install deltalake
-      env:
-        PYARROW_VER: ${{ matrix.config.pyarrow_version }}
       run: |
         pip install virtualenv
         virtualenv venv
         source venv/bin/activate
         make setup
-        if [ "${PYARROW_VER}" = "latest" ]; then
-          pip install pyarrow
-        else
-          pip install pyarrow==${PYARROW_VER}
-        fi
+        # Install minimum PyArrow version
+        pip install pyarrow==4.0.0
         make develop
 
     - name: Run tests
@@ -100,9 +79,45 @@ jobs:
     #   run: |
     #     py.test --cov tests -m integration
 
+
+  test:
+    name: Python Build (Python 3.10 PyArrow latest)
+    runs-on: ubuntu-latest
+    steps:
+    # actions/checkout@v2 is a node action, which runs on a fairly new
+    # version of node. however, manylinux environment's glibc is too old for
+    # that version of the node. so we will have to use v1 instead, which is a
+    # docker based action.
+    - uses: actions/checkout@v1
+
+    # Require for building openssl-sys
+    - name: Install perl-IPC/Cmd
+      run: yum install -y perl-IPC-Cmd
+
+    - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+    - uses: actions/setup-python@v3
+      with:
+        python-version: '3.10' 
+
+    - name: Build and install deltalake
+      run: |
+        pip install virtualenv
+        virtualenv venv
+        source venv/bin/activate
+        make develop
+
+    - name: Run tests
+      run: |
+        source venv/bin/activate
+        make unit-test
+
     - name: Build Sphinx documentation
-      # Sphinx support for typehints before 3.8 aren't great.
-      if: matrix.config.python_version >= 38
       run: |
         source venv/bin/activate
         make build-documentation

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -33,6 +33,7 @@ jobs:
       run: make check-rust
 
   test:
+    name: Python Build (Python ${{ matrix.config.python_version }} PyArrow ${{ matrix.config.pyarrow_version }})
     runs-on: ubuntu-latest
     # use the same environment we have for python release
     container: quay.io/pypa/manylinux2010_x86_64:2020-12-31-4928808
@@ -66,7 +67,14 @@ jobs:
     - name: Enable manylinux Python targets
       env:
         PY_VER: ${{ matrix.config.python_version }}
-      run: echo "/opt/python/cp${PY_VER}-cp${PY_VER}m/bin" >> $GITHUB_PATH
+      run:
+        if (( ${PYARROW_VER} > 37 )); then
+          VERSION_STRING=cp${PY_VER}-cp${PY_VER}
+        else
+          # "m" is for pymalloc, which doesn't seem to be used after 3.7
+          VERSION_STRING=cp${PY_VER}-cp${PY_VER}m
+        fi
+        echo "/opt/python/${VERSION_STRING}/bin" >> $GITHUB_PATH
 
     - name: Build and install deltalake
       env:

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -68,7 +68,7 @@ jobs:
       env:
         PY_VER: ${{ matrix.config.python_version }}
       run: |
-        if (( ${PYARROW_VER} > 37 )); then
+        if (( $PY_VER > 37 )); then
           VERSION_STRING=cp${PY_VER}-cp${PY_VER}
         else
           # "m" is for pymalloc, which doesn't seem to be used after 3.7

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -67,7 +67,7 @@ jobs:
     needs: validate-release-tag
     name: PyPI release manylinux
     runs-on: ubuntu-20.04
-    container: quay.io/pypa/manylinux2010_x86_64:2020-12-31-4928808
+    container: quay.io/pypa/manylinux2010_x86_64:2022-03-14-b2cd80b
     steps:
       # actions/checkout@v2 is a node action, which runs on a fairly new
       # version of node. however, manylinux environment's glibc is too old for


### PR DESCRIPTION
# Description

In #566 we ran into an issue where changes meant docs couldn't build with Python older than 3.8. We should simply build them in a newer version of Python.

In addition, we should be testing the Python package with both the minimal PyArrow version and the latest PyArrow version, since they are several major versions apart. (PyArrow right now just releases new major versions quarterly, so breaking API changes are common in experimental parts of the package.)

# Related Issue(s)

None

# Documentation

<!---
Share links to useful documentation
--->
