### PR TITLE
Fix parsing null counts for struct type columns in the struct stats

### DIFF
--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -397,7 +397,7 @@ impl From<&Field> for ColumnCountStat {
                     .map(|(field_name, field)| (field_name.clone(), field.into())),
             )),
             Field::Long(value) => ColumnCountStat::Value(value.clone()),
-            _ => panic!("DataType::Map should contain a struct field child"),
+            _ => panic!("nullCount columns stats must be a struct of int64s."),
         }
     }
 }

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -396,7 +396,7 @@ impl From<&Field> for ColumnCountStat {
                     .get_column_iter()
                     .map(|(field_name, field)| (field_name.clone(), field.into())),
             )),
-            Field::Long(value) => ColumnCountStat::Value(value.clone()),
+            Field::Long(value) => ColumnCountStat::Value(*value),
             _ => panic!("nullCount columns stats must be a struct of int64s."),
         }
     }

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -358,7 +358,7 @@ impl Add {
                                         stats.null_count.insert(name.clone(), count);
                                     },
                                     _ => {
-                                        log::error!("failed parsing null_counts for column")
+                                        log::warn!("Expect type of nullCount field to be struct or int64, got: {}", field);
                                     },
                                 };
                             }
@@ -405,11 +405,18 @@ impl TryFrom<&Field> for ColumnCountStat {
                     .get_column_iter()
                     .filter_map(|(field_name, field)| match field.try_into() {
                         Ok(value) => Some((field_name.clone(), value)),
-                        Err(_) => None,
+                        _ => {
+                            log::warn!(
+                                "Unexpected type when parsing nullCounts for {}. Found {}",
+                                field_name,
+                                field
+                            );
+                            None
+                        }
                     }),
             ))),
             Field::Long(value) => Ok(ColumnCountStat::Value(*value)),
-            _ => Err("nullCount columns stats must be a struct of int64s."),
+            _ => Err("Invalid type for nullCounts"),
         }
     }
 }

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -436,24 +436,9 @@ async fn read_delta_1_2_1_struct_stats_table_without_version() {
 
     let file_to_compare = "part-00000-51653f4d-b029-44bd-9fda-578e73518a26-c000.snappy.parquet";
 
-    let struct_stats_for_file = get_stats_for_file(&table_from_struct_stats, &file_to_compare);
-    let json_stats_for_file = get_stats_for_file(&table_from_json_stats, &file_to_compare);
-
     assert_eq!(
-        struct_stats_for_file.min_values,
-        json_stats_for_file.min_values,
-    );
-    assert_eq!(
-        struct_stats_for_file.max_values,
-        json_stats_for_file.max_values,
-    );
-    assert_eq!(
-        struct_stats_for_file.null_count,
-        json_stats_for_file.null_count,
-    );
-    assert_eq!(
-        struct_stats_for_file.num_records,
-        json_stats_for_file.num_records,
+        get_stats_for_file(&table_from_struct_stats, &file_to_compare),
+        get_stats_for_file(&table_from_json_stats, &file_to_compare),
     );
 }
 

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -409,7 +409,7 @@ async fn read_delta_8_0_table_partition_with_compare_op() {
 }
 
 #[tokio::test]
-async fn read_delta_1_2_1_struct_stats_table_without_version() {
+async fn read_delta_1_2_1_struct_stats_table() {
     let table_uri = "./tests/data/delta-1.2.1-only-struct-stats";
     let table_from_struct_stats = deltalake::open_table(table_uri).await.unwrap();
     let table_from_json_stats = deltalake::open_table_with_version(table_uri, 1)

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -436,10 +436,25 @@ async fn read_delta_1_2_1_struct_stats_table_without_version() {
 
     let file_to_compare = "part-00000-51653f4d-b029-44bd-9fda-578e73518a26-c000.snappy.parquet";
 
+    let struct_stats_for_file = get_stats_for_file(&table_from_struct_stats, &file_to_compare);
+    let json_stats_for_file = get_stats_for_file(&table_from_json_stats, &file_to_compare);
+
     assert_eq!(
-        get_stats_for_file(&table_from_struct_stats, &file_to_compare).min_values,
-        get_stats_for_file(&table_from_json_stats, &file_to_compare).min_values,
-    )
+        struct_stats_for_file.min_values,
+        json_stats_for_file.min_values,
+    );
+    assert_eq!(
+        struct_stats_for_file.max_values,
+        json_stats_for_file.max_values,
+    );
+    assert_eq!(
+        struct_stats_for_file.null_count,
+        json_stats_for_file.null_count,
+    );
+    assert_eq!(
+        struct_stats_for_file.num_records,
+        json_stats_for_file.num_records,
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description
When reading the struct column stats (as opposed to json column stats) the null counts where ignored for struct type columns. Completely ignoring is probably less bad than parsing them wrongly but if the user was filtering on a struct column this may have impacted performance. It was also spamming error logs:
```
[2022-07-26T19:33:52Z ERROR deltalake::action] Expect type of stats_parsed.nullRecords value to be struct, got: {integer: 0, null: 1, boolean: 0, double: 0, decimal: 0, string: 0, binary: 0, date: 0, timestamp: 0, struct: {struct_element: 0}, map: 0, array: 0, nested_struct: {struct_element: {nested_struct_element: 0}}, struct_of_array_of_map: {struct_element: 0}}
```

I probably should have done this as part of https://github.com/delta-io/delta-rs/pull/656. Sorry for introducing this slight regression. I think some logging was getting suppressed during the unittest so I didn't notice it was an issue. 

# Related Issue(s)
<!---
For example:

- closes #106
--->
Relates to #653 but that was for the most part already solved by https://github.com/delta-io/delta-rs/pull/656

# Changes
- In the test assert that all stats are the same not just the min_values stats. This prevents a similar mistake in future.
- Updated logic to handle struct types when parsing null_counts from struct stats.
