### PR TITLE
Python: fix: fix minimal test and bump minimum pyarrow version

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -69,8 +69,7 @@ jobs:
           # Install minimum PyArrow version
           # pandas and numpy versions are most recent with Python 3.7 wheels.
           # Otherwise, we have to build those from source.
-          pip install pyarrow==4.0.0 pandas==1.2.5 numpy==1.20.3
-          make develop
+          pip install -e .[pandas,devel] pyarrow==4.0.0 pandas==1.2.5 numpy==1.20.3
 
       - name: Run tests
         run: |

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -33,7 +33,7 @@ jobs:
         run: make check-rust
 
   test-minimal:
-    name: Python Build (Python 3.7 PyArrow 4.0.0)
+    name: Python Build (Python 3.7 PyArrow 7.0.0)
     runs-on: ubuntu-latest
     # use the same environment we have for python release
     container: quay.io/pypa/manylinux2010_x86_64:2022-03-14-b2cd80b
@@ -69,7 +69,7 @@ jobs:
           # Install minimum PyArrow version
           # pandas and numpy versions are most recent with Python 3.7 wheels.
           # Otherwise, we have to build those from source.
-          pip install -e .[pandas,devel] pyarrow==4.0.0 pandas==1.2.5 numpy==1.20.3
+          pip install -e .[pandas,devel] pyarrow==7.0.0 pandas==1.2.5 numpy==1.20.3
 
       - name: Run tests
         run: |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only"
 ]
 dependencies = [
-    "pyarrow>=4",
+    "pyarrow>=7",
     'numpy<1.20.0;python_version<="3.6"',
     'dataclasses;python_version<="3.6"',
 ]

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -11,7 +11,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 from packaging import version
-from pyarrow._dataset_parquet import ParquetReadOptions
+from pyarrow.dataset import ParquetReadOptions
 from pyarrow.dataset import ParquetFileFormat
 from pyarrow.lib import RecordBatchReader
 

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -11,8 +11,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 from packaging import version
-from pyarrow.dataset import ParquetReadOptions
-from pyarrow.dataset import ParquetFileFormat
+from pyarrow.dataset import ParquetFileFormat, ParquetReadOptions
 from pyarrow.lib import RecordBatchReader
 
 from deltalake import DeltaTable, write_deltalake


### PR DESCRIPTION
# Description

I thought we were testing with `pyarrow==4`, but turns out `maturin develop` silently upgrades all dependencies :facepalm:.

It seems that our actual minimum version is pyarrow 7.0.0 (released in February 2022), which was mostly pushed up by my work on the writer. This PR pushes up the minimum version. If that feels to aggressive, I could refactor so that only the writer module requires this more recent version.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
