### PR TITLE
Configure Azure storage using a map (#555)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["fs", "macros", "rt", "io-util"] }
 tokio-stream = { version = "0", features = ["fs"] }
+tokio-util = { version = "0.7.1", features = ["rt"] }
 futures = "0.3"
 bytes = "1"
 log = "0"
@@ -32,11 +33,11 @@ reqwest = { version = "0.11", default-features = false, features = [
 ], optional = true }
 
 # Azure
-azure_core = { version = "0.1", optional = true }
-azure_storage = { version = "0.1", optional = true }
-azure_storage_blobs = { version = "0.1", optional = true }
-azure_storage_datalake = { version = "0.1.1", optional = true }
-azure_identity = { version = "0.1", optional = true }
+azure_core = { version = "0.2.2", optional = true }
+azure_storage = { version = "0.2", optional = true }
+azure_storage_blobs = { version = "0.2", optional = true }
+azure_storage_datalake = { version = "0.2", optional = true }
+azure_identity = { version = "0.2", optional = true }
 
 # S3
 rusoto_core = { version = "0.46", default-features = false, optional = true }

--- a/rust/src/storage/azure/mod.rs
+++ b/rust/src/storage/azure/mod.rs
@@ -7,12 +7,13 @@
 /// `AZURE_STORAGE_ACCOUNT_NAME` is required to be set in the environment.
 /// `AZURE_STORAGE_ACCOUNT_KEY` is required to be set in the environment.
 use super::{parse_uri, ObjectMeta, StorageBackend, StorageError, UriError};
-use azure_core::new_http_client;
-use azure_storage::core::clients::{AsStorageClient, StorageAccountClient};
+use azure_core::auth::TokenCredential;
+use azure_core::ClientOptions;
 use azure_storage::storage_shared_key_credential::StorageSharedKeyCredential;
-use azure_storage_blobs::prelude::*;
 use azure_storage_datalake::prelude::*;
+//use azure_storage_datalake::file_system::Path;
 use futures::stream::Stream;
+use futures::StreamExt;
 use log::debug;
 use std::collections::HashMap;
 use std::env;
@@ -20,6 +21,9 @@ use std::error::Error;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::{fmt, pin::Pin};
+use tokio::sync::mpsc::{self, Sender};
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::task::LocalPoolHandle;
 
 ///The ADLS Gen2 Access Key
 pub const AZURE_STORAGE_ACCOUNT_KEY: &str = "AZURE_STORAGE_ACCOUNT_KEY";
@@ -56,8 +60,8 @@ impl<'a> fmt::Display for AdlsGen2Object<'a> {
 pub struct AdlsGen2Backend {
     storage_account_name: String,
     file_system_name: String,
-    file_system_client: FileSystemClient, // TODO: use Arc?
-    container_client: Arc<ContainerClient>,
+    file_system_client: FileSystemClient,
+    local_pool_handle: LocalPoolHandle,
 }
 
 impl AdlsGen2Backend {
@@ -84,6 +88,55 @@ impl AdlsGen2Backend {
         Self::from_map(file_system_name, map)
     }
 
+    ///TODO
+    pub fn new_with_token_credential(
+        storage_account_name: &str,
+        file_system_name: &str,
+        token_credential: Arc<dyn TokenCredential>,
+    ) -> Result<Self, StorageError> {
+        let data_lake_client = DataLakeClient::new_with_token_credential(
+            token_credential.clone(),
+            storage_account_name,
+            None,
+            ClientOptions::default(),
+        );
+
+        let file_system_client =
+            data_lake_client.into_file_system_client(file_system_name.to_owned());
+
+        Ok(AdlsGen2Backend {
+            storage_account_name: storage_account_name.to_string(),
+            file_system_name: file_system_name.to_string(),
+            file_system_client,
+            local_pool_handle: LocalPoolHandle::new(1),
+        })
+    }
+
+    ///TODO
+    pub fn new_with_shared_key(
+        storage_account_name: &str,
+        file_system_name: &str,
+        storage_account_key: &str,
+    ) -> Result<Self, StorageError> {
+        let key = StorageSharedKeyCredential::new(
+            storage_account_name.to_owned(),
+            storage_account_key.to_owned(),
+        );
+
+        let data_lake_client =
+            DataLakeClient::new_with_shared_key(key, None, ClientOptions::default());
+
+        let file_system_client =
+            data_lake_client.into_file_system_client(file_system_name.to_owned());
+
+        Ok(AdlsGen2Backend {
+            storage_account_name: storage_account_name.to_string(),
+            file_system_name: file_system_name.to_string(),
+            file_system_client,
+            local_pool_handle: LocalPoolHandle::new(1),
+        })
+    }
+
     /// Create a new [`AdlsGen2Backend`].
     ///
     /// Shared key authentication is used (temporarily).
@@ -102,36 +155,7 @@ impl AdlsGen2Backend {
             StorageError::AzureConfig("AZURE_STORAGE_ACCOUNT_KEY must be set".to_string())
         })?;
 
-        let data_lake_client = DataLakeClient::new(
-            StorageSharedKeyCredential::new(
-                storage_account_name.to_owned(),
-                storage_account_key.to_owned(),
-            ),
-            None,
-        );
-
-        let file_system_client =
-            data_lake_client.into_file_system_client(file_system_name.to_owned());
-
-        // TODO: The container_client should go away in favor of using DirectoryClient and FileClient
-        // See: https://github.com/Azure/azure-sdk-for-rust/issues/496
-        // See: https://github.com/Azure/azure-sdk-for-rust/pull/610
-        // Missing: get_file_properties, read_file, list_directory
-        let http_client = new_http_client();
-        let storage_account_client = StorageAccountClient::new_access_key(
-            http_client.clone(),
-            storage_account_name.to_owned(),
-            storage_account_key,
-        );
-        let storage_client = storage_account_client.as_storage_client();
-        let container_client = storage_client.as_container_client(file_system_name.to_owned());
-
-        Ok(Self {
-            storage_account_name: storage_account_name.to_owned(),
-            file_system_name: file_system_name.to_owned(),
-            file_system_client,
-            container_client,
-        })
+        Self::new_with_shared_key(storage_account_name, file_system_name, storage_account_key)
     }
 
     fn validate_container<'a>(&self, obj: &AdlsGen2Object<'a>) -> Result<(), StorageError> {
@@ -158,7 +182,57 @@ fn to_storage_err(err: Box<dyn Error + Sync + std::marker::Send>) -> StorageErro
 }
 
 fn to_storage_err2(err: azure_storage::core::Error) -> StorageError {
+    if let azure_storage::core::Error::CoreError(azure_core::Error::Other(ref other_err)) = err {
+        match other_err.downcast_ref::<azure_core::error::Error>() {
+            Some(other_err) => match other_err.downcast_ref::<azure_core::error::HttpError>() {
+                Some(e) => {
+                    if e.status() == 404 {
+                        return StorageError::NotFound;
+                    }
+                }
+                None => {}
+            },
+            None => {}
+        }
+    }
     StorageError::AzureStorage { source: err }
+}
+
+async fn list_obj_future(
+    client: FileSystemClient,
+    path: String,
+    storage_account_name: String,
+    file_system_name: String,
+    tx: Sender<Result<ObjectMeta, StorageError>>,
+) {
+    let mut stream = client.list_paths().directory(path).into_stream();
+
+    while let Some(path_response_res) = stream.next().await {
+        match path_response_res {
+            Ok(path_response) => {
+                for path in path_response.paths {
+                    let object = AdlsGen2Object {
+                        account_name: &storage_account_name,
+                        file_system: &file_system_name,
+                        path: &path.name,
+                    };
+                    let object_meta = Ok(ObjectMeta {
+                        path: object.to_string(),
+                        modified: path.last_modified,
+                    });
+                    let res = tx.send(object_meta).await;
+
+                    if let Err(_e) = res {
+                        return;
+                    }
+                }
+            }
+            Err(err) => {
+                let _res = tx.send(Err(to_storage_err(Box::new(err)))).await;
+                return;
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -168,15 +242,15 @@ impl StorageBackend for AdlsGen2Backend {
         let obj = parse_uri(path)?.into_adlsgen2_object()?;
         self.validate_container(&obj)?;
 
-        // TODO: Use file_system_client once it can get file properties
         let properties = self
-            .container_client
-            .as_blob_client(obj.path)
+            .file_system_client
+            .get_file_client(obj.path)
             .get_properties()
-            .execute()
+            .into_future()
             .await
-            .map_err(to_storage_err)?;
-        let modified = properties.blob.properties.last_modified;
+            .map_err(to_storage_err2)?;
+
+        let modified = properties.last_modified;
         Ok(ObjectMeta {
             path: path.to_string(),
             modified,
@@ -188,16 +262,16 @@ impl StorageBackend for AdlsGen2Backend {
         let obj = parse_uri(path)?.into_adlsgen2_object()?;
         self.validate_container(&obj)?;
 
-        // TODO: Use file_system_client once it can read files
-        Ok(self
-            .container_client
-            .as_blob_client(obj.path)
-            .get()
-            .execute()
+        let data = self
+            .file_system_client
+            .get_file_client(obj.path)
+            .read()
+            .into_future()
             .await
-            .map_err(to_storage_err)?
+            .map_err(to_storage_err2)?
             .data
-            .to_vec())
+            .to_vec();
+        Ok(data)
     }
 
     async fn list_objs<'a>(
@@ -211,35 +285,24 @@ impl StorageBackend for AdlsGen2Backend {
         let obj = parse_uri(path)?.into_adlsgen2_object()?;
         self.validate_container(&obj)?;
 
-        // TODO: Use file_system_client once it can list files
-        let objs = self
-            .container_client
-            .list_blobs()
-            .prefix(obj.path)
-            .execute()
-            .await
-            .unwrap()
-            .blobs
-            .blobs
-            .into_iter()
-            .map(|blob| {
-                let object = AdlsGen2Object {
-                    account_name: &self.storage_account_name,
-                    file_system: &self.file_system_name,
-                    path: &blob.name,
-                };
-                Ok(ObjectMeta {
-                    path: object.to_string(),
-                    modified: blob.properties.last_modified,
-                })
-            })
-            .collect::<Vec<Result<ObjectMeta, StorageError>>>();
+        let client = self.file_system_client.clone();
+        let storage_account_name = self.storage_account_name.to_owned();
+        let file_system_name = self.file_system_name.to_owned();
+        let prefix_path = path.to_owned();
+        let (tx, rx) = mpsc::channel(1024);
 
-        // Likely due to https://github.com/Azure/azure-sdk-for-rust/issues/377
-        // we have to collect the stream and then forward it again, instead of
-        // just passing it down ...
-        let output = futures::stream::iter(objs);
-        Ok(Box::pin(output))
+        let handle = self.local_pool_handle.spawn_pinned(|| {
+            list_obj_future(
+                client,
+                prefix_path,
+                storage_account_name,
+                file_system_name,
+                tx,
+            )
+        });
+
+        tokio::spawn(handle);
+        Ok(Box::pin(ReceiverStream::new(rx)))
     }
 
     async fn put_obj(&self, path: &str, obj_bytes: &[u8]) -> Result<(), StorageError> {
@@ -284,22 +347,27 @@ impl StorageBackend for AdlsGen2Backend {
             .into_future()
             .await;
 
-        match result {
-            Err(err) => match err {
-                azure_storage::core::Error::CoreError(azure_core::Error::Policy(
-                    ref policy_error_source,
-                )) => match policy_error_source.downcast_ref::<azure_core::HttpError>() {
-                    Some(azure_core::HttpError::StatusCode { status, body: _ })
-                        if status.as_u16() == 409 =>
-                    {
-                        Err(StorageError::AlreadyExists(dst.to_string()))
+        if let Err(err) = result {
+            if let azure_storage::core::Error::CoreError(azure_core::Error::Other(ref other_err)) =
+                err
+            {
+                match other_err.downcast_ref::<azure_core::error::Error>() {
+                    Some(other_err) => {
+                        match other_err.downcast_ref::<azure_core::error::HttpError>() {
+                            Some(e) => {
+                                if e.status() == 409 {
+                                    return Err(StorageError::AlreadyExists(dst.to_string()));
+                                }
+                            }
+                            None => {}
+                        }
                     }
-                    _ => Err(StorageError::AzureStorage { source: err }),
-                },
-                _ => Err(StorageError::AzureStorage { source: err }),
-            },
-            _ => Ok(()),
+                    None => {}
+                }
+            }
+            return Err(StorageError::AzureStorage { source: err });
         }
+        Ok(())
     }
 
     async fn delete_obj(&self, path: &str) -> Result<(), StorageError> {

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -612,6 +612,11 @@ pub fn get_backend_for_uri_with_options(
         Uri::S3Object(_) => Ok(Box::new(s3::S3StorageBackend::new_from_options(
             S3StorageOptions::from_map(_options),
         )?)),
+        #[cfg(feature = "azure")]
+        Uri::AdlsGen2Object(obj) => Ok(Box::new(azure::AdlsGen2Backend::from_map(
+            obj.file_system,
+            _options,
+        )?)),
         _ => get_backend_for_uri(uri),
     }
 }


### PR DESCRIPTION
# Description
Allows a user to create a DeltaTable backed by ADLS storage by simply passing uri and a map of options.

This helps promote the usage of different storage backends by only having to change some configuration rather than explicitly creating a storage backend instance in the user's code. 

# Related Issue(s)
Related to #555 since it allows an alternative from using environment variables for creation.
# Documentation

<!---
Share links to useful documentation
--->
