### PR TITLE
Read remove action num records field

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -322,6 +322,7 @@ impl RawDeltaTable {
                         partition_values: Some(old_add.partition_values.clone()),
                         size: Some(old_add.size),
                         tags: old_add.tags.clone(),
+                        num_records: None,
                     });
                     actions.push(remove_action);
                 }

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -561,6 +561,8 @@ pub struct Remove {
     pub size: Option<DeltaDataTypeLong>,
     /// Map containing metadata about this file
     pub tags: Option<HashMap<String, Option<String>>>,
+    /// Number of records in the file associated with the log action.
+    pub num_records: Option<DeltaDataTypeLong>,
 }
 
 impl Hash for Remove {
@@ -656,6 +658,11 @@ impl Remove {
                 },
                 "size" => {
                     re.size = record.get_long(i).map(Some).unwrap_or(None);
+                }
+                "numRecords" => {
+                    re.num_records = Some(record.get_long(i).map_err(|_| {
+                        gen_action_type_error("remove", "numRecords", "long")
+                    })?);
                 }
                 _ => {
                     log::warn!(

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -660,9 +660,7 @@ impl Remove {
                     re.size = record.get_long(i).map(Some).unwrap_or(None);
                 }
                 "numRecords" => {
-                    re.num_records = Some(record.get_long(i).map_err(|_| {
-                        gen_action_type_error("remove", "numRecords", "long")
-                    })?);
+                    re.num_records = record.get_long(i).map(Some).unwrap_or(None);
                 }
                 _ => {
                     log::warn!(

--- a/rust/src/optimize.rs
+++ b/rust/src/optimize.rs
@@ -186,6 +186,7 @@ fn create_remove(
         partition_values: Some(partitions.to_owned()),
         size: Some(size),
         tags: None,
+        num_records: None,
     }))
 }
 

--- a/rust/tests/checkpoint_writer_test.rs
+++ b/rust/tests/checkpoint_writer_test.rs
@@ -302,6 +302,7 @@ mod checkpoints_with_tombstones {
                 partition_values: None,
                 size: None,
                 tags: None,
+                num_records: None,
             })
             .collect();
 
@@ -353,7 +354,7 @@ mod checkpoints_with_tombstones {
         (HashSet::from_iter(fields), actions)
     }
 
-    // The tags and partition values could be missing, but the size has to present
+    // The num_records, tags and partition values could be missing, but the size has to present
     fn remove_metadata_true() -> Remove {
         Remove {
             path: Uuid::new_v4().to_string(),
@@ -363,6 +364,7 @@ mod checkpoints_with_tombstones {
             partition_values: None,
             size: Some(100),
             tags: None,
+            num_records: None,
         }
     }
 

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -470,6 +470,7 @@ async fn test_action_reconciliation() {
         partition_values: None,
         size: None,
         tags: None,
+        num_records: None,
     };
 
     assert_eq!(2, fs_common::commit_removes(&mut table, vec![&r]).await);


### PR DESCRIPTION
# Description
When reading the field is parsed and set to null if the field is not present or `null`. When writing `numRecords` is set always set to null, the same as is currently the case when writing with spark based delta 1.2.1.

# Related Issue(s)
- closes #614 

# Documentation

<!---
Share links to useful documentation
--->
