### PR TITLE
default to root for empty path in azure store

### DIFF
--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -251,10 +251,7 @@ pub fn parse_uri<'a>(path: &'a str) -> Result<Uri<'a>, UriError> {
                             return Err(UriError::MissingObjectFileSystem);
                         }
                     };
-                    let path = match path_parts.next() {
-                        Some(x) => x,
-                        None => "/",
-                    };
+                    let path = path_parts.next().unwrap_or("/");
 
                     Ok(Uri::AdlsGen2Object(azure::AdlsGen2Object { account_name, file_system, path }))
                 } else {

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -253,9 +253,7 @@ pub fn parse_uri<'a>(path: &'a str) -> Result<Uri<'a>, UriError> {
                     };
                     let path = match path_parts.next() {
                         Some(x) => x,
-                        None => {
-                            return Err(UriError::MissingObjectPath);
-                        }
+                        None => "/",
                     };
 
                     Ok(Uri::AdlsGen2Object(azure::AdlsGen2Object { account_name, file_system, path }))


### PR DESCRIPTION
# Description

Defaults to a root path if there is no path segment in an azure storage path.

i..e this does work right now `adls2://account/container/`, while this does not work `adls2://devargusadlsv2/simple`. THis PR makes the second option also work.

# Related Issue(s)

closes #602

# Documentation

<!---
Share links to useful documentation
--->
