### PR TITLE
Avoid building pandas and numpy from source

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -44,6 +44,16 @@ jobs:
     # docker based action.
     - uses: actions/checkout@v1
 
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: python-test-minimal-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+
     # Require for building openssl-sys
     - name: Install perl-IPC/Cmd
       run: yum install -y perl-IPC-Cmd
@@ -87,6 +97,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: python-test-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
 
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -67,7 +67,9 @@ jobs:
         source venv/bin/activate
         make setup
         # Install minimum PyArrow version
-        pip install pyarrow==4.0.0
+        # pandas and numpy versions are most recent with Python 3.7 wheels.
+        # Otherwise, we have to build those from source.
+        pip install pyarrow==4.0.0 pandas==1.3.5 numpy==1.21.6
         make develop
 
     - name: Run tests

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -44,16 +44,6 @@ jobs:
     # docker based action.
     - uses: actions/checkout@v1
 
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: python-test-minimal-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-
     # Require for building openssl-sys
     - name: Install perl-IPC/Cmd
       run: yum install -y perl-IPC-Cmd

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -69,7 +69,7 @@ jobs:
         # Install minimum PyArrow version
         # pandas and numpy versions are most recent with Python 3.7 wheels.
         # Otherwise, we have to build those from source.
-        pip install pyarrow==4.0.0 pandas==1.3.5 numpy==1.21.6
+        pip install pyarrow==4.0.0 pandas==1.2.5 numpy==1.20.3
         make develop
 
     - name: Run tests


### PR DESCRIPTION
# Description

I noticed the CI job " Python Build (Python 3.7 PyArrow 4.0.0) " was taking a while, and it looks like it was building pandas from source. 

Before (16m45s): https://github.com/delta-io/delta-rs/runs/6282672393?check_suite_focus=true
After (8m57s): https://github.com/delta-io/delta-rs/runs/6283588059?check_suite_focus=true

Also added caching to the latest Python build, since it was easy. Can't add it to minimal due to issues with old glibc.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
