### PR TITLE
Implement vacuum tests and general test setup utils

### DIFF
--- a/rust/src/vacuum.rs
+++ b/rust/src/vacuum.rs
@@ -24,6 +24,7 @@ use chrono::{Duration, Utc};
 use futures::StreamExt;
 use std::collections::HashSet;
 use std::fmt::Debug;
+use std::sync::Arc;
 
 #[derive(Debug)]
 /// Vacuum a Delta table with the given options
@@ -35,6 +36,8 @@ pub struct Vacuum {
     pub enforce_retention_duration: bool,
     /// Don't delete the files. Just determine which files can be deleted
     pub dry_run: bool,
+    /// Override the source of time
+    pub clock: Option<Arc<dyn Clock>>,
 }
 
 impl Default for Vacuum {
@@ -43,6 +46,7 @@ impl Default for Vacuum {
             retention_period: None,
             enforce_retention_duration: true,
             dry_run: false,
+            clock: None,
         }
     }
 }
@@ -163,7 +167,11 @@ pub async fn create_vacuum_plan(
         });
     }
 
-    let now_millis = Utc::now().timestamp_millis();
+    let now_millis = match params.clock {
+        Some(clock) => clock.current_timestamp_millis(),
+        None => Utc::now().timestamp_millis(),
+    };
+
     let expired_tombstones = get_stale_files(table, retention_period, now_millis)?;
     let valid_files = table.get_file_set();
 
@@ -224,4 +232,10 @@ impl Vacuum {
 
         return plan.execute(table).await;
     }
+}
+
+/// A source of time
+pub trait Clock: Debug {
+    /// get the current time in milliseconds since epoch
+    fn current_timestamp_millis(&self) -> i64;
 }

--- a/rust/src/vacuum.rs
+++ b/rust/src/vacuum.rs
@@ -12,6 +12,9 @@
 //! When you run vacuum then you cannot use time travel to a version older than
 //! the specified retention period.
 //!
+//! Warning: Vacuum does not support partitioned tables on Windows. This is due
+//! to Windows not using unix style paths. See #682
+//!
 //! # Example
 //! ```rust ignore
 //! let table = open_table("../path/to/table")?;

--- a/rust/tests/common/adls.rs
+++ b/rust/tests/common/adls.rs
@@ -1,0 +1,82 @@
+use chrono::Utc;
+use std::collections::HashMap;
+
+use azure_storage::storage_shared_key_credential::StorageSharedKeyCredential;
+use azure_storage_datalake::clients::DataLakeClient;
+use rand::Rng;
+
+use super::TestContext;
+
+pub struct AzureGen2 {
+    account_name: String,
+    account_key: String,
+    file_system_name: String,
+}
+
+impl Drop for AzureGen2 {
+    fn drop(&mut self) {
+        let storage_account_name = self.account_name.clone();
+        let storage_account_key = self.account_key.clone();
+        let file_system_name = self.file_system_name.clone();
+
+        let thread_handle = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            let data_lake_client = DataLakeClient::new(
+                StorageSharedKeyCredential::new(
+                    storage_account_name.to_owned(),
+                    storage_account_key.to_owned(),
+                ),
+                None,
+            );
+            let file_system_client =
+                data_lake_client.into_file_system_client(file_system_name.to_owned());
+            runtime
+                .block_on(file_system_client.delete().into_future())
+                .unwrap();
+        });
+
+        thread_handle.join().unwrap();
+    }
+}
+
+pub async fn setup_azure_gen2_context() -> TestContext {
+    let mut config = HashMap::new();
+
+    let storage_account_name = std::env::var("AZURE_STORAGE_ACCOUNT_NAME").unwrap();
+    let storage_account_key = std::env::var("AZURE_STORAGE_ACCOUNT_KEY").unwrap();
+
+    let data_lake_client = DataLakeClient::new(
+        StorageSharedKeyCredential::new(
+            storage_account_name.to_owned(),
+            storage_account_key.to_owned(),
+        ),
+        None,
+    );
+    let rand: u16 = rand::thread_rng().gen();
+    let file_system_name = format!("delta-rs-test-{}-{}", Utc::now().timestamp(), rand);
+
+    let file_system_client = data_lake_client.into_file_system_client(file_system_name.to_owned());
+    file_system_client.create().into_future().await.unwrap();
+
+    let table_uri = format!("adls2://{}/{}/", storage_account_name, file_system_name);
+
+    config.insert("URI".to_string(), table_uri);
+    config.insert(
+        "AZURE_STORAGE_ACCOUNT_NAME".to_string(),
+        storage_account_name.clone(),
+    );
+    config.insert(
+        "AZRUE_STORAGE_ACCOUNT_KEY".to_string(),
+        storage_account_key.clone(),
+    );
+
+    TestContext {
+        storage_context: Some(Box::new(AzureGen2 {
+            account_name: storage_account_name,
+            account_key: storage_account_key,
+            file_system_name,
+        })),
+        config,
+        ..TestContext::default()
+    }
+}

--- a/rust/tests/common/clock.rs
+++ b/rust/tests/common/clock.rs
@@ -1,0 +1,40 @@
+use chrono::{Duration, Utc};
+use deltalake::vacuum::Clock;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Debug)]
+pub struct TestClock {
+    //TODO: mutex might be overkill. Maybe just use an atomic i64..
+    now: Arc<Mutex<i64>>,
+}
+
+impl Clock for TestClock {
+    fn current_timestamp_millis(&self) -> i64 {
+        let inner = self.now.lock().unwrap();
+        return *inner;
+    }
+}
+
+impl TestClock {
+    pub fn new(start: i64) -> Self {
+        TestClock {
+            now: Arc::new(Mutex::new(start)),
+        }
+    }
+
+    pub fn from_systemtime() -> Self {
+        TestClock {
+            now: Arc::new(Mutex::new(Utc::now().timestamp_millis())),
+        }
+    }
+
+    pub fn set_timestamp(&self, timestamp: i64) {
+        let mut inner = self.now.lock().unwrap();
+        *inner = timestamp;
+    }
+
+    pub fn tick(&self, duration: Duration) {
+        let mut inner = self.now.lock().unwrap();
+        *inner = *inner + duration.num_milliseconds();
+    }
+}

--- a/rust/tests/common/clock.rs
+++ b/rust/tests/common/clock.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct TestClock {
-    //TODO: mutex might be overkill. Maybe just use an atomic i64..
     now: Arc<Mutex<i64>>,
 }
 
@@ -16,21 +15,10 @@ impl Clock for TestClock {
 }
 
 impl TestClock {
-    pub fn new(start: i64) -> Self {
-        TestClock {
-            now: Arc::new(Mutex::new(start)),
-        }
-    }
-
     pub fn from_systemtime() -> Self {
         TestClock {
             now: Arc::new(Mutex::new(Utc::now().timestamp_millis())),
         }
-    }
-
-    pub fn set_timestamp(&self, timestamp: i64) {
-        let mut inner = self.now.lock().unwrap();
-        *inner = timestamp;
     }
 
     pub fn tick(&self, duration: Duration) {

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -1,0 +1,181 @@
+use std::any::Any;
+use tempdir::TempDir;
+
+use deltalake::action;
+use deltalake::action::{Add, Remove};
+use deltalake::get_backend_for_uri_with_options;
+use deltalake::StorageBackend;
+use deltalake::{DeltaTable, DeltaTableConfig, DeltaTableMetaData, Schema};
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+
+#[cfg(feature = "azure")]
+pub mod adls;
+#[cfg(feature = "s3")]
+pub mod s3;
+pub mod clock;
+pub mod schemas;
+
+#[derive(Default)]
+pub struct TestContext {
+    /// The main table under test
+    pub table: Option<DeltaTable>,
+    pub backend: Option<Box<dyn StorageBackend>>,
+    /// The configuration used to create the backend.
+    pub config: HashMap<String, String>,
+    /// An object when it is dropped will clean up any temporary resources created for the test
+    pub storage_context: Option<Box<dyn Any>>,
+}
+
+pub struct LocalFS {
+    pub tmp_dir: TempDir,
+}
+
+impl TestContext {
+    pub async fn from_env() -> Self {
+        let backend = std::env::var("DELTA_RS_TEST_BACKEND");
+        let backend_ref = backend.as_ref().map(|s| s.as_str());
+        let context = match backend_ref {
+            Ok("LOCALFS") | Err(std::env::VarError::NotPresent) => setup_local_context().await,
+            #[cfg(feature = "azure")]
+            Ok("AZURE_GEN2") => adls::setup_azure_gen2_context().await,
+            #[cfg(feature = "s3")]
+            Ok("S3_LOCAL_STACK") => s3::setup_s3_context().await,
+            _ => panic!("Invalid backend for delta-rs tests"),
+        };
+
+        return context;
+    }
+
+    pub fn get_storage(&mut self) -> &Box<dyn StorageBackend> {
+        if self.backend.is_none() {
+            self.backend = Some(self.new_storage())
+        }
+
+        return self.backend.as_ref().unwrap();
+    }
+
+    fn new_storage(&self) -> Box<dyn StorageBackend> {
+        let config = self.config.clone();
+        let uri = config.get("URI").unwrap().to_string();
+        get_backend_for_uri_with_options(&uri, config).unwrap()
+    }
+
+    pub async fn add_file(
+        &mut self,
+        path: &str,
+        data: &[u8],
+        partition_values: &[(&str, Option<&str>)],
+        create_time: i64,
+        commit_to_log: bool,
+    ) {
+        let uri = self.table.as_ref().unwrap().table_uri.to_string();
+        let backend = self.get_storage();
+        let remote_path = uri + "/" + path;
+
+        backend.put_obj(&remote_path, data).await.unwrap();
+
+        if commit_to_log {
+            let mut part_values = HashMap::new();
+            for v in partition_values {
+                part_values.insert(v.0.to_string(), v.1.map(|v| v.to_string()));
+            }
+
+            let add = Add {
+                path: path.into(),
+                size: data.len() as i64,
+                modification_time: create_time,
+                partition_values: part_values,
+                data_change: true,
+                ..Default::default()
+            };
+            let table = self.table.as_mut().unwrap();
+            let mut transaction = table.create_transaction(None);
+            transaction.add_action(action::Action::add(add));
+            transaction.commit(None, None).await.unwrap();
+        }
+    }
+
+    pub async fn remove_file(
+        &mut self,
+        path: &str,
+        partition_values: &[(&str, Option<&str>)],
+        deletion_timestamp: i64,
+    ) {
+        let mut part_values = HashMap::new();
+        for v in partition_values {
+            part_values.insert(v.0.to_string(), v.1.map(|v| v.to_string()));
+        }
+
+        let remove = Remove {
+            path: path.into(),
+            deletion_timestamp: Some(deletion_timestamp),
+            partition_values: Some(part_values),
+            data_change: true,
+            ..Default::default()
+        };
+        let table = self.table.as_mut().unwrap();
+        let mut transaction = table.create_transaction(None);
+        transaction.add_action(action::Action::remove(remove));
+        transaction.commit(None, None).await.unwrap();
+    }
+
+    //Create and set a new table from the provided schema
+    pub async fn create_table_from_schema(&mut self, schema: Schema, partitions: &[&str]) {
+        let p = partitions
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>();
+        let table_meta = DeltaTableMetaData::new(
+            Some("delta-rs_test_table".to_owned()),
+            Some("Table created by delta-rs tests".to_owned()),
+            None,
+            schema.clone(),
+            p,
+            HashMap::new(),
+        );
+
+        let backend = self.new_storage();
+        let p = self.config.get("URI").unwrap().to_string();
+        let mut dt = DeltaTable::new(&p, backend, DeltaTableConfig::default()).unwrap();
+        let mut commit_info = Map::<String, Value>::new();
+
+        let protocol = action::Protocol {
+            min_reader_version: 1,
+            min_writer_version: 2,
+        };
+
+        commit_info.insert(
+            "operation".to_string(),
+            serde_json::Value::String("CREATE TABLE".to_string()),
+        );
+        let _res = dt
+            .create(
+                table_meta.clone(),
+                protocol.clone(),
+                Some(commit_info),
+                None,
+            )
+            .await
+            .unwrap();
+
+        self.table = Some(dt);
+    }
+}
+
+pub async fn setup_local_context() -> TestContext {
+    let tmp_dir = tempdir::TempDir::new("delta-rs_tests").unwrap();
+    let mut config = HashMap::new();
+    config.insert(
+        "URI".to_owned(),
+        tmp_dir.path().to_str().to_owned().unwrap().to_string(),
+    );
+
+    let localfs = LocalFS { tmp_dir };
+
+    TestContext {
+        storage_context: Some(Box::new(localfs)),
+        config,
+        ..TestContext::default()
+    }
+}

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -11,9 +11,9 @@ use std::collections::HashMap;
 
 #[cfg(feature = "azure")]
 pub mod adls;
+pub mod clock;
 #[cfg(feature = "s3")]
 pub mod s3;
-pub mod clock;
 pub mod schemas;
 
 #[derive(Default)]

--- a/rust/tests/common/s3.rs
+++ b/rust/tests/common/s3.rs
@@ -1,0 +1,122 @@
+use super::TestContext;
+use std::collections::HashMap;
+use std::process::Command;
+use rand::Rng;
+use chrono::Utc;
+use std::env;
+
+/// TODO: Currently this requires local stack to be setup prior to test execution.
+/// If we want to have this automated these are the key requirements:
+///     Multiple tests using the backend can run at the same time
+///     The start time for local stack is expensive so it should only setup once per execution not per test run
+///     When all tests have finished executing, local stack must terminate
+///  
+/// A possible solution is to have global variable to indicate if it was setup is complete.
+/// First obtain a read lock and check if local stack was setup. If it was not
+/// setup, then release the read lock and obtain a write lock. When the write
+/// lock is obtained, check the global variable again and return early if it was
+/// set. Otherwise, Spawn a new process which will setup local stack and then
+/// notify the parent of completion. The parent can then set the global variable
+/// and release the lock. The child will then wait until the parent process
+/// terminates then will clean up local stack.
+/// 
+/// Problems: This solution might have some issues on Windows and Mac
+/// 
+pub async fn setup_s3_context() -> TestContext {
+    
+    // Create a new prefix per test run.
+    let rand: u16 = rand::thread_rng().gen();
+    let cli = S3Cli::default();
+    let endpoint = "http://localhost:4566".to_string();
+    let bucket_name = "delta-rs-tests";
+    let uri = format!("s3://{}/{}/{}/", bucket_name, Utc::now().timestamp(), rand);
+    let lock_table = format!("delta_rs_lock_table_{}", rand);
+
+    let region = "us-east-1".to_string();;
+
+    env::set_var("AWS_ACCESS_KEY_ID", "test");
+    env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+    env::set_var("AWS_DEFAULT_REGION", &region);
+
+    cli.create_bucket(bucket_name, &endpoint);
+    cli.create_table(&lock_table,
+    "AttributeName=key,AttributeType=S",
+    "AttributeName=key,KeyType=HASH",
+    "ReadCapacityUnits=10,WriteCapacityUnits=10", &endpoint);
+    
+
+    let mut config = HashMap::new();
+    config.insert("URI".to_owned(), uri.clone());
+    config.insert("AWS_ENDPOINT_URL".to_owned(), endpoint.clone());
+    config.insert("AWS_REGION".to_owned(), region.clone());
+    config.insert("AWS_ACCESS_KEY_ID".to_owned(), "test".to_owned());
+    config.insert("AWS_SECRET_ACCESS_KEY".to_owned(), "test".to_owned());
+    config.insert("AWS_S3_LOCKING_PROVIDER".to_owned(), "dynamodb".to_owned());
+    config.insert("DYNAMO_LOCK_TABLE_NAME".to_owned(), lock_table.clone());
+
+    TestContext {
+        config,
+        storage_context: Some(Box::new(S3 {
+            endpoint,
+            uri,
+            lock_table,
+        })),
+        ..TestContext::default()
+    }
+} 
+
+#[derive(Default)]
+struct S3Cli { }
+
+impl S3Cli {
+
+    pub fn create_bucket(&self, bucket_name: &str, endpoint: &str) {
+        let mut child = Command::new("aws")
+            .args(["s3api", "create-bucket", "--bucket", bucket_name, "--endpoint-url", endpoint])
+            .spawn()
+            .expect("aws command is installed");
+        child.wait();
+    }
+
+    pub fn rm_recurive(&self, prefix: &str, endpoint: &str) {
+        let mut child = Command::new("aws")
+            .args(["s3", "rm", "--recursive", prefix, "--endpoint-url", endpoint])
+            .spawn()
+            .expect("aws command is installed");
+        child.wait();
+    }
+
+    pub fn delete_table(&self, table_name: &str, endpoint: &str) {
+        let mut child = Command::new("aws")
+            .args(["dynamodb", "delete-table", "--table-name", table_name, "--endpoint-url", endpoint])
+            .spawn()
+            .expect("aws command is installed");
+        child.wait();
+    }
+
+    pub fn create_table(&self, table_name: &str, attribute_definitions: &str,
+    key_schema: &str, provisioned_throughput:  &str,endpoint: &str) {
+        let mut child = Command::new("aws")
+            .args(["dynamodb", "create-table", "--table-name", table_name,
+            "--endpoint-url", endpoint, "--attribute-definitions",
+            attribute_definitions, "--key-schema",  key_schema, "--provisioned-throughput", provisioned_throughput])
+            .spawn()
+            .expect("aws command is installed");
+        child.wait();
+
+    }
+}
+
+struct S3 {
+    endpoint: String,
+    uri: String,
+    lock_table: String
+}
+
+impl Drop for S3 {
+    fn drop(&mut self) {
+        let cli = S3Cli::default();
+        cli.rm_recurive(&self.uri, &self.endpoint);
+        cli.delete_table(&self.lock_table, &self.endpoint);
+    }
+}

--- a/rust/tests/common/s3.rs
+++ b/rust/tests/common/s3.rs
@@ -5,23 +5,7 @@ use std::collections::HashMap;
 use std::env;
 use std::process::Command;
 
-/// TODO: Currently this requires local stack to be setup prior to test execution.
-/// If we want to have this automated these are the key requirements:
-///     Multiple tests using the backend can run at the same time
-///     The start time for local stack is expensive so it should only setup once per execution not per test run
-///     When all tests have finished executing, local stack must terminate
-///  
-/// A possible solution is to have global variable to indicate if it was setup is complete.
-/// First obtain a read lock and check if local stack was setup. If it was not
-/// setup, then release the read lock and obtain a write lock. When the write
-/// lock is obtained, check the global variable again and return early if it was
-/// set. Otherwise, Spawn a new process which will setup local stack and then
-/// notify the parent of completion. The parent can then set the global variable
-/// and release the lock. The child will then wait until the parent process
-/// terminates then will clean up local stack.
-///
-/// Problems: This solution might have some issues on Windows and Mac
-///
+/// Create a bucket and dynamodb lock table for s3 backend tests
 pub async fn setup_s3_context() -> TestContext {
     // Create a new prefix per test run.
     let rand: u16 = rand::thread_rng().gen();

--- a/rust/tests/common/s3.rs
+++ b/rust/tests/common/s3.rs
@@ -6,6 +6,7 @@ use std::env;
 use std::process::Command;
 
 /// Create a bucket and dynamodb lock table for s3 backend tests
+/// Requires local stack running in the background
 pub async fn setup_s3_context() -> TestContext {
     // Create a new prefix per test run.
     let rand: u16 = rand::thread_rng().gen();

--- a/rust/tests/common/schemas.rs
+++ b/rust/tests/common/schemas.rs
@@ -1,50 +1,29 @@
-use deltalake::{Schema, SchemaDataType, SchemaField};
+use serde_json::json;
 use std::collections::HashMap;
+use deltalake::Schema;
 
 /// Basic schema
 pub fn get_xy_date_schema() -> Schema {
-    return Schema::new(vec![
-        SchemaField::new(
-            "x".to_owned(),
-            SchemaDataType::primitive("integer".to_owned()),
-            false,
-            HashMap::new(),
-        ),
-        SchemaField::new(
-            "y".to_owned(),
-            SchemaDataType::primitive("integer".to_owned()),
-            false,
-            HashMap::new(),
-        ),
-        SchemaField::new(
-            "date".to_owned(),
-            SchemaDataType::primitive("string".to_owned()),
-            false,
-            HashMap::new(),
-        ),
-    ]);
+    serde_json::from_value(json!({
+        "type": "struct",
+        "fields": [
+          {"name": "x", "type": "integer", "nullable": false, "metadata": {}},
+          {"name": "y", "type": "integer", "nullable": false, "metadata": {}},
+          {"name": "date", "type": "string", "nullable": false, "metadata": {}},
+        ]
+      })
+    ).unwrap()
 }
 
 /// Schema that contains a column prefiexed with _
 pub fn get_vacuum_underscore_schema() -> Schema {
-    return Schema::new(vec![
-        SchemaField::new(
-            "x".to_owned(),
-            SchemaDataType::primitive("integer".to_owned()),
-            false,
-            HashMap::new(),
-        ),
-        SchemaField::new(
-            "y".to_owned(),
-            SchemaDataType::primitive("integer".to_owned()),
-            false,
-            HashMap::new(),
-        ),
-        SchemaField::new(
-            "_date".to_owned(),
-            SchemaDataType::primitive("string".to_owned()),
-            false,
-            HashMap::new(),
-        ),
-    ]);
+    serde_json::from_value::<Schema>(json!({
+        "type": "struct",
+        "fields": [
+          {"name": "x", "type": "integer", "nullable": false, "metadata": {}},
+          {"name": "y", "type": "integer", "nullable": false, "metadata": {}},
+          {"name": "_date", "type": "string", "nullable": false, "metadata": {}},
+        ]
+      })
+    ).unwrap()
 }

--- a/rust/tests/common/schemas.rs
+++ b/rust/tests/common/schemas.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use deltalake::{Schema, SchemaDataType, SchemaField};
+use std::collections::HashMap;
 
 /// Basic schema
 pub fn get_xy_date_schema() -> Schema {

--- a/rust/tests/common/schemas.rs
+++ b/rust/tests/common/schemas.rs
@@ -1,6 +1,5 @@
 use deltalake::Schema;
 use serde_json::json;
-use std::collections::HashMap;
 
 /// Basic schema
 pub fn get_xy_date_schema() -> Schema {

--- a/rust/tests/common/schemas.rs
+++ b/rust/tests/common/schemas.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+use deltalake::{Schema, SchemaDataType, SchemaField};
+
+/// Basic schema
+pub fn get_xy_date_schema() -> Schema {
+    return Schema::new(vec![
+        SchemaField::new(
+            "x".to_owned(),
+            SchemaDataType::primitive("integer".to_owned()),
+            false,
+            HashMap::new(),
+        ),
+        SchemaField::new(
+            "y".to_owned(),
+            SchemaDataType::primitive("integer".to_owned()),
+            false,
+            HashMap::new(),
+        ),
+        SchemaField::new(
+            "date".to_owned(),
+            SchemaDataType::primitive("string".to_owned()),
+            false,
+            HashMap::new(),
+        ),
+    ]);
+}
+
+/// Schema that contains a column prefiexed with _
+pub fn get_vacuum_underscore_schema() -> Schema {
+    return Schema::new(vec![
+        SchemaField::new(
+            "x".to_owned(),
+            SchemaDataType::primitive("integer".to_owned()),
+            false,
+            HashMap::new(),
+        ),
+        SchemaField::new(
+            "y".to_owned(),
+            SchemaDataType::primitive("integer".to_owned()),
+            false,
+            HashMap::new(),
+        ),
+        SchemaField::new(
+            "_date".to_owned(),
+            SchemaDataType::primitive("string".to_owned()),
+            false,
+            HashMap::new(),
+        ),
+    ]);
+}

--- a/rust/tests/common/schemas.rs
+++ b/rust/tests/common/schemas.rs
@@ -1,29 +1,29 @@
+use deltalake::Schema;
 use serde_json::json;
 use std::collections::HashMap;
-use deltalake::Schema;
 
 /// Basic schema
 pub fn get_xy_date_schema() -> Schema {
     serde_json::from_value(json!({
-        "type": "struct",
-        "fields": [
-          {"name": "x", "type": "integer", "nullable": false, "metadata": {}},
-          {"name": "y", "type": "integer", "nullable": false, "metadata": {}},
-          {"name": "date", "type": "string", "nullable": false, "metadata": {}},
-        ]
-      })
-    ).unwrap()
+      "type": "struct",
+      "fields": [
+        {"name": "x", "type": "integer", "nullable": false, "metadata": {}},
+        {"name": "y", "type": "integer", "nullable": false, "metadata": {}},
+        {"name": "date", "type": "string", "nullable": false, "metadata": {}},
+      ]
+    }))
+    .unwrap()
 }
 
 /// Schema that contains a column prefiexed with _
 pub fn get_vacuum_underscore_schema() -> Schema {
     serde_json::from_value::<Schema>(json!({
-        "type": "struct",
-        "fields": [
-          {"name": "x", "type": "integer", "nullable": false, "metadata": {}},
-          {"name": "y", "type": "integer", "nullable": false, "metadata": {}},
-          {"name": "_date", "type": "string", "nullable": false, "metadata": {}},
-        ]
-      })
-    ).unwrap()
+      "type": "struct",
+      "fields": [
+        {"name": "x", "type": "integer", "nullable": false, "metadata": {}},
+        {"name": "y", "type": "integer", "nullable": false, "metadata": {}},
+        {"name": "_date", "type": "string", "nullable": false, "metadata": {}},
+      ]
+    }))
+    .unwrap()
 }

--- a/rust/tests/vacuum_test.rs
+++ b/rust/tests/vacuum_test.rs
@@ -1,9 +1,19 @@
 use chrono::Duration;
 use deltalake::storage::file::FileStorageBackend;
+use deltalake::storage::StorageError;
+use deltalake::vacuum::Clock;
 use deltalake::vacuum::Vacuum;
 use deltalake::StorageBackend;
+use std::collections::HashMap;
+use std::sync::Arc;
 
+use common::clock::TestClock;
+use common::TestContext;
+use common::schemas::{get_vacuum_underscore_schema, get_xy_date_schema};
 use std::time::SystemTime;
+
+
+mod common;
 
 #[tokio::test]
 async fn vacuum_delta_8_0_table() {
@@ -76,3 +86,260 @@ async fn vacuum_delta_8_0_table() {
 
     assert_eq!(result.files_deleted, empty);
 }
+
+#[tokio::test]
+// Validate vacuum works on a non-partitioned table
+async fn test_non_partitioned_table() {
+    let mut context = TestContext::from_env().await;
+    context.create_table_from_schema(get_xy_date_schema(), &[]).await;
+    let clock = TestClock::from_systemtime();
+
+    let paths = ["delete_me.parquet", "dont_delete_me.parquet"];
+
+    for path in paths {
+        context
+            .add_file(
+                path,
+                "random junk".as_ref(),
+                &[],
+                clock.current_timestamp_millis(),
+                true,
+            )
+            .await;
+    }
+
+    clock.tick(Duration::seconds(10));
+
+    context
+        .remove_file("delete_me.parquet", &[], clock.current_timestamp_millis())
+        .await;
+
+    let res = {
+        clock.tick(Duration::days(8));
+        let table = context.table.as_mut().unwrap();
+        let mut plan = Vacuum::default();
+        plan.clock = Some(Arc::new(clock.clone()));
+        plan.execute(table).await.unwrap()
+    };
+
+    assert_eq!(res.files_deleted.len(), 1);
+    assert!(is_deleted(&mut context, "delete_me.parquet").await);
+    assert!(!is_deleted(&mut context, "dont_delete_me.parquet").await);
+}
+
+#[tokio::test]
+// Validate vacuum works on a table with multiple partitions
+async fn test_partitioned_table() {
+    let mut context = TestContext::from_env().await;
+    context
+        .create_table_from_schema(get_xy_date_schema(), &["date", "x"])
+        .await;
+    let clock = TestClock::from_systemtime();
+
+    let paths = [
+        "date=2022-07-03/x=2/delete_me.parquet",
+        "date=2022-07-03/x=2/dont_delete_me.parquet",
+    ];
+    let partition_values = [("date", Some("2022-07-03")), ("x", Some("2"))];
+
+    for path in paths {
+        context
+            .add_file(
+                path,
+                "random junk".as_ref(),
+                &partition_values,
+                clock.current_timestamp_millis(),
+                true,
+            )
+            .await;
+    }
+
+    clock.tick(Duration::seconds(10));
+
+    context
+        .remove_file(
+            "date=2022-07-03/x=2/delete_me.parquet",
+            &partition_values,
+            clock.current_timestamp_millis(),
+        )
+        .await;
+
+    let res = {
+        clock.tick(Duration::days(8));
+        let table = context.table.as_mut().unwrap();
+        let mut plan = Vacuum::default();
+        plan.clock = Some(Arc::new(clock.clone()));
+        plan.execute(table).await.unwrap()
+    };
+
+    assert_eq!(res.files_deleted.len(), 1);
+    assert!(is_deleted(&mut context, "date=2022-07-03/x=2/delete_me.parquet").await);
+    assert!(!is_deleted(&mut context, "date=2022-07-03/x=2/dont_delete_me.parquet").await);
+}
+
+#[tokio::test]
+// Validate that files and directories that start with '.' or '_' are ignored
+async fn test_ignored_files() {
+    let mut context = TestContext::from_env().await;
+    context
+        .create_table_from_schema(get_xy_date_schema(), &["date"])
+        .await;
+    let clock = TestClock::from_systemtime();
+
+    let paths = [
+        ".dotfile",
+        "_underscore",
+        "nested/.dotfile",
+        "nested2/really/deep/_underscore",
+        // Directories
+        "_underscoredir/dont_delete_me",
+        "_dotdir/dont_delete_me",
+        "nested3/_underscoredir/dont_delete_me",
+        "nested4/really/deep/.dotdir/dont_delete_me",
+    ];
+
+    for path in paths {
+        context
+            .add_file(
+                path,
+                "random junk".as_ref(),
+                &[],
+                clock.current_timestamp_millis(),
+                false,
+            )
+            .await;
+    }
+
+    let res = {
+        clock.tick(Duration::days(8));
+        let table = context.table.as_mut().unwrap();
+        let mut plan = Vacuum::default();
+        plan.clock = Some(Arc::new(clock.clone()));
+        plan.execute(table).await.unwrap()
+    };
+
+    assert_eq!(res.files_deleted.len(), 0);
+    for path in paths {
+        assert!(!is_deleted(&mut context, path).await);
+    }
+}
+
+#[tokio::test]
+//Partitions that start with _ are not ignored
+async fn test_partitions_included() {
+    let mut context = TestContext::from_env().await;
+    context
+        .create_table_from_schema(get_vacuum_underscore_schema(), &["_date"])
+        .await;
+    let clock = TestClock::from_systemtime();
+
+    let paths = [
+        "_date=2022-07-03/delete_me.parquet",
+        "_date=2022-07-03/dont_delete_me.parquet",
+    ];
+
+    let partition_values = &[("_date", Some("2022-07-03"))];
+
+    for path in paths {
+        context
+            .add_file(
+                path,
+                "random junk".as_ref(),
+                partition_values,
+                clock.current_timestamp_millis(),
+                true,
+            )
+            .await;
+    }
+
+    clock.tick(Duration::seconds(10));
+
+    context
+        .remove_file(
+            "_date=2022-07-03/delete_me.parquet",
+            partition_values,
+            clock.current_timestamp_millis(),
+        )
+        .await;
+
+    let res = {
+        clock.tick(Duration::days(8));
+        let table = context.table.as_mut().unwrap();
+        let mut plan = Vacuum::default();
+        plan.clock = Some(Arc::new(clock.clone()));
+        plan.execute(table).await.unwrap()
+    };
+
+    assert_eq!(res.files_deleted.len(), 1);
+    assert!(is_deleted(&mut context, "_date=2022-07-03/delete_me.parquet").await);
+    assert!(!is_deleted(&mut context, "_date=2022-07-03/dont_delete_me.parquet").await);
+}
+
+#[tokio::test]
+// files that are not managed by the delta log and have a last_modified greater than the retention period should be deleted
+async fn test_non_managed_files() {
+    let mut context = TestContext::from_env().await;
+    context
+        .create_table_from_schema(get_xy_date_schema(), &["date"])
+        .await;
+    let clock = TestClock::from_systemtime();
+
+    let paths = [
+        "garbage_file",
+        "nested/garbage_file",
+        "nested2/really/deep/garbage_file",
+    ];
+
+    for path in paths {
+        context
+            .add_file(
+                path,
+                "random junk".as_ref(),
+                &[],
+                clock.current_timestamp_millis(),
+                false,
+            )
+            .await;
+    }
+
+    // Validate unmanaged files are not deleted within the retention period
+
+    let res = {
+        clock.tick(Duration::hours(1));
+        let table = context.table.as_mut().unwrap();
+        let mut plan = Vacuum::default();
+        plan.clock = Some(Arc::new(clock.clone()));
+        plan.execute(table).await.unwrap()
+    };
+
+    assert_eq!(res.files_deleted.len(), 0);
+    for path in paths {
+        assert!(!is_deleted(&mut context, path).await);
+    }
+
+    // Validate unmanaged files are deleted after the retention period
+    let res = {
+        clock.tick(Duration::days(8));
+        let table = context.table.as_mut().unwrap();
+        let mut plan = Vacuum::default();
+        plan.clock = Some(Arc::new(clock.clone()));
+        plan.execute(table).await.unwrap()
+    };
+
+    assert_eq!(res.files_deleted.len(), paths.len());
+    for path in paths {
+        assert!(is_deleted(&mut context, path).await);
+    }
+}
+
+async fn is_deleted(context: &mut TestContext, path: &str) -> bool {
+    let uri = context.table.as_ref().unwrap().table_uri.to_string();
+    let backend = context.get_storage();
+    let path = uri + "/" + path;
+    let res = backend.head_obj(&path).await;
+    match res {
+        Err(StorageError::NotFound) => true,
+        _ => false,
+    }
+}
+

--- a/rust/tests/vacuum_test.rs
+++ b/rust/tests/vacuum_test.rs
@@ -8,10 +8,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use common::clock::TestClock;
-use common::TestContext;
 use common::schemas::{get_vacuum_underscore_schema, get_xy_date_schema};
+use common::TestContext;
 use std::time::SystemTime;
-
 
 mod common;
 
@@ -91,7 +90,9 @@ async fn vacuum_delta_8_0_table() {
 // Validate vacuum works on a non-partitioned table
 async fn test_non_partitioned_table() {
     let mut context = TestContext::from_env().await;
-    context.create_table_from_schema(get_xy_date_schema(), &[]).await;
+    context
+        .create_table_from_schema(get_xy_date_schema(), &[])
+        .await;
     let clock = TestClock::from_systemtime();
 
     let paths = ["delete_me.parquet", "dont_delete_me.parquet"];
@@ -342,4 +343,3 @@ async fn is_deleted(context: &mut TestContext, path: &str) -> bool {
         _ => false,
     }
 }
-

--- a/rust/tests/vacuum_test.rs
+++ b/rust/tests/vacuum_test.rs
@@ -4,7 +4,6 @@ use deltalake::storage::StorageError;
 use deltalake::vacuum::Clock;
 use deltalake::vacuum::Vacuum;
 use deltalake::StorageBackend;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use common::clock::TestClock;
@@ -282,7 +281,7 @@ async fn test_non_managed_files() {
     };
 
     assert_eq!(res.files_deleted.len(), 0);
-    for path in paths_delete.iter().chain(paths_ignore.iter()){
+    for path in paths_delete.iter().chain(paths_ignore.iter()) {
         assert!(!is_deleted(&mut context, path).await);
     }
 

--- a/rust/tests/vacuum_test.rs
+++ b/rust/tests/vacuum_test.rs
@@ -127,6 +127,8 @@ async fn test_non_partitioned_table() {
     assert!(!is_deleted(&mut context, "dont_delete_me.parquet").await);
 }
 
+// TODO: See #682. Issues with deleting since windows uses \ for paths
+#[cfg(not(target_os = "windows"))]
 #[tokio::test]
 // Validate vacuum works on a table with multiple partitions
 async fn test_partitioned_table() {
@@ -177,8 +179,10 @@ async fn test_partitioned_table() {
     assert!(!is_deleted(&mut context, "date=2022-07-03/x=2/dont_delete_me.parquet").await);
 }
 
+// TODO: See #682. Issues with deleting since windows uses \ for paths
+#[cfg(not(target_os = "windows"))]
 #[tokio::test]
-//Partitions that start with _ are not ignored
+// Partitions that start with _ are not ignored
 async fn test_partitions_included() {
     let mut context = TestContext::from_env().await;
     context


### PR DESCRIPTION
# Description
Continuation of #669 but only contains the parts required to run the tests. My intent for this PR is to review the test utilities and vacuum test cases. It will not address the failing test cases for each backend. Once we have sign off on that part we can mark the failing tests as `ignore`

Currently this is the status for each vacuum tests against each backend

| Test Name                               | Local FS | S3 | ADLS|
|-----------------------------------------|-------------|-----|---------|
| test_non_partitioned_table      | :heavy_check_mark:  | :heavy_check_mark: | :x: | 
| test_partitioned_table              | :x: | :heavy_check_mark:  | :x: | 
| test_ignored_files                    | :heavy_check_mark:  | :heavy_check_mark: | :x: | 
| test_partitions_included          | :x: | :heavy_check_mark:  | :x: | 
| test_non_managed_files         |   :x:   |  :x: | :x: | 

# Related Issue(s)
Once #681 is merged I expect the local fs to match S3 
Makes investigating #647 a bit easier

# Documentation

The vacuum tests allow swapable backends using environment variables. The variable `DELTA_RS_TEST_BACKEND` can to be to `LOCAL_FS`, `AZURE_GEN2`, and `S3_LOCAL_STACK`. The S3 tests requires local stack to be setup prior to execution and the Azure tests require additional environment variables to be setup. 

To run the S3 Tests
setup local stack 
```
localstack start
```
execute the tests
 ```
DELTA_RS_TEST_BACKEND=S3_LOCAL_STACK cargo test --features s3 -p deltalake --test vacuum_test -- --nocapture
```

