### PR TITLE
Defer creation of storage backend in DeltaTableBuilder

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -540,7 +540,7 @@ impl DeltaTableBuilder {
         self
     }
 
-    /// explicitely set a backend (override backend derived from `table_uri`)
+    /// Set the storage backend. If a backend is not provided then it is derived from `table_uri` when `load` is called.
     pub fn with_storage_backend(mut self, storage: Box<dyn StorageBackend>) -> Self {
         self.options.storage_backend = Some(storage);
         self


### PR DESCRIPTION
# Description
Defers the creation of the storage backend until `build` is called on the builder unless a backend is provided by the user.

An alternative approach to resolving this is to add a new method called `from_uri_with_map` which will use a map when creating a backend. If we want to use this approach I have no problem with changing the implementation.

# Related Issue(s)

- closes #638
