### PR TITLE
Prune scanned files on column stats

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -62,7 +62,6 @@ jobs:
 
       - name: Build and install deltalake
         run: |
-          pip install --upgrade pip
           pip install virtualenv
           virtualenv venv
           source venv/bin/activate

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Build and install deltalake
         run: |
+          pip install --upgrade pip
           pip install virtualenv
           virtualenv venv
           source venv/bin/activate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,15 +394,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
 dependencies = [
- "libc",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "wasm-bindgen",
  "winapi",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,7 @@ futures = "0.3"
 bytes = "1"
 log = "0"
 regex = "1"
-chrono = "0"
+chrono = { version = "0.4", default-features = false }
 uuid = { version = "1", features = ["serde", "v4"] }
 lazy_static = "1"
 percent-encoding = "2"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,7 @@ futures = "0.3"
 bytes = "1"
 log = "0"
 regex = "1"
-chrono = { version = "0.4", default-features = false }
+chrono = "0.4.20"
 uuid = { version = "1", features = ["serde", "v4"] }
 lazy_static = "1"
 percent-encoding = "2"

--- a/rust/src/checkpoints.rs
+++ b/rust/src/checkpoints.rs
@@ -3,10 +3,7 @@
 use arrow::datatypes::Schema as ArrowSchema;
 use arrow::error::ArrowError;
 use arrow::json::reader::{Decoder, DecoderOptions};
-use chrono::Datelike;
-use chrono::Duration;
-use chrono::Utc;
-use chrono::MIN_DATETIME;
+use chrono::{DateTime, Datelike, Duration, Utc};
 use futures::StreamExt;
 use lazy_static::lazy_static;
 use log::*;
@@ -229,7 +226,7 @@ async fn cleanup_expired_logs_for(
         0,
         ObjectMeta {
             location: Path::from(""),
-            last_modified: MIN_DATETIME,
+            last_modified: DateTime::<Utc>::MIN_UTC,
             size: 0,
         },
     );

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -351,7 +351,7 @@ fn to_scalar_value(stat_val: &serde_json::Value) -> Option<datafusion::scalar::S
             }
         }
         serde_json::Value::String(s) => Some(ScalarValue::from(s.as_str())),
-        // TODO is it permissible to encode arrays / objects as partition values
+        // TODO is it permissible to encode arrays / objects as partition values?
         serde_json::Value::Array(_) => None,
         serde_json::Value::Object(_) => None,
         serde_json::Value::Null => None,

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -359,9 +359,11 @@ impl TableProvider for delta::DeltaTable {
                             Some(partitioned_file_from_action(action, &schema))
                         }))
                 })
-                .ok_or(DataFusionError::Execution(
-                    "Failed to evaluate table pruning predicates.".to_string(),
-                ))??
+                .ok_or_else(|| {
+                    DataFusionError::Execution(
+                        "Failed to evaluate table pruning predicates.".to_string(),
+                    )
+                })??
                 .for_each(|f| {
                     file_groups
                         .entry(f.partition_values.clone())

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -342,12 +342,7 @@ impl TableProvider for delta::DeltaTable {
         // and partitions are somewhat evenly distributed, probably not the worst choice ...
         // However we may want to do some additional balancing in case we are far off from the above.
         let mut file_groups: HashMap<Vec<ScalarValue>, Vec<PartitionedFile>> = HashMap::new();
-        if !filters.is_empty() {
-            let predicate = combine_filters(filters).ok_or_else(|| {
-                DataFusionError::Execution(
-                    "Failed to evaluate table pruning predicates.".to_string(),
-                )
-            })?;
+        if let Some(Some(predicate)) = (!filters.is_empty()).then_some(combine_filters(filters)) {
             let pruning_predicate = PruningPredicate::try_new(predicate, schema.clone())?;
             let files_to_prune = pruning_predicate.prune(self)?;
             self.get_state()

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -24,19 +24,19 @@ use std::any::Any;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
+use arrow::array::ArrayRef;
 use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, TimeUnit};
 use async_trait::async_trait;
 use chrono::{DateTime, NaiveDateTime, Utc};
-use datafusion::datasource::file_format::parquet::ParquetFormat;
-use datafusion::datasource::file_format::FileFormat;
+use datafusion::datasource::file_format::{parquet::ParquetFormat, FileFormat};
 use datafusion::datasource::listing::PartitionedFile;
 use datafusion::datasource::{TableProvider, TableType};
-use datafusion::error::Result as DataFusionResult;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::context::SessionState;
-use datafusion::logical_plan::Expr;
+use datafusion::logical_plan::{combine_filters, Column, Expr};
+use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
 use datafusion::physical_plan::file_format::FileScanConfig;
-use datafusion::physical_plan::ExecutionPlan;
-use datafusion::physical_plan::{ColumnStatistics, Statistics};
+use datafusion::physical_plan::{ColumnStatistics, ExecutionPlan, Statistics};
 use datafusion::scalar::ScalarValue;
 use object_store::{path::Path, ObjectMeta};
 use url::Url;
@@ -44,6 +44,27 @@ use url::Url;
 use crate::action;
 use crate::delta;
 use crate::schema;
+use crate::DeltaTableError;
+
+impl From<DeltaTableError> for DataFusionError {
+    fn from(err: DeltaTableError) -> Self {
+        match err {
+            DeltaTableError::ArrowError { source } => DataFusionError::ArrowError(source),
+            DeltaTableError::Io { source } => DataFusionError::IoError(source),
+            _ => DataFusionError::External(Box::new(err)),
+        }
+    }
+}
+
+impl From<DataFusionError> for crate::DeltaTableError {
+    fn from(err: DataFusionError) -> Self {
+        match err {
+            DataFusionError::ArrowError(source) => DeltaTableError::ArrowError { source },
+            DataFusionError::IoError(source) => DeltaTableError::Io { source },
+            _ => DeltaTableError::Generic(err.to_string()),
+        }
+    }
+}
 
 impl delta::DeltaTable {
     /// Return statistics for Datafusion Table
@@ -195,39 +216,98 @@ impl delta::DeltaTable {
     }
 }
 
-// TODO: uncomment this when datafusion supports per partitioned file stats
-// fn add_action_df_stats(add: &action::Add, schema: &schema::Schema) -> Statistics {
-//     if let Ok(Some(statistics)) = add.get_stats() {
-//         Statistics {
-//             num_rows: Some(statistics.num_records as usize),
-//             total_byte_size: Some(add.size as usize),
-//             column_statistics: Some(
-//                 schema
-//                     .get_fields()
-//                     .iter()
-//                     .map(|field| ColumnStatistics {
-//                         null_count: statistics
-//                             .null_count
-//                             .get(field.get_name())
-//                             .and_then(|f| f.as_value().map(|v| v as usize)),
-//                         max_value: statistics
-//                             .max_values
-//                             .get(field.get_name())
-//                             .and_then(|f| to_scalar_value(f.as_value()?)),
-//                         min_value: statistics
-//                             .min_values
-//                             .get(field.get_name())
-//                             .and_then(|f| to_scalar_value(f.as_value()?)),
-//                         distinct_count: None, // TODO: distinct
-//                     })
-//                     .collect(),
-//             ),
-//             is_exact: true,
-//         }
-//     } else {
-//         Statistics::default()
-//     }
-// }
+impl PruningStatistics for delta::DeltaTable {
+    /// return the minimum values for the named column, if known.
+    /// Note: the returned array must contain `num_containers()` rows
+    fn min_values(&self, column: &Column) -> Option<ArrayRef> {
+        let values = self.get_state().files().iter().map(|add| {
+            if let Ok(Some(statistics)) = add.get_stats() {
+                self.get_schema()
+                    .ok()
+                    .map(|s| {
+                        s.get_field_with_name(&column.name)
+                            .ok()
+                            .map(|field| {
+                                statistics
+                                    .min_values
+                                    .get(&column.name)
+                                    .and_then(|f| {
+                                        correct_scalar_value_type(
+                                            to_scalar_value(f.as_value()?)
+                                                .unwrap_or(ScalarValue::Null),
+                                            &field.get_type().try_into().ok()?,
+                                        )
+                                    })
+                                    .unwrap_or(ScalarValue::Null)
+                            })
+                            .unwrap_or(ScalarValue::Null)
+                    })
+                    .unwrap_or(ScalarValue::Null)
+            } else {
+                ScalarValue::Null
+            }
+        });
+        ScalarValue::iter_to_array(values).ok()
+    }
+
+    /// return the maximum values for the named column, if known.
+    /// Note: the returned array must contain `num_containers()` rows.
+    fn max_values(&self, column: &Column) -> Option<ArrayRef> {
+        let values = self.get_state().files().iter().map(|add| {
+            if let Ok(Some(statistics)) = add.get_stats() {
+                self.get_schema()
+                    .ok()
+                    .map(|s| {
+                        s.get_field_with_name(&column.name)
+                            .ok()
+                            .map(|field| {
+                                statistics
+                                    .max_values
+                                    .get(&column.name)
+                                    .and_then(|f| {
+                                        correct_scalar_value_type(
+                                            to_scalar_value(f.as_value()?)
+                                                .unwrap_or(ScalarValue::Null),
+                                            &field.get_type().try_into().ok()?,
+                                        )
+                                    })
+                                    .unwrap_or(ScalarValue::Null)
+                            })
+                            .unwrap_or(ScalarValue::Null)
+                    })
+                    .unwrap_or(ScalarValue::Null)
+            } else {
+                ScalarValue::Null
+            }
+        });
+        ScalarValue::iter_to_array(values).ok()
+    }
+
+    /// return the number of containers (e.g. row groups) being
+    /// pruned with these statistics
+    fn num_containers(&self) -> usize {
+        self.get_state().files().len()
+    }
+
+    /// return the number of null values for the named column as an
+    /// `Option<UInt64Array>`.
+    ///
+    /// Note: the returned array must contain `num_containers()` rows.
+    fn null_counts(&self, column: &Column) -> Option<ArrayRef> {
+        let values = self.get_state().files().iter().map(|add| {
+            if let Ok(Some(statistics)) = add.get_stats() {
+                statistics
+                    .null_count
+                    .get(&column.name)
+                    .and_then(|f| Some(ScalarValue::UInt64(f.as_value().map(|val| val as u64))))
+                    .unwrap_or(ScalarValue::UInt64(None))
+            } else {
+                ScalarValue::UInt64(None)
+            }
+        });
+        ScalarValue::iter_to_array(values).ok()
+    }
+}
 
 #[async_trait]
 impl TableProvider for delta::DeltaTable {
@@ -264,14 +344,29 @@ impl TableProvider for delta::DeltaTable {
             url.host_str().unwrap_or_default(),
             self.object_store(),
         );
-        let table_partition_cols = self.get_metadata().unwrap().partition_columns.clone();
 
-        // TODO prune files based on file statistics and filter expressions
+        // The pruning predicate indicates which containers / files can be pruned.
+        // i.e. 'true' means the file is to be excluded
+        let files_to_prune = if !filters.is_empty() {
+            if let Some(predicate) = combine_filters(filters) {
+                let pruning_predicate = PruningPredicate::try_new(predicate, schema.clone())?;
+                pruning_predicate.prune(self)?
+            } else {
+                vec![false; self.get_state().files().len()]
+            }
+        } else {
+            vec![false; self.get_state().files().len()]
+        };
+
         let partitions = self
             .get_state()
             .files()
             .iter()
-            .map(|action| {
+            .zip(files_to_prune.into_iter())
+            .filter_map(|(action, prune_file)| {
+                if prune_file {
+                    return None;
+                }
                 let partition_values = schema
                     .fields()
                     .iter()
@@ -297,7 +392,8 @@ impl TableProvider for delta::DeltaTable {
                     NaiveDateTime::from_timestamp(ts_secs, ts_ns as u32),
                     Utc,
                 );
-                Ok(vec![PartitionedFile {
+                // TODO group by partition values, not every file in its own vec ...
+                Some(Ok(vec![PartitionedFile {
                     object_meta: ObjectMeta {
                         location: Path::from(action.path.clone()),
                         last_modified,
@@ -305,10 +401,11 @@ impl TableProvider for delta::DeltaTable {
                     },
                     partition_values,
                     range: None,
-                }])
+                }]))
             })
             .collect::<DataFusionResult<_>>()?;
 
+        let table_partition_cols = self.get_metadata()?.partition_columns.clone();
         let file_schema = Arc::new(ArrowSchema::new(
             schema
                 .fields()

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -299,7 +299,7 @@ impl PruningStatistics for delta::DeltaTable {
                 statistics
                     .null_count
                     .get(&column.name)
-                    .and_then(|f| Some(ScalarValue::UInt64(f.as_value().map(|val| val as u64))))
+                    .map(|f| ScalarValue::UInt64(f.as_value().map(|val| val as u64)))
                     .unwrap_or(ScalarValue::UInt64(None))
             } else {
                 ScalarValue::UInt64(None)

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -237,6 +237,12 @@ impl From<DeltaTable> for DeltaCommands {
     }
 }
 
+impl From<DeltaCommands> for DeltaTable {
+    fn from(comm: DeltaCommands) -> Self {
+        comm.table
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -231,6 +231,12 @@ fn get_table_from_uri_without_update(table_uri: String) -> DeltaCommandResult<De
     Ok(table)
 }
 
+impl From<DeltaTable> for DeltaCommands {
+    fn from(table: DeltaTable) -> Self {
+        Self { table }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -43,6 +43,25 @@ impl SchemaTypeStruct {
     pub fn get_fields(&self) -> &Vec<SchemaField> {
         &self.fields
     }
+
+    /// Returns an immutable reference of a specific `Field` instance selected by name.
+    pub fn get_field_with_name(&self, name: &str) -> Result<&SchemaField, crate::DeltaTableError> {
+        Ok(&self.fields[self.index_of(name)?])
+    }
+
+    /// Find the index of the column with the given name.
+    pub fn index_of(&self, name: &str) -> Result<usize, crate::DeltaTableError> {
+        for i in 0..self.fields.len() {
+            if self.fields[i].get_name() == name {
+                return Ok(i);
+            }
+        }
+        let valid_fields: Vec<String> = self.fields.iter().map(|f| f.name.clone()).collect();
+        Err(crate::DeltaTableError::Generic(format!(
+            "Unable to get field named \"{}\". Valid fields: {:?}",
+            name, valid_fields
+        )))
+    }
 }
 
 /// Describes a specific field of the Delta table schema.

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -8,18 +8,91 @@ mod datafusion {
 
     use arrow::{
         array::*,
-        datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema},
+        datatypes::{
+            DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+            SchemaRef as ArrowSchemaRef,
+        },
         record_batch::RecordBatch,
     };
     use datafusion::datasource::TableProvider;
-    use datafusion::error::Result;
+    use datafusion::error::{DataFusionError, Result};
     use datafusion::execution::context::{SessionContext, TaskContext};
     use datafusion::logical_expr::Expr;
     use datafusion::logical_plan::Column;
-    use datafusion::physical_plan::{coalesce_partitions::CoalescePartitionsExec, ExecutionPlan};
+    use datafusion::physical_plan::{
+        coalesce_partitions::CoalescePartitionsExec, common, file_format::ParquetExec,
+        metrics::Label, visit_execution_plan, ExecutionPlan, ExecutionPlanVisitor,
+    };
     use datafusion::scalar::ScalarValue;
-    use deltalake::{action::SaveMode, operations::DeltaCommands, DeltaTableMetaData};
+    use deltalake::{action::SaveMode, operations::DeltaCommands, DeltaTable, DeltaTableMetaData};
     use std::collections::HashMap;
+
+    fn get_scanned_files(node: &dyn ExecutionPlan) -> HashSet<Label> {
+        node.metrics()
+            .unwrap()
+            .clone()
+            .iter()
+            .cloned()
+            .flat_map(|m| m.labels().to_vec())
+            .collect()
+    }
+
+    #[derive(Debug, Default)]
+    pub struct ExecutionMetricsCollector {
+        scanned_files: HashSet<Label>,
+    }
+
+    impl ExecutionMetricsCollector {
+        fn num_scanned_files(&self) -> usize {
+            self.scanned_files.len()
+        }
+    }
+
+    impl ExecutionPlanVisitor for ExecutionMetricsCollector {
+        type Error = DataFusionError;
+
+        fn pre_visit(
+            &mut self,
+            plan: &dyn ExecutionPlan,
+        ) -> std::result::Result<bool, Self::Error> {
+            if let Some(exec) = plan.as_any().downcast_ref::<ParquetExec>() {
+                let files = get_scanned_files(exec);
+                self.scanned_files.extend(files);
+            }
+            Ok(true)
+        }
+    }
+
+    async fn prepare_table(
+        schema: ArrowSchemaRef,
+        batches: Vec<RecordBatch>,
+        save_mode: SaveMode,
+    ) -> (tempfile::TempDir, Arc<DeltaTable>) {
+        let table_dir = tempfile::tempdir().unwrap();
+        let table_path = table_dir.path();
+        let table_uri = table_path.to_str().unwrap().to_string();
+
+        let mut commands = DeltaCommands::try_from_uri(table_uri.clone())
+            .await
+            .unwrap();
+
+        let table_schema = schema.clone().try_into().unwrap();
+        let metadata =
+            DeltaTableMetaData::new(None, None, None, table_schema, vec![], HashMap::new());
+        let _ = commands
+            .create(metadata.clone(), SaveMode::Ignore)
+            .await
+            .unwrap();
+
+        for batch in batches {
+            commands
+                .write(vec![batch], save_mode.clone(), None)
+                .await
+                .unwrap();
+        }
+
+        (table_dir, Arc::new(commands.into()))
+    }
 
     #[tokio::test]
     async fn test_datafusion_simple_query() -> Result<()> {
@@ -162,49 +235,24 @@ mod datafusion {
 
     #[tokio::test]
     async fn test_files_scanned() -> Result<()> {
-        let table_dir = tempfile::tempdir().unwrap();
-        let table_path = table_dir.path();
-        let table_uri = table_path.to_str().unwrap().to_string();
-
-        let mut commands = DeltaCommands::try_from_uri(table_uri.clone())
-            .await
-            .unwrap();
-
         let arrow_schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new("id", ArrowDataType::Int32, true),
             ArrowField::new("string", ArrowDataType::Utf8, true),
         ]));
-
-        let table_schema = arrow_schema.clone().try_into()?;
-        let metadata =
-            DeltaTableMetaData::new(None, None, None, table_schema, vec![], HashMap::new());
-
-        let _ = commands
-            .create(metadata.clone(), SaveMode::Ignore)
-            .await
-            .unwrap();
-
-        let columns: Vec<ArrayRef> = vec![
+        let columns_1: Vec<ArrayRef> = vec![
             Arc::new(Int32Array::from(vec![Some(1), Some(2)])),
             Arc::new(StringArray::from(vec![Some("hello"), Some("world")])),
         ];
-        let batch = RecordBatch::try_new(arrow_schema.clone(), columns)?;
-        let _ = commands
-            .write(vec![batch], SaveMode::Overwrite, None)
-            .await
-            .unwrap();
-
-        let columns: Vec<ArrayRef> = vec![
+        let columns_2: Vec<ArrayRef> = vec![
             Arc::new(Int32Array::from(vec![Some(10), Some(20)])),
             Arc::new(StringArray::from(vec![Some("hello"), Some("world")])),
         ];
-        let batch = RecordBatch::try_new(arrow_schema.clone(), columns)?;
-        let _ = commands
-            .write(vec![batch], SaveMode::Append, None)
-            .await
-            .unwrap();
-
-        let table = Arc::new(deltalake::open_table(&table_uri).await?);
+        let batches = vec![
+            RecordBatch::try_new(arrow_schema.clone(), columns_1)?,
+            RecordBatch::try_new(arrow_schema.clone(), columns_2)?,
+        ];
+        let (_temp_dir, table) =
+            prepare_table(arrow_schema.clone(), batches, SaveMode::Append).await;
         assert_eq!(table.version(), 2);
 
         let ctx = SessionContext::new();
@@ -212,41 +260,25 @@ mod datafusion {
         let plan = CoalescePartitionsExec::new(plan.clone());
 
         let task_ctx = Arc::new(TaskContext::from(&ctx.state()));
-        let stream = plan.execute(0, task_ctx)?;
-        let _result = datafusion::physical_plan::common::collect(stream).await?;
+        let _ = common::collect(plan.execute(0, task_ctx)?).await?;
 
-        let files_scanned = plan.children()[0]
-            .metrics()
-            .unwrap()
-            .clone()
-            .iter()
-            .cloned()
-            .flat_map(|m| m.labels().to_vec())
-            .collect::<HashSet<_>>();
-
-        assert!(files_scanned.len() == 2);
+        let mut metrics = ExecutionMetricsCollector::default();
+        visit_execution_plan(&plan, &mut metrics).unwrap();
+        assert!(metrics.num_scanned_files() == 2);
 
         let filter = Expr::gt(
             Expr::Column(Column::from_name("id")),
             Expr::Literal(ScalarValue::Int32(Some(5))),
         );
 
-        let plan = table.scan(&ctx.state(), &None, &[filter], None).await?;
-        let plan = CoalescePartitionsExec::new(plan.clone());
+        let plan =
+            CoalescePartitionsExec::new(table.scan(&ctx.state(), &None, &[filter], None).await?);
         let task_ctx = Arc::new(TaskContext::from(&ctx.state()));
-        let stream = plan.execute(0, task_ctx)?;
-        let _result = datafusion::physical_plan::common::collect(stream).await?;
+        let _result = common::collect(plan.execute(0, task_ctx)?).await?;
 
-        let files_scanned = plan.children()[0]
-            .metrics()
-            .unwrap()
-            .clone()
-            .iter()
-            .cloned()
-            .flat_map(|m| m.labels().to_vec())
-            .collect::<HashSet<_>>();
-
-        assert!(files_scanned.len() == 1);
+        let mut metrics = ExecutionMetricsCollector::default();
+        visit_execution_plan(&plan, &mut metrics).unwrap();
+        assert!(metrics.num_scanned_files() == 1);
 
         Ok(())
     }


### PR DESCRIPTION
# Description

This PR deepens the integration with datafusion by leveraging the column statistics from the delta log to prune the files that need to be scanned when additional constraints are supplied. Luckily datafusion provides some excellent utilities to implement this. Specifically we implement `PruningStatistics` for `DeltaTable`,  use that with `PruningPredicate`, and the rest just kind of happens 😆. 

I still need to do cleanup and more testing as well as have a look how much effort and dependency growth it would be to adopt datafusion expressions for our partition / stats handling. However if there is feedback as to if this is the right way to go, I'd be happy to hear it.

_cc_ @houqp @wjones127 - maybe even @tustvold has some feedback? :) 

# Related Issue(s)

Especially the statistics recorded during scans should get us a lot closer to finishing #632

# Documentation

<!---
Share links to useful documentation
--->
