### PR TITLE
Refactor azure storage with crate updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,28 +31,17 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-10.15
-          - windows-2019
+          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rs/toolchain@v1
         with:
           profile: default
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v1
       - name: build and lint with clippy
         run: cargo clippy --features azure,datafusion-ext,s3
       - name: Spot-check build for rustls features
@@ -65,88 +54,31 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-10.15
-          # - windows-2019
+          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-            test-${{ runner.os }}-cargo-
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rs/toolchain@v1
         with:
           profile: default
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v1
       - name: Run tests
-        run: cargo test --verbose --features datafusion-ext,azure
-
-  test-win:
-    # running windows tests on separate machine due to space constraints
-    # workaround based on https://github.com/actions/virtual-environments/issues/1341
-    name: Test (Windows)
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-      - name: Copy to C drive
-        run: cp D:\a C:\ -Recurse
-      - uses: actions/cache@v2
-        with:
-          working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-            test-${{ runner.os }}-cargo-
-      - name: Install minimal stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
-        with:
-          working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-          profile: default
-          toolchain: stable
-          override: true
-      - name: Run tests
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
         run: cargo test --verbose --features datafusion-ext,azure
 
   s3_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: s3-test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            s3-test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-            s3-test-${{ runner.os }}-cargo-
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rs/toolchain@v1
         with:
           profile: default
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v1
       - name: Setup localstack
         run: docker-compose up setup
       - name: Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-10.15
-          - windows-2019
+          # - windows-2019
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -88,6 +88,41 @@ jobs:
           toolchain: stable
           override: true
       - name: Run tests
+        run: cargo test --verbose --features datafusion-ext,azure
+
+  test-win:
+    # running windows tests on separate machine due to space constraints
+    # workaround based on https://github.com/actions/virtual-environments/issues/1341
+    name: Test (Windows)
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - name: Copy to C drive
+        run: cp D:\a C:\ -Recurse
+      - uses: actions/cache@v2
+        with:
+          working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            test-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+            test-${{ runner.os }}-cargo-
+      - name: Install minimal stable with clippy and rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+          profile: default
+          toolchain: stable
+          override: true
+      - name: Run tests
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
         run: cargo test --verbose --features datafusion-ext,azure
 
   s3_test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,8 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "azure_core"
 version = "0.3.0"
-source = "git+https://github.com/roeap/azure-sdk-for-rust/?branch=head-datalake#8f9c0e6fdf9a01f6b0438464ed3204f2f33ce743"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0e2c7582699a3af9cc8a7bc81259519d8afb8eded1090d4fcd86de3db0eace1"
 dependencies = [
  "async-trait",
  "base64",
@@ -201,7 +202,8 @@ dependencies = [
 [[package]]
 name = "azure_identity"
 version = "0.4.0"
-source = "git+https://github.com/roeap/azure-sdk-for-rust/?branch=head-datalake#8f9c0e6fdf9a01f6b0438464ed3204f2f33ce743"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80434580cb2e2a1915b57fbd3655b513c4acf149cfbb85747f91649d48833ae"
 dependencies = [
  "async-lock",
  "async-timer",
@@ -222,8 +224,9 @@ dependencies = [
 
 [[package]]
 name = "azure_storage"
-version = "0.3.0"
-source = "git+https://github.com/roeap/azure-sdk-for-rust/?branch=head-datalake#8f9c0e6fdf9a01f6b0438464ed3204f2f33ce743"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a5bc29e999268e618c202f157291930d749f1e4de55e01ecfda3990dd37dc7"
 dependencies = [
  "RustyXML",
  "async-trait",
@@ -247,8 +250,9 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_datalake"
-version = "0.3.0"
-source = "git+https://github.com/roeap/azure-sdk-for-rust/?branch=head-datalake#8f9c0e6fdf9a01f6b0438464ed3204f2f33ce743"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41971cdf60cf59647979ef373b02ecc156fa126e99730e1674b8595f46797462"
 dependencies = [
  "async-trait",
  "azure_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,8 +175,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "azure_core"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e2c7582699a3af9cc8a7bc81259519d8afb8eded1090d4fcd86de3db0eace1"
+source = "git+https://github.com/roeap/azure-sdk-for-rust/?branch=head-datalake#8f9c0e6fdf9a01f6b0438464ed3204f2f33ce743"
 dependencies = [
  "async-trait",
  "base64",
@@ -202,8 +201,7 @@ dependencies = [
 [[package]]
 name = "azure_identity"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80434580cb2e2a1915b57fbd3655b513c4acf149cfbb85747f91649d48833ae"
+source = "git+https://github.com/roeap/azure-sdk-for-rust/?branch=head-datalake#8f9c0e6fdf9a01f6b0438464ed3204f2f33ce743"
 dependencies = [
  "async-lock",
  "async-timer",
@@ -225,8 +223,7 @@ dependencies = [
 [[package]]
 name = "azure_storage"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21c9efa0126aefcdf620395b262143e86aa95002df3c3030a471ed9f5c4dad4"
+source = "git+https://github.com/roeap/azure-sdk-for-rust/?branch=head-datalake#8f9c0e6fdf9a01f6b0438464ed3204f2f33ce743"
 dependencies = [
  "RustyXML",
  "async-trait",
@@ -251,8 +248,7 @@ dependencies = [
 [[package]]
 name = "azure_storage_datalake"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d891ba3035da009368372dabf3f23706c81e91db871a0de37ab712e292a10d7"
+source = "git+https://github.com/roeap/azure-sdk-for-rust/?branch=head-datalake#8f9c0e6fdf9a01f6b0438464ed3204f2f33ce743"
 dependencies = [
  "async-trait",
  "azure_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.1",
  "utime",
  "uuid 1.0.0",
 ]
@@ -3025,7 +3024,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "futures-util",
  "pin-project-lite",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "azure_core"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4393afee90ad13c987a2cbfeb5bbb0b9fb3c86585e42ed3ed151babaa93da1"
+checksum = "c0e2c7582699a3af9cc8a7bc81259519d8afb8eded1090d4fcd86de3db0eace1"
 dependencies = [
  "async-trait",
  "base64",
@@ -195,16 +195,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror",
  "url",
  "uuid 1.0.0",
 ]
 
 [[package]]
 name = "azure_identity"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a931af53bade449760620b429cad695a72bf07e7864d0e39e11fa442ee0458"
+checksum = "a80434580cb2e2a1915b57fbd3655b513c4acf149cfbb85747f91649d48833ae"
 dependencies = [
  "async-lock",
  "async-timer",
@@ -212,22 +211,22 @@ dependencies = [
  "azure_core",
  "base64",
  "chrono",
+ "fix-hidden-lifetime-bug",
  "futures",
+ "http",
  "log",
  "oauth2",
- "reqwest",
  "serde",
  "serde_json",
- "thiserror",
  "url",
  "uuid 1.0.0",
 ]
 
 [[package]]
 name = "azure_storage"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9f2aee687da9817f7b332e1e01dda51cd9f7a0a68a5abcfec7c4c494a65546"
+checksum = "d21c9efa0126aefcdf620395b262143e86aa95002df3c3030a471ed9f5c4dad4"
 dependencies = [
  "RustyXML",
  "async-trait",
@@ -245,16 +244,15 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.2",
- "thiserror",
  "url",
  "uuid 1.0.0",
 ]
 
 [[package]]
 name = "azure_storage_blobs"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17982127c4a34736a60656ddbd05b1714420686b6e6304145ee3b4501395e75"
+checksum = "47f61c2e25e51058f4ff5a9298620e4b8534326a9f2d2936b6aca5c0ac76aaca"
 dependencies = [
  "RustyXML",
  "azure_core",
@@ -270,16 +268,15 @@ dependencies = [
  "serde-xml-rs",
  "serde_derive",
  "serde_json",
- "thiserror",
  "url",
  "uuid 1.0.0",
 ]
 
 [[package]]
 name = "azure_storage_datalake"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78936621558980aa1e5d861690999f8cdc89a6203e21d04ae45c36e9e454930"
+checksum = "1d891ba3035da009368372dabf3f23706c81e91db871a0de37ab712e292a10d7"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -743,6 +740,7 @@ dependencies = [
  "parquet-format",
  "percent-encoding",
  "pretty_assertions",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "rusoto_core",
@@ -935,6 +933,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fix-hidden-lifetime-bug"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b7e739f1d47bbc5185391f0b280ef0bd953fa2327d0bf0c619183502923938"
+dependencies = [
+ "fix-hidden-lifetime-bug-proc_macros",
+]
+
+[[package]]
+name = "fix-hidden-lifetime-bug-proc_macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb97774845ef67bfa186b3a39ed2dec87ed70b4932f076ca75392e9c58a6bda1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,30 +249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "azure_storage_blobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f61c2e25e51058f4ff5a9298620e4b8534326a9f2d2936b6aca5c0ac76aaca"
-dependencies = [
- "RustyXML",
- "azure_core",
- "azure_storage",
- "base64",
- "bytes",
- "chrono",
- "futures",
- "http",
- "log",
- "md5",
- "serde",
- "serde-xml-rs",
- "serde_derive",
- "serde_json",
- "url",
- "uuid 1.0.0",
-]
-
-[[package]]
 name = "azure_storage_datalake"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,7 +697,6 @@ dependencies = [
  "azure_core",
  "azure_identity",
  "azure_storage",
- "azure_storage_blobs",
  "azure_storage_datalake",
  "bytes",
  "cfg-if",
@@ -1602,12 +1577,6 @@ checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
 dependencies = [
  "digest 0.10.3",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,11 +33,11 @@ reqwest = { version = "0.11", default-features = false, features = [
 ], optional = true }
 
 # Azure
-azure_core = { version = "0.2.2", optional = true }
-azure_storage = { version = "0.2", optional = true }
-azure_storage_blobs = { version = "0.2", optional = true }
-azure_storage_datalake = { version = "0.2", optional = true }
-azure_identity = { version = "0.2", optional = true }
+azure_core = { version = "0.3", optional = true }
+azure_storage = { version = "0.3", optional = true }
+azure_storage_blobs = { version = "0.3", optional = true }
+azure_storage_datalake = { version = "0.3", optional = true }
+azure_identity = { version = "0.4", optional = true }
 
 # S3
 rusoto_core = { version = "0.48", default-features = false, optional = true }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,10 +33,10 @@ reqwest = { version = "0.11", default-features = false, features = [
 ], optional = true }
 
 # Azure
-azure_core = { version = "0.3", optional = true }
-azure_storage = { version = "0.3", optional = true }
-azure_storage_datalake = { version = "0.3", optional = true }
-azure_identity = { version = "0.4", optional = true }
+azure_core = { git = "https://github.com/roeap/azure-sdk-for-rust/", branch = "head-datalake", optional = true }
+azure_storage = { git = "https://github.com/roeap/azure-sdk-for-rust/", branch = "head-datalake", optional = true }
+azure_storage_datalake = { git = "https://github.com/roeap/azure-sdk-for-rust/", branch = "head-datalake", optional = true }
+azure_identity = { git = "https://github.com/roeap/azure-sdk-for-rust/", branch = "head-datalake", optional = true }
 
 # S3
 rusoto_core = { version = "0.48", default-features = false, optional = true }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["fs", "macros", "rt", "io-util"] }
 tokio-stream = { version = "0", features = ["fs"] }
-tokio-util = { version = "0.7.1", features = ["rt"] }
 futures = "0.3"
 bytes = "1"
 log = "0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,10 +33,10 @@ reqwest = { version = "0.11", default-features = false, features = [
 ], optional = true }
 
 # Azure
-azure_core = { git = "https://github.com/roeap/azure-sdk-for-rust/", branch = "head-datalake", optional = true }
-azure_storage = { git = "https://github.com/roeap/azure-sdk-for-rust/", branch = "head-datalake", optional = true }
-azure_storage_datalake = { git = "https://github.com/roeap/azure-sdk-for-rust/", branch = "head-datalake", optional = true }
-azure_identity = { git = "https://github.com/roeap/azure-sdk-for-rust/", branch = "head-datalake", optional = true }
+azure_core = { version = "0.3", optional = true }
+azure_storage = { version = "0.4", optional = true }
+azure_storage_datalake = { version = "0.4", optional = true }
+azure_identity = { version = "0.4", optional = true }
 
 # S3
 rusoto_core = { version = "0.48", default-features = false, optional = true }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,7 +35,6 @@ reqwest = { version = "0.11", default-features = false, features = [
 # Azure
 azure_core = { version = "0.3", optional = true }
 azure_storage = { version = "0.3", optional = true }
-azure_storage_blobs = { version = "0.3", optional = true }
 azure_storage_datalake = { version = "0.3", optional = true }
 azure_identity = { version = "0.4", optional = true }
 
@@ -80,7 +79,6 @@ datafusion-ext = ["datafusion"]
 azure = [
     "azure_core",
     "azure_storage",
-    "azure_storage_blobs",
     "azure_storage_datalake",
     "azure_identity",
     "reqwest",

--- a/rust/src/storage/azure/mod.rs
+++ b/rust/src/storage/azure/mod.rs
@@ -401,8 +401,8 @@ impl StorageBackend for AdlsGen2Backend {
         let dst_obj = parse_uri(dst)?.into_adlsgen2_object()?;
         self.validate_container(&dst_obj)?;
 
-        let file_client = self.file_system_client.get_file_client(src_obj.path);
-        file_client
+        self.file_system_client
+            .get_file_client(src_obj.path)
             .rename_if_not_exists(dst_obj.path)
             .into_future()
             .await

--- a/rust/src/storage/azure/mod.rs
+++ b/rust/src/storage/azure/mod.rs
@@ -358,7 +358,11 @@ impl StorageBackend for AdlsGen2Backend {
         Ok(self
             .file_system_client
             .list_paths()
-            .directory(path)
+            // TODO this assumes we are always only interested in listing contents in one directory.
+            // to make list requests cheaper. As far as I can tell this should work in this case,
+            // although this behavior might be different in other object store implementations.
+            .recursive(false)
+            .directory(obj.path)
             .into_stream()
             .flat_map(|it| match it {
                 Ok(paths) => Either::Left(stream::iter(paths.into_iter().map(|p| {

--- a/rust/src/storage/azure/mod.rs
+++ b/rust/src/storage/azure/mod.rs
@@ -4,8 +4,8 @@
 //!
 use super::{parse_uri, str_option, ObjectMeta, StorageBackend, StorageError, UriError};
 use azure_core::auth::TokenCredential;
-use azure_core::ClientOptions;
-use azure_identity::token_credentials::{
+use azure_core::{error::ErrorKind as AzureErrorKind, ClientOptions};
+use azure_identity::{
     AutoRefreshingTokenCredential, ClientSecretCredential, TokenCredentialOptions,
 };
 use azure_storage::storage_shared_key_credential::StorageSharedKeyCredential;
@@ -14,13 +14,9 @@ use futures::stream::Stream;
 use futures::StreamExt;
 use log::debug;
 use std::collections::HashMap;
-use std::error::Error;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::{fmt, pin::Pin};
-use tokio::sync::mpsc::{self, Sender};
-use tokio_stream::wrappers::ReceiverStream;
-use tokio_util::task::LocalPoolHandle;
 
 /// Storage option keys to use when creating [crate::storage::azure::AzureStorageOptions].
 /// The same key should be used whether passing a key in the hashmap or setting it as an environment variable.
@@ -188,10 +184,8 @@ impl<'a> fmt::Display for AdlsGen2Object<'a> {
 /// This uses the `dfs.core.windows.net` endpoint.
 #[derive(Debug)]
 pub struct AdlsGen2Backend {
-    storage_account_name: String,
     file_system_name: String,
     file_system_client: FileSystemClient,
-    local_pool_handle: LocalPoolHandle,
 }
 
 impl AdlsGen2Backend {
@@ -228,7 +222,7 @@ impl AdlsGen2Backend {
         let storage_account_name: String = storage_account_name.into();
         let data_lake_client = DataLakeClient::new_with_token_credential(
             token_credential,
-            storage_account_name.clone(),
+            storage_account_name,
             None,
             ClientOptions::default(),
         );
@@ -236,10 +230,8 @@ impl AdlsGen2Backend {
         let file_system_client = data_lake_client.into_file_system_client(file_system_name.clone());
 
         Ok(AdlsGen2Backend {
-            storage_account_name,
             file_system_name: file_system_name.into(),
             file_system_client,
-            local_pool_handle: LocalPoolHandle::new(1),
         })
     }
 
@@ -292,18 +284,12 @@ impl AdlsGen2Backend {
         file_system_name: impl Into<String> + Clone,
         options: AzureStorageOptions,
     ) -> Result<Self, StorageError> {
-        let storage_account_name = options.account_name.clone().ok_or_else(|| {
-            StorageError::AzureConfig("account name must be provided".to_string())
-        })?;
-
         let data_lake_client: DataLakeClient = options.try_into()?;
         let file_system_client = data_lake_client.into_file_system_client(file_system_name.clone());
 
         Ok(AdlsGen2Backend {
-            storage_account_name,
             file_system_name: file_system_name.into(),
             file_system_client,
-            local_pool_handle: LocalPoolHandle::new(1),
         })
     }
 
@@ -321,71 +307,6 @@ impl AdlsGen2Backend {
     }
 }
 
-fn to_storage_err(err: Box<dyn Error + Sync + std::marker::Send>) -> StorageError {
-    match err.downcast_ref::<azure_core::HttpError>() {
-        Some(azure_core::HttpError::StatusCode { status, body: _ }) if status.as_u16() == 404 => {
-            StorageError::NotFound
-        }
-        _ => StorageError::AzureGeneric { source: err },
-    }
-}
-
-fn to_storage_err2(err: azure_storage::core::Error) -> StorageError {
-    if let azure_storage::core::Error::CoreError(azure_core::Error::Other(ref other_err)) = err {
-        match other_err.downcast_ref::<azure_core::error::Error>() {
-            Some(other_err) => match other_err.downcast_ref::<azure_core::error::HttpError>() {
-                Some(e) => {
-                    if e.status() == 404 {
-                        return StorageError::NotFound;
-                    }
-                }
-                None => {}
-            },
-            None => {}
-        }
-    }
-    StorageError::AzureStorage { source: err }
-}
-
-// TODO: This implementation exists since Azure's Pageable is !Send.
-// When this is resolved in the Azure crates, fix this up too
-async fn list_obj_future(
-    client: FileSystemClient,
-    path: String,
-    storage_account_name: String,
-    file_system_name: String,
-    tx: Sender<Result<ObjectMeta, StorageError>>,
-) {
-    let mut stream = client.list_paths().directory(path).into_stream();
-
-    while let Some(path_response_res) = stream.next().await {
-        match path_response_res {
-            Ok(path_response) => {
-                for path in path_response.paths {
-                    let object = AdlsGen2Object {
-                        account_name: &storage_account_name,
-                        file_system: &file_system_name,
-                        path: &path.name,
-                    };
-                    let object_meta = Ok(ObjectMeta {
-                        path: object.to_string(),
-                        modified: path.last_modified,
-                    });
-                    let res = tx.send(object_meta).await;
-
-                    if let Err(_e) = res {
-                        return;
-                    }
-                }
-            }
-            Err(err) => {
-                let _res = tx.send(Err(to_storage_err(Box::new(err)))).await;
-                return;
-            }
-        }
-    }
-}
-
 #[async_trait::async_trait]
 impl StorageBackend for AdlsGen2Backend {
     async fn head_obj(&self, path: &str) -> Result<ObjectMeta, StorageError> {
@@ -398,8 +319,7 @@ impl StorageBackend for AdlsGen2Backend {
             .get_file_client(obj.path)
             .get_properties()
             .into_future()
-            .await
-            .map_err(to_storage_err2)?;
+            .await?;
 
         let modified = properties.last_modified;
         Ok(ObjectMeta {
@@ -418,8 +338,7 @@ impl StorageBackend for AdlsGen2Backend {
             .get_file_client(obj.path)
             .read()
             .into_future()
-            .await
-            .map_err(to_storage_err2)?
+            .await?
             .data
             .to_vec();
         Ok(data)
@@ -436,24 +355,25 @@ impl StorageBackend for AdlsGen2Backend {
         let obj = parse_uri(path)?.into_adlsgen2_object()?;
         self.validate_container(&obj)?;
 
-        let client = self.file_system_client.clone();
-        let storage_account_name = self.storage_account_name.to_owned();
-        let file_system_name = self.file_system_name.to_owned();
-        let prefix_path = path.to_owned();
-        let (tx, rx) = mpsc::channel(1024);
-
-        let handle = self.local_pool_handle.spawn_pinned(|| {
-            list_obj_future(
-                client,
-                prefix_path,
-                storage_account_name,
-                file_system_name,
-                tx,
-            )
-        });
-
-        tokio::spawn(handle);
-        Ok(Box::pin(ReceiverStream::new(rx)))
+        Ok(self
+            .file_system_client
+            .list_paths()
+            .directory(path)
+            .into_stream()
+            .flat_map(|it| match it {
+                Ok(paths) => futures::future::Either::Left(futures::stream::iter(
+                    paths.into_iter().map(|p| {
+                        Ok(ObjectMeta {
+                            path: path.to_string(),
+                            modified: p.last_modified,
+                        })
+                    }),
+                )),
+                Err(err) => futures::future::Either::Right(futures::stream::iter(vec![Err(
+                    StorageError::Azure { source: err },
+                )])),
+            })
+            .boxed())
     }
 
     async fn put_obj(&self, path: &str, obj_bytes: &[u8]) -> Result<(), StorageError> {
@@ -465,22 +385,9 @@ impl StorageBackend for AdlsGen2Backend {
 
         // TODO: Consider using Blob API again since it's just 1 REST call instead of 3
         let file_client = self.file_system_client.get_file_client(obj.path);
-        file_client
-            .create()
-            .into_future()
-            .await
-            .map_err(to_storage_err2)?;
-        file_client
-            .append(0, data)
-            .into_future()
-            .await
-            .map_err(to_storage_err2)?;
-        file_client
-            .flush(length)
-            .close(true)
-            .into_future()
-            .await
-            .map_err(to_storage_err2)?;
+        file_client.create().into_future().await?;
+        file_client.append(0, data).into_future().await?;
+        file_client.flush(length).close(true).into_future().await?;
 
         Ok(())
     }
@@ -493,31 +400,17 @@ impl StorageBackend for AdlsGen2Backend {
         self.validate_container(&dst_obj)?;
 
         let file_client = self.file_system_client.get_file_client(src_obj.path);
-        let result = file_client
+        file_client
             .rename_if_not_exists(dst_obj.path)
             .into_future()
-            .await;
-
-        if let Err(err) = result {
-            if let azure_storage::core::Error::CoreError(azure_core::Error::Other(ref other_err)) =
-                err
-            {
-                match other_err.downcast_ref::<azure_core::error::Error>() {
-                    Some(other_err) => {
-                        match other_err.downcast_ref::<azure_core::error::HttpError>() {
-                            Some(e) => {
-                                if e.status() == 409 {
-                                    return Err(StorageError::AlreadyExists(dst.to_string()));
-                                }
-                            }
-                            None => {}
-                        }
-                    }
-                    None => {}
+            .await
+            .map_err(|err| match err.kind() {
+                AzureErrorKind::HttpResponse { status, .. } if *status == 409 => {
+                    StorageError::AlreadyExists(dst.to_string())
                 }
-            }
-            return Err(StorageError::AzureStorage { source: err });
-        }
+                _ => err.into(),
+            })?;
+
         Ok(())
     }
 
@@ -526,12 +419,7 @@ impl StorageBackend for AdlsGen2Backend {
         self.validate_container(&obj)?;
 
         let file_client = self.file_system_client.get_file_client(obj.path);
-        file_client
-            .delete()
-            .into_future()
-            .await
-            .map_err(to_storage_err2)?;
-
+        file_client.delete().into_future().await?;
         Ok(())
     }
 }

--- a/rust/tests/adls_gen2_table_test.rs
+++ b/rust/tests/adls_gen2_table_test.rs
@@ -10,6 +10,7 @@ mod adls_gen2_table {
     use azure_storage::storage_shared_key_credential::StorageSharedKeyCredential;
     use azure_storage_datalake::prelude::DataLakeClient;
     use chrono::Utc;
+    use deltalake::storage::azure::azure_storage_options;
     use deltalake::{
         action, DeltaTable, DeltaTableConfig, DeltaTableMetaData, Schema, SchemaDataType,
         SchemaField,
@@ -31,6 +32,60 @@ mod adls_gen2_table {
         let table = deltalake::open_table(format!("adls2://{}/simple/", account).as_str())
             .await
             .unwrap();
+
+        assert_eq!(table.version, 4);
+        assert_eq!(table.get_min_writer_version(), 2);
+        assert_eq!(table.get_min_reader_version(), 1);
+        assert_eq!(
+            table.get_files(),
+            vec![
+                "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
+                "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
+                "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
+                "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
+                "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet",
+            ]
+        );
+
+        let tombstones = table.get_state().all_tombstones();
+        assert_eq!(tombstones.len(), 31);
+        let remove = deltalake::action::Remove {
+            path: "part-00006-63ce9deb-bc0f-482d-b9a1-7e717b67f294-c000.snappy.parquet".to_string(),
+            deletion_timestamp: Some(1587968596250),
+            data_change: true,
+            ..Default::default()
+        };
+        assert!(tombstones.contains(&remove));
+    }
+
+    #[ignore]
+    #[tokio::test]
+    #[serial]
+    async fn read_simple_table_with_service_principal() {
+        let account = std::env::var("AZURE_STORAGE_ACCOUNT_NAME").unwrap();
+        let client_id = std::env::var("AZURE_CLIENT_ID").unwrap();
+        let client_secret = std::env::var("AZURE_CLIENT_SECRET").unwrap();
+        let tenant_id = std::env::var("AZURE_TENANT_ID").unwrap();
+        let mut options = std::collections::HashMap::new();
+        options.insert(
+            azure_storage_options::AZURE_CLIENT_ID.to_string(),
+            client_id,
+        );
+        options.insert(
+            azure_storage_options::AZURE_CLIENT_SECRET.to_string(),
+            client_secret,
+        );
+        options.insert(
+            azure_storage_options::AZURE_TENANT_ID.to_string(),
+            tenant_id,
+        );
+
+        let table_uri = format!("adls2://{}/simple/", account);
+        let mut builder = deltalake::DeltaTableBuilder::from_uri(&table_uri).unwrap();
+        let backend = deltalake::get_backend_for_uri_with_options(&table_uri, options).unwrap();
+        builder = builder.with_storage_backend(backend);
+
+        let table = builder.load().await.unwrap();
 
         assert_eq!(table.version, 4);
         assert_eq!(table.get_min_writer_version(), 2);

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -52,7 +52,7 @@ async fn read_simple_table() {
     {
         let mut paths: Vec<String> = table.get_file_uris().collect();
         paths.sort();
-        let mut expected_paths: Vec<String> = vec![
+        let expected_paths: Vec<String> = vec![
                 "./tests/data/simple_table\\part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),
                 "./tests/data/simple_table\\part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet".to_string(),
                 "./tests/data/simple_table\\part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet".to_string(),


### PR DESCRIPTION
# Description

With the latest version of the azure SDKs some annoyances got fixed. specifically, list now returns something `Send`able, which allows us to significantly simplify the `list_objs` method. Secondly the errors are no longer a deeply nested nightmare 😆.

Also added a test for validating that service principal access works (#609) - currently i am guessing the issues encountered there are more related to #643

# Related Issue(s)

validate the SP access works for #609

# Documentation

<!---
Share links to useful documentation
--->
