### PR TITLE
fix: Address clippy lint warnings.

### DIFF
--- a/dynamodb_lock/src/lib.rs
+++ b/dynamodb_lock/src/lib.rs
@@ -81,7 +81,7 @@ pub mod dynamo_lock_options {
 /// Configuration options for [`DynamoDbLockClient`].
 ///
 /// Available options are described in [dynamo_lock_options].
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DynamoDbOptions {
     /// Partition key value of DynamoDB table,
     /// Should be the same among the clients which work with the lock.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+#![allow(clippy::borrow_deref_ref)]
 
 extern crate pyo3;
 

--- a/rust/src/action.rs
+++ b/rust/src/action.rs
@@ -459,7 +459,7 @@ fn convert_date_to_string(value: u32) -> String {
 }
 
 /// Describes the data format of files in the table.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Format {
     /// Name of the encoding for files in this table.
     provider: String,
@@ -822,7 +822,7 @@ impl Txn {
 
 /// Action used to increase the version of the Delta protocol required to read or write to the
 /// table.
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Protocol {
     /// Minimum version of the Delta read protocol a client must implement to correctly read the

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -694,7 +694,7 @@ impl DeltaTable {
                 Err(ObjectStoreError::NotFound { .. }) => continue,
                 Err(err) => Err(err),
             }?;
-            if let Some(captures) = CHECKPOINT_REGEX.captures(&obj_meta.location.to_string()) {
+            if let Some(captures) = CHECKPOINT_REGEX.captures(obj_meta.location.as_ref()) {
                 let curr_ver_str = captures.get(1).unwrap().as_str();
                 let curr_ver: DeltaDataTypeVersion = curr_ver_str.parse().unwrap();
                 if curr_ver > version {
@@ -711,8 +711,7 @@ impl DeltaTable {
                 continue;
             }
 
-            if let Some(captures) = CHECKPOINT_PARTS_REGEX.captures(&obj_meta.location.to_string())
-            {
+            if let Some(captures) = CHECKPOINT_PARTS_REGEX.captures(obj_meta.location.as_ref()) {
                 let curr_ver_str = captures.get(1).unwrap().as_str();
                 let curr_ver: DeltaDataTypeVersion = curr_ver_str.parse().unwrap();
                 if curr_ver > version {

--- a/rust/src/delta_config.rs
+++ b/rust/src/delta_config.rs
@@ -29,7 +29,7 @@ lazy_static! {
 }
 
 /// Delta configuration error
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum DeltaConfigError {
     /// Error returned when configuration validation failed.
     #[error("Validation failed - {0}")]

--- a/rust/src/storage/azure/mod.rs
+++ b/rust/src/storage/azure/mod.rs
@@ -39,7 +39,7 @@ pub mod azure_storage_options {
 /// Options used to configure the AdlsGen2Backend.
 ///
 /// Available options are described in [azure_storage_options].
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AzureStorageOptions {
     account_key: Option<String>,
     account_name: Option<String>,
@@ -158,7 +158,7 @@ impl TryInto<DataLakeClient> for AzureStorageOptions {
 }
 
 /// An object on an Azure Data Lake Storage Gen2 account.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AdlsGen2Object<'a> {
     /// The storage account name.
     pub account_name: &'a str,

--- a/rust/src/storage/file/rename.rs
+++ b/rust/src/storage/file/rename.rs
@@ -71,10 +71,10 @@ mod imp {
                         e
                     )));
                 }
-                return Err(StorageError::other_std_io_err(format!(
+                Err(StorageError::other_std_io_err(format!(
                     "failed to rename {} to {}: {}",
                     from, to, e
-                )));
+                )))
             }
             Ok(_) => Ok(()),
         }

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -22,7 +22,7 @@ pub mod gcs;
 pub mod s3;
 
 /// Error enum that represents an invalid URI.
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum UriError {
     /// Error returned when the URI contains a scheme that is not handled.
     #[error("Invalid URI scheme: {0}")]

--- a/rust/src/storage/s3/mod.rs
+++ b/rust/src/storage/s3/mod.rs
@@ -222,7 +222,7 @@ pub mod s3_storage_options {
 /// Options used to configure the S3StorageBackend.
 ///
 /// Available options are described in [s3_storage_options].
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct S3StorageOptions {
     _endpoint_url: Option<String>,
     region: Region,
@@ -531,7 +531,7 @@ fn try_object_meta_from(bucket: &str, obj: rusoto_s3::Object) -> Result<ObjectMe
 }
 
 /// Struct describing an object stored in S3.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct S3Object<'a> {
     /// The bucket where the object is stored.
     pub bucket: &'a str,

--- a/rust/src/vacuum.rs
+++ b/rust/src/vacuum.rs
@@ -236,7 +236,7 @@ impl Vacuum {
             });
         }
 
-        return plan.execute(table).await;
+        plan.execute(table).await
     }
 }
 


### PR DESCRIPTION
# Description
This addresses clippy lint warnings that appeared with the 1.63.0 release of rust. Most of the changes are reasonable and straight forward. I'm unsure about the best way to resolve python/src/lib.rs. I whitelisted the check, as py03 wants pymethods to have parameters with known sizes as compile time.

# Related Issue(s)
- closes #741 

# Documentation
https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq
https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref
