### PR TITLE
refactor: move version field to  `DeltaTableState`

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -137,7 +137,7 @@ impl RawDeltaTable {
     }
 
     pub fn version(&self) -> PyResult<i64> {
-        Ok(self._table.version)
+        Ok(self._table.version())
     }
 
     pub fn metadata(&self) -> PyResult<RawDeltaTableMetaData> {

--- a/ruby/src/lib.rs
+++ b/ruby/src/lib.rs
@@ -33,7 +33,7 @@ impl TableData {
     }
 
     fn version(&self) -> i64 {
-        self.actual.version
+        self.actual.version()
     }
 
     fn files(&self) -> Vec<String> {

--- a/rust/src/checkpoints.rs
+++ b/rust/src/checkpoints.rs
@@ -86,10 +86,10 @@ impl From<CheckpointError> for ArrowError {
     }
 }
 
-/// Creates checkpoint at `table.version` for given `table`.
+/// Creates checkpoint at current table version
 pub async fn create_checkpoint(table: &DeltaTable) -> Result<(), CheckpointError> {
     create_checkpoint_for(
-        table.version,
+        table.version(),
         table.get_state(),
         table.storage.as_ref(),
         &table.table_uri,
@@ -105,7 +105,7 @@ pub async fn cleanup_metadata(table: &DeltaTable) -> Result<i32, DeltaTableError
     let log_retention_timestamp =
         Utc::now().timestamp_millis() - table.get_state().log_retention_millis();
     cleanup_expired_logs_for(
-        table.version + 1,
+        table.version() + 1,
         table.storage.as_ref(),
         log_retention_timestamp,
         &table.table_uri,
@@ -133,7 +133,7 @@ pub async fn create_checkpoint_from_table_uri_and_cleanup(
     let enable_expired_log_cleanup =
         cleanup.unwrap_or_else(|| table.get_state().enable_expired_log_cleanup());
 
-    if table.version >= 0 && enable_expired_log_cleanup {
+    if table.version() >= 0 && enable_expired_log_cleanup {
         let deleted_log_num = cleanup_metadata(&table).await?;
         debug!("Deleted {:?} log files.", deleted_log_num);
     }

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -203,7 +203,7 @@ mod tests {
         assert!(log_path.exists());
 
         let mut table = open_table(&table_uri).await.unwrap();
-        assert_eq!(table.version, 0);
+        assert_eq!(table.version(), 0);
 
         // Check we can create an existing table with ignore
         let ts1 = table.get_version_timestamp(0).await.unwrap();
@@ -211,7 +211,7 @@ mod tests {
         let _result = child.wait().unwrap();
         let _ = collect(transaction, task_ctx.clone()).await.unwrap();
         let mut table = open_table(&table_uri).await.unwrap();
-        assert_eq!(table.version, 0);
+        assert_eq!(table.version(), 0);
         let ts2 = table.get_version_timestamp(0).await.unwrap();
         assert_eq!(ts1, ts2);
 

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -122,7 +122,7 @@ impl DeltaCommands {
     ) -> DeltaCommandResult<()> {
         let transaction = Arc::new(DeltaTransactionPlan::new(
             self.table.table_uri.clone(),
-            self.table.version,
+            self.table.version(),
             plan,
             operation,
             None,
@@ -259,7 +259,7 @@ mod tests {
             .unwrap();
 
         let table = open_table(&table_uri).await.unwrap();
-        assert_eq!(table.version, 0);
+        assert_eq!(table.version(), 0);
 
         let res = commands.create(metadata, SaveMode::ErrorIfExists).await;
         assert!(res.is_err())
@@ -270,7 +270,7 @@ mod tests {
         let batch = get_record_batch(None, false);
         let partition_cols = vec!["modified".to_string()];
         let mut table = create_initialized_table(&partition_cols).await;
-        assert_eq!(table.version, 0);
+        assert_eq!(table.version(), 0);
 
         let mut commands = DeltaCommands::try_from_uri(table.table_uri.to_string())
             .await
@@ -286,7 +286,7 @@ mod tests {
             .unwrap();
 
         table.update().await.unwrap();
-        assert_eq!(table.version, 1);
+        assert_eq!(table.version(), 1);
 
         let files = table.get_file_uris();
         assert_eq!(files.collect::<Vec<_>>().len(), 2)
@@ -311,7 +311,7 @@ mod tests {
             .unwrap();
 
         let table = open_table(&table_uri).await.unwrap();
-        assert_eq!(table.version, 0);
+        assert_eq!(table.version(), 0);
 
         let files = table.get_file_uris();
         assert_eq!(files.collect::<Vec<_>>().len(), 2)

--- a/rust/src/operations/write.rs
+++ b/rust/src/operations/write.rs
@@ -423,7 +423,7 @@ mod tests {
     async fn test_append_data() {
         let partition_cols = vec!["modified".to_string()];
         let mut table = create_initialized_table(&partition_cols).await;
-        assert_eq!(table.version, 0);
+        assert_eq!(table.version(), 0);
 
         let transaction = get_transaction(table.table_uri.clone(), 0, SaveMode::Append);
         let session_ctx = SessionContext::new();
@@ -434,20 +434,20 @@ mod tests {
             .unwrap();
         table.update().await.unwrap();
         assert_eq!(table.get_file_uris().collect::<Vec<_>>().len(), 2);
-        assert_eq!(table.version, 1);
+        assert_eq!(table.version(), 1);
 
         let transaction = get_transaction(table.table_uri.clone(), 1, SaveMode::Append);
         let _ = collect(transaction.clone(), task_ctx).await.unwrap();
         table.update().await.unwrap();
         assert_eq!(table.get_file_uris().collect::<Vec<_>>().len(), 4);
-        assert_eq!(table.version, 2);
+        assert_eq!(table.version(), 2);
     }
 
     #[tokio::test]
     async fn test_overwrite_data() {
         let partition_cols = vec!["modified".to_string()];
         let mut table = create_initialized_table(&partition_cols).await;
-        assert_eq!(table.version, 0);
+        assert_eq!(table.version(), 0);
 
         let transaction = get_transaction(table.table_uri.clone(), 0, SaveMode::Overwrite);
         let session_ctx = SessionContext::new();
@@ -458,13 +458,13 @@ mod tests {
             .unwrap();
         table.update().await.unwrap();
         assert_eq!(table.get_file_uris().collect::<Vec<_>>().len(), 2);
-        assert_eq!(table.version, 1);
+        assert_eq!(table.version(), 1);
 
         let transaction = get_transaction(table.table_uri.clone(), 1, SaveMode::Overwrite);
         let _ = collect(transaction.clone(), task_ctx).await.unwrap();
         table.update().await.unwrap();
         assert_eq!(table.get_file_uris().collect::<Vec<_>>().len(), 2);
-        assert_eq!(table.version, 2);
+        assert_eq!(table.version(), 2);
     }
 
     #[tokio::test]
@@ -487,7 +487,7 @@ mod tests {
         // THe table should be created on write and thus have version 0
         let table = open_table(table_path.to_str().unwrap()).await.unwrap();
         assert_eq!(table.get_file_uris().collect::<Vec<_>>().len(), 2);
-        assert_eq!(table.version, 0);
+        assert_eq!(table.version(), 0);
     }
 
     fn get_transaction(

--- a/rust/src/optimize.rs
+++ b/rust/src/optimize.rs
@@ -284,7 +284,7 @@ impl MergePlan {
         // optimized partition was updated then abort the commit. Requires (#593).
         if !actions.is_empty() {
             let mut metadata = Map::new();
-            metadata.insert("readVersion".to_owned(), table.version.into());
+            metadata.insert("readVersion".to_owned(), table.version().into());
             let maybe_map_metrics = serde_json::to_value(metrics.clone());
             if let Ok(map) = maybe_map_metrics {
                 metadata.insert("operationMetrics".to_owned(), map);

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -165,11 +165,17 @@ impl DeltaTableState {
 
     /// The most recent metadata of the table.
     pub fn current_metadata(&self) -> Option<&DeltaTableMetaData> {
-        println!("current metadata");
         self.current_metadata.as_ref()
     }
 
     /// Merges new state information into our state
+    ///
+    /// The DeltaTableState also carries the version information for the given state,
+    /// as there is a one-to-one match between a table state and a version. In merge/update
+    /// scenarios we cannot infer the intended / correct version number. By default this
+    /// function will update the tracked version if the version on `new_state` is larger then the
+    /// currently set version however it is up to the caller to update the `version` field according
+    /// to the version the merged state represents.
     pub fn merge(
         &mut self,
         mut new_state: DeltaTableState,

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -229,7 +229,6 @@ impl DeltaTableState {
             self.commit_infos.append(&mut new_state.commit_infos);
         }
 
-        // TODO should we make sure versions are consistent (i.e. +1) or just update to highest?
         if self.version < new_state.version {
             self.version = new_state.version
         }

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -21,6 +21,7 @@ use crate::delta_config;
 /// State snapshot currently held by the Delta Table instance.
 #[derive(Default, Debug, Clone)]
 pub struct DeltaTableState {
+    pub version: DeltaDataTypeVersion,
     // A remove action should remain in the state of the table as a tombstone until it has expired.
     // A tombstone expires when the creation timestamp of the delta file exceeds the expiration
     tombstones: HashSet<action::Remove>,
@@ -36,6 +37,12 @@ pub struct DeltaTableState {
 }
 
 impl DeltaTableState {
+    pub fn with_version(version: DeltaDataTypeVersion) -> Self {
+        Self {
+            version,
+            ..Self::default()
+        }
+    }
     /// Construct a delta table state object from commit version.
     pub async fn from_commit(
         table: &DeltaTable,
@@ -45,7 +52,7 @@ impl DeltaTableState {
         let commit_log_bytes = table.storage.get_obj(&commit_uri).await?;
         let reader = BufReader::new(Cursor::new(commit_log_bytes));
 
-        let mut new_state = DeltaTableState::default();
+        let mut new_state = DeltaTableState::with_version(version);
         for line in reader.lines() {
             let action: action::Action = serde_json::from_str(line?.as_str())?;
             new_state.process_action(
@@ -59,8 +66,11 @@ impl DeltaTableState {
     }
 
     /// Construct a delta table state object from a list of actions
-    pub fn from_actions(actions: Vec<Action>) -> Result<Self, ApplyLogError> {
-        let mut new_state = DeltaTableState::default();
+    pub fn from_actions(
+        actions: Vec<Action>,
+        version: DeltaDataTypeVersion,
+    ) -> Result<Self, ApplyLogError> {
+        let mut new_state = DeltaTableState::with_version(version);
         for action in actions {
             new_state.process_action(action, true, true)?;
         }
@@ -74,7 +84,7 @@ impl DeltaTableState {
     ) -> Result<Self, DeltaTableError> {
         let checkpoint_data_paths = table.get_checkpoint_data_paths(check_point);
         // process actions from checkpoint
-        let mut new_state = DeltaTableState::default();
+        let mut new_state = DeltaTableState::with_version(check_point.version);
 
         for f in &checkpoint_data_paths {
             let obj = table.storage.get_obj(f).await?;
@@ -155,6 +165,7 @@ impl DeltaTableState {
 
     /// The most recent metadata of the table.
     pub fn current_metadata(&self) -> Option<&DeltaTableMetaData> {
+        println!("current metadata");
         self.current_metadata.as_ref()
     }
 
@@ -210,6 +221,11 @@ impl DeltaTableState {
 
         if !new_state.commit_infos.is_empty() {
             self.commit_infos.append(&mut new_state.commit_infos);
+        }
+
+        // TODO should we make sure versions are consistent (i.e. +1) or just update to highest?
+        if self.version < new_state.version {
+            self.version = new_state.version
         }
     }
 
@@ -276,6 +292,7 @@ mod tests {
         app_transaction_version.insert("xyz".to_string(), 1);
 
         let mut state = DeltaTableState {
+            version: -1,
             files: vec![],
             commit_infos: vec![],
             tombstones: HashSet::new(),

--- a/rust/tests/adls_gen2_table_test.rs
+++ b/rust/tests/adls_gen2_table_test.rs
@@ -33,7 +33,7 @@ mod adls_gen2_table {
             .await
             .unwrap();
 
-        assert_eq!(table.version, 4);
+        assert_eq!(table.version(), 4);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
         assert_eq!(
@@ -87,7 +87,7 @@ mod adls_gen2_table {
 
         let table = builder.load().await.unwrap();
 
-        assert_eq!(table.version, 4);
+        assert_eq!(table.version(), 4);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
         assert_eq!(
@@ -148,7 +148,7 @@ mod adls_gen2_table {
             .unwrap();
 
         // Assert 1
-        assert_eq!(0, dt.version);
+        assert_eq!(0, dt.version());
         assert_eq!(1, dt.get_min_reader_version());
         assert_eq!(2, dt.get_min_writer_version());
         assert_eq!(0, dt.get_files().len());
@@ -161,7 +161,7 @@ mod adls_gen2_table {
 
         // Assert 2
         assert_eq!(1, version);
-        assert_eq!(version, dt.version);
+        assert_eq!(version, dt.version());
         assert_eq!(2, dt.get_files().len());
 
         // Cleanup

--- a/rust/tests/checkpoint_writer_test.rs
+++ b/rust/tests/checkpoint_writer_test.rs
@@ -135,7 +135,7 @@ mod delete_expired_delta_log_in_checkpoint {
 
         checkpoints::create_checkpoint_from_table_uri_and_cleanup(
             &table.table_uri,
-            table.version,
+            table.version(),
             None,
         )
         .await
@@ -178,7 +178,7 @@ mod delete_expired_delta_log_in_checkpoint {
 
         checkpoints::create_checkpoint_from_table_uri_and_cleanup(
             &table.table_uri,
-            table.version,
+            table.version(),
             None,
         )
         .await

--- a/rust/tests/concurrent_writes_test.rs
+++ b/rust/tests/concurrent_writes_test.rs
@@ -87,7 +87,7 @@ async fn concurrent_writes_azure() {
         .await
         .unwrap();
 
-    assert_eq!(0, dt.version);
+    assert_eq!(0, dt.version());
     assert_eq!(1, dt.get_min_reader_version());
     assert_eq!(2, dt.get_min_writer_version());
     assert_eq!(0, dt.get_files().len());

--- a/rust/tests/gcs_test.rs
+++ b/rust/tests/gcs_test.rs
@@ -18,7 +18,7 @@ mod gcs {
         let table = deltalake::open_table(format!("gs://{}/simple_table", bucket).as_str())
             .await
             .unwrap();
-        assert_eq!(table.version, 4);
+        assert_eq!(table.version(), 4);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
         assert_eq!(

--- a/rust/tests/optimize_test.rs
+++ b/rust/tests/optimize_test.rs
@@ -196,13 +196,13 @@ mod optimize {
         )
         .await?;
 
-        let version = dt.version;
+        let version = dt.version();
         assert_eq!(dt.get_active_add_actions().len(), 5);
 
         let optimize = Optimize::default().target_size(2_000_000);
         let metrics = optimize.execute(&mut dt).await?;
 
-        assert_eq!(version + 1, dt.version);
+        assert_eq!(version + 1, dt.version());
         assert_eq!(metrics.num_files_added, 1);
         assert_eq!(metrics.num_files_removed, 4);
         assert_eq!(metrics.total_considered_files, 5);
@@ -253,14 +253,14 @@ mod optimize {
         )
         .await?;
 
-        let version = dt.version;
+        let version = dt.version();
         let mut filter = vec![];
         filter.push(PartitionFilter::try_from(("date", "=", "2022-05-22"))?);
 
         let optimize = Optimize::default().filter(&filter);
         let metrics = optimize.execute(&mut dt).await?;
 
-        assert_eq!(version + 1, dt.version);
+        assert_eq!(version + 1, dt.version());
         assert_eq!(metrics.num_files_added, 1);
         assert_eq!(metrics.num_files_removed, 2);
         assert_eq!(dt.get_active_add_actions().len(), 3);
@@ -290,7 +290,7 @@ mod optimize {
         )
         .await?;
 
-        let version = dt.version;
+        let version = dt.version();
 
         //create the merge plan, remove a file, and execute the plan.
         let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
@@ -320,7 +320,7 @@ mod optimize {
 
         let maybe_metrics = plan.execute(&mut dt).await;
         assert!(maybe_metrics.is_err());
-        assert_eq!(dt.version, version + 1);
+        assert_eq!(dt.version(), version + 1);
         Ok(())
     }
 
@@ -345,7 +345,7 @@ mod optimize {
         )
         .await?;
 
-        let version = dt.version;
+        let version = dt.version();
 
         //create the merge plan, remove a file, and execute the plan.
         let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
@@ -364,7 +364,7 @@ mod optimize {
         let metrics = plan.execute(&mut dt).await?;
         assert_eq!(metrics.num_files_added, 1);
         assert_eq!(metrics.num_files_removed, 2);
-        assert_eq!(dt.version, version + 2);
+        assert_eq!(dt.version(), version + 2);
         Ok(())
     }
 
@@ -397,7 +397,7 @@ mod optimize {
         )
         .await?;
 
-        let version = dt.version;
+        let version = dt.version();
 
         let mut filter = vec![];
         filter.push(PartitionFilter::try_from(("date", "=", "2022-05-22"))?);
@@ -406,13 +406,13 @@ mod optimize {
         let metrics = optimize.execute(&mut dt).await?;
         assert_eq!(metrics.num_files_added, 1);
         assert_eq!(metrics.num_files_removed, 2);
-        assert_eq!(dt.version, version + 1);
+        assert_eq!(dt.version(), version + 1);
 
         let metrics = optimize.execute(&mut dt).await?;
 
         assert_eq!(metrics.num_files_added, 0);
         assert_eq!(metrics.num_files_removed, 0);
-        assert_eq!(dt.version, version + 1);
+        assert_eq!(dt.version(), version + 1);
 
         Ok(())
     }
@@ -431,7 +431,7 @@ mod optimize {
         )
         .await?;
 
-        let version = dt.version;
+        let version = dt.version();
         let optimize = Optimize::default().target_size(10_000_000);
         let metrics = optimize.execute(&mut dt).await?;
 
@@ -454,7 +454,7 @@ mod optimize {
         expected.files_removed = expected_metric_details.clone();
 
         assert_eq!(expected, metrics);
-        assert_eq!(version, dt.version);
+        assert_eq!(version, dt.version());
         Ok(())
     }
 
@@ -479,7 +479,7 @@ mod optimize {
         )
         .await?;
 
-        let version = dt.version;
+        let version = dt.version();
 
         let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
 

--- a/rust/tests/read_delta_partitions_test.rs
+++ b/rust/tests/read_delta_partitions_test.rs
@@ -165,5 +165,5 @@ async fn read_null_partitions_from_checkpoint() {
 
     // verify that table loads from checkpoint and handles null partitions
     let table = deltalake::open_table(&table.table_uri).await.unwrap();
-    assert_eq!(table.version, 2);
+    assert_eq!(table.version(), 2);
 }

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -17,7 +17,7 @@ async fn read_delta_2_0_table_without_version() {
     let table = deltalake::open_table("./tests/data/delta-0.2.0")
         .await
         .unwrap();
-    assert_eq!(table.version, 3);
+    assert_eq!(table.version(), 3);
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
@@ -103,7 +103,7 @@ async fn read_delta_table_with_ignoring_files_on_apply_log() {
         .await
         .unwrap();
 
-    assert_eq!(table.version, 0);
+    assert_eq!(table.version(), 0);
     assert!(table.get_files().is_empty(), "files should be empty");
     assert!(
         table.get_tombstones().next().is_none(),
@@ -111,7 +111,7 @@ async fn read_delta_table_with_ignoring_files_on_apply_log() {
     );
 
     table.update().await.unwrap();
-    assert_eq!(table.version, 1);
+    assert_eq!(table.version(), 1);
     assert!(table.get_files().is_empty(), "files should be empty");
     assert!(
         table.get_tombstones().next().is_none(),
@@ -124,7 +124,7 @@ async fn read_delta_2_0_table_with_version() {
     let mut table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 0)
         .await
         .unwrap();
-    assert_eq!(table.version, 0);
+    assert_eq!(table.version(), 0);
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
@@ -138,7 +138,7 @@ async fn read_delta_2_0_table_with_version() {
     table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 2)
         .await
         .unwrap();
-    assert_eq!(table.version, 2);
+    assert_eq!(table.version(), 2);
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
@@ -152,7 +152,7 @@ async fn read_delta_2_0_table_with_version() {
     table = deltalake::open_table_with_version("./tests/data/delta-0.2.0", 3)
         .await
         .unwrap();
-    assert_eq!(table.version, 3);
+    assert_eq!(table.version(), 3);
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
@@ -170,7 +170,7 @@ async fn read_delta_8_0_table_without_version() {
     let table = deltalake::open_table("./tests/data/delta-0.8.0")
         .await
         .unwrap();
-    assert_eq!(table.version, 1);
+    assert_eq!(table.version(), 1);
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
@@ -215,7 +215,7 @@ async fn read_delta_8_0_table_with_load_version() {
     let mut table = deltalake::open_table("./tests/data/delta-0.8.0")
         .await
         .unwrap();
-    assert_eq!(table.version, 1);
+    assert_eq!(table.version(), 1);
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
@@ -226,7 +226,7 @@ async fn read_delta_8_0_table_with_load_version() {
         ]
     );
     table.load_version(0).await.unwrap();
-    assert_eq!(table.version, 0);
+    assert_eq!(table.version(), 0);
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     assert_eq!(
@@ -517,10 +517,10 @@ async fn test_table_history() {
 async fn test_poll_table_commits() {
     let path = "./tests/data/simple_table_with_checkpoint";
     let mut table = deltalake::open_table_with_version(path, 9).await.unwrap();
-    let peek = table.peek_next_commit(table.version).await.unwrap();
+    let peek = table.peek_next_commit(table.version()).await.unwrap();
 
     let is_new = if let PeekCommit::New(version, actions) = peek {
-        assert_eq!(table.version, 9);
+        assert_eq!(table.version(), 9);
         assert!(!table
             .get_files_iter()
             .any(|f| f == "part-00000-f0e955c5-a1e3-4eec-834e-dcc098fc9005-c000.snappy.parquet"));
@@ -530,7 +530,7 @@ async fn test_poll_table_commits() {
 
         table.apply_actions(version, actions).unwrap();
 
-        assert_eq!(table.version, 10);
+        assert_eq!(table.version(), 10);
         assert!(table
             .get_files_iter()
             .any(|f| f == "part-00000-f0e955c5-a1e3-4eec-834e-dcc098fc9005-c000.snappy.parquet"));
@@ -541,7 +541,7 @@ async fn test_poll_table_commits() {
     };
     assert!(is_new);
 
-    let peek = table.peek_next_commit(table.version).await.unwrap();
+    let peek = table.peek_next_commit(table.version()).await.unwrap();
     let is_up_to_date = match peek {
         PeekCommit::UpToDate => true,
         _ => false,

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -11,7 +11,7 @@ async fn read_simple_table() {
     let table = deltalake::open_table("./tests/data/simple_table")
         .await
         .unwrap();
-    assert_eq!(table.version, 4);
+    assert_eq!(table.version(), 4);
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     let mut files = table.get_files();
@@ -68,7 +68,7 @@ async fn read_simple_table_with_version() {
     let table = deltalake::open_table_with_version("./tests/data/simple_table", 0)
         .await
         .unwrap();
-    assert_eq!(table.version, 0);
+    assert_eq!(table.version(), 0);
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     let mut files = table.get_files();
@@ -88,7 +88,7 @@ async fn read_simple_table_with_version() {
     let table = deltalake::open_table_with_version("./tests/data/simple_table", 2)
         .await
         .unwrap();
-    assert_eq!(table.version, 2);
+    assert_eq!(table.version(), 2);
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     let mut files = table.get_files();
@@ -108,7 +108,7 @@ async fn read_simple_table_with_version() {
     let table = deltalake::open_table_with_version("./tests/data/simple_table", 3)
         .await
         .unwrap();
-    assert_eq!(table.version, 3);
+    assert_eq!(table.version(), 3);
     assert_eq!(table.get_min_writer_version(), 2);
     assert_eq!(table.get_min_reader_version(), 1);
     let mut files = table.get_files();
@@ -151,40 +151,40 @@ async fn time_travel_by_ds() {
         deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-01T00:47:31-07:00")
             .await
             .unwrap();
-    assert_eq!(table.version, 0);
+    assert_eq!(table.version(), 0);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-02T22:47:31-07:00")
         .await
         .unwrap();
-    assert_eq!(table.version, 1);
+    assert_eq!(table.version(), 1);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-02T23:47:31-07:00")
         .await
         .unwrap();
-    assert_eq!(table.version, 1);
+    assert_eq!(table.version(), 1);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-03T22:47:31-07:00")
         .await
         .unwrap();
-    assert_eq!(table.version, 2);
+    assert_eq!(table.version(), 2);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-04T22:47:31-07:00")
         .await
         .unwrap();
-    assert_eq!(table.version, 3);
+    assert_eq!(table.version(), 3);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-05T21:47:31-07:00")
         .await
         .unwrap();
-    assert_eq!(table.version, 3);
+    assert_eq!(table.version(), 3);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-05T22:47:31-07:00")
         .await
         .unwrap();
-    assert_eq!(table.version, 4);
+    assert_eq!(table.version(), 4);
 
     table = deltalake::open_table_with_ds("./tests/data/simple_table", "2020-05-25T22:47:31-07:00")
         .await
         .unwrap();
-    assert_eq!(table.version, 4);
+    assert_eq!(table.version(), 4);
 }

--- a/rust/tests/s3_test.rs
+++ b/rust/tests/s3_test.rs
@@ -40,7 +40,7 @@ mod s3 {
         table.load().await.unwrap();
         println!("{}", table);
 
-        assert_eq!(table.version, 4);
+        assert_eq!(table.version(), 4);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
         assert_eq!(
@@ -71,7 +71,7 @@ mod s3 {
             .await
             .unwrap();
         println!("{}", table);
-        assert_eq!(table.version, 3);
+        assert_eq!(table.version(), 3);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
         assert_eq!(
@@ -101,7 +101,7 @@ mod s3 {
         setup();
         let table = deltalake::open_table("s3://deltars/simple/").await.unwrap();
         println!("{}", table);
-        assert_eq!(table.version, 4);
+        assert_eq!(table.version(), 4);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
     }
@@ -115,7 +115,7 @@ mod s3 {
             .await
             .unwrap();
         println!("{}", table);
-        assert_eq!(table.version, 0);
+        assert_eq!(table.version(), 0);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
     }

--- a/rust/tests/simple_commit_test.rs
+++ b/rust/tests/simple_commit_test.rs
@@ -78,7 +78,7 @@ mod simple_commit_fs {
         let table_path = "./tests/data/simple_commit";
         let mut table = deltalake::open_table(table_path).await.unwrap();
 
-        assert_eq!(0, table.version);
+        assert_eq!(0, table.version());
         assert_eq!(0, table.get_files().len());
 
         let mut tx1 = table.create_transaction(None);
@@ -87,7 +87,7 @@ mod simple_commit_fs {
         let result = table.try_commit_transaction(&commit, 1).await.unwrap();
 
         assert_eq!(1, result);
-        assert_eq!(1, table.version);
+        assert_eq!(1, table.version());
         assert_eq!(2, table.get_files().len());
     }
 
@@ -99,7 +99,7 @@ mod simple_commit_fs {
         let table_path = "./tests/data/simple_commit";
         let mut table = deltalake::open_table(table_path).await.unwrap();
 
-        assert_eq!(0, table.version);
+        assert_eq!(0, table.version());
         assert_eq!(0, table.get_files().len());
 
         let mut tx1 = table.create_transaction(None);
@@ -123,7 +123,7 @@ mod simple_commit_fs {
         }
 
         assert!(result.is_err());
-        assert_eq!(1, table.version);
+        assert_eq!(1, table.version());
         assert_eq!(2, table.get_files().len());
     }
 
@@ -137,7 +137,7 @@ mod simple_commit_fs {
         let table_path = "./tests/data/simple_commit";
         let mut table = deltalake::open_table(table_path).await.unwrap();
 
-        assert_eq!(0, table.version);
+        assert_eq!(0, table.version());
         assert_eq!(0, table.get_files().len());
 
         let mut attempt = 0;
@@ -150,7 +150,7 @@ mod simple_commit_fs {
         loop {
             table.update().await.unwrap();
 
-            let version = table.version + 1;
+            let version = table.version() + 1;
             match table
                 .try_commit_transaction(&prepared_commit, version)
                 .await
@@ -168,7 +168,7 @@ mod simple_commit_fs {
         }
 
         assert_eq!(0, attempt);
-        assert_eq!(1, table.version);
+        assert_eq!(1, table.version());
         assert_eq!(2, table.get_files().len());
     }
 
@@ -183,7 +183,7 @@ mod simple_commit_fs {
 async fn test_two_commits(table_path: &str) -> Result<(), DeltaTableError> {
     let mut table = deltalake::open_table(table_path).await?;
 
-    assert_eq!(0, table.version);
+    assert_eq!(0, table.version());
     assert_eq!(0, table.get_files().len());
 
     let mut tx1 = table.create_transaction(None);
@@ -191,7 +191,7 @@ async fn test_two_commits(table_path: &str) -> Result<(), DeltaTableError> {
     let version = tx1.commit(None, None).await?;
 
     assert_eq!(1, version);
-    assert_eq!(version, table.version);
+    assert_eq!(version, table.version());
     assert_eq!(2, table.get_files().len());
 
     let mut tx2 = table.create_transaction(None);
@@ -199,7 +199,7 @@ async fn test_two_commits(table_path: &str) -> Result<(), DeltaTableError> {
     let version = tx2.commit(None, None).await.unwrap();
 
     assert_eq!(2, version);
-    assert_eq!(version, table.version);
+    assert_eq!(version, table.version());
     assert_eq!(4, table.get_files().len());
     Ok(())
 }


### PR DESCRIPTION
# Description

This PR moves the `version` field into `DeltaTableState`. The added consistency helps implementing #632 - split this in a separate PR to make review easier.

# Related Issue(s)

closes #390 

# Documentation

<!---
Share links to useful documentation
--->
