### PR TITLE
fix: cap sphinx version to avoid bug in 5.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -33,7 +33,7 @@ devel = [
     "pytest-mock",
     "pytest-cov",
     "pytest-timeout",
-    "sphinx",
+    "sphinx<=4.5",
     "sphinx-rtd-theme",
     "toml",
     "typing-extensions"


### PR DESCRIPTION
# Description

There seems to be a bug in 5.0 when handling `Literal[]` type hints.

# Related Issue(s)

I've raised an issue upstream: https://github.com/sphinx-doc/sphinx/issues/10497

# Documentation

<!---
Share links to useful documentation
--->
