### PR TITLE
Allow metadata for write_deltalake

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -56,6 +56,8 @@ def write_deltalake(
     to write to an existing table with a higher min_writer_version, this
     function will throw DeltaTableProtocolError.
 
+    Note that this function does NOT register this table in a data catalog.
+
     :param table_or_uri: URI of a table or a DeltaTable object.
     :param data: Data to write. If passing iterable, the schema must also be given.
     :param schema: Optional schema to write.
@@ -67,6 +69,9 @@ def write_deltalake(
         already exists. If 'append', will add new data. If 'overwrite', will
         replace table with new data. If 'ignore', will not write anything if
         table already exists.
+    :param name: User-provided identifier for this table.
+    :param description: User-provided description for this table.
+    :param configuration: A map containing configuration options for the metadata action.
     """
     if isinstance(data, pd.DataFrame):
         data = pa.Table.from_pandas(data)

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -3,6 +3,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
+from optparse import Option
 from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Union
 
 import pandas as pd
@@ -44,6 +45,9 @@ def write_deltalake(
     partition_by: Optional[List[str]] = None,
     filesystem: Optional[pa_fs.FileSystem] = None,
     mode: Literal["error", "append", "overwrite", "ignore"] = "error",
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    configuration: Optional[Mapping[str, Optional[str]]] = None,
 ) -> None:
     """Write to a Delta Lake table (Experimental)
 
@@ -147,7 +151,16 @@ def write_deltalake(
     )
 
     if table is None:
-        _write_new_deltalake(table_uri, schema, add_actions, mode, partition_by or [])
+        _write_new_deltalake(
+            table_uri,
+            schema,
+            add_actions,
+            mode,
+            partition_by or [],
+            name,
+            description,
+            configuration,
+        )
     else:
         table._table.create_write_transaction(
             add_actions,

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -3,7 +3,6 @@ import uuid
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
-from optparse import Option
 from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Union
 
 import pandas as pd

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -150,7 +150,7 @@ def write_deltalake(
     )
 
     if table is None:
-        _write_new_deltalake(
+        _write_new_deltalake(  # type: ignore[call-arg]
             table_uri,
             schema,
             add_actions,

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -514,6 +514,7 @@ impl From<&PyAddAction> for action::Add {
 }
 
 #[pyfunction]
+#[allow(clippy::too_many_arguments)]
 fn write_new_deltalake(
     table_uri: String,
     schema: ArrowSchema,
@@ -532,12 +533,12 @@ fn write_new_deltalake(
     .map_err(PyDeltaTableError::from_raw)?;
 
     let metadata = DeltaTableMetaData::new(
-        name,                                            // User-provided identifer (NAME)
-        description,                                     // DESC,
-        None,                                            // Format?
-        (&schema).try_into()?,                           // SCHEMA
-        partition_by,                                    // PARTITION_COLUMNS
-        configuration.unwrap_or_else(|| HashMap::new()), //HashMap::new(), //CONFIGURATION HASHMAP
+        name,
+        description,
+        None, // Format
+        (&schema).try_into()?,
+        partition_by,
+        configuration.unwrap_or_default(),
     );
 
     let fut = table.create(

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -520,6 +520,9 @@ fn write_new_deltalake(
     add_actions: Vec<PyAddAction>,
     _mode: &str,
     partition_by: Vec<String>,
+    name: Option<String>,
+    description: Option<String>,
+    configuration: Option<HashMap<String, Option<String>>>,
 ) -> PyResult<()> {
     let mut table = deltalake::DeltaTable::new(
         &table_uri,
@@ -529,12 +532,12 @@ fn write_new_deltalake(
     .map_err(PyDeltaTableError::from_raw)?;
 
     let metadata = DeltaTableMetaData::new(
-        None,
-        None,
-        None,
-        (&schema).try_into()?,
-        partition_by,
-        HashMap::new(),
+        name,                                            // User-provided identifer (NAME)
+        description,                                     // DESC,
+        None,                                            // Format?
+        (&schema).try_into()?,                           // SCHEMA
+        partition_by,                                    // PARTITION_COLUMNS
+        configuration.unwrap_or_else(|| HashMap::new()), //HashMap::new(), //CONFIGURATION HASHMAP
     );
 
     let fut = table.create(

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -95,6 +95,24 @@ def test_roundtrip_basic(tmp_path: pathlib.Path, sample_data: pa.Table):
     assert table == sample_data
 
 
+def test_roundtrip_metadata(tmp_path: pathlib.Path, sample_data: pa.Table):
+    write_deltalake(
+        str(tmp_path),
+        sample_data,
+        name="test_name",
+        description="test_desc",
+        configuration={"configTest": "foobar"},
+    )
+
+    delta_table = DeltaTable(str(tmp_path))
+
+    metadata = delta_table.metadata()
+
+    assert metadata.name == "test_name"
+    assert metadata.description == "test_desc"
+    assert metadata.configuration == {"configTest": "foobar"}
+
+
 @pytest.mark.parametrize(
     "column",
     [


### PR DESCRIPTION
# Description
+ Add Name, Description, and Configuration arguments to write_new_datalake in python and python-rust bindings
+ Add round trip metadata writing test
+ Suppress write clippy "too many arguments" (Default max seems to be 7, function has 8). 

# Related Issue(s)
Should resolve #576 

# Documentation

<!---
Share links to useful documentation
--->
