### PR TITLE
fix: Prevent warning spam when reading tables generated by delta 1.2.1

### DIFF
--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -657,6 +657,7 @@ impl Remove {
                 "size" => {
                     re.size = record.get_long(i).map(Some).unwrap_or(None);
                 }
+                "numRecords" => {}
                 _ => {
                     log::warn!(
                         "Unexpected field name `{}` for remove action: {:?}",


### PR DESCRIPTION
# Description
https://github.com/delta-io/delta/commit/6f396301f74bea16ad27404a7c79e9aa698d6e2c added a new numRecords field on remove actions. To prevent a large spam of warnings when reading tables with this new field delta-rs needs to be updated to accept this field.

I've just gone for the simplest possible fix which is to just ignore `numRecords` when reading. I had a go at [making it read the field](https://github.com/delta-io/delta-rs/pull/650) but being a novice I didn't really know what the impact of those changes would be. 

# Related Issue(s)
- closes #614 

