### PR TITLE
Introduce require_files for tracking the add files in table state

### DIFF
--- a/rust/src/writer/stats.rs
+++ b/rust/src/writer/stats.rs
@@ -542,13 +542,7 @@ mod tests {
         options: HashMap<String, String>,
     ) -> Result<DeltaTable, DeltaTableError> {
         let backend = crate::get_backend_for_uri_with_options(table_uri, options)?;
-        let mut table = DeltaTable::new(
-            table_uri,
-            backend,
-            crate::DeltaTableConfig {
-                require_tombstones: true,
-            },
-        )?;
+        let mut table = DeltaTable::new(table_uri, backend, crate::DeltaTableConfig::default())?;
         table.load().await?;
         Ok(table)
     }

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -78,6 +78,48 @@ async fn read_delta_table_ignoring_tombstones() {
 }
 
 #[tokio::test]
+async fn read_delta_table_ignoring_files() {
+    let table = DeltaTableBuilder::from_uri("./tests/data/delta-0.8.0")
+        .unwrap()
+        .without_files()
+        .load()
+        .await
+        .unwrap();
+
+    assert!(table.get_files().is_empty(), "files should be empty");
+    assert!(
+        table.get_tombstones().next().is_none(),
+        "tombstones should be empty"
+    );
+}
+
+#[tokio::test]
+async fn read_delta_table_with_ignoring_files_on_apply_log() {
+    let mut table = DeltaTableBuilder::from_uri("./tests/data/delta-0.8.0")
+        .unwrap()
+        .with_version(0)
+        .without_files()
+        .load()
+        .await
+        .unwrap();
+
+    assert_eq!(table.version, 0);
+    assert!(table.get_files().is_empty(), "files should be empty");
+    assert!(
+        table.get_tombstones().next().is_none(),
+        "tombstones should be empty"
+    );
+
+    table.update().await.unwrap();
+    assert_eq!(table.version, 1);
+    assert!(table.get_files().is_empty(), "files should be empty");
+    assert!(
+        table.get_tombstones().next().is_none(),
+        "tombstones should be empty"
+    );
+}
+
+#[tokio::test]
 async fn read_delta_2_0_table_with_version() {
     let mut table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 0)
         .await


### PR DESCRIPTION
# Description
Since #454 dev is stopped. We aim to gradually address that issue.
Firstly, this PR. The changes introduces  `require_files` which similar to `require_tombstones`, filters out any files if the flag is set to `false`. Hence the table state will end up with metadata only. This is a perfect behavior for append only apps (like kafka delta ingest for example). 

Secondly, the catch is the how to create a checkpoint, because we need both adds & removes for that. One possible approach is a create checkpoint in another process, which is applicable. However we can omit that and do in process if we apply the work from #454. E.g. by operating on arrow/record batch objects to reduce memory usage / decentralization just enough to read/create checkpoint.

Thirdly, if 2nd step is successful, we can leverage that experience to finish/enhance the idea from #454

# Related Issue(s)
A follow up of https://github.com/delta-io/delta-rs/pull/445. But here we introduce ignoring of add files.


