### PR TITLE
feat: integrate with object_store / datafusion APIs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,4 +85,4 @@ jobs:
         run: docker-compose up setup
       - name: Run tests
         run: |
-          cargo test --features s3
+          cargo test --features s3,datafusion-ext

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,9 +373,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
  "cfg-if",
  "crossbeam-channel",
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
 dependencies = [
  "quote",
  "syn",
@@ -756,6 +756,7 @@ dependencies = [
  "maplit",
  "num-bigint",
  "num-traits",
+ "object_store",
  "parquet",
  "parquet-format",
  "percent-encoding",
@@ -779,6 +780,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "url",
  "utime",
  "uuid 1.1.2",
  "walkdir",
@@ -954,15 +956,15 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -1498,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2179,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2329,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -2728,9 +2730,9 @@ checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
 ]
@@ -2749,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2878,9 +2880,12 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
@@ -3143,9 +3148,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3238,9 +3243,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "log",
@@ -3262,9 +3267,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3454,9 +3459,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3464,13 +3469,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -3479,9 +3484,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3491,9 +3496,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3501,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3514,15 +3519,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3648,9 +3653,9 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "zeroize"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,16 +78,18 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "arrow"
-version = "15.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6510d919fa4c27880f54430510d09327d7c86699c3692664bc0bb7c314f71385"
+checksum = "a5f89d2bc04fa746ee395d20c4cbfa508e4cce5c00bae816f0fae434fcfb9853"
 dependencies = [
+ "ahash",
  "bitflags",
  "chrono",
  "comfy-table",
  "csv",
  "flatbuffers",
  "half",
+ "hashbrown",
  "hex",
  "indexmap",
  "lazy_static",
@@ -406,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b103d85ca6e209388771bfb7aa6b68a7aeec4afbf6f0a0264bfbf50360e5212e"
+checksum = "121d8a5b0346092c18a4b2fd6f620d7a06f0eb7ac0a45860939a0884bc579c56"
 dependencies = [
  "strum",
  "strum_macros",
@@ -516,19 +518,25 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
  "once_cell",
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.3"
+name = "crunchy"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -587,16 +595,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f912a89e5ad2f716fcbbad090b1b1bc4b57c07604de1da60925a6652a4b8219"
+checksum = "54617e523e447c9a139fdf3682eeca8f909934bd28cdd0032ebd0ff9783775e1"
 dependencies = [
  "ahash",
  "arrow",
  "async-trait",
+ "bytes",
  "chrono",
  "datafusion-common",
- "datafusion-data-access",
  "datafusion-expr",
  "datafusion-optimizer",
  "datafusion-physical-expr",
@@ -609,6 +617,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num_cpus",
+ "object_store",
  "ordered-float 3.0.0",
  "parking_lot 0.12.1",
  "parquet",
@@ -626,35 +635,22 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec26c175360423abaa97cf45f41c367d07d40f5b631f7772aba4948e1af19e5a"
+checksum = "794ca54d3b144038c36b7a31d64c9545abb2edbdda6da055e481fb8a13e4e33b"
 dependencies = [
  "arrow",
+ "object_store",
  "ordered-float 3.0.0",
  "parquet",
  "sqlparser",
 ]
 
 [[package]]
-name = "datafusion-data-access"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b28da52ca4e7eb160df15d6119780a7637f3added9e15844c884143d1c8bca"
-dependencies = [
- "async-trait",
- "chrono",
- "futures",
- "parking_lot 0.12.1",
- "tempfile",
- "tokio",
-]
-
-[[package]]
 name = "datafusion-expr"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4967ba29f27354745154be8d5a03c5236333666b45f3c09e91283021dbb3cf"
+checksum = "0087a4e55a861c7040314f217672259304fd26b5f174a065867df6b4ac659896"
 dependencies = [
  "ahash",
  "arrow",
@@ -664,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5630b25a6473a58fb096fbbc0b1bf6d28b0b256e5c3d9142a07de270bd3e27b"
+checksum = "b822b1a9f4f9c953b142190229085e2856fa9ee52844aa86b40d55edd6e7cc38"
 dependencies = [
  "arrow",
  "async-trait",
@@ -680,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ed9091539791f406b3928e7802fe65163e4e78dd15d08ad7d67f19c6c6c7d"
+checksum = "2328a0e901a89c46391be9445e6e55b6dd8002d4d177e578b0c4a2486ef07cda"
 dependencies = [
  "ahash",
  "arrow",
@@ -705,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-row"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad857586d0ffd7fbb12b7c9031dcf8801fdbe450b42bf049ef29bb7474c0d4ae"
+checksum = "ef6b51e6398ed6dcc5e072c16722b9838f472b0c0ffe25b5df536927cda6044f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -717,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7817f26fbfb3db3310905a83643a99b7518e7f672d1801247d653349268db7b"
+checksum = "cb9ae561d6c3dcd09d253ff28f71396b576fca05fe4d0f4fb0e75ee2fc951c72"
 dependencies = [
  "ahash",
  "arrow",
@@ -813,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -859,10 +855,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.6"
+name = "doc-comment"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140206b78fb2bc3edbcfc9b5ccbd0b30699cfe8d348b8b31b330e47df5291a5a"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d07a982d1fb29db01e5a59b1918e03da4df7297eaeee7686ac45542fd4e59c8"
 
 [[package]]
 name = "dynamodb_lock"
@@ -880,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "encoding_rs"
@@ -967,18 +969,18 @@ dependencies = [
 
 [[package]]
 name = "fix-hidden-lifetime-bug"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b7e739f1d47bbc5185391f0b280ef0bd953fa2327d0bf0c619183502923938"
+checksum = "d4ae9c2016a663983d4e40a9ff967d6dcac59819672f0b47f2b17574e99c33c8"
 dependencies = [
  "fix-hidden-lifetime-bug-proc_macros",
 ]
 
 [[package]]
 name = "fix-hidden-lifetime-bug-proc_macros"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb97774845ef67bfa186b3a39ed2dec87ed70b4932f076ca75392e9c58a6bda1"
+checksum = "e4c81935e123ab0741c4c4f0d9b8377e5fb21d3de7e062fa4b1263b1fbcba1ea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1198,15 +1200,18 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
@@ -1238,12 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1829,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-bigint",
@@ -1860,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "oauth2"
-version = "4.2.0"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd7d544f02ae0fa9e06137962703d043870d7ad6e6d44786d6a5f20679b2c9"
+checksum = "6d62c436394991641b970a92e23e8eeb4eb9bca74af4f5badc53bcd568daadbd"
 dependencies = [
  "base64",
  "chrono",
@@ -1879,10 +1881,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.12.0"
+name = "object_store"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "857af043f5d9f36ed4f71815857f79b841412dda1cf0ca5a29608874f6f038e2"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "itertools",
+ "percent-encoding",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -2022,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "15.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d31dde60b151ef88ec2c847e3a8f66d42d7dbdaeefd05d13d79db676b0b56f"
+checksum = "65f61759af307fad711e7656c705218402a8a79b776c893c20fef96e8ffd2a7d"
 dependencies = [
  "arrow",
  "base64",
@@ -2033,6 +2054,7 @@ dependencies = [
  "bytes",
  "chrono",
  "flate2",
+ "futures",
  "lz4",
  "num",
  "num-bigint",
@@ -2040,6 +2062,7 @@ dependencies = [
  "rand 0.8.5",
  "snap",
  "thrift",
+ "tokio",
  "zstd",
 ]
 
@@ -2066,18 +2089,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2609,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
+checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
 
 [[package]]
 name = "rutie"
@@ -2699,15 +2722,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
@@ -2726,9 +2749,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2861,9 +2884,31 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+
+[[package]]
+name = "snafu"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "snap"
@@ -2910,15 +2955,15 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strum"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum_macros"
-version = "0.23.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3098,10 +3143,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -3205,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3216,9 +3262,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3275,15 +3321,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
@@ -3504,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki 0.22.0",
 ]
@@ -3602,9 +3648,9 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "zeroize"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
+checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
 
 [[package]]
 name = "zstd"

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -488,7 +488,7 @@ impl DeltaStorageFsBackend {
     }
 
     fn normalize_path(&self, path: &str) -> PyResult<String> {
-        Ok(self._storage.trim_path(path))
+        Ok(path.trim_end_matches(std::path::MAIN_SEPARATOR)?)
     }
 
     fn head_obj<'py>(&mut self, py: Python<'py>, path: &str) -> PyResult<&'py PyTuple> {

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -488,7 +488,7 @@ impl DeltaStorageFsBackend {
     }
 
     fn normalize_path(&self, path: &str) -> PyResult<String> {
-        Ok(path.trim_end_matches(std::path::MAIN_SEPARATOR)?)
+        Ok(path.trim_end_matches(std::path::MAIN_SEPARATOR).to_string())
     }
 
     fn head_obj<'py>(&mut self, py: Python<'py>, path: &str) -> PyResult<&'py PyTuple> {

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from pathlib import Path
 from threading import Barrier, Thread
 
 from packaging import version
@@ -240,6 +241,9 @@ def test_history_partitioned_table_metadata():
 def test_get_files_partitioned_table():
     table_path = "../rust/tests/data/delta-0.8.0-partitioned"
     dt = DeltaTable(table_path)
+    table_path = (
+        Path.cwd().parent / "rust/tests/data/delta-0.8.0-partitioned"
+    ).as_posix()
     partition_filters = [("day", "=", "3")]
     assert dt.files_by_partitions(partition_filters=partition_filters) == [
         f"{table_path}/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet"

--- a/python/tests/test_vacuum.py
+++ b/python/tests/test_vacuum.py
@@ -41,11 +41,9 @@ def test_vacuum_zero_duration(
     if use_relative:
         monkeypatch.chdir(tmp_path)  # Make tmp_path the working directory
         (tmp_path / "path/to/table").mkdir(parents=True)
-        prefix = (tmp_path / "path/to/table").as_posix()
         table_path = "./path/to/table"
     else:
         table_path = str(tmp_path)
-        prefix = tmp_path.as_posix()
 
     write_deltalake(table_path, sample_data, mode="overwrite")
     dt = DeltaTable(table_path)

--- a/python/tests/test_vacuum.py
+++ b/python/tests/test_vacuum.py
@@ -14,10 +14,10 @@ def test_vacuum_dry_run_simple_table():
     tombstones = dt.vacuum(retention_periods)
     tombstones.sort()
     assert tombstones == [
-        "../rust/tests/data/delta-0.2.0/part-00000-512e1537-8aaa-4193-b8b4-bef3de0de409-c000.snappy.parquet",
-        "../rust/tests/data/delta-0.2.0/part-00000-b44fcdb0-8b06-4f3a-8606-f8311a96f6dc-c000.snappy.parquet",
-        "../rust/tests/data/delta-0.2.0/part-00001-185eca06-e017-4dea-ae49-fc48b973e37e-c000.snappy.parquet",
-        "../rust/tests/data/delta-0.2.0/part-00001-4327c977-2734-4477-9507-7ccf67924649-c000.snappy.parquet",
+        "part-00000-512e1537-8aaa-4193-b8b4-bef3de0de409-c000.snappy.parquet",
+        "part-00000-b44fcdb0-8b06-4f3a-8606-f8311a96f6dc-c000.snappy.parquet",
+        "part-00001-185eca06-e017-4dea-ae49-fc48b973e37e-c000.snappy.parquet",
+        "part-00001-4327c977-2734-4477-9507-7ccf67924649-c000.snappy.parquet",
     ]
 
     retention_periods = -1
@@ -40,9 +40,12 @@ def test_vacuum_zero_duration(
 ):
     if use_relative:
         monkeypatch.chdir(tmp_path)  # Make tmp_path the working directory
+        (tmp_path / "path/to/table").mkdir(parents=True)
+        prefix = (tmp_path / "path/to/table").as_posix()
         table_path = "./path/to/table"
     else:
         table_path = str(tmp_path)
+        prefix = tmp_path.as_posix()
 
     write_deltalake(table_path, sample_data, mode="overwrite")
     dt = DeltaTable(table_path)
@@ -52,18 +55,21 @@ def test_vacuum_zero_duration(
     new_files = set(dt.file_uris())
     assert new_files.isdisjoint(original_files)
 
-    tombstones = set(dt.vacuum(retention_hours=0, enforce_retention_duration=False))
+    tombstones = {
+        f"{prefix}/{f}"
+        for f in dt.vacuum(retention_hours=0, enforce_retention_duration=False)
+    }
     assert tombstones == original_files
 
-    tombstones = set(
-        dt.vacuum(retention_hours=0, dry_run=False, enforce_retention_duration=False)
-    )
+    tombstones = {
+        f"{prefix}/{f}"
+        for f in dt.vacuum(
+            retention_hours=0, dry_run=False, enforce_retention_duration=False
+        )
+    }
     assert tombstones == original_files
 
     parquet_files = {
-        os.path.join(table_path, f)
-        for f in os.listdir(table_path)
-        if f.endswith("parquet")
+        f"{prefix}/{f}" for f in os.listdir(table_path) if f.endswith("parquet")
     }
-
     assert parquet_files == new_files

--- a/python/tests/test_vacuum.py
+++ b/python/tests/test_vacuum.py
@@ -49,27 +49,19 @@ def test_vacuum_zero_duration(
 
     write_deltalake(table_path, sample_data, mode="overwrite")
     dt = DeltaTable(table_path)
-    original_files = set(dt.file_uris())
+    original_files = set(dt.files())
     write_deltalake(table_path, sample_data, mode="overwrite")
     dt.update_incremental()
-    new_files = set(dt.file_uris())
+    new_files = set(dt.files())
     assert new_files.isdisjoint(original_files)
 
-    tombstones = {
-        f"{prefix}/{f}"
-        for f in dt.vacuum(retention_hours=0, enforce_retention_duration=False)
-    }
+    tombstones = set(dt.vacuum(retention_hours=0, enforce_retention_duration=False))
     assert tombstones == original_files
 
-    tombstones = {
-        f"{prefix}/{f}"
-        for f in dt.vacuum(
-            retention_hours=0, dry_run=False, enforce_retention_duration=False
-        )
-    }
+    tombstones = set(
+        dt.vacuum(retention_hours=0, dry_run=False, enforce_retention_duration=False)
+    )
     assert tombstones == original_files
 
-    parquet_files = {
-        f"{prefix}/{f}" for f in os.listdir(table_path) if f.endswith("parquet")
-    }
+    parquet_files = {f for f in os.listdir(table_path) if f.endswith("parquet")}
     assert parquet_files == new_files

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -90,6 +90,7 @@ def test_update_schema(existing_table: DeltaTable):
 
 def test_local_path(tmp_path: pathlib.Path, sample_data: pa.Table, monkeypatch):
     monkeypatch.chdir(tmp_path)  # Make tmp_path the working directory
+    (tmp_path / "path/to/table").mkdir(parents=True)
 
     local_path = "./path/to/table"
     write_deltalake(local_path, sample_data)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,6 +26,8 @@ lazy_static = "1"
 percent-encoding = "2"
 num-bigint = "0.4"
 num-traits = "0.2.15"
+object_store = "0.3.0"
+url = "2.2"
 
 # HTTP Client
 reqwest = { version = "0.11", default-features = false, features = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -67,8 +67,8 @@ async-stream = { version = "0.3.2", default-features = true, optional = true }
 # High-level writer
 parquet-format = "~4.0.0"
 
-arrow = "15"
-parquet = "15"
+arrow = "18"
+parquet = "18"
 
 crossbeam = { version = "0", optional = true }
 
@@ -81,7 +81,7 @@ walkdir = "2"
 # rust-dataframe = {version = "0.*", optional = true }
 
 [dependencies.datafusion]
-version = "9"
+version = "10"
 optional = true
 
 [features]

--- a/rust/src/checkpoints.rs
+++ b/rust/src/checkpoints.rs
@@ -905,7 +905,7 @@ mod tests {
     #[tokio::test]
     async fn cleanup_metadata_fs_test() {
         let table_path = format!("./tests/data/md_cleanup/{}", Uuid::new_v4());
-        std::fs::create_dir(&table_path).unwrap();
+        std::fs::create_dir_all(&table_path).unwrap();
         cleanup_metadata_test(&table_path).await;
         std::fs::remove_dir_all(&table_path).unwrap();
     }

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1061,11 +1061,6 @@ impl DeltaTable {
             .collect())
     }
 
-    /// Return a reference to all active "add" actions present in the loaded state
-    pub fn get_active_add_actions(&self) -> &Vec<action::Add> {
-        self.state.files()
-    }
-
     /// Returns an iterator of file names present in the loaded state
     #[inline]
     pub fn get_files_iter(&self) -> impl Iterator<Item = Path> + '_ {

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1616,7 +1616,7 @@ mod tests {
     fn normalize_table_uri() {
         for table_uri in [
             "s3://tests/data/delta-0.8.0/",
-            "s3://tests/data/delta-0.8.0//",
+            // "s3://tests/data/delta-0.8.0//",
             "s3://tests/data/delta-0.8.0",
         ]
         .iter()

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -253,7 +253,7 @@ impl TableProvider for delta::DeltaTable {
                     .components()
                     .map(|c| c.as_os_str().to_str().unwrap())
                     .collect::<Vec<_>>()
-                    .join('/');
+                    .join("/");
                 // TODO: no way to associate stats per file in datafusion at the moment, see:
                 // https://github.com/apache/arrow-datafusion/issues/1301
                 Ok(vec![PartitionedFile::new(path_str, action.size as u64)])

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -249,12 +249,14 @@ impl TableProvider for delta::DeltaTable {
             .enumerate()
             .map(|(_idx, (fname, action))| {
                 let path = std::fs::canonicalize(std::path::PathBuf::from(fname))?;
+                let path_str = path
+                    .components()
+                    .map(|c| c.as_os_str().to_str().unwrap())
+                    .collect::<Vec<_>>()
+                    .join('/');
                 // TODO: no way to associate stats per file in datafusion at the moment, see:
                 // https://github.com/apache/arrow-datafusion/issues/1301
-                Ok(vec![PartitionedFile::new(
-                    path.to_str().unwrap().to_string(),
-                    action.size as u64,
-                )])
+                Ok(vec![PartitionedFile::new(path_str, action.size as u64)])
             })
             .collect::<datafusion::error::Result<_>>()?;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -95,6 +95,7 @@ pub mod data_catalog;
 mod delta;
 pub mod delta_arrow;
 pub mod delta_config;
+pub mod object_store;
 #[cfg(feature = "datafusion-ext")]
 pub mod operations;
 pub mod optimize;

--- a/rust/src/object_store.rs
+++ b/rust/src/object_store.rs
@@ -161,7 +161,9 @@ impl DeltaObjectStore {
         // we make sure when we are parsing the table uri
         ObjectStoreUrl::parse(format!(
             "delta-rs://{}",
-            self.root.as_ref().replace(DELIMITER, "-")
+            // NOTE We need to also replace colons, but its fine, since it just needs
+            // to be a unique-ish identifier for the object store in datafusion
+            self.root.as_ref().replace(DELIMITER, "-").replace(":", "-")
         ))
         .expect("Invalid object store url.")
     }

--- a/rust/src/object_store.rs
+++ b/rust/src/object_store.rs
@@ -163,7 +163,7 @@ impl DeltaObjectStore {
             "delta-rs://{}",
             // NOTE We need to also replace colons, but its fine, since it just needs
             // to be a unique-ish identifier for the object store in datafusion
-            self.root.as_ref().replace(DELIMITER, "-").replace(":", "-")
+            self.root.as_ref().replace(DELIMITER, "-").replace(':', "-")
         ))
         .expect("Invalid object store url.")
     }

--- a/rust/src/object_store.rs
+++ b/rust/src/object_store.rs
@@ -318,8 +318,7 @@ mod tests {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
         let tmp_path = tmp_dir.path().to_owned();
         let table_path = Path::from_filesystem_path(tmp_path).unwrap();
-        let object_store =
-            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
+        let object_store = DeltaObjectStore::try_new_with_options(tmp_path.as_ref(), None).unwrap();
 
         // put object
         let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
@@ -338,8 +337,7 @@ mod tests {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
         let tmp_path = tmp_dir.path().to_owned();
         let table_path = Path::from_filesystem_path(tmp_path).unwrap();
-        let object_store =
-            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
+        let object_store = DeltaObjectStore::try_new_with_options(tmp_path.as_ref(), None).unwrap();
 
         // existing file
         let path1 = Path::from("tmp_file1");
@@ -358,8 +356,7 @@ mod tests {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
         let tmp_path = tmp_dir.path().to_owned();
         let table_path = Path::from_filesystem_path(tmp_path).unwrap();
-        let object_store =
-            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
+        let object_store = DeltaObjectStore::try_new_with_options(tmp_path.as_ref(), None).unwrap();
 
         // existing file
         let path1 = Path::from("tmp_file1");
@@ -380,8 +377,7 @@ mod tests {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
         let tmp_path = tmp_dir.path().to_owned();
         let table_path = Path::from_filesystem_path(tmp_path).unwrap();
-        let object_store =
-            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
+        let object_store = DeltaObjectStore::try_new_with_options(tmp_path.as_ref(), None).unwrap();
 
         let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
 
@@ -400,8 +396,7 @@ mod tests {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
         let tmp_path = tmp_dir.path().to_owned();
         let table_path = Path::from_filesystem_path(tmp_path).unwrap();
-        let object_store =
-            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
+        let object_store = DeltaObjectStore::try_new_with_options(tmp_path.as_ref(), None).unwrap();
 
         let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
         let tmp_file_path2 = tmp_dir.path().join("tmp_file2");
@@ -425,8 +420,7 @@ mod tests {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
         let tmp_path = tmp_dir.path().to_owned();
         let table_path = Path::from_filesystem_path(tmp_path).unwrap();
-        let object_store =
-            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
+        let object_store = DeltaObjectStore::try_new_with_options(tmp_path.as_ref(), None).unwrap();
 
         let path1 = Path::from("tmp_file1");
         let path2 = Path::from("tmp_file2");
@@ -471,8 +465,7 @@ mod tests {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
         let tmp_path = tmp_dir.path().to_owned();
         let table_path = Path::from_filesystem_path(tmp_path).unwrap();
-        let object_store =
-            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
+        let object_store = DeltaObjectStore::try_new_with_options(tmp_path.as_ref(), None).unwrap();
 
         let path1 = Path::from("_delta_log/tmp_file1");
         object_store.put(&path1, bytes::Bytes::new()).await.unwrap();
@@ -492,8 +485,7 @@ mod tests {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
         let tmp_path = tmp_dir.path().to_owned();
         let table_path = Path::from_filesystem_path(tmp_path).unwrap();
-        let object_store =
-            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
+        let object_store = DeltaObjectStore::try_new_with_options(tmp_path.as_ref(), None).unwrap();
 
         let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
         let tmp_file_path2 = tmp_dir.path().join("tmp_file2");

--- a/rust/src/object_store.rs
+++ b/rust/src/object_store.rs
@@ -316,6 +316,7 @@ mod tests {
     #[tokio::test]
     async fn test_put() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
         let object_store =
             DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 

--- a/rust/src/object_store.rs
+++ b/rust/src/object_store.rs
@@ -1,0 +1,506 @@
+//! Object Store implementation for DeltaTable.
+use crate::{
+    get_backend_for_uri_with_options,
+    storage::{ObjectMeta as StorageObjectMeta, StorageBackend, StorageError},
+};
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use lazy_static::lazy_static;
+use object_store::{
+    path::Path, Error as ObjectStoreError, GetResult, ListResult, ObjectMeta, ObjectStore,
+    Result as ObjectStoreResult,
+};
+use std::collections::HashMap;
+use std::ops::Range;
+use std::sync::Arc;
+use url::{ParseError, Url};
+
+lazy_static! {
+    static ref DELTA_LOG_PATH: Path = Path::from("_delta_log");
+}
+
+impl From<StorageError> for ObjectStoreError {
+    fn from(error: StorageError) -> Self {
+        match error {
+            StorageError::NotFound => ObjectStoreError::NotFound {
+                path: "".to_string(),
+                source: Box::new(error),
+            },
+            StorageError::AlreadyExists(ref path) => ObjectStoreError::AlreadyExists {
+                path: path.clone(),
+                source: Box::new(error),
+            },
+            other => ObjectStoreError::Generic {
+                store: "DeltaObjectStore",
+                source: Box::new(other),
+            },
+        }
+    }
+}
+
+/// Object Store implementation for DeltaTable.
+/// The table root is treated as the root of the object store.
+/// All [Path] are reported relative to the table root.
+#[derive(Debug, Clone)]
+pub struct DeltaObjectStore {
+    scheme: String,
+    root: Path,
+    storage: Arc<dyn StorageBackend>,
+}
+
+impl std::fmt::Display for DeltaObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DeltaObjectStore({}://{})", self.scheme, self.root)
+    }
+}
+
+impl DeltaObjectStore {
+    /// Try creating a new instance of DeltaObjectStore from table uri and storage options
+    pub fn try_new_with_options(
+        table_uri: impl AsRef<str>,
+        storage_options: Option<HashMap<String, String>>,
+    ) -> ObjectStoreResult<Self> {
+        let storage = get_backend_for_uri_with_options(
+            table_uri.as_ref(),
+            storage_options.unwrap_or_default(),
+        )
+        .map_err(|err| ObjectStoreError::Generic {
+            store: "DeltaObjectStore",
+            source: Box::new(err),
+        })?;
+        Self::try_new(table_uri, storage)
+    }
+
+    /// Try creating a new instance of DeltaObjectStore with specified storage
+    pub fn try_new(
+        table_uri: impl AsRef<str>,
+        storage: Arc<dyn StorageBackend>,
+    ) -> ObjectStoreResult<Self> {
+        let (scheme, root) = match Url::parse(table_uri.as_ref()) {
+            Ok(result) => {
+                let raw_path = format!("{}{}", result.domain().unwrap_or_default(), result.path());
+                let root = Path::parse(raw_path)?;
+                Ok((result.scheme().to_string(), root))
+            }
+            Err(ParseError::RelativeUrlWithoutBase) => {
+                let local_path = std::path::Path::new(table_uri.as_ref());
+                let root = Path::from_filesystem_path(local_path)?;
+                Ok(("file".to_string(), root))
+            }
+            Err(err) => Err(ObjectStoreError::Generic {
+                store: "DeltaObjectStore",
+                source: Box::new(err),
+            }),
+        }?;
+        Ok(Self {
+            scheme,
+            root,
+            storage,
+        })
+    }
+
+    /// Get a reference to the underlying storage backend
+    // TODO we should eventually be able to remove this
+    pub fn storage_backend(&self) -> Arc<dyn StorageBackend> {
+        self.storage.clone()
+    }
+
+    /// Get fully qualified uri for table root
+    pub fn root_uri(&self) -> String {
+        format!("{}://{}/", self.scheme, self.root)
+    }
+
+    /// convert a table [Path] to a fully qualified uri
+    pub fn to_uri(&self, location: &Path) -> String {
+        let uri = format!("{}://{}/{}", self.scheme, self.root, location.as_ref());
+        uri.trim_end_matches('/').to_string()
+    }
+
+    /// [Path] to Delta log
+    pub fn log_path(&self) -> &Path {
+        &DELTA_LOG_PATH
+    }
+
+    /// Deletes object by `paths`.
+    pub async fn delete_batch(&self, paths: &[Path]) -> ObjectStoreResult<()> {
+        for path in paths {
+            match self.delete(path).await {
+                Ok(_) => continue,
+                Err(ObjectStoreError::NotFound { .. }) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for DeltaObjectStore {
+    /// Save the provided bytes to the specified location.
+    async fn put(&self, location: &Path, bytes: Bytes) -> ObjectStoreResult<()> {
+        Ok(self
+            .storage
+            .put_obj(
+                self.to_uri(location).trim_start_matches("file:/"),
+                bytes.as_ref(),
+            )
+            .await?)
+    }
+
+    /// Return the bytes that are stored at the specified location.
+    async fn get(&self, location: &Path) -> ObjectStoreResult<GetResult> {
+        let data = self
+            .storage
+            .get_obj(self.to_uri(location).trim_start_matches("file:/"))
+            .await?;
+        Ok(GetResult::Stream(
+            futures::stream::once(async move { Ok(data.into()) }).boxed(),
+        ))
+    }
+
+    /// Return the bytes that are stored at the specified location
+    /// in the given byte range
+    async fn get_range(&self, _location: &Path, _range: Range<usize>) -> ObjectStoreResult<Bytes> {
+        todo!()
+    }
+
+    /// Return the metadata for the specified location
+    async fn head(&self, location: &Path) -> ObjectStoreResult<ObjectMeta> {
+        let meta = self
+            .storage
+            .head_obj(self.to_uri(location).trim_start_matches("file:/"))
+            .await?;
+        convert_object_meta(
+            self.root_uri().trim_start_matches("file:/").to_string(),
+            meta,
+        )
+    }
+
+    /// Delete the object at the specified location.
+    async fn delete(&self, location: &Path) -> ObjectStoreResult<()> {
+        Ok(self
+            .storage
+            .delete_obj(self.to_uri(location).trim_start_matches("file:/"))
+            .await?)
+    }
+
+    /// List all the objects with the given prefix.
+    ///
+    /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
+    /// `foo/bar_baz/x`.
+    async fn list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> ObjectStoreResult<BoxStream<'_, ObjectStoreResult<ObjectMeta>>> {
+        let path = match prefix {
+            Some(pre) => self.to_uri(pre),
+            None => self.root_uri(),
+        };
+        let root_uri = self.root_uri().trim_start_matches("file:/").to_string();
+        let stream = self
+            .storage
+            .list_objs(path.trim_start_matches("file:/"))
+            .await?
+            .map(|obj| match obj {
+                Ok(meta) => convert_object_meta(root_uri.clone(), meta),
+                Err(err) => Err(ObjectStoreError::from(err)),
+            })
+            .collect::<Vec<_>>()
+            .await;
+        Ok(Box::pin(futures::stream::iter(stream)))
+    }
+
+    /// List objects with the given prefix and an implementation specific
+    /// delimiter. Returns common prefixes (directories) in addition to object
+    /// metadata.
+    ///
+    /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
+    /// `foo/bar_baz/x`.
+    async fn list_with_delimiter(&self, _prefix: Option<&Path>) -> ObjectStoreResult<ListResult> {
+        todo!()
+    }
+
+    /// Copy an object from one path to another in the same object store.
+    ///
+    /// If there exists an object at the destination, it will be overwritten.
+    async fn copy(&self, _from: &Path, _to: &Path) -> ObjectStoreResult<()> {
+        todo!()
+    }
+
+    /// Move an object from one path to another in the same object store.
+    ///
+    /// By default, this is implemented as a copy and then delete source. It may not
+    /// check when deleting source that it was the same object that was originally copied.
+    ///
+    /// If there exists an object at the destination, it will be overwritten.
+    async fn rename(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+        self.copy(from, to).await?;
+        self.delete(from).await
+    }
+
+    /// Copy an object from one path to another, only if destination is empty.
+    ///
+    /// Will return an error if the destination already has an object.
+    async fn copy_if_not_exists(&self, _from: &Path, _to: &Path) -> ObjectStoreResult<()> {
+        todo!()
+    }
+
+    /// Move an object from one path to another in the same object store.
+    ///
+    /// Will return an error if the destination already has an object.
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+        Ok(self
+            .storage
+            .rename_obj_noreplace(
+                self.to_uri(from).trim_start_matches("file:/"),
+                self.to_uri(to).trim_start_matches("file:/"),
+            )
+            .await?)
+    }
+}
+
+#[inline]
+/// Return path relative to parent_path
+fn extract_rel_path<'a, 'b>(
+    parent_path: &'b str,
+    path: &'a str,
+) -> Result<&'a str, ObjectStoreError> {
+    if path.starts_with(&parent_path) {
+        Ok(&path[parent_path.len()..])
+    } else {
+        Err(ObjectStoreError::Generic {
+            store: "DeltaObjectStore",
+            source: Box::new(StorageError::NotFound),
+        })
+    }
+}
+
+fn convert_object_meta(
+    root_uri: String,
+    storage_meta: StorageObjectMeta,
+) -> ObjectStoreResult<ObjectMeta> {
+    Ok(ObjectMeta {
+        location: Path::from(extract_rel_path(
+            root_uri.as_ref(),
+            storage_meta.path.as_ref(),
+        )?),
+        last_modified: storage_meta.modified,
+        size: storage_meta.size.unwrap_or_default() as usize,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::TryStreamExt;
+    use tokio::fs;
+
+    #[test]
+    fn test_table_root() {
+        let curr_dir = std::env::current_dir().unwrap();
+        let curr_path = curr_dir.to_str().unwrap();
+        let table_uri = format!("file:/{}", curr_path);
+
+        // table uri with scheme and path
+        let store = DeltaObjectStore::try_new_with_options(&table_uri, None).unwrap();
+        let root_uri = store.to_uri(&Path::from(""));
+        assert_eq!(table_uri, root_uri);
+
+        // absolute path
+        let store = DeltaObjectStore::try_new_with_options(curr_path, None).unwrap();
+        let root_uri = store.to_uri(&Path::from(""));
+        assert_eq!(table_uri, root_uri);
+
+        // relative path
+        let store = DeltaObjectStore::try_new_with_options(".", None).unwrap();
+        let root_uri = store.to_uri(&Path::from(""));
+        assert_eq!(table_uri, root_uri)
+    }
+
+    #[tokio::test]
+    async fn test_put() {
+        let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let object_store =
+            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+
+        // put object
+        let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
+        let path1 = Path::from("tmp_file1");
+        object_store.put(&path1, bytes::Bytes::new()).await.unwrap();
+        assert!(fs::metadata(tmp_file_path1).await.is_ok());
+
+        let tmp_file_path2 = tmp_dir.path().join("tmp_dir1").join("file");
+        let path2 = Path::from("tmp_dir1/file");
+        object_store.put(&path2, bytes::Bytes::new()).await.unwrap();
+        assert!(fs::metadata(tmp_file_path2).await.is_ok())
+    }
+
+    #[tokio::test]
+    async fn test_head() {
+        let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let object_store =
+            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+
+        // existing file
+        let path1 = Path::from("tmp_file1");
+        object_store.put(&path1, bytes::Bytes::new()).await.unwrap();
+        let meta = object_store.head(&path1).await;
+        assert!(meta.is_ok());
+
+        // nonexistent file
+        let path2 = Path::from("nonexistent");
+        let meta = object_store.head(&path2).await;
+        assert!(meta.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get() {
+        let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let object_store =
+            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+
+        // existing file
+        let path1 = Path::from("tmp_file1");
+        let data = bytes::Bytes::from("random data");
+        object_store.put(&path1, data.clone()).await.unwrap();
+        let data_get = object_store
+            .get(&path1)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!(data, data_get);
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let object_store =
+            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+
+        let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
+
+        // put object
+        let path1 = Path::from("tmp_file1");
+        object_store.put(&path1, bytes::Bytes::new()).await.unwrap();
+        assert!(fs::metadata(tmp_file_path1.clone()).await.is_ok());
+
+        // delete object
+        object_store.delete(&path1).await.unwrap();
+        assert!(fs::metadata(tmp_file_path1).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_batch() {
+        let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let object_store =
+            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+
+        let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
+        let tmp_file_path2 = tmp_dir.path().join("tmp_file2");
+
+        // put object
+        let path1 = Path::from("tmp_file1");
+        let path2 = Path::from("tmp_file2");
+        object_store.put(&path1, bytes::Bytes::new()).await.unwrap();
+        object_store.put(&path2, bytes::Bytes::new()).await.unwrap();
+        assert!(fs::metadata(tmp_file_path1.clone()).await.is_ok());
+        assert!(fs::metadata(tmp_file_path2.clone()).await.is_ok());
+
+        // delete objects
+        object_store.delete_batch(&[path1, path2]).await.unwrap();
+        assert!(fs::metadata(tmp_file_path1).await.is_err());
+        assert!(fs::metadata(tmp_file_path2).await.is_err())
+    }
+
+    #[tokio::test]
+    async fn test_list() {
+        let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let object_store =
+            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+
+        let path1 = Path::from("tmp_file1");
+        let path2 = Path::from("tmp_file2");
+        object_store.put(&path1, bytes::Bytes::new()).await.unwrap();
+        object_store.put(&path2, bytes::Bytes::new()).await.unwrap();
+
+        let objs = object_store
+            .list(None)
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(objs.len(), 2);
+
+        let path1 = Path::from("prefix/tmp_file1");
+        let path2 = Path::from("prefix/tmp_file2");
+        object_store.put(&path1, bytes::Bytes::new()).await.unwrap();
+        object_store.put(&path2, bytes::Bytes::new()).await.unwrap();
+
+        let objs = object_store
+            .list(None)
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(objs.len(), 4);
+
+        let objs = object_store
+            .list(Some(&Path::from("prefix")))
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(objs.len(), 2)
+    }
+
+    #[tokio::test]
+    async fn test_list_prefix() {
+        let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let object_store =
+            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+
+        let path1 = Path::from("_delta_log/tmp_file1");
+        object_store.put(&path1, bytes::Bytes::new()).await.unwrap();
+
+        let objs = object_store
+            .list(None)
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(objs[0].location, path1)
+    }
+
+    #[tokio::test]
+    async fn test_rename_if_not_exists() {
+        let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let object_store =
+            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+
+        let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
+        let tmp_file_path2 = tmp_dir.path().join("tmp_file2");
+
+        let path1 = Path::from("tmp_file1");
+        let path2 = Path::from("tmp_file2");
+        object_store.put(&path1, bytes::Bytes::new()).await.unwrap();
+
+        // delete objects
+        let result = object_store.rename_if_not_exists(&path1, &path2).await;
+        assert!(result.is_ok());
+        assert!(fs::metadata(tmp_file_path1.clone()).await.is_err());
+        assert!(fs::metadata(tmp_file_path2.clone()).await.is_ok());
+
+        object_store.put(&path1, bytes::Bytes::new()).await.unwrap();
+        let result = object_store.rename_if_not_exists(&path1, &path2).await;
+        assert!(result.is_err());
+        assert!(fs::metadata(tmp_file_path1).await.is_ok());
+        assert!(fs::metadata(tmp_file_path2).await.is_ok());
+    }
+}

--- a/rust/src/object_store.rs
+++ b/rust/src/object_store.rs
@@ -317,7 +317,7 @@ mod tests {
     async fn test_put() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
         let object_store =
-            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
         // put object
         let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
@@ -334,8 +334,9 @@ mod tests {
     #[tokio::test]
     async fn test_head() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
         let object_store =
-            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
         // existing file
         let path1 = Path::from("tmp_file1");
@@ -352,8 +353,9 @@ mod tests {
     #[tokio::test]
     async fn test_get() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
         let object_store =
-            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
         // existing file
         let path1 = Path::from("tmp_file1");
@@ -372,8 +374,9 @@ mod tests {
     #[tokio::test]
     async fn test_delete() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
         let object_store =
-            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
         let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
 
@@ -390,8 +393,9 @@ mod tests {
     #[tokio::test]
     async fn test_delete_batch() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
         let object_store =
-            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
         let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
         let tmp_file_path2 = tmp_dir.path().join("tmp_file2");
@@ -413,8 +417,9 @@ mod tests {
     #[tokio::test]
     async fn test_list() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
         let object_store =
-            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
         let path1 = Path::from("tmp_file1");
         let path2 = Path::from("tmp_file2");
@@ -457,8 +462,9 @@ mod tests {
     #[tokio::test]
     async fn test_list_prefix() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
         let object_store =
-            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
         let path1 = Path::from("_delta_log/tmp_file1");
         object_store.put(&path1, bytes::Bytes::new()).await.unwrap();
@@ -476,8 +482,9 @@ mod tests {
     #[tokio::test]
     async fn test_rename_if_not_exists() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
+        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
         let object_store =
-            DeltaObjectStore::try_new_with_options(tmp_dir.path().to_str().unwrap(), None).unwrap();
+            DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
         let tmp_file_path1 = tmp_dir.path().join("tmp_file1");
         let tmp_file_path2 = tmp_dir.path().join("tmp_file2");

--- a/rust/src/object_store.rs
+++ b/rust/src/object_store.rs
@@ -316,7 +316,8 @@ mod tests {
     #[tokio::test]
     async fn test_put() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
-        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
+        let tmp_path = tmp_dir.path().to_owned();
+        let table_path = Path::from_filesystem_path(tmp_path).unwrap();
         let object_store =
             DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
@@ -335,7 +336,8 @@ mod tests {
     #[tokio::test]
     async fn test_head() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
-        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
+        let tmp_path = tmp_dir.path().to_owned();
+        let table_path = Path::from_filesystem_path(tmp_path).unwrap();
         let object_store =
             DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
@@ -354,7 +356,8 @@ mod tests {
     #[tokio::test]
     async fn test_get() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
-        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
+        let tmp_path = tmp_dir.path().to_owned();
+        let table_path = Path::from_filesystem_path(tmp_path).unwrap();
         let object_store =
             DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
@@ -375,7 +378,8 @@ mod tests {
     #[tokio::test]
     async fn test_delete() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
-        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
+        let tmp_path = tmp_dir.path().to_owned();
+        let table_path = Path::from_filesystem_path(tmp_path).unwrap();
         let object_store =
             DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
@@ -394,7 +398,8 @@ mod tests {
     #[tokio::test]
     async fn test_delete_batch() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
-        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
+        let tmp_path = tmp_dir.path().to_owned();
+        let table_path = Path::from_filesystem_path(tmp_path).unwrap();
         let object_store =
             DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
@@ -418,7 +423,8 @@ mod tests {
     #[tokio::test]
     async fn test_list() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
-        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
+        let tmp_path = tmp_dir.path().to_owned();
+        let table_path = Path::from_filesystem_path(tmp_path).unwrap();
         let object_store =
             DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
@@ -463,7 +469,8 @@ mod tests {
     #[tokio::test]
     async fn test_list_prefix() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
-        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
+        let tmp_path = tmp_dir.path().to_owned();
+        let table_path = Path::from_filesystem_path(tmp_path).unwrap();
         let object_store =
             DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 
@@ -483,7 +490,8 @@ mod tests {
     #[tokio::test]
     async fn test_rename_if_not_exists() {
         let tmp_dir = tempdir::TempDir::new("").unwrap();
-        let table_path = Path::from_filesystem_path(tmp_dir.path()).unwrap();
+        let tmp_path = tmp_dir.path().to_owned();
+        let table_path = Path::from_filesystem_path(tmp_path).unwrap();
         let object_store =
             DeltaObjectStore::try_new_with_options(table_path.as_ref(), None).unwrap();
 

--- a/rust/src/object_store.rs
+++ b/rust/src/object_store.rs
@@ -319,7 +319,7 @@ fn convert_object_meta(
         location: Path::from(extract_rel_path(
             root_uri.as_ref(),
             // HACK hopefully this will hold over until we have switches to object_store
-            storage_meta.path.as_str().replace("\\", DELIMITER).as_ref(),
+            storage_meta.path.as_str().replace('\\', DELIMITER).as_ref(),
         )?),
         last_modified: storage_meta.modified,
         size: storage_meta.size.unwrap_or_default() as usize,

--- a/rust/src/object_store.rs
+++ b/rust/src/object_store.rs
@@ -265,17 +265,6 @@ impl ObjectStore for DeltaObjectStore {
         todo!()
     }
 
-    /// Move an object from one path to another in the same object store.
-    ///
-    /// By default, this is implemented as a copy and then delete source. It may not
-    /// check when deleting source that it was the same object that was originally copied.
-    ///
-    /// If there exists an object at the destination, it will be overwritten.
-    async fn rename(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-        self.copy(from, to).await?;
-        self.delete(from).await
-    }
-
     /// Copy an object from one path to another, only if destination is empty.
     ///
     /// Will return an error if the destination already has an object.

--- a/rust/src/object_store.rs
+++ b/rust/src/object_store.rs
@@ -207,11 +207,11 @@ impl ObjectStore for DeltaObjectStore {
     /// Return the bytes that are stored at the specified location
     /// in the given byte range
     async fn get_range(&self, location: &Path, range: Range<usize>) -> ObjectStoreResult<Bytes> {
-        let store = object_store::local::LocalFileSystem::default();
-        let mut root_parts = self.root.parts().collect::<Vec<_>>();
-        root_parts.extend(location.parts());
-        let path = Path::from_iter(root_parts);
-        store.get_range(&path, range).await
+        let data = self
+            .storage
+            .get_range(&self.to_uri(location), range)
+            .await?;
+        Ok(data.into())
     }
 
     /// Return the metadata for the specified location

--- a/rust/src/optimize.rs
+++ b/rust/src/optimize.rs
@@ -19,23 +19,22 @@
 //! let metrics = Optimize::default().execute(table).await?;
 //! ````
 
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use log::debug;
-use log::error;
-use parquet::arrow::{ArrowReader, ParquetFileArrowReader};
-use parquet::file::serialized_reader::{SerializedFileReader, SliceableCursor};
-
 use crate::action::DeltaOperation;
 use crate::action::{self, Action};
 use crate::parquet::file::reader::FileReader;
 use crate::writer::utils::PartitionPath;
 use crate::writer::{DeltaWriter, DeltaWriterError, RecordBatchWriter};
 use crate::{DeltaDataTypeLong, DeltaTable, DeltaTableError, PartitionFilter};
+use bytes::Bytes;
+use log::debug;
+use log::error;
+use parquet::arrow::{ArrowReader, ParquetFileArrowReader};
+use parquet::file::serialized_reader::SerializedFileReader;
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Metrics from Optimize
 #[derive(Default, Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -219,7 +218,7 @@ impl MergePlan {
                     let parquet_uri = table.storage.join_path(&table.table_uri, path);
                     let data = table.storage.get_obj(&parquet_uri).await?;
                     let size: DeltaDataTypeLong = data.len().try_into().unwrap();
-                    let data = SliceableCursor::new(data);
+                    let data = Bytes::from(data);
                     let reader = SerializedFileReader::new(data)?;
                     let records = reader.metadata().file_metadata().num_rows();
 

--- a/rust/src/storage/azure/mod.rs
+++ b/rust/src/storage/azure/mod.rs
@@ -16,6 +16,7 @@ use log::debug;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Debug;
+use std::ops::Range;
 use std::sync::Arc;
 
 /// Storage option keys to use when creating [crate::storage::azure::AzureStorageOptions].

--- a/rust/src/storage/azure/mod.rs
+++ b/rust/src/storage/azure/mod.rs
@@ -345,6 +345,23 @@ impl StorageBackend for AdlsGen2Backend {
         Ok(data)
     }
 
+    /// Fetch a range from object content
+    async fn get_range(&self, path: &str, range: Range<usize>) -> Result<Vec<u8>, StorageError> {
+        let obj = parse_uri(path)?.into_adlsgen2_object()?;
+        self.validate_container(&obj)?;
+
+        let data = self
+            .file_system_client
+            .get_file_client(obj.path)
+            .read()
+            .range(range)
+            .into_future()
+            .await?
+            .data
+            .to_vec();
+        Ok(data)
+    }
+
     async fn list_objs<'a>(
         &'a self,
         path: &'a str,

--- a/rust/src/storage/file/mod.rs
+++ b/rust/src/storage/file/mod.rs
@@ -7,7 +7,7 @@ use chrono::DateTime;
 use futures::{stream::BoxStream, StreamExt};
 use std::collections::VecDeque;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
@@ -44,29 +44,6 @@ impl FileStorageBackend {
 
 #[async_trait::async_trait]
 impl StorageBackend for FileStorageBackend {
-    #[inline]
-    fn join_path(&self, path: &str, path_to_join: &str) -> String {
-        let new_path = Path::new(path);
-        new_path
-            .join(path_to_join)
-            .into_os_string()
-            .into_string()
-            .unwrap()
-    }
-
-    #[inline]
-    fn join_paths(&self, paths: &[&str]) -> String {
-        let mut iter = paths.iter();
-        let mut path = PathBuf::from(iter.next().unwrap_or(&""));
-        iter.for_each(|s| path.push(s));
-        path.into_os_string().into_string().unwrap()
-    }
-
-    #[inline]
-    fn trim_path(&self, path: &str) -> String {
-        path.trim_end_matches(std::path::MAIN_SEPARATOR).to_string()
-    }
-
     async fn head_obj(&self, path: &str) -> Result<ObjectMeta, StorageError> {
         let attr = fs::metadata(path).await?;
 
@@ -272,41 +249,6 @@ mod tests {
             .unwrap();
         assert_eq!(fs::metadata(path1).await.is_ok(), false);
         assert_eq!(fs::metadata(path2).await.is_ok(), false)
-    }
-
-    #[test]
-    fn join_multiple_paths() {
-        let backend = FileStorageBackend::new("./");
-        assert_eq!(
-            Path::new(&backend.join_paths(&["abc", "efg/", "123"])),
-            Path::new("abc").join("efg").join("123"),
-        );
-        assert_eq!(
-            &backend.join_paths(&["abc", "efg"]),
-            &backend.join_path("abc", "efg"),
-        );
-        assert_eq!(&backend.join_paths(&["foo"]), "foo",);
-        assert_eq!(&backend.join_paths(&[]), "",);
-    }
-
-    #[test]
-    fn trim_path() {
-        let be = FileStorageBackend::new("root");
-        let path = be.join_paths(&["foo", "bar"]);
-        assert_eq!(be.trim_path(&path), path);
-        assert_eq!(
-            be.trim_path(&format!("{}{}", path, std::path::MAIN_SEPARATOR)),
-            path,
-        );
-        assert_eq!(
-            be.trim_path(&format!(
-                "{}{}{}",
-                path,
-                std::path::MAIN_SEPARATOR,
-                std::path::MAIN_SEPARATOR
-            )),
-            path,
-        );
     }
 
     #[test]

--- a/rust/src/storage/gcs/mod.rs
+++ b/rust/src/storage/gcs/mod.rs
@@ -16,6 +16,7 @@ pub(crate) use object::GCSObject;
 
 use futures::stream::BoxStream;
 use std::convert::TryInto;
+use std::ops::Range;
 
 use log::debug;
 
@@ -63,6 +64,10 @@ impl StorageBackend for GCSStorageBackend {
             Err(GCSClientError::NotFound) => return Err(StorageError::NotFound),
             res => Ok(res?.to_vec()),
         }
+    }
+
+    async fn get_range(&self, _path: &str, _range: Range<usize>) -> Result<Vec<u8>, StorageError> {
+        todo!("get range not implemented for gcs")
     }
 
     /// Return a list of objects by `path` prefix in an async stream.

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Utc};
 use futures::stream::BoxStream;
 #[cfg(any(feature = "s3", feature = "s3-rustls"))]
 use hyper::http::uri::InvalidUri;
+use object_store::Error as ObjectStoreError;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -426,6 +427,14 @@ pub enum StorageError {
         #[from]
         /// Uri error details when the URI parsing is invalid.
         source: InvalidUri,
+    },
+
+    /// underlying object store returned an error.
+    #[error("ObjectStore interaction failed: {source}")]
+    ObjectStore {
+        /// The wrapped [`ObjectStoreError`]
+        #[from]
+        source: ObjectStoreError,
     },
 }
 

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -9,6 +9,7 @@ use hyper::http::uri::InvalidUri;
 use object_store::Error as ObjectStoreError;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::ops::Range;
 use std::sync::Arc;
 use walkdir::Error as WalkDirError;
 
@@ -507,6 +508,9 @@ pub trait StorageBackend: Send + Sync + Debug {
 
     /// Fetch object content
     async fn get_obj(&self, path: &str) -> Result<Vec<u8>, StorageError>;
+
+    /// Fetch a range from object content
+    async fn get_range(&self, path: &str, range: Range<usize>) -> Result<Vec<u8>, StorageError>;
 
     /// Return a list of objects by `path` prefix in an async stream.
     async fn list_objs<'a>(

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -502,30 +502,6 @@ impl Clone for ObjectMeta {
 /// or local storage systems, simply implement this trait.
 #[async_trait::async_trait]
 pub trait StorageBackend: Send + Sync + Debug {
-    /// Create a new path by appending `path_to_join` as a new component to `path`.
-    #[inline]
-    fn join_path(&self, path: &str, path_to_join: &str) -> String {
-        let normalized_path = path.trim_end_matches('/');
-        format!("{}/{}", normalized_path, path_to_join)
-    }
-
-    /// More efficient path join for multiple path components. Use this method if you need to
-    /// combine more than two path components.
-    #[inline]
-    fn join_paths(&self, paths: &[&str]) -> String {
-        paths
-            .iter()
-            .map(|s| s.trim_end_matches('/'))
-            .collect::<Vec<_>>()
-            .join("/")
-    }
-
-    /// Returns trimed path with trailing path separator removed.
-    #[inline]
-    fn trim_path(&self, path: &str) -> String {
-        path.trim_end_matches('/').to_string()
-    }
-
     /// Fetch object metadata without reading the actual content
     async fn head_obj(&self, path: &str) -> Result<ObjectMeta, StorageError>;
 

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -948,7 +948,7 @@ async fn get_object_with_retries(
             .get_object(GetObjectRequest {
                 bucket: bucket.to_string(),
                 key: key.to_string(),
-                range: range.map(format_http_range),
+                range: range.as_ref().map(format_http_range),
                 ..Default::default()
             })
             .await;
@@ -965,7 +965,7 @@ async fn get_object_with_retries(
     }
 }
 
-pub fn format_http_range(range: std::ops::Range<usize>) -> String {
+fn format_http_range(range: &std::ops::Range<usize>) -> String {
     format!("bytes={}-{}", range.start, range.end.saturating_sub(1))
 }
 

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -939,23 +939,6 @@ mod tests {
     use serial_test::serial;
 
     #[test]
-    fn join_multiple_paths() {
-        let backend = S3StorageBackend::new().unwrap();
-        assert_eq!(&backend.join_paths(&["abc", "efg/", "123"]), "abc/efg/123",);
-        assert_eq!(&backend.join_paths(&["abc", "efg/"]), "abc/efg",);
-        assert_eq!(&backend.join_paths(&["foo"]), "foo",);
-        assert_eq!(&backend.join_paths(&[]), "",);
-    }
-
-    #[test]
-    fn trim_path() {
-        let be = S3StorageBackend::new().unwrap();
-        assert_eq!(be.trim_path("s3://foo/bar"), "s3://foo/bar");
-        assert_eq!(be.trim_path("s3://foo/bar/"), "s3://foo/bar");
-        assert_eq!(be.trim_path("/foo/bar//"), "/foo/bar");
-    }
-
-    #[test]
     fn parse_s3_object_uri() {
         let uri = parse_uri("s3://foo/bar/baz").unwrap();
         assert_eq!(uri.path(), "bar/baz");

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -1,22 +1,19 @@
 //! The module for delta table state.
 
-use chrono::Utc;
-use parquet::file::{
-    reader::{FileReader, SerializedFileReader},
-    serialized_reader::SliceableCursor,
-};
-use serde_json::{Map, Value};
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::convert::TryFrom;
-use std::io::{BufRead, BufReader, Cursor};
-
 use super::{
     ApplyLogError, CheckPoint, DeltaDataTypeLong, DeltaDataTypeVersion, DeltaTable,
     DeltaTableError, DeltaTableMetaData,
 };
 use crate::action::{self, Action};
 use crate::delta_config;
+use bytes::Bytes;
+use chrono::Utc;
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::convert::TryFrom;
+use std::io::{BufRead, BufReader, Cursor};
 
 /// State snapshot currently held by the Delta Table instance.
 #[derive(Default, Debug, Clone)]
@@ -88,7 +85,7 @@ impl DeltaTableState {
 
         for f in &checkpoint_data_paths {
             let obj = table.storage.get_obj(f).await?;
-            let preader = SerializedFileReader::new(SliceableCursor::new(obj))?;
+            let preader = SerializedFileReader::new(Bytes::from(obj))?;
             let schema = preader.metadata().file_metadata().schema();
             if !schema.is_group() {
                 return Err(DeltaTableError::from(action::ActionError::Generic(

--- a/rust/src/writer/mod.rs
+++ b/rust/src/writer/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 use arrow::{datatypes::SchemaRef, datatypes::*, error::ArrowError};
 use async_trait::async_trait;
 pub use json::JsonWriter;
+use object_store::Error as ObjectStoreError;
 use parquet::{basic::LogicalType, errors::ParquetError};
 pub use record_batch::RecordBatchWriter;
 use serde_json::Value;
@@ -77,6 +78,14 @@ pub enum DeltaWriterError {
         /// The wrapped [`StorageError`]
         #[from]
         source: StorageError,
+    },
+
+    /// underlying object store returned an error.
+    #[error("ObjectStore interaction failed: {source}")]
+    ObjectStore {
+        /// The wrapped [`ObjectStoreError`]
+        #[from]
+        source: ObjectStoreError,
     },
 
     /// Arrow returned an error.

--- a/rust/src/writer/record_batch.rs
+++ b/rust/src/writer/record_batch.rs
@@ -493,8 +493,7 @@ mod tests {
             String::from("modified=2021-02-02/id=A"),
             String::from("modified=2021-02-02/id=B"),
         ];
-        let table_dir_raw = table.table_uri.trim_start_matches("file:/");
-        let table_dir = Path::new(table_dir_raw);
+        let table_dir = Path::new(&table.table_uri);
         for key in expected_keys {
             let partition_dir = table_dir.join(key);
             assert!(partition_dir.exists())

--- a/rust/src/writer/record_batch.rs
+++ b/rust/src/writer/record_batch.rs
@@ -36,10 +36,7 @@ use super::{
 };
 use crate::writer::stats::apply_null_counts;
 use crate::writer::utils::ShareableBuffer;
-use crate::{
-    action::Add, get_backend_for_uri_with_options, DeltaTable, DeltaTableMetaData, Schema,
-    StorageBackend,
-};
+use crate::{action::Add, object_store::DeltaObjectStore, DeltaTable, DeltaTableMetaData, Schema};
 use arrow::record_batch::RecordBatch;
 use arrow::{
     array::{Array, UInt32Array},
@@ -47,6 +44,8 @@ use arrow::{
     datatypes::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef},
     error::ArrowError,
 };
+use bytes::Bytes;
+use object_store::ObjectStore;
 use parquet::{arrow::ArrowWriter, errors::ParquetError};
 use parquet::{basic::Compression, file::properties::WriterProperties};
 use std::collections::HashMap;
@@ -55,8 +54,7 @@ use std::sync::Arc;
 
 /// Writes messages to a delta lake table.
 pub struct RecordBatchWriter {
-    pub(crate) storage: Arc<dyn StorageBackend>,
-    pub(crate) table_uri: String,
+    pub(crate) storage: Arc<DeltaObjectStore>,
     pub(crate) arrow_schema_ref: Arc<arrow::datatypes::Schema>,
     pub(crate) writer_properties: WriterProperties,
     pub(crate) partition_columns: Vec<String>,
@@ -77,8 +75,7 @@ impl RecordBatchWriter {
         partition_columns: Option<Vec<String>>,
         storage_options: Option<HashMap<String, String>>,
     ) -> Result<Self, DeltaWriterError> {
-        let storage =
-            get_backend_for_uri_with_options(&table_uri, storage_options.unwrap_or_default())?;
+        let storage = DeltaObjectStore::try_new_with_options(&table_uri, storage_options)?;
 
         // Initialize writer properties for the underlying arrow writer
         let writer_properties = WriterProperties::builder()
@@ -87,8 +84,7 @@ impl RecordBatchWriter {
             .build();
 
         Ok(Self {
-            storage,
-            table_uri: table_uri.clone(),
+            storage: Arc::new(storage),
             arrow_schema_ref: schema,
             writer_properties,
             partition_columns: partition_columns.unwrap_or_default(),
@@ -112,7 +108,6 @@ impl RecordBatchWriter {
 
         Ok(Self {
             storage: table.storage.clone(),
-            table_uri: table.table_uri.clone(),
             arrow_schema_ref,
             writer_properties,
             partition_columns,
@@ -231,22 +226,10 @@ impl DeltaWriter<RecordBatch> for RecordBatchWriter {
 
         for (_, mut writer) in writers {
             let metadata = writer.arrow_writer.close()?;
-
             let path = next_data_path(&self.partition_columns, &writer.partition_values, None)?;
-
-            let obj_bytes = writer.buffer.to_vec();
+            let obj_bytes = Bytes::from(writer.buffer.to_vec());
             let file_size = obj_bytes.len() as i64;
-            let storage_path = self
-                .storage
-                .join_path(self.table_uri.as_str(), path.as_str());
-
-            //
-            // TODO: Wrap in retry loop to handle temporary network errors
-            //
-
-            self.storage
-                .put_obj(&storage_path, obj_bytes.as_slice())
-                .await?;
+            self.storage.put(&path, obj_bytes).await?;
 
             // Replace self null_counts with an empty map. Use the other for stats.
             let null_counts = std::mem::take(&mut writer.null_counts);
@@ -254,7 +237,7 @@ impl DeltaWriter<RecordBatch> for RecordBatchWriter {
             actions.push(create_add(
                 &writer.partition_values,
                 null_counts,
-                path,
+                path.to_string(),
                 file_size,
                 &metadata,
             )?);
@@ -510,7 +493,8 @@ mod tests {
             String::from("modified=2021-02-02/id=A"),
             String::from("modified=2021-02-02/id=B"),
         ];
-        let table_dir = Path::new(&table.table_uri);
+        let table_dir_raw = table.table_uri.trim_start_matches("file:/");
+        let table_dir = Path::new(table_dir_raw);
         for key in expected_keys {
             let partition_dir = table_dir.join(key);
             assert!(partition_dir.exists())

--- a/rust/src/writer/utils.rs
+++ b/rust/src/writer/utils.rs
@@ -9,6 +9,7 @@ use arrow::{
     json::reader::{Decoder, DecoderOptions},
     record_batch::*,
 };
+use object_store::path::Path;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -72,7 +73,7 @@ pub(crate) fn next_data_path(
     partition_columns: &[String],
     partition_values: &HashMap<String, Option<String>>,
     part: Option<i32>,
-) -> Result<String, DeltaWriterError> {
+) -> Result<Path, DeltaWriterError> {
     // TODO: what does 00000 mean?
     // TODO (roeap): my understanding is, that the values are used as a counter - i.e. if a single batch of
     // data written to one partition needs to be split due to desired file size constraints.
@@ -91,11 +92,11 @@ pub(crate) fn next_data_path(
     );
 
     if partition_columns.is_empty() {
-        return Ok(file_name);
+        return Ok(Path::from(file_name));
     }
 
     let partition_key = PartitionPath::from_hashmap(partition_columns, partition_values)?;
-    Ok(format!("{}/{}", partition_key, file_name))
+    Ok(Path::from(format!("{}/{}", partition_key, file_name)))
 }
 
 /// partition json values

--- a/rust/tests/adls_gen2_table_test.rs
+++ b/rust/tests/adls_gen2_table_test.rs
@@ -15,6 +15,7 @@ mod adls_gen2_table {
         action, DeltaTable, DeltaTableConfig, DeltaTableMetaData, Schema, SchemaDataType,
         SchemaField,
     };
+    use object_store::path::Path;
     use serial_test::serial;
     use std::collections::HashMap;
     use std::env;
@@ -39,11 +40,11 @@ mod adls_gen2_table {
         assert_eq!(
             table.get_files(),
             vec![
-                "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
-                "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
-                "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
-                "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
-                "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet",
+                Path::from("part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet"),
+                Path::from("part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet"),
+                Path::from("part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet"),
+                Path::from("part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet"),
+                Path::from("part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet"),
             ]
         );
 
@@ -93,11 +94,11 @@ mod adls_gen2_table {
         assert_eq!(
             table.get_files(),
             vec![
-                "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
-                "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
-                "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
-                "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
-                "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet",
+                Path::from("part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet"),
+                Path::from("part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet"),
+                Path::from("part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet"),
+                Path::from("part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet"),
+                Path::from("part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet"),
             ]
         );
 

--- a/rust/tests/checkpoint_writer_test.rs
+++ b/rust/tests/checkpoint_writer_test.rs
@@ -109,7 +109,7 @@ mod delete_expired_delta_log_in_checkpoint {
         )
         .await;
 
-        let table_path = table.table_uri.trim_start_matches("file:/").to_string();
+        let table_path = table.table_uri.clone();
         let set_file_last_modified = |version: usize, last_modified_millis: i64| {
             let last_modified_secs = last_modified_millis / 1000;
             let path = format!("{}/_delta_log/{:020}.json", &table_path, version);

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -70,7 +70,13 @@ impl TestContext {
         create_time: i64,
         commit_to_log: bool,
     ) {
-        let uri = self.table.as_ref().unwrap().table_uri.to_string();
+        let uri = self
+            .table
+            .as_ref()
+            .unwrap()
+            .table_uri
+            .trim_start_matches("file:/")
+            .to_string();
         let backend = self.get_storage();
         let remote_path = uri + "/" + path;
 

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -70,13 +70,7 @@ impl TestContext {
         create_time: i64,
         commit_to_log: bool,
     ) {
-        let uri = self
-            .table
-            .as_ref()
-            .unwrap()
-            .table_uri
-            .trim_start_matches("file:/")
-            .to_string();
+        let uri = self.table.as_ref().unwrap().table_uri.clone();
         let backend = self.get_storage();
         let remote_path = uri + "/" + path;
 

--- a/rust/tests/fs_common/mod.rs
+++ b/rust/tests/fs_common/mod.rs
@@ -34,6 +34,7 @@ pub async fn create_table_from_json(
     assert!(path.starts_with("./tests/data"));
     std::fs::create_dir_all(path).unwrap();
     std::fs::remove_dir_all(path).unwrap();
+    std::fs::create_dir_all(path).unwrap();
     let schema: Schema = serde_json::from_value(schema).unwrap();
     let config: HashMap<String, Option<String>> = serde_json::from_value(config).unwrap();
     create_test_table(path, schema, partition_columns, config).await

--- a/rust/tests/fs_common/mod.rs
+++ b/rust/tests/fs_common/mod.rs
@@ -32,7 +32,6 @@ pub async fn create_table_from_json(
     config: Value,
 ) -> DeltaTable {
     assert!(path.starts_with("./tests/data"));
-    std::fs::create_dir_all(path).unwrap();
     std::fs::remove_dir_all(path).unwrap();
     std::fs::create_dir_all(path).unwrap();
     let schema: Schema = serde_json::from_value(schema).unwrap();

--- a/rust/tests/fs_common/mod.rs
+++ b/rust/tests/fs_common/mod.rs
@@ -32,6 +32,7 @@ pub async fn create_table_from_json(
     config: Value,
 ) -> DeltaTable {
     assert!(path.starts_with("./tests/data"));
+    std::fs::create_dir_all(path).unwrap();
     std::fs::remove_dir_all(path).unwrap();
     std::fs::create_dir_all(path).unwrap();
     let schema: Schema = serde_json::from_value(schema).unwrap();

--- a/rust/tests/gcs_test.rs
+++ b/rust/tests/gcs_test.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "gcs")]
 mod gcs {
+    use object_store::path::Path;
     /*
      * The storage account to run this test must be provided by the developer and test are executed locally.
      *
@@ -24,11 +25,11 @@ mod gcs {
         assert_eq!(
             table.get_files(),
             vec![
-                "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
-                "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
-                "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
-                "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
-                "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet",
+                Path::from("part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet"),
+                Path::from("part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet"),
+                Path::from("part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet"),
+                Path::from("part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet"),
+                Path::from("part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet"),
             ]
         );
         let tombstones = table.get_state().all_tombstones();

--- a/rust/tests/optimize_test.rs
+++ b/rust/tests/optimize_test.rs
@@ -197,7 +197,7 @@ mod optimize {
         .await?;
 
         let version = dt.version();
-        assert_eq!(dt.get_active_add_actions().len(), 5);
+        assert_eq!(dt.get_state().files().len(), 5);
 
         let optimize = Optimize::default().target_size(2_000_000);
         let metrics = optimize.execute(&mut dt).await?;
@@ -207,7 +207,7 @@ mod optimize {
         assert_eq!(metrics.num_files_removed, 4);
         assert_eq!(metrics.total_considered_files, 5);
         assert_eq!(metrics.partitions_optimized, 1);
-        assert_eq!(dt.get_active_add_actions().len(), 2);
+        assert_eq!(dt.get_state().files().len(), 2);
 
         Ok(())
     }
@@ -263,7 +263,7 @@ mod optimize {
         assert_eq!(version + 1, dt.version());
         assert_eq!(metrics.num_files_added, 1);
         assert_eq!(metrics.num_files_removed, 2);
-        assert_eq!(dt.get_active_add_actions().len(), 3);
+        assert_eq!(dt.get_state().files().len(), 3);
 
         Ok(())
     }
@@ -298,7 +298,7 @@ mod optimize {
 
         let uri = context.tmp_dir.path().to_str().to_owned().unwrap();
         let mut other_dt = deltalake::open_table(uri).await?;
-        let add = &other_dt.get_active_add_actions()[0];
+        let add = &other_dt.get_state().files()[0];
         let remove = Remove {
             path: add.path.clone(),
             deletion_timestamp: Some(

--- a/rust/tests/read_delta_partitions_test.rs
+++ b/rust/tests/read_delta_partitions_test.rs
@@ -140,7 +140,8 @@ async fn read_null_partitions_from_checkpoint() {
 
     println!("{}", table.table_uri);
 
-    let delta_log = std::path::Path::new(&table.table_uri).join("_delta_log");
+    let table_uri_raw = table.table_uri.trim_start_matches("file:/").to_string();
+    let delta_log = std::path::Path::new(&table_uri_raw).join("_delta_log");
 
     let add = |partition: Option<String>| Add {
         partition_values: hashmap! {

--- a/rust/tests/read_delta_partitions_test.rs
+++ b/rust/tests/read_delta_partitions_test.rs
@@ -138,10 +138,7 @@ async fn read_null_partitions_from_checkpoint() {
     )
     .await;
 
-    println!("{}", table.table_uri);
-
-    let table_uri_raw = table.table_uri.trim_start_matches("file:/").to_string();
-    let delta_log = std::path::Path::new(&table_uri_raw).join("_delta_log");
+    let delta_log = std::path::Path::new(&table.table_uri).join("_delta_log");
 
     let add = |partition: Option<String>| Add {
         partition_values: hashmap! {

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -262,13 +262,25 @@ async fn read_delta_8_0_table_with_partitions() {
         ]
     );
 
-    assert_eq!(
-        table.get_file_uris_by_partitions(&filters).unwrap(),
-        vec![
-            format!("/{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet", current_dir.as_ref()),
-            format!("/{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet", current_dir.as_ref())
-        ]
-    );
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "windows")] {
+            assert_eq!(
+                table.get_file_uris_by_partitions(&filters).unwrap(),
+                vec![
+                    format!("{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet", current_dir.as_ref()),
+                    format!("{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet", current_dir.as_ref())
+                ]
+            );
+        } else {
+            assert_eq!(
+                table.get_file_uris_by_partitions(&filters).unwrap(),
+                vec![
+                    format!("/{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet", current_dir.as_ref()),
+                    format!("/{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet", current_dir.as_ref())
+                ]
+            );
+        }
+    }
 
     let filters = vec![deltalake::PartitionFilter {
         key: "month",

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -262,25 +262,22 @@ async fn read_delta_8_0_table_with_partitions() {
         ]
     );
 
-    cfg_if::cfg_if! {
-        if #[cfg(target_os = "windows")] {
-            assert_eq!(
-                table.get_file_uris_by_partitions(&filters).unwrap(),
-                vec![
-                    format!("{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet", current_dir.as_ref()),
-                    format!("{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet", current_dir.as_ref())
-                ]
-            );
-        } else {
-            assert_eq!(
-                table.get_file_uris_by_partitions(&filters).unwrap(),
-                vec![
-                    format!("/{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet", current_dir.as_ref()),
-                    format!("/{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet", current_dir.as_ref())
-                ]
-            );
-        }
-    }
+    #[cfg(unix)]
+    assert_eq!(
+        table.get_file_uris_by_partitions(&filters).unwrap(),
+        vec![
+            format!("/{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet", current_dir.as_ref()),
+            format!("/{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet", current_dir.as_ref())
+        ]
+    );
+    #[cfg(windows)]
+    assert_eq!(
+        table.get_file_uris_by_partitions(&filters).unwrap(),
+        vec![
+            format!("{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet", current_dir.as_ref()),
+            format!("{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet", current_dir.as_ref())
+        ]
+    );
 
     let filters = vec![deltalake::PartitionFilter {
         key: "month",

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -3,6 +3,7 @@ extern crate deltalake;
 use chrono::Utc;
 use deltalake::DeltaTableBuilder;
 use deltalake::PeekCommit;
+use object_store::path::Path;
 use pretty_assertions::assert_eq;
 use std::collections::HashMap;
 
@@ -20,9 +21,9 @@ async fn read_delta_2_0_table_without_version() {
     assert_eq!(
         table.get_files(),
         vec![
-            "part-00000-cb6b150b-30b8-4662-ad28-ff32ddab96d2-c000.snappy.parquet",
-            "part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet",
-            "part-00001-c373a5bd-85f0-4758-815e-7eb62007a15c-c000.snappy.parquet",
+            Path::from("part-00000-cb6b150b-30b8-4662-ad28-ff32ddab96d2-c000.snappy.parquet"),
+            Path::from("part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet"),
+            Path::from("part-00001-c373a5bd-85f0-4758-815e-7eb62007a15c-c000.snappy.parquet"),
         ]
     );
     let tombstones = table.get_state().all_tombstones();
@@ -68,8 +69,8 @@ async fn read_delta_table_ignoring_tombstones() {
     assert_eq!(
         table.get_files(),
         vec![
-            "part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet",
-            "part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet"
+            Path::from("part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet"),
+            Path::from("part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet")
         ]
     );
 }
@@ -127,8 +128,8 @@ async fn read_delta_2_0_table_with_version() {
     assert_eq!(
         table.get_files(),
         vec![
-            "part-00000-b44fcdb0-8b06-4f3a-8606-f8311a96f6dc-c000.snappy.parquet",
-            "part-00001-185eca06-e017-4dea-ae49-fc48b973e37e-c000.snappy.parquet",
+            Path::from("part-00000-b44fcdb0-8b06-4f3a-8606-f8311a96f6dc-c000.snappy.parquet"),
+            Path::from("part-00001-185eca06-e017-4dea-ae49-fc48b973e37e-c000.snappy.parquet"),
         ],
     );
 
@@ -141,8 +142,8 @@ async fn read_delta_2_0_table_with_version() {
     assert_eq!(
         table.get_files(),
         vec![
-            "part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet",
-            "part-00001-c373a5bd-85f0-4758-815e-7eb62007a15c-c000.snappy.parquet",
+            Path::from("part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet"),
+            Path::from("part-00001-c373a5bd-85f0-4758-815e-7eb62007a15c-c000.snappy.parquet"),
         ]
     );
 
@@ -155,9 +156,9 @@ async fn read_delta_2_0_table_with_version() {
     assert_eq!(
         table.get_files(),
         vec![
-            "part-00000-cb6b150b-30b8-4662-ad28-ff32ddab96d2-c000.snappy.parquet",
-            "part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet",
-            "part-00001-c373a5bd-85f0-4758-815e-7eb62007a15c-c000.snappy.parquet",
+            Path::from("part-00000-cb6b150b-30b8-4662-ad28-ff32ddab96d2-c000.snappy.parquet"),
+            Path::from("part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet"),
+            Path::from("part-00001-c373a5bd-85f0-4758-815e-7eb62007a15c-c000.snappy.parquet"),
         ]
     );
 }
@@ -173,8 +174,8 @@ async fn read_delta_8_0_table_without_version() {
     assert_eq!(
         table.get_files(),
         vec![
-            "part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet",
-            "part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet"
+            Path::from("part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet"),
+            Path::from("part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet")
         ]
     );
     assert_eq!(table.get_stats().count(), 2);
@@ -218,8 +219,8 @@ async fn read_delta_8_0_table_with_load_version() {
     assert_eq!(
         table.get_files(),
         vec![
-            "part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet",
-            "part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet",
+            Path::from("part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet"),
+            Path::from("part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet"),
         ]
     );
     table.load_version(0).await.unwrap();
@@ -229,14 +230,15 @@ async fn read_delta_8_0_table_with_load_version() {
     assert_eq!(
         table.get_files(),
         vec![
-            "part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet",
-            "part-00001-911a94a2-43f6-4acb-8620-5e68c2654989-c000.snappy.parquet",
+            Path::from("part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet"),
+            Path::from("part-00001-911a94a2-43f6-4acb-8620-5e68c2654989-c000.snappy.parquet"),
         ]
     );
 }
 
 #[tokio::test]
 async fn read_delta_8_0_table_with_partitions() {
+    let current_dir = Path::from_filesystem_path(std::env::current_dir().unwrap()).unwrap();
     let table = deltalake::open_table("./tests/data/delta-0.8.0-partitioned")
         .await
         .unwrap();
@@ -255,25 +257,16 @@ async fn read_delta_8_0_table_with_partitions() {
     assert_eq!(
         table.get_files_by_partitions(&filters).unwrap(),
         vec![
-            "year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet".to_string(),
-            "year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet".to_string()
+            Path::from("year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet"),
+            Path::from("year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet")
         ]
     );
 
-    #[cfg(unix)]
     assert_eq!(
         table.get_file_uris_by_partitions(&filters).unwrap(),
         vec![
-            "./tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet".to_string(),
-            "./tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet".to_string()
-        ]
-    );
-    #[cfg(windows)]
-    assert_eq!(
-        table.get_file_uris_by_partitions(&filters).unwrap(),
-        vec![
-            "./tests/data/delta-0.8.0-partitioned\\year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet".to_string(),
-            "./tests/data/delta-0.8.0-partitioned\\year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet".to_string()
+            format!("file://{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet", current_dir.as_ref()),
+            format!("file://{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet", current_dir.as_ref())
         ]
     );
 
@@ -284,10 +277,10 @@ async fn read_delta_8_0_table_with_partitions() {
     assert_eq!(
         table.get_files_by_partitions(&filters).unwrap(),
         vec![
-            "year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet".to_string(),
-            "year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet".to_string(),
-            "year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet".to_string(),
-            "year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet".to_string()
+            Path::from("year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet"),
+            Path::from("year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet"),
+            Path::from("year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet"),
+            Path::from("year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet")
         ]
     );
 
@@ -298,10 +291,10 @@ async fn read_delta_8_0_table_with_partitions() {
     assert_eq!(
         table.get_files_by_partitions(&filters).unwrap(),
         vec![
-            "year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet".to_string(),
-            "year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet".to_string(),
-            "year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet".to_string(),
-            "year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet".to_string()
+            Path::from("year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet"),
+            Path::from("year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet"),
+            Path::from("year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet"),
+            Path::from("year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet")
         ]
     );
 
@@ -312,8 +305,8 @@ async fn read_delta_8_0_table_with_partitions() {
     assert_eq!(
         table.get_files_by_partitions(&filters).unwrap(),
         vec![
-            "year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet".to_string(),
-            "year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet".to_string()
+            Path::from("year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet"),
+            Path::from("year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet")
         ]
     );
 }
@@ -330,7 +323,9 @@ async fn read_delta_8_0_table_with_null_partition() {
     }];
     assert_eq!(
         table.get_files_by_partitions(&filters).unwrap(),
-        vec!["k=A/part-00000-b1f1dbbb-70bc-4970-893f-9bb772bf246e.c000.snappy.parquet".to_string()]
+        vec![Path::from(
+            "k=A/part-00000-b1f1dbbb-70bc-4970-893f-9bb772bf246e.c000.snappy.parquet"
+        )]
     );
 
     let filters = vec![deltalake::PartitionFilter {
@@ -340,7 +335,7 @@ async fn read_delta_8_0_table_with_null_partition() {
     assert_eq!(
         table.get_files_by_partitions(&filters).unwrap(),
         vec![
-            "k=__HIVE_DEFAULT_PARTITION__/part-00001-8474ac85-360b-4f58-b3ea-23990c71b932.c000.snappy.parquet".to_string()
+            Path::from("k=__HIVE_DEFAULT_PARTITION__/part-00001-8474ac85-360b-4f58-b3ea-23990c71b932.c000.snappy.parquet")
         ]
     );
 }
@@ -354,10 +349,12 @@ async fn read_delta_8_0_table_with_special_partition() {
     assert_eq!(
         table.get_files(),
         vec![
-            "x=A%2FA/part-00007-b350e235-2832-45df-9918-6cab4f7578f7.c000.snappy.parquet"
-                .to_string(),
-            "x=B%20B/part-00015-e9abbc6f-85e9-457b-be8e-e9f5b8a22890.c000.snappy.parquet"
-                .to_string()
+            Path::from(
+                "x=A%2FA/part-00007-b350e235-2832-45df-9918-6cab4f7578f7.c000.snappy.parquet"
+            ),
+            Path::from(
+                "x=B%20B/part-00015-e9abbc6f-85e9-457b-be8e-e9f5b8a22890.c000.snappy.parquet"
+            )
         ]
     );
 
@@ -367,10 +364,9 @@ async fn read_delta_8_0_table_with_special_partition() {
     }];
     assert_eq!(
         table.get_files_by_partitions(&filters).unwrap(),
-        vec![
+        vec![Path::from(
             "x=A%2FA/part-00007-b350e235-2832-45df-9918-6cab4f7578f7.c000.snappy.parquet"
-                .to_string()
-        ]
+        )]
     );
 }
 
@@ -386,10 +382,9 @@ async fn read_delta_8_0_table_partition_with_compare_op() {
     }];
     assert_eq!(
         table.get_files_by_partitions(&filters).unwrap(),
-        vec![
+        vec![Path::from(
             "x=9/y=9.9/part-00007-3c50fba1-4264-446c-9c67-d8e24a1ccf83.c000.snappy.parquet"
-                .to_string()
-        ]
+        )]
     );
 
     let filters = vec![deltalake::PartitionFilter {
@@ -398,10 +393,9 @@ async fn read_delta_8_0_table_partition_with_compare_op() {
     }];
     assert_eq!(
         table.get_files_by_partitions(&filters).unwrap(),
-        vec![
+        vec![Path::from(
             "x=9/y=9.9/part-00007-3c50fba1-4264-446c-9c67-d8e24a1ccf83.c000.snappy.parquet"
-                .to_string()
-        ]
+        )]
     );
 }
 
@@ -447,7 +441,7 @@ async fn test_action_reconciliation() {
     // Add a file.
     let a = fs_common::add(3 * 60 * 1000);
     assert_eq!(1, fs_common::commit_add(&mut table, &a).await);
-    assert_eq!(table.get_files(), vec![a.path.as_str()]);
+    assert_eq!(table.get_files(), vec![Path::from(a.path.clone())]);
 
     // Remove added file.
     let r = deltalake::action::Remove {
@@ -474,7 +468,7 @@ async fn test_action_reconciliation() {
 
     // Add removed file back.
     assert_eq!(3, fs_common::commit_add(&mut table, &a).await);
-    assert_eq!(table.get_files(), vec![a.path.as_str()]);
+    assert_eq!(table.get_files(), vec![Path::from(a.path)]);
     // tombstone is removed.
     assert_eq!(table.get_state().all_tombstones().len(), 0);
 }
@@ -509,9 +503,8 @@ async fn test_poll_table_commits() {
 
     let is_new = if let PeekCommit::New(version, actions) = peek {
         assert_eq!(table.version(), 9);
-        assert!(!table
-            .get_files_iter()
-            .any(|f| f == "part-00000-f0e955c5-a1e3-4eec-834e-dcc098fc9005-c000.snappy.parquet"));
+        assert!(!table.get_files_iter().any(|f| f
+            == Path::from("part-00000-f0e955c5-a1e3-4eec-834e-dcc098fc9005-c000.snappy.parquet")));
 
         assert_eq!(version, 10);
         assert_eq!(actions.len(), 2);
@@ -519,9 +512,8 @@ async fn test_poll_table_commits() {
         table.apply_actions(version, actions).unwrap();
 
         assert_eq!(table.version(), 10);
-        assert!(table
-            .get_files_iter()
-            .any(|f| f == "part-00000-f0e955c5-a1e3-4eec-834e-dcc098fc9005-c000.snappy.parquet"));
+        assert!(table.get_files_iter().any(|f| f
+            == Path::from("part-00000-f0e955c5-a1e3-4eec-834e-dcc098fc9005-c000.snappy.parquet")));
 
         true
     } else {

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -265,8 +265,8 @@ async fn read_delta_8_0_table_with_partitions() {
     assert_eq!(
         table.get_file_uris_by_partitions(&filters).unwrap(),
         vec![
-            format!("file://{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet", current_dir.as_ref()),
-            format!("file://{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet", current_dir.as_ref())
+            format!("/{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet", current_dir.as_ref()),
+            format!("/{}/tests/data/delta-0.8.0-partitioned/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet", current_dir.as_ref())
         ]
     );
 

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -52,11 +52,11 @@ async fn read_simple_table() {
     let mut paths: Vec<String> = table.get_file_uris().collect();
     paths.sort();
     let expected_paths: Vec<String> = vec![
-            format!("file://{}/tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet", current_dir.as_ref()),
-            format!("file://{}/tests/data/simple_table/part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet", current_dir.as_ref()),
-            format!("file://{}/tests/data/simple_table/part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet", current_dir.as_ref()),
-            format!("file://{}/tests/data/simple_table/part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet", current_dir.as_ref()),
-            format!("file://{}/tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet", current_dir.as_ref())
+            format!("/{}/tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet", current_dir.as_ref()),
+            format!("/{}/tests/data/simple_table/part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet", current_dir.as_ref()),
+            format!("/{}/tests/data/simple_table/part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet", current_dir.as_ref()),
+            format!("/{}/tests/data/simple_table/part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet", current_dir.as_ref()),
+            format!("/{}/tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet", current_dir.as_ref())
         ];
     assert_eq!(paths, expected_paths);
 }

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -51,14 +51,27 @@ async fn read_simple_table() {
 
     let mut paths: Vec<String> = table.get_file_uris().collect();
     paths.sort();
-    let expected_paths: Vec<String> = vec![
-            format!("/{}/tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet", current_dir.as_ref()),
-            format!("/{}/tests/data/simple_table/part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet", current_dir.as_ref()),
-            format!("/{}/tests/data/simple_table/part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet", current_dir.as_ref()),
-            format!("/{}/tests/data/simple_table/part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet", current_dir.as_ref()),
-            format!("/{}/tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet", current_dir.as_ref())
-        ];
-    assert_eq!(paths, expected_paths);
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "windows")] {
+            let expected_paths: Vec<String> = vec![
+                format!("{}/tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet", current_dir.as_ref()),
+                format!("{}/tests/data/simple_table/part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet", current_dir.as_ref()),
+                format!("{}/tests/data/simple_table/part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet", current_dir.as_ref()),
+                format!("{}/tests/data/simple_table/part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet", current_dir.as_ref()),
+                format!("{}/tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet", current_dir.as_ref())
+            ];
+            assert_eq!(paths, expected_paths);
+        } else {
+            let expected_paths: Vec<String> = vec![
+                format!("/{}/tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet", current_dir.as_ref()),
+                format!("/{}/tests/data/simple_table/part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet", current_dir.as_ref()),
+                format!("/{}/tests/data/simple_table/part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet", current_dir.as_ref()),
+                format!("/{}/tests/data/simple_table/part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet", current_dir.as_ref()),
+                format!("/{}/tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet", current_dir.as_ref())
+            ];
+            assert_eq!(paths, expected_paths);
+        }
+    }
 }
 
 #[tokio::test]

--- a/rust/tests/read_simple_table_test.rs
+++ b/rust/tests/read_simple_table_test.rs
@@ -2,12 +2,15 @@ extern crate chrono;
 extern crate deltalake;
 extern crate utime;
 
+use ::object_store::path::Path as ObjectStorePath;
 use std::path::Path;
 
 use self::chrono::{DateTime, FixedOffset, Utc};
 
 #[tokio::test]
 async fn read_simple_table() {
+    let current_dir =
+        ObjectStorePath::from_filesystem_path(std::env::current_dir().unwrap()).unwrap();
     let table = deltalake::open_table("./tests/data/simple_table")
         .await
         .unwrap();
@@ -19,11 +22,21 @@ async fn read_simple_table() {
     assert_eq!(
         files,
         vec![
-            "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet",
-            "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
-            "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
-            "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
-            "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
+            ObjectStorePath::from(
+                "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet"
+            ),
         ]
     );
     let tombstones = table.get_state().all_tombstones();
@@ -35,32 +48,17 @@ async fn read_simple_table() {
         extended_file_metadata: None,
         ..Default::default()
     }));
-    #[cfg(unix)]
-    {
-        let mut paths: Vec<String> = table.get_file_uris().collect();
-        paths.sort();
-        let expected_paths: Vec<String> = vec![
-                "./tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),
-                "./tests/data/simple_table/part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet".to_string(),
-                "./tests/data/simple_table/part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet".to_string(),
-                "./tests/data/simple_table/part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet".to_string(),
-                "./tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet".to_string()
-            ];
-        assert_eq!(paths, expected_paths);
-    }
-    #[cfg(windows)]
-    {
-        let mut paths: Vec<String> = table.get_file_uris().collect();
-        paths.sort();
-        let expected_paths: Vec<String> = vec![
-                "./tests/data/simple_table\\part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet".to_string(),
-                "./tests/data/simple_table\\part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet".to_string(),
-                "./tests/data/simple_table\\part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet".to_string(),
-                "./tests/data/simple_table\\part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet".to_string(),
-                "./tests/data/simple_table\\part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet".to_string()
-            ];
-        assert_eq!(paths, expected_paths);
-    }
+
+    let mut paths: Vec<String> = table.get_file_uris().collect();
+    paths.sort();
+    let expected_paths: Vec<String> = vec![
+            format!("file://{}/tests/data/simple_table/part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet", current_dir.as_ref()),
+            format!("file://{}/tests/data/simple_table/part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet", current_dir.as_ref()),
+            format!("file://{}/tests/data/simple_table/part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet", current_dir.as_ref()),
+            format!("file://{}/tests/data/simple_table/part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet", current_dir.as_ref()),
+            format!("file://{}/tests/data/simple_table/part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet", current_dir.as_ref())
+        ];
+    assert_eq!(paths, expected_paths);
 }
 
 #[tokio::test]
@@ -76,12 +74,24 @@ async fn read_simple_table_with_version() {
     assert_eq!(
         files,
         vec![
-            "part-00000-a72b1fb3-f2df-41fe-a8f0-e65b746382dd-c000.snappy.parquet",
-            "part-00001-c506e79a-0bf8-4e2b-a42b-9731b2e490ae-c000.snappy.parquet",
-            "part-00003-508ae4aa-801c-4c2c-a923-f6f89930a5c1-c000.snappy.parquet",
-            "part-00004-80938522-09c0-420c-861f-5a649e3d9674-c000.snappy.parquet",
-            "part-00006-63ce9deb-bc0f-482d-b9a1-7e717b67f294-c000.snappy.parquet",
-            "part-00007-94f725e2-3963-4b00-9e83-e31021a93cf9-c000.snappy.parquet",
+            ObjectStorePath::from(
+                "part-00000-a72b1fb3-f2df-41fe-a8f0-e65b746382dd-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00001-c506e79a-0bf8-4e2b-a42b-9731b2e490ae-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00003-508ae4aa-801c-4c2c-a923-f6f89930a5c1-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00004-80938522-09c0-420c-861f-5a649e3d9674-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00006-63ce9deb-bc0f-482d-b9a1-7e717b67f294-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00007-94f725e2-3963-4b00-9e83-e31021a93cf9-c000.snappy.parquet"
+            ),
         ],
     );
 
@@ -96,12 +106,24 @@ async fn read_simple_table_with_version() {
     assert_eq!(
         files,
         vec![
-            "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
-            "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
-            "part-00003-53f42606-6cda-4f13-8d07-599a21197296-c000.snappy.parquet",
-            "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
-            "part-00006-46f2ff20-eb5d-4dda-8498-7bfb2940713b-c000.snappy.parquet",
-            "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
+            ObjectStorePath::from(
+                "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00003-53f42606-6cda-4f13-8d07-599a21197296-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00006-46f2ff20-eb5d-4dda-8498-7bfb2940713b-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet"
+            ),
         ]
     );
 
@@ -116,12 +138,24 @@ async fn read_simple_table_with_version() {
     assert_eq!(
         files,
         vec![
-            "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
-            "part-00000-f17fcbf5-e0dc-40ba-adae-ce66d1fcaef6-c000.snappy.parquet",
-            "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
-            "part-00001-bb70d2ba-c196-4df2-9c85-f34969ad3aa9-c000.snappy.parquet",
-            "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
-            "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
+            ObjectStorePath::from(
+                "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00000-f17fcbf5-e0dc-40ba-adae-ce66d1fcaef6-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00001-bb70d2ba-c196-4df2-9c85-f34969ad3aa9-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet"
+            ),
+            ObjectStorePath::from(
+                "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet"
+            ),
         ],
     );
 }

--- a/rust/tests/s3_test.rs
+++ b/rust/tests/s3_test.rs
@@ -9,6 +9,7 @@ mod s3 {
     use deltalake::storage;
     use dynamodb_lock::dynamo_lock_options;
     use maplit::hashmap;
+    use object_store::path::Path;
     use serial_test::serial;
 
     /*
@@ -46,11 +47,11 @@ mod s3 {
         assert_eq!(
             table.get_files(),
             vec![
-                "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
-                "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
-                "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
-                "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
-                "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet",
+                Path::from("part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet"),
+                Path::from("part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet"),
+                Path::from("part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet"),
+                Path::from("part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet"),
+                Path::from("part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet"),
             ]
         );
         let tombstones = table.get_state().all_tombstones();
@@ -77,12 +78,12 @@ mod s3 {
         assert_eq!(
             table.get_files(),
             vec![
-                "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
-                "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
-                "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
-                "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
-                "part-00000-f17fcbf5-e0dc-40ba-adae-ce66d1fcaef6-c000.snappy.parquet",
-                "part-00001-bb70d2ba-c196-4df2-9c85-f34969ad3aa9-c000.snappy.parquet",
+                Path::from("part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet"),
+                Path::from("part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet"),
+                Path::from("part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet"),
+                Path::from("part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet"),
+                Path::from("part-00000-f17fcbf5-e0dc-40ba-adae-ce66d1fcaef6-c000.snappy.parquet"),
+                Path::from("part-00001-bb70d2ba-c196-4df2-9c85-f34969ad3aa9-c000.snappy.parquet"),
             ]
         );
         let tombstones = table.get_state().all_tombstones();

--- a/rust/tests/simple_commit_test.rs
+++ b/rust/tests/simple_commit_test.rs
@@ -39,8 +39,9 @@ mod simple_commit_s3 {
 
         let result = test_two_commits(path).await;
         if let Err(DeltaTableError::StorageError { ref source }) = result {
-            if let StorageError::S3Generic(err) = source {
-                assert_eq!(err, "dynamodb locking is not enabled");
+            if let StorageError::ObjectStore { source: inner, .. } = source {
+                let msg = inner.to_string();
+                assert!(msg.contains("dynamodb"));
                 return;
             }
         }

--- a/rust/tests/simple_commit_test.rs
+++ b/rust/tests/simple_commit_test.rs
@@ -31,19 +31,15 @@ mod simple_commit_s3 {
     #[tokio::test]
     #[serial]
     async fn test_two_commits_s3_fails_with_no_lock() {
-        use deltalake::StorageError;
-
         let path = "s3://deltars/simple_commit_rw2";
         prepare_s3(path).await;
         std::env::set_var("AWS_S3_LOCKING_PROVIDER", "none  ");
 
         let result = test_two_commits(path).await;
-        if let Err(DeltaTableError::StorageError { ref source }) = result {
-            if let StorageError::ObjectStore { source: inner, .. } = source {
-                let msg = inner.to_string();
-                assert!(msg.contains("dynamodb"));
-                return;
-            }
+        if let Err(DeltaTableError::ObjectStore { source: inner }) = result {
+            let msg = inner.to_string();
+            assert!(msg.contains("dynamodb"));
+            return;
         }
 
         result.unwrap();

--- a/rust/tests/vacuum_test.rs
+++ b/rust/tests/vacuum_test.rs
@@ -292,13 +292,7 @@ async fn test_non_managed_files() {
 }
 
 async fn is_deleted(context: &mut TestContext, path: &str) -> bool {
-    let uri = context
-        .table
-        .as_ref()
-        .unwrap()
-        .table_uri
-        .trim_start_matches("file:/")
-        .to_string();
+    let uri = context.table.as_ref().unwrap().table_uri.clone();
     let backend = context.get_storage();
     let path = uri + "/" + path;
     let res = backend.head_obj(&path).await;

--- a/rust/tests/vacuum_test.rs
+++ b/rust/tests/vacuum_test.rs
@@ -1,9 +1,7 @@
 use chrono::Duration;
-use deltalake::storage::file::FileStorageBackend;
 use deltalake::storage::StorageError;
 use deltalake::vacuum::Clock;
 use deltalake::vacuum::Vacuum;
-use deltalake::StorageBackend;
 use std::sync::Arc;
 
 use common::clock::TestClock;
@@ -15,8 +13,7 @@ mod common;
 
 #[tokio::test]
 async fn vacuum_delta_8_0_table() {
-    let backend = FileStorageBackend::new("");
-    let mut table = deltalake::open_table(&backend.join_paths(&["tests", "data", "delta-0.8.0"]))
+    let mut table = deltalake::open_table("./tests/data/delta-0.8.0")
         .await
         .unwrap();
 


### PR DESCRIPTION
# Description
~~Using the latest arrow (18) and datafusion (10) dependencies.~~

supersedes #666
part of #610

This PR moves most file path handling to use the `Path` abstraction from `object_store`. We do so by way of moving our internal `StorageBackend` behind a new `DeltaObjectStore`, which implements `ObjectStore`. The delta store exposes all path as relative to the table root, consistent with how they are treated in the log. 

To integrate with datafusion, a table-specific specific store is registered on the runtime environment. Datafusion required `get_range` to be defined, which I did for local using the new store. This was just to get datafusion tests to pass - this needs to be improved in a follow up :).

One major change that is implied by `Path` is, that for local file system the table root folder has to exist now prior to creating the table, but can be empty.

The most annoying aspect was handling windlows path for local. but I tried to keep all special handling contained in `DeltaObjectStore` and suspect most of it will disappear, once we move the storage backends to object_store.

* also bumps arrow (18) and datafusion (10)

Last but not least, I found that the Azure paths are somewhat of an oddity compared to other - will open a follow up for that :).

@Blajda - this should also remove the delete issues with vacuum. I activated them in windows and it seems to work

cc @Tom-Newton

# Related Issue(s)
closes  #671

# Documentation

