### PR TITLE
fix: traverse directories in local `list_objs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
  "tokio-stream",
  "utime",
  "uuid 1.1.2",
+ "walkdir",
 ]
 
 [[package]]
@@ -2629,6 +2630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,6 +3371,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,9 +46,15 @@ rusoto_s3 = { version = "0.48", default-features = false, optional = true }
 rusoto_sts = { version = "0.48", default-features = false, optional = true }
 rusoto_dynamodb = { version = "0.48", default-features = false, optional = true }
 maplit = { version = "1", optional = true }
-hyper = {  version = "0.14.19", default-features = false, optional = true}
-hyper-rustls = {  version = "0.23.0", default-features = false, optional = true, features = ["http2", "rustls-native-certs", "tokio-runtime"] } 
-hyper-proxy = {  version = "0.9.1", default-features = false, optional = true, features = ["rustls"] }
+hyper = { version = "0.14.19", default-features = false, optional = true }
+hyper-rustls = { version = "0.23.0", default-features = false, optional = true, features = [
+    "http2",
+    "rustls-native-certs",
+    "tokio-runtime",
+] }
+hyper-proxy = { version = "0.9.1", default-features = false, optional = true, features = [
+    "rustls",
+] }
 
 # Glue
 rusoto_glue = { version = "0.48", default-features = false, optional = true }
@@ -68,6 +74,7 @@ crossbeam = { version = "0", optional = true }
 
 cfg-if = "1"
 async-trait = "0.1"
+walkdir = "2"
 
 # NOTE: disable rust-dataframe integration since it currently doesn't have a
 # version published in crates.io
@@ -98,7 +105,7 @@ s3 = [
     "dynamodb_lock/native-tls",
     "hyper",
     "hyper-rustls",
-    "hyper-proxy"
+    "hyper-proxy",
 ]
 s3-rustls = [
     "rusoto_core/rustls",
@@ -110,7 +117,7 @@ s3-rustls = [
     "dynamodb_lock/rustls",
     "hyper",
     "hyper-rustls",
-    "hyper-proxy"
+    "hyper-proxy",
 ]
 gcs = ["async-stream", "tame-gcs", "tame-oauth", "reqwest"]
 glue = ["s3", "rusoto_glue"]

--- a/rust/src/storage/azure/mod.rs
+++ b/rust/src/storage/azure/mod.rs
@@ -10,13 +10,13 @@ use azure_identity::{
 };
 use azure_storage::storage_shared_key_credential::StorageSharedKeyCredential;
 use azure_storage_datalake::prelude::*;
-use futures::stream::{self, Stream};
+use futures::stream::{self, BoxStream};
 use futures::{future::Either, StreamExt};
 use log::debug;
 use std::collections::HashMap;
+use std::fmt;
 use std::fmt::Debug;
 use std::sync::Arc;
-use std::{fmt, pin::Pin};
 
 /// Storage option keys to use when creating [crate::storage::azure::AzureStorageOptions].
 /// The same key should be used whether passing a key in the hashmap or setting it as an environment variable.
@@ -348,10 +348,7 @@ impl StorageBackend for AdlsGen2Backend {
     async fn list_objs<'a>(
         &'a self,
         path: &'a str,
-    ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + Send + 'a>>,
-        StorageError,
-    > {
+    ) -> Result<BoxStream<'a, Result<ObjectMeta, StorageError>>, StorageError> {
         debug!("Listing objects under {}", path);
         let obj = parse_uri(path)?.into_adlsgen2_object()?;
         self.validate_container(&obj)?;

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -25,7 +25,6 @@ mod rename;
 ///   *  xfs requires >= Linux 4.0
 ///   *  ext2, minix, reiserfs, jfs, vfat, and bpf requires >= Linux 4.9
 /// * Darwin is supported but not fully tested.
-/// * Windows is not supported because we are not using native atomic file rename system call.
 /// Patches welcome.
 /// * Support for other platforms are not implemented at the moment.
 #[derive(Default, Debug)]

--- a/rust/src/storage/gcs/mod.rs
+++ b/rust/src/storage/gcs/mod.rs
@@ -14,9 +14,8 @@ pub(crate) use client::GCSStorageBackend;
 pub(crate) use error::GCSClientError;
 pub(crate) use object::GCSObject;
 
-use futures::Stream;
+use futures::stream::BoxStream;
 use std::convert::TryInto;
-use std::pin::Pin;
 
 use log::debug;
 
@@ -70,10 +69,7 @@ impl StorageBackend for GCSStorageBackend {
     async fn list_objs<'a>(
         &'a self,
         path: &'a str,
-    ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + Send + 'a>>,
-        StorageError,
-    > {
+    ) -> Result<BoxStream<'a, Result<ObjectMeta, StorageError>>, StorageError> {
         let prefix = parse_uri(path)?.into_gcs_object()?;
         let obj_meta_stream = async_stream::stream! {
             for await meta in self.list(prefix) {

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -1,15 +1,14 @@
 //! Object storage backend abstraction layer for Delta Table transaction logs and data
 
-#[cfg(any(feature = "s3", feature = "s3-rustls"))]
-use hyper::http::uri::InvalidUri;
-use std::fmt::Debug;
-use std::pin::Pin;
-
 #[cfg(feature = "azure")]
 use azure_core::error::{Error as AzureError, ErrorKind as AzureErrorKind};
 use chrono::{DateTime, Utc};
-use futures::Stream;
+use futures::stream::BoxStream;
+#[cfg(any(feature = "s3", feature = "s3-rustls"))]
+use hyper::http::uri::InvalidUri;
 use std::collections::HashMap;
+use std::fmt::Debug;
+use walkdir::Error as WalkDirError;
 
 #[cfg(feature = "azure")]
 pub mod azure;
@@ -278,6 +277,14 @@ pub enum StorageError {
         /// The raw error returned when trying to read the local file.
         source: std::io::Error,
     },
+
+    #[error("Failed to walk directory: {source}")]
+    /// Error raised when failing to traverse a directory
+    WalkDir {
+        /// The raw error returned when trying to read the local file.
+        #[from]
+        source: WalkDirError,
+    },
     /// The file system represented by the scheme is not known.
     #[error("File system not supported")]
     FileSystemNotSupported,
@@ -519,10 +526,7 @@ pub trait StorageBackend: Send + Sync + Debug {
     async fn list_objs<'a>(
         &'a self,
         path: &'a str,
-    ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + Send + 'a>>,
-        StorageError,
-    >;
+    ) -> Result<BoxStream<'a, Result<ObjectMeta, StorageError>>, StorageError>;
 
     /// Create new object with `obj_bytes` as content.
     ///

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -1,11 +1,11 @@
 //! AWS S3 storage backend. It only supports a single writer and is not multi-writer safe.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::fmt::Debug;
-use std::{fmt, pin::Pin};
 
 use chrono::{DateTime, FixedOffset, Utc};
-use futures::Stream;
+use futures::stream::BoxStream;
 
 use log::debug;
 use rusoto_core::{HttpClient, HttpConfig, Region, RusotoError};
@@ -714,10 +714,7 @@ impl StorageBackend for S3StorageBackend {
     async fn list_objs<'a>(
         &'a self,
         path: &'a str,
-    ) -> Result<
-        Pin<Box<dyn Stream<Item = Result<ObjectMeta, StorageError>> + Send + 'a>>,
-        StorageError,
-    > {
+    ) -> Result<BoxStream<'_, Result<ObjectMeta, StorageError>>, StorageError> {
         let uri = parse_uri(path)?.into_s3object()?;
 
         /// This enum is used to represent 3 states in our object metadata streaming logic:


### PR DESCRIPTION
# Description

So far we were not traversing into directories when listing objects with the local storage backend - this is required for the vacuum command to work properly (i.e discovering orphaned files not in the log).
I more or less ported the implementation from object_store_rs, as I believe the code over there is of very high quality.

As a "drive-by" I updated the return type definitions on all `list_objs` using the `BoxStream` shorthand.

@Blajda  - would the vacuum tests validate this fix?

# Related Issue(s)
towards #671

# Documentation

<!---
Share links to useful documentation
--->
