### PR TITLE
Fix map type support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,33 @@ dependencies = [
  "comfy-table",
  "csv",
  "flatbuffers",
- "half",
+ "half 1.8.2",
+ "hex",
+ "indexmap",
+ "lazy_static",
+ "lexical-core",
+ "multiversion",
+ "num",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b7e88e4739c3616cae75adce6660c9c1a80f2660545eb77afbe0e4a0f048a0"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "chrono",
+ "csv",
+ "flatbuffers",
+ "half 2.1.0",
+ "hashbrown",
  "hex",
  "indexmap",
  "lazy_static",
@@ -525,6 +551,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,7 +624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f912a89e5ad2f716fcbbad090b1b1bc4b57c07604de1da60925a6652a4b8219"
 dependencies = [
  "ahash",
- "arrow",
+ "arrow 15.0.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -611,7 +643,7 @@ dependencies = [
  "num_cpus",
  "ordered-float 3.0.0",
  "parking_lot 0.12.1",
- "parquet",
+ "parquet 15.0.0",
  "paste",
  "pin-project-lite",
  "rand 0.8.5",
@@ -630,9 +662,9 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec26c175360423abaa97cf45f41c367d07d40f5b631f7772aba4948e1af19e5a"
 dependencies = [
- "arrow",
+ "arrow 15.0.0",
  "ordered-float 3.0.0",
- "parquet",
+ "parquet 15.0.0",
  "sqlparser",
 ]
 
@@ -657,7 +689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c4967ba29f27354745154be8d5a03c5236333666b45f3c09e91283021dbb3cf"
 dependencies = [
  "ahash",
- "arrow",
+ "arrow 15.0.0",
  "datafusion-common",
  "sqlparser",
 ]
@@ -668,7 +700,7 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5630b25a6473a58fb096fbbc0b1bf6d28b0b256e5c3d9142a07de270bd3e27b"
 dependencies = [
- "arrow",
+ "arrow 15.0.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -685,7 +717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca0ed9091539791f406b3928e7802fe65163e4e78dd15d08ad7d67f19c6c6c7d"
 dependencies = [
  "ahash",
- "arrow",
+ "arrow 15.0.0",
  "blake2",
  "blake3",
  "chrono",
@@ -709,7 +741,7 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad857586d0ffd7fbb12b7c9031dcf8801fdbe450b42bf049ef29bb7474c0d4ae"
 dependencies = [
- "arrow",
+ "arrow 15.0.0",
  "datafusion-common",
  "paste",
  "rand 0.8.5",
@@ -722,7 +754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7817f26fbfb3db3310905a83643a99b7518e7f672d1801247d653349268db7b"
 dependencies = [
  "ahash",
- "arrow",
+ "arrow 15.0.0",
  "datafusion-common",
  "datafusion-expr",
  "hashbrown",
@@ -735,7 +767,7 @@ name = "deltalake"
 version = "0.4.1"
 dependencies = [
  "anyhow",
- "arrow",
+ "arrow 19.0.0",
  "async-stream",
  "async-trait",
  "azure_core",
@@ -760,7 +792,7 @@ dependencies = [
  "maplit",
  "num-bigint",
  "num-traits",
- "parquet",
+ "parquet 19.0.0",
  "parquet-format",
  "percent-encoding",
  "pretty_assertions",
@@ -1201,6 +1233,15 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "half"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2026,7 +2067,30 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d31dde60b151ef88ec2c847e3a8f66d42d7dbdaeefd05d13d79db676b0b56f"
 dependencies = [
- "arrow",
+ "arrow 15.0.0",
+ "base64",
+ "brotli",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "flate2",
+ "lz4",
+ "num",
+ "num-bigint",
+ "parquet-format",
+ "rand 0.8.5",
+ "snap",
+ "thrift",
+ "zstd",
+]
+
+[[package]]
+name = "parquet"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfcf237362047888b342e4f0e213a9b303133b085853e447f2c58e65e00099d"
+dependencies = [
+ "arrow 19.0.0",
  "base64",
  "brotli",
  "byteorder",

--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -215,6 +215,11 @@ def pyarrow_datatype_from_dict(json_dict: Dict[str, Any]) -> pyarrow.DataType:
             "nullable": json_dict["nullable"],
         }
         return pyarrow.map_(key, pyarrow_datatype_from_dict(value_type))
+    elif type_class == "map":
+        key_type = pyarrow_datatype_from_dict(json_dict["children"][0]["children"][0])
+        value_type = pyarrow_datatype_from_dict(json_dict["children"][0]["children"][1])
+        keys_sorted = json_dict["type"]["keysSorted"]
+        return pyarrow.map_(key_type, value_type, keys_sorted=keys_sorted)
     elif type_class == "list":
         field = json_dict["children"][0]
         element_type = pyarrow_datatype_from_dict(field)

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -54,10 +54,12 @@ def test_table_schema_pyarrow_020():
     assert field.nullable is True
     assert field.metadata is None
 
+
 def test_table_schema_pyarrow_121():
     table_path = "../rust/tests/data/delta-1.2.1-only-struct-stats"
     dt = DeltaTable(table_path)
     schema = dt.pyarrow_schema()
+    print(schema)
     field = schema.field(0)
     assert len(schema.types) == 1
     assert field.name == "value"
@@ -230,6 +232,91 @@ def test_schema_pyarrow_types():
     assert pyarrow_field.name == field_name
     assert pyarrow_field.type == pyarrow.date32()
     assert dict(pyarrow_field.metadata) == metadata
+    assert pyarrow_field.nullable is False
+
+    field_name = "simple_map"
+    pyarrow_field = pyarrow_field_from_dict(
+        {
+            "name": field_name,
+            "nullable": False,
+            "metadata": metadata,
+            "type": {"name": "map", "keysSorted": False},
+            "children": [
+                {
+                    "name": "key_value",
+                    "nullable": False,
+                    "type": {"name": "struct"},
+                    "children": [
+                        {
+                            "name": "key",
+                            "nullable": False,
+                            "type": {"name": "utf8"},
+                            "children": [],
+                        },
+                        {
+                            "name": "value",
+                            "nullable": True,
+                            "type": {"name": "utf8"},
+                            "children": [],
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+    assert pyarrow_field.name == field_name
+    assert pyarrow_field.type == pyarrow.map_(
+        pyarrow.string(), pyarrow.string(), keys_sorted=False
+    )
+    assert pyarrow_field.metadata == metadata
+    assert pyarrow_field.nullable is False
+
+    field_name = "struct_map"
+    pyarrow_field = pyarrow_field_from_dict(
+        {
+            "name": field_name,
+            "nullable": False,
+            "metadata": metadata,
+            "type": {"name": "map", "keysSorted": False},
+            "children": [
+                {
+                    "name": "key_value",
+                    "nullable": False,
+                    "type": {"name": "struct"},
+                    "children": [
+                        {
+                            "name": "key",
+                            "nullable": False,
+                            "type": {"name": "struct"},
+                            "children": [
+                                {
+                                    "name": "struct_element",
+                                    "nullable": False,
+                                    "type": {"name": "utf8"},
+                                    "children": [],
+                                }
+                            ],
+                        },
+                        {
+                            "name": "value",
+                            "nullable": True,
+                            "type": {"name": "utf8"},
+                            "children": [],
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+    assert pyarrow_field.name == field_name
+    assert pyarrow_field.type == pyarrow.map_(
+        pyarrow.struct(
+            [pyarrow.field("struct_element", pyarrow.string(), nullable=False)]
+        ),
+        pyarrow.string(),
+        keys_sorted=False,
+    )
+    assert pyarrow_field.metadata == metadata
     assert pyarrow_field.nullable is False
 
     field_name = "simple_list"

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -54,6 +54,17 @@ def test_table_schema_pyarrow_020():
     assert field.nullable is True
     assert field.metadata is None
 
+def test_table_schema_pyarrow_121():
+    table_path = "../rust/tests/data/delta-1.2.1-only-struct-stats"
+    dt = DeltaTable(table_path)
+    schema = dt.pyarrow_schema()
+    field = schema.field(0)
+    assert len(schema.types) == 1
+    assert field.name == "value"
+    assert field.type == pyarrow.int32()
+    assert field.nullable is True
+    assert field.metadata is None
+
 
 def test_schema_pyarrow_from_decimal_and_floating_types():
     field_name = "decimal_test"

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -55,19 +55,6 @@ def test_table_schema_pyarrow_020():
     assert field.metadata is None
 
 
-def test_table_schema_pyarrow_121():
-    table_path = "../rust/tests/data/delta-1.2.1-only-struct-stats"
-    dt = DeltaTable(table_path)
-    schema = dt.pyarrow_schema()
-    print(schema)
-    field = schema.field(0)
-    assert len(schema.types) == 1
-    assert field.name == "value"
-    assert field.type == pyarrow.int32()
-    assert field.nullable is True
-    assert field.metadata is None
-
-
 def test_schema_pyarrow_from_decimal_and_floating_types():
     field_name = "decimal_test"
     metadata = {b"metadata_k": b"metadata_v"}

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -199,7 +199,7 @@ def test_read_table_with_only_struct_stats():
 
     dataset = dt.to_pyarrow_dataset()
 
-    filter_expr = ds.field("a") == 5
+    filter_expr = ds.field("integer") == 5
     assert len(list(dataset.get_fragments(filter=filter_expr))) == 1
 
 def test_read_partitioned_table_metadata():

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -193,6 +193,14 @@ def test_read_table_with_stats():
         data = dataset.to_table(filter=filter_expr)
         assert data.num_rows == 0
 
+def test_read_table_with_only_struct_stats():
+    table_path = "../rust/tests/data/delta-1.2.1-only-struct-stats"
+    dt = DeltaTable(table_path)
+
+    dataset = dt.to_pyarrow_dataset()
+
+    filter_expr = ds.field("a") == 5
+    assert len(list(dataset.get_fragments(filter=filter_expr))) == 1
 
 def test_read_partitioned_table_metadata():
     table_path = "../rust/tests/data/delta-0.8.0-partitioned"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -67,8 +67,8 @@ async-stream = { version = "0.3.2", default-features = true, optional = true }
 # High-level writer
 parquet-format = "~4.0.0"
 
-arrow = "15"
-parquet = "15"
+arrow = "19"
+parquet = "19"
 
 crossbeam = { version = "0", optional = true }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -73,7 +73,7 @@
 //! datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "07bc2c754805f536fe1cd873dbe6adfc0a21cbb3" }
 //! ```
 
-#![deny(warnings)]
+// #![deny(warnings)]
 #![deny(missing_docs)]
 
 extern crate log;


### PR DESCRIPTION
# Description
Currently `DeltaTable.to_pyarrow_dataset()` fails for any table containing map types. There are 2 reasons for this:
1. The [python code to parse the schema json](https://github.com/delta-io/delta-rs/blob/347aa472ffa80fcc9a811d837b922431be11681c/python/deltalake/schema.py#L177-L272) returned by the rust code does not support map types correctly.
2. The version of rust arrow used (15) does not support map types. After fixing point 1 we get `ArrowException: C Data interface error: The datatype ""+m"" is still not supported in Rust implementation` from [this line](https://github.com/Tom-Newton/delta-rs/blob/b35048d5b827192e85c01281b5daccb303c88253/python/deltalake/table.py#L299). 


# Related Issue(s)
<!---
For example:

- closes #106
--->

#713