### PR TITLE
fix: Add correct size and null paritition values to add actions

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -88,15 +88,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: python-test-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+    - uses: Swatinem/rust-cache@v1
 
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
@@ -139,15 +131,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: python-pyspark-test-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+    - uses: Swatinem/rust-cache@v1
 
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -132,3 +132,46 @@ jobs:
       run: |
         source venv/bin/activate
         make build-documentation
+
+  test-pyspark:
+    name: PySpark Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: python-pyspark-test-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+
+    - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+    - uses: actions/setup-python@v3
+      with:
+        python-version: '3.10' 
+    
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '11'
+
+    - name: Build and install deltalake
+      run: |
+        pip install virtualenv
+        virtualenv venv
+        source venv/bin/activate
+        make develop-pyspark
+
+    - name: Run tests
+      run: |
+        source venv/bin/activate
+        make test-pyspark

--- a/python/Makefile
+++ b/python/Makefile
@@ -32,6 +32,11 @@ install: build ## Install Python binding of delta-rs
 	$(eval TARGET_WHEEL := $(shell ls ../target/wheels/deltalake-${PACKAGE_VERSION}-*.whl))
 	pip install $(TARGET_WHEEL)[devel,pandas]
 
+.PHONY: develop-pyspark
+install-pyspark: build
+	$(info --- Develop with Python binding ---)
+	maturin develop --extras=devel,pandas,pyspark $(MATURIN_EXTRA_ARGS)
+
 .PHONY: format
 format: ## Format the code
 	$(info --- Rust format ---)
@@ -60,6 +65,10 @@ check-python: ## Run check on Python
 unit-test: ## Run unit test
 	$(info --- Run Python unit-test ---)
 	python -m pytest
+
+.PHONY: test-pyspark
+test-pyspark:
+	python -m pytest -m 'pyspark and integration'
 
 .PHONY: build-documentation
 build-documentation: ## Build documentation with Sphinx

--- a/python/Makefile
+++ b/python/Makefile
@@ -33,7 +33,7 @@ install: build ## Install Python binding of delta-rs
 	pip install $(TARGET_WHEEL)[devel,pandas]
 
 .PHONY: develop-pyspark
-install-pyspark: build
+develop-pyspark: setup
 	$(info --- Develop with Python binding ---)
 	maturin develop --extras=devel,pandas,pyspark $(MATURIN_EXTRA_ARGS)
 

--- a/python/deltalake/fs.py
+++ b/python/deltalake/fs.py
@@ -46,8 +46,10 @@ class DeltaStorageHandler(FileSystemHandler):
         """
         infos = []
         for path in paths:
-            path, secs = self._storage.head_obj(path)
-            infos.append(FileInfo(path, type=FileType.File, mtime=float(secs)))
+            path, secs, size = self._storage.head_obj(path)
+            infos.append(
+                FileInfo(path, type=FileType.File, mtime=float(secs), size=size)
+            )
         return infos
 
     def get_file_info_selector(self, selector: FileSelector) -> List[FileInfo]:

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -276,18 +276,23 @@ def try_get_deltatable(table_uri: str) -> Optional[DeltaTable]:
         return None
 
 
-def get_partitions_from_path(base_path: str, path: str) -> Tuple[str, Dict[str, str]]:
+def get_partitions_from_path(
+    base_path: str, path: str
+) -> Tuple[str, Dict[str, Optional[str]]]:
     path = path.split(base_path, maxsplit=1)[1]
     if path[0] == "/":
         path = path[1:]
     parts = path.split("/")
     parts.pop()  # remove filename
-    out = {}
+    out: Dict[str, Optional[str]] = {}
     for part in parts:
         if part == "":
             continue
         key, value = part.split("=", maxsplit=1)
-        out[key] = value
+        if value == "__HIVE_DEFAULT_PARTITION__":
+            out[key] = None
+        else:
+            out[key] = value
     return path, out
 
 

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -191,7 +191,7 @@ def write_deltalake(
         add_actions.append(
             AddAction(
                 path,
-                written_file.metadata.serialized_size,
+                written_file.metadata.serialized_size, # TODO: find accurate source of file sizes
                 partition_values,
                 int(datetime.now().timestamp()),
                 True,

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -191,7 +191,7 @@ def write_deltalake(
         add_actions.append(
             AddAction(
                 path,
-                written_file.metadata.serialized_size, # TODO: find accurate source of file sizes
+                1024,  # TODO: find accurate source of file sizes
                 partition_values,
                 int(datetime.now().timestamp()),
                 True,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,6 +38,10 @@ devel = [
     "toml",
     "typing-extensions"
 ]
+pyspark = [
+    "pyspark",
+    "delta-spark"
+]
 
 [project.urls]
 documentation = "https://delta-io.github.io/delta-rs/python/"
@@ -78,4 +82,5 @@ markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
     "s3: marks tests as integration tests with S3 (deselect with '-m \"not s3\"')",
     "pandas: marks tests that require pandas",
+    "pyspark: marks tests that require pyspark",
 ]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -484,7 +484,11 @@ impl DeltaStorageFsBackend {
             .map_err(PyDeltaTableError::from_storage)?;
         Ok(PyTuple::new(
             py,
-            &[obj.path, obj.modified.timestamp().to_string()],
+            &[
+                obj.path.into_py(py),
+                obj.modified.timestamp().to_string().into_py(py),
+                obj.size.into_py(py),
+            ],
         ))
     }
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,6 +1,12 @@
 import os
+import pathlib
+from datetime import date, datetime, timedelta
+from decimal import Decimal
 
+import pyarrow as pa
 import pytest
+
+from deltalake import DeltaTable, write_deltalake
 
 
 @pytest.fixture(scope="session")
@@ -16,3 +22,39 @@ def s3_localstack(monkeypatch):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
     monkeypatch.setenv("AWS_ENDPOINT_URL", "http://localhost:4566")
+
+
+@pytest.fixture()
+def sample_data():
+    nrows = 5
+    return pa.table(
+        {
+            "utf8": pa.array([str(x) for x in range(nrows)]),
+            "int64": pa.array(list(range(nrows)), pa.int64()),
+            "int32": pa.array(list(range(nrows)), pa.int32()),
+            "int16": pa.array(list(range(nrows)), pa.int16()),
+            "int8": pa.array(list(range(nrows)), pa.int8()),
+            "float32": pa.array([float(x) for x in range(nrows)], pa.float32()),
+            "float64": pa.array([float(x) for x in range(nrows)], pa.float64()),
+            "bool": pa.array([x % 2 == 0 for x in range(nrows)]),
+            "binary": pa.array([str(x).encode() for x in range(nrows)]),
+            "decimal": pa.array([Decimal("10.000") + x for x in range(nrows)]),
+            "date32": pa.array(
+                [date(2022, 1, 1) + timedelta(days=x) for x in range(nrows)]
+            ),
+            "timestamp": pa.array(
+                [datetime(2022, 1, 1) + timedelta(hours=x) for x in range(nrows)]
+            ),
+            "struct": pa.array([{"x": x, "y": str(x)} for x in range(nrows)]),
+            "list": pa.array([list(range(x + 1)) for x in range(nrows)]),
+            # NOTE: https://github.com/apache/arrow-rs/issues/477
+            #'map': pa.array([[(str(y), y) for y in range(x)] for x in range(nrows)], pa.map_(pa.string(), pa.int64())),
+        }
+    )
+
+
+@pytest.fixture()
+def existing_table(tmp_path: pathlib.Path, sample_data: pa.Table):
+    path = str(tmp_path)
+    write_deltalake(path, sample_data)
+    return DeltaTable(path)

--- a/python/tests/pyspark_integration/test_writer_readable.py
+++ b/python/tests/pyspark_integration/test_writer_readable.py
@@ -3,7 +3,6 @@ import pathlib
 from typing import List
 
 import pyarrow as pa
-import pyspark
 import pytest
 
 from deltalake import DeltaTable, write_deltalake

--- a/python/tests/pyspark_integration/test_writer_readable.py
+++ b/python/tests/pyspark_integration/test_writer_readable.py
@@ -1,9 +1,10 @@
 """Test that pyspark can read tables written by deltalake(delta-rs)"""
-import delta
+import pathlib
+from typing import List
+
 import pyarrow as pa
 import pyspark
 import pytest
-from delta.tables import DeltaTable as SparkDeltaTable
 
 from deltalake import DeltaTable, write_deltalake
 
@@ -37,21 +38,66 @@ except ModuleNotFoundError:
     pass
 
 
+def assert_spark_read_equal(
+    expected: pa.Table, uri: str, sort_by: List[str] = ["int32"]
+):
+    df = spark.read.format("delta").load(uri)
+
+    # Spark and pyarrow don't convert these types to the same Pandas values
+    incompatible_types = ["timestamp", "struct"]
+
+    assert_frame_equal(
+        df.toPandas()
+        .sort_values(sort_by, ignore_index=True)
+        .drop(incompatible_types, axis="columns"),
+        expected.to_pandas()
+        .sort_values(sort_by, ignore_index=True)
+        .drop(incompatible_types, axis="columns"),
+    )
+
+
 @pytest.mark.pyspark
 @pytest.mark.integration
 def test_basic_read(sample_data: pa.Table, existing_table: DeltaTable):
     uri = existing_table._table.table_uri() + "/"
 
-    # Spark and pyarrow don't convert these types the same
-    incompatible_types = ["timestamp", "struct"]
+    assert_spark_read_equal(sample_data, uri)
 
-    df = spark.read.format("delta").load(uri).orderBy("int32")
-    assert_frame_equal(
-        df.toPandas().drop(incompatible_types, axis="columns"),
-        existing_table.to_pandas().drop(incompatible_types, axis="columns"),
-    )
-
-    dt = delta.tables.DeltaTable(spark, uri)
+    dt = delta.tables.DeltaTable.forPath(spark, uri)
     history = dt.history().collect()
     assert len(history) == 1
     assert history[0].version == 0
+
+
+@pytest.mark.pyspark
+@pytest.mark.integration
+def test_partitioned(tmp_path: pathlib.Path, sample_data: pa.Table):
+    partition_cols = ["date32", "utf8"]
+
+    # Add null values to sample data to verify we can read null partitions
+    sample_data_with_null = sample_data
+    for col in partition_cols:
+        i = sample_data.schema.get_field_index(col)
+        field = sample_data.schema.field(i)
+        nulls = pa.array([None] * sample_data.num_rows, type=field.type)
+        sample_data_with_null = sample_data_with_null.set_column(i, field, nulls)
+    data = pa.concat_tables([sample_data, sample_data_with_null])
+
+    write_deltalake(str(tmp_path), data, partition_by=partition_cols)
+
+    assert_spark_read_equal(data, str(tmp_path), sort_by=["utf8", "int32"])
+
+
+@pytest.mark.pyspark
+@pytest.mark.integration
+def test_overwrite(
+    tmp_path: pathlib.Path, sample_data: pa.Table, existing_table: DeltaTable
+):
+    path = str(tmp_path)
+
+    write_deltalake(path, sample_data, mode="append")
+    expected = pa.concat_tables([sample_data, sample_data])
+    assert_spark_read_equal(expected, path)
+
+    write_deltalake(path, sample_data, mode="overwrite")
+    assert_spark_read_equal(sample_data, path)

--- a/python/tests/pyspark_integration/test_writer_readable.py
+++ b/python/tests/pyspark_integration/test_writer_readable.py
@@ -1,0 +1,47 @@
+"""Test that pyspark can read tables written by deltalake(delta-rs)"""
+import delta
+import pyarrow as pa
+import pyspark
+import pytest
+from delta.tables import DeltaTable as SparkDeltaTable
+
+from deltalake import DeltaTable, write_deltalake
+
+try:
+    from pandas.testing import assert_frame_equal
+except ModuleNotFoundError:
+    _has_pandas = False
+else:
+    _has_pandas = True
+
+
+@pytest.fixture
+def spark():
+    builder = (
+        pyspark.sql.SparkSession.builder.appName("MyApp")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+    )
+    return delta.configure_spark_with_delta_pip(builder).getOrCreate()
+
+
+@pytest.mark.pyspark
+@pytest.mark.integration
+def test_basic_read(
+    sample_data: pa.Table, existing_table: DeltaTable, spark: pyspark.sql.SparkSession
+):
+    uri = existing_table._table.table_uri()
+
+    dt = SparkDeltaTable(spark, uri)
+    history = dt.history().collect()
+    assert len(history) == 1
+    assert history[0].version == 0
+
+    df = spark.read.format("delta").load(uri)
+    # print(df.count())
+    # print(df.toPandas())
+    # import pdb; pdb.set_trace()
+    assert_frame_equal(df.toPandas(), existing_table.to_pandas())

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -57,8 +57,6 @@ def test_roundtrip_basic(tmp_path: pathlib.Path, sample_data: pa.Table):
     for action in get_add_actions(delta_table):
         path = os.path.join(tmp_path, action["path"])
         actual_size = os.path.getsize(path)
-        assert action["size"] > 0
-        # TODO: fix this
         assert actual_size == action["size"]
 
 

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -3,7 +3,6 @@ import json
 import os
 import pathlib
 import random
-import sys
 from datetime import datetime
 from typing import Dict, Iterable, List
 from unittest.mock import Mock

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -60,7 +60,7 @@ def test_roundtrip_basic(tmp_path: pathlib.Path, sample_data: pa.Table):
         actual_size = os.path.getsize(path)
         assert action["size"] > 0
         # TODO: fix this
-        # assert actual_size == action["size"]
+        assert actual_size == action["size"]
 
 
 @pytest.mark.parametrize("mode", ["append", "overwrite"])

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -54,11 +54,13 @@ def test_roundtrip_basic(tmp_path: pathlib.Path, sample_data: pa.Table):
     for add_path in get_add_paths(delta_table):
         # Paths should be relative, and with no partitioning have no directories
         assert "/" not in add_path
-    
+
     for action in get_add_actions(delta_table):
         path = os.path.join(tmp_path, action["path"])
         actual_size = os.path.getsize(path)
-        assert actual_size == action["size"]
+        assert action["size"] > 0
+        # TODO: fix this
+        # assert actual_size == action["size"]
 
 
 @pytest.mark.parametrize("mode", ["append", "overwrite"])
@@ -296,7 +298,7 @@ def get_stats(table: DeltaTable):
     if len(actions) == 1:
         return json.loads(actions[0]["stats"])
     else:
-        raise AssertionError("No add action found!")        
+        raise AssertionError("No add action found!")
 
 
 def get_add_paths(table: DeltaTable) -> List[str]:

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -4,8 +4,7 @@ import os
 import pathlib
 import random
 import sys
-from datetime import date, datetime, timedelta
-from decimal import Decimal
+from datetime import datetime
 from typing import Dict, Iterable, List
 from unittest.mock import Mock
 
@@ -26,42 +25,6 @@ except ModuleNotFoundError:
     _has_pandas = False
 else:
     _has_pandas = True
-
-
-@pytest.fixture()
-def sample_data():
-    nrows = 5
-    return pa.table(
-        {
-            "utf8": pa.array([str(x) for x in range(nrows)]),
-            "int64": pa.array(list(range(nrows)), pa.int64()),
-            "int32": pa.array(list(range(nrows)), pa.int32()),
-            "int16": pa.array(list(range(nrows)), pa.int16()),
-            "int8": pa.array(list(range(nrows)), pa.int8()),
-            "float32": pa.array([float(x) for x in range(nrows)], pa.float32()),
-            "float64": pa.array([float(x) for x in range(nrows)], pa.float64()),
-            "bool": pa.array([x % 2 == 0 for x in range(nrows)]),
-            "binary": pa.array([str(x).encode() for x in range(nrows)]),
-            "decimal": pa.array([Decimal("10.000") + x for x in range(nrows)]),
-            "date32": pa.array(
-                [date(2022, 1, 1) + timedelta(days=x) for x in range(nrows)]
-            ),
-            "timestamp": pa.array(
-                [datetime(2022, 1, 1) + timedelta(hours=x) for x in range(nrows)]
-            ),
-            "struct": pa.array([{"x": x, "y": str(x)} for x in range(nrows)]),
-            "list": pa.array([list(range(x + 1)) for x in range(nrows)]),
-            # NOTE: https://github.com/apache/arrow-rs/issues/477
-            #'map': pa.array([[(str(y), y) for y in range(x)] for x in range(nrows)], pa.map_(pa.string(), pa.int64())),
-        }
-    )
-
-
-@pytest.fixture()
-def existing_table(tmp_path: pathlib.Path, sample_data: pa.Table):
-    path = str(tmp_path)
-    write_deltalake(path, sample_data)
-    return DeltaTable(path)
 
 
 @pytest.mark.skip(reason="Waiting on #570")

--- a/rust/src/checkpoints.rs
+++ b/rust/src/checkpoints.rs
@@ -250,6 +250,7 @@ async fn cleanup_expired_logs_for(
         ObjectMeta {
             path: String::new(),
             modified: MIN_DATETIME,
+            size: None,
         },
     );
     let file_needs_time_adjustment =
@@ -293,6 +294,7 @@ async fn cleanup_expired_logs_for(
                 ObjectMeta {
                     path: current_file.1.path.clone(),
                     modified: last_file.1.modified.add(Duration::seconds(1)),
+                    size: None,
                 },
             );
             maybe_delete_files.push(updated);

--- a/rust/src/storage/azure/mod.rs
+++ b/rust/src/storage/azure/mod.rs
@@ -325,6 +325,7 @@ impl StorageBackend for AdlsGen2Backend {
         Ok(ObjectMeta {
             path: path.to_string(),
             modified,
+            size: properties.content_length,
         })
     }
 
@@ -369,6 +370,7 @@ impl StorageBackend for AdlsGen2Backend {
                     Ok(ObjectMeta {
                         path: path.to_string(),
                         modified: p.last_modified,
+                        size: Some(p.content_length),
                     })
                 }))),
                 Err(err) => Either::Right(stream::once(async {

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -75,6 +75,7 @@ impl StorageBackend for FileStorageBackend {
         Ok(ObjectMeta {
             path: path.to_string(),
             modified: DateTime::from(attr.modified().unwrap()),
+            size: Some(attr.len().try_into().unwrap()),
         })
     }
 
@@ -95,6 +96,7 @@ impl StorageBackend for FileStorageBackend {
             Ok(ObjectMeta {
                 path: String::from(entry.path().to_str().unwrap()),
                 modified: DateTime::from(entry.metadata().await.unwrap().modified().unwrap()),
+                size: Some(entry.metadata().await.unwrap().len().try_into().unwrap()),
             })
         })))
     }

--- a/rust/src/storage/gcs/mod.rs
+++ b/rust/src/storage/gcs/mod.rs
@@ -41,6 +41,7 @@ impl From<tame_gcs::objects::Metadata> for ObjectMeta {
         ObjectMeta {
             path: metadata.name.unwrap(),
             modified: metadata.updated.unwrap(),
+            size: metadata.size.map(|s| s.try_into().unwrap()),
         }
     }
 }

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -456,6 +456,8 @@ pub struct ObjectMeta {
     // The timestamp of a commit comes from the remote storage `lastModifiedTime`, and can be
     // adjusted for clock skew.
     pub modified: DateTime<Utc>,
+    /// Size of the object in bytes
+    pub size: Option<i64>,
 }
 
 impl Clone for ObjectMeta {
@@ -463,6 +465,7 @@ impl Clone for ObjectMeta {
         Self {
             path: self.path.clone(),
             modified: self.modified,
+            size: self.size,
         }
     }
 }

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -490,6 +490,7 @@ fn try_object_meta_from(bucket: &str, obj: rusoto_s3::Object) -> Result<ObjectMe
     Ok(ObjectMeta {
         path: format!("s3://{}/{}", bucket, key),
         modified: parse_obj_last_modified_time(&obj.last_modified)?,
+        size: obj.size,
     })
 }
 
@@ -621,6 +622,7 @@ impl StorageBackend for S3StorageBackend {
         Ok(ObjectMeta {
             path: path.to_string(),
             modified: parse_head_obj_last_modified_time(&result.last_modified)?,
+            size: result.content_length,
         })
     }
 

--- a/rust/tests/adls_gen2_backend_test.rs
+++ b/rust/tests/adls_gen2_backend_test.rs
@@ -102,6 +102,7 @@ mod adls_gen2_backend {
         // Assert
         let file_meta_data = result.unwrap();
         assert_eq!(file_meta_data.path, *file_path);
+        assert_eq!(file_meta_data.size, Some(3));
 
         // Cleanup
         file_system_client.delete().into_future().await.unwrap();

--- a/rust/tests/s3_test.rs
+++ b/rust/tests/s3_test.rs
@@ -130,6 +130,14 @@ mod s3 {
         let err = backend.head_obj(key).await.err().unwrap();
 
         assert!(matches!(err, StorageError::NotFound));
+
+        let key = "s3://deltars/head_test";
+        let data: &[u8] = b"Hello world!";
+        backend.put_obj(key, data).await.unwrap();
+        let head_data = backend.head_obj(key).await.unwrap();
+        assert_eq!(head_data.size, Some(data.len().try_into().unwrap()));
+        assert_eq!(head_data.path, key);
+        assert!(head_data.modified > (chrono::offset::Utc::now() - chrono::Duration::seconds(30)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description

Fixes two bugs:

 1. The `size` field of add actions was always being set to zero. This PR corrrect that to always use the correct file size.
 2. Null partition values were being recorded in add actions with the string `"__HIVE_DEFAULT_PARTITION__"`. They are now correctly recorded as JSON `null` values. 

Other changes in service of fixing those bugs:

 1. Added pyspark integration tests that run in CI. This is what allowed me to catch the bugs. Right now it just tests that the output of our writer is readable in Spark. Our existing tests show that we can read their tables. We can't write to each others tables yet, because we don't support the same writer versions. (But maybe I should double check we are enforcing that 🤔 .)
 2. Added `size` field to `ObjectMeta`, so we can use `head_object()` to get file sizes to solve bug (1). In the future, I hope PyArrow will provide the file sizes in the visitor so we don't have to make these extra API calls. (object_store_rs already has this field in it's [ObjectMeta struct](https://github.com/influxdata/object_store_rs/blob/b98d6b5015cebc292f6174d06cfb5a424999bcc9/src/lib.rs#L123-L130).)

# Related Issue(s)

 * Related to #619.
 * This starts work on #579.

# Documentation

<!---
Share links to useful documentation
--->
