### PR TITLE
feat(python): validate schema in write_deltalake

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -142,6 +142,12 @@ def write_deltalake(
     #    filesystem = pa_fs.PyFileSystem(DeltaStorageHandler(table_uri))
 
     if table:  # already exists
+        if schema != table.pyarrow_schema():
+            raise ValueError(
+                "Schema of data does not match table schema\n"
+                f"Table schema:\n  {schema}\nData Schema:\n  {table.pyarrow_schema()}"
+            )
+
         if mode == "error":
             raise AssertionError("DeltaTable already exists.")
         elif mode == "ignore":

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -60,6 +60,7 @@ def write_deltalake(
         Iterable[pa.RecordBatch],
         RecordBatchReader,
     ],
+    *,
     schema: Optional[pa.Schema] = None,
     partition_by: Optional[List[str]] = None,
     filesystem: Optional[pa_fs.FileSystem] = None,
@@ -72,6 +73,7 @@ def write_deltalake(
     name: Optional[str] = None,
     description: Optional[str] = None,
     configuration: Optional[Mapping[str, Optional[str]]] = None,
+    overwrite_schema: bool = False,
 ) -> None:
     """Write to a Delta Lake table (Experimental)
 
@@ -116,6 +118,7 @@ def write_deltalake(
     :param name: User-provided identifier for this table.
     :param description: User-provided description for this table.
     :param configuration: A map containing configuration options for the metadata action.
+    :param overwrite_schema: If True, allows updating the schema of the table.
     """
     if _has_pandas and isinstance(data, pd.DataFrame):
         data = pa.Table.from_pandas(data)
@@ -142,10 +145,12 @@ def write_deltalake(
     #    filesystem = pa_fs.PyFileSystem(DeltaStorageHandler(table_uri))
 
     if table:  # already exists
-        if schema != table.pyarrow_schema():
+        if schema != table.pyarrow_schema() and not (
+            mode == "overwrite" and overwrite_schema
+        ):
             raise ValueError(
                 "Schema of data does not match table schema\n"
-                f"Table schema:\n  {schema}\nData Schema:\n  {table.pyarrow_schema()}"
+                f"Table schema:\n{schema}\nData Schema:\n{table.pyarrow_schema()}"
             )
 
         if mode == "error":
@@ -227,6 +232,7 @@ def write_deltalake(
             add_actions,
             mode,
             partition_by or [],
+            schema,
         )
 
 

--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -357,3 +357,7 @@ to append pass in ``mode='append'``:
 
     >>> write_deltalake('path/to/table', df, mode='overwrite')
     >>> write_deltalake('path/to/table', df, mode='append')
+
+:py:meth:`write_deltalake` will raise :py:exc:`ValueError` if the schema of
+the data passed to it differs from the existing table's schema. If you wish to 
+alter the schema as part of an overwrite pass in ``overwrite_schema=True``.

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -110,6 +110,18 @@ def test_roundtrip_basic(tmp_path: pathlib.Path, sample_data: pa.Table):
         assert "/" not in add_path
 
 
+@pytest.mark.parametrize("mode", ["append", "overwrite"])
+def test_enforce_schema(existing_table: DeltaTable, mode: str):
+    bad_data = pa.table({"x": pa.array([1, 2, 3])})
+
+    with pytest.raises(ValueError):
+        write_deltalake(existing_table, bad_data, mode=mode)
+
+    table_uri = existing_table._table.table_uri()
+    with pytest.raises(ValueError):
+        write_deltalake(table_uri, bad_data, mode=mode)
+
+
 def test_local_path(tmp_path: pathlib.Path, sample_data: pa.Table, monkeypatch):
     monkeypatch.chdir(tmp_path)  # Make tmp_path the working directory
 


### PR DESCRIPTION
# Description

Changes:

 * Fixes `write_deltalake()` to enforce the existing schema of the table
 * Makes most arguments of `write_deltalake()` keyword-only. This is nice because it means re-ordering them later will no longer be a breaking change.
 * Added `overwrite_schema` argument, which allows providing a new schema when `mode="overwrite"`. This is meant to parallel the PySpark option `option(“overwriteSchema”, “true”)`.

# Related Issue(s)

 * Fixes #623

# Documentation

<!---
Share links to useful documentation
--->
