### PR TITLE
feat: add enforce_retention_duration param to vacuum method

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -241,20 +241,24 @@ class DeltaTable:
         ]
 
     def vacuum(
-        self, retention_hours: Optional[int] = None, dry_run: bool = True
+        self,
+        retention_hours: Optional[int] = None,
+        dry_run: bool = True,
+        enforce_retention_duration: bool = True,
     ) -> List[str]:
         """
         Run the Vacuum command on the Delta Table: list and delete files no longer referenced by the Delta table and are older than the retention threshold.
 
         :param retention_hours: the retention threshold in hours, if none then the value from `configuration.deletedFileRetentionDuration` is used or default of 1 week otherwise.
         :param dry_run: when activated, list only the files, delete otherwise
+        :param enforce_retention_duration: when disabled, accepts retention hours smaller than the value from `configuration.deletedFileRetentionDuration`.
         :return: the list of files no longer referenced by the Delta Table and are older than the retention threshold.
         """
         if retention_hours:
             if retention_hours < 0:
                 raise ValueError("The retention periods should be positive.")
 
-        return self._table.vacuum(dry_run, retention_hours)
+        return self._table.vacuum(dry_run, retention_hours, enforce_retention_duration)
 
     def pyarrow_schema(self) -> pyarrow.Schema:
         """

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -225,9 +225,18 @@ impl RawDeltaTable {
     }
 
     /// Run the Vacuum command on the Delta Table: list and delete files no longer referenced by the Delta table and are older than the retention threshold.
-    pub fn vacuum(&mut self, dry_run: bool, retention_hours: Option<u64>) -> PyResult<Vec<String>> {
+    pub fn vacuum(
+        &mut self,
+        dry_run: bool,
+        retention_hours: Option<u64>,
+        enforce_retention_duration: bool,
+    ) -> PyResult<Vec<String>> {
         rt()?
-            .block_on(self._table.vacuum(retention_hours, dry_run))
+            .block_on(self._table.vacuum(
+                retention_hours,
+                dry_run,
+                Some(enforce_retention_duration),
+            ))
             .map_err(PyDeltaTableError::from_raw)
     }
 

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -216,7 +216,7 @@ def test_vacuum_dry_run_simple_table():
         dt.vacuum(retention_periods)
     assert (
         str(exception.value)
-        == "Invalid retention period, retention for Vacuum must be greater than 1 week (168 hours)"
+        == "Invalid retention period, minimum retention for vacuum is configured to be greater than 168 hours, got 167 hours"
     )
 
 


### PR DESCRIPTION


# Description

This maps to the reference implementation's
spark.databricks.delta.retentionDurationCheck.enabled config.

