### PR TITLE
Fix usage documentation in Python binding

### DIFF
--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -79,7 +79,7 @@ number or datetime string:
 .. code-block:: python
 
     >>> dt.load_version(1)
-    >>> dt.load_with_timestamp("2021-11-04 00:05:23.283+00:00")
+    >>> dt.load_with_datetime("2021-11-04 00:05:23.283+00:00")
 
 .. warning::
 


### PR DESCRIPTION
# Description
- Fix usage section in the Python documentation: use `load_with_datetime()`