### PR TITLE
Replace table location prefix from s3a to s3

### DIFF
--- a/rust/src/data_catalog/glue/mod.rs
+++ b/rust/src/data_catalog/glue/mod.rs
@@ -91,6 +91,7 @@ impl DataCatalog for GlueDataCatalog {
                 metadata: "Storage Descriptor".to_string(),
             })?
             .location
+            .map(|l| l.replace("s3a", "s3"))
             .ok_or(DataCatalogError::MissingMetadata {
                 metadata: "Location".to_string(),
             });


### PR DESCRIPTION
Replace **s3a** table location prefix to **s3** when table location is taken from Glue catalog .

# Description
Table location from Glue Catalog is modified to let the Rust code to use native S3 protocol, instead of s3a, which is used when table is ingested by Spark. This patch is fixing "path not found" error when using Python API to load table from Data Catalog: 
- Loading Delta table in Python from Data Catalog: https://delta-io.github.io/delta-rs/python/usage.html#loading-a-delta-table

# Documentation

<!---
Share links to useful documentation
--->
- Hadoop S3A used by Spark: https://hadoop.apache.org/docs/current2/hadoop-aws/tools/hadoop-aws/index.html#S3A
- Spark Cloud Integration: https://spark.apache.org/docs/latest/cloud-integration.html#recommended-settings-for-writing-to-object-stores
