### PR TITLE
cleanup errors and make `DeltaWriterError` internal

### DIFF
--- a/rust/src/action/parquet2_read/mod.rs
+++ b/rust/src/action/parquet2_read/mod.rs
@@ -38,7 +38,7 @@ pub enum ParseError {
     InvalidAction(String),
     /// Error returned when parsing checkpoint parquet using parquet2 crate.
     #[error("Failed to parse parquet: {}", .source)]
-    ParquetError {
+    Parquet {
         /// Parquet error details returned when parsing the checkpoint parquet
         #[from]
         source: parquet2::error::Error,

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -123,7 +123,7 @@ pub struct DeltaTableBuilder {
 impl DeltaTableBuilder {
     /// Creates `DeltaTableBuilder` from table uri
     pub fn from_uri(table_uri: impl AsRef<str>) -> Self {
-        DeltaTableBuilder {
+        Self {
             options: DeltaTableLoadOptions::new(table_uri.as_ref()),
             storage_options: None,
             allow_http: None,
@@ -149,9 +149,10 @@ impl DeltaTableBuilder {
     }
 
     /// specify the timestamp given as ISO-8601/RFC-3339 timestamp
-    pub fn with_datestring(self, date_string: &str) -> Result<Self, DeltaTableError> {
-        let datetime =
-            DateTime::<Utc>::from(DateTime::<FixedOffset>::parse_from_rfc3339(date_string)?);
+    pub fn with_datestring(self, date_string: impl AsRef<str>) -> Result<Self, DeltaTableError> {
+        let datetime = DateTime::<Utc>::from(DateTime::<FixedOffset>::parse_from_rfc3339(
+            date_string.as_ref(),
+        )?);
         Ok(self.with_timestamp(datetime))
     }
 

--- a/rust/src/checkpoints.rs
+++ b/rust/src/checkpoints.rs
@@ -46,14 +46,14 @@ pub enum CheckpointError {
     },
     /// Error returned when the parquet writer fails while writing the checkpoint.
     #[error("Failed to write parquet: {}", .source)]
-    ParquetError {
+    Parquet {
         /// Parquet error details returned when writing the checkpoint failed.
         #[from]
         source: ParquetError,
     },
     /// Error returned when converting the schema to Arrow format failed.
     #[error("Failed to convert into Arrow schema: {}", .source)]
-    ArrowError {
+    Arrow {
         /// Arrow error details returned when converting the schema in Arrow format failed
         #[from]
         source: ArrowError,

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1395,7 +1395,7 @@ fn log_entry_from_actions(actions: &[Action]) -> Result<String, serde_json::Erro
 
 /// Creates and loads a DeltaTable from the given path with current metadata.
 /// Infers the storage backend to use from the scheme in the given table path.
-pub async fn open_table(table_uri: &str) -> Result<DeltaTable, DeltaTableError> {
+pub async fn open_table(table_uri: impl AsRef<str>) -> Result<DeltaTable, DeltaTableError> {
     let table = DeltaTableBuilder::from_uri(table_uri).load().await?;
     Ok(table)
 }
@@ -1403,7 +1403,7 @@ pub async fn open_table(table_uri: &str) -> Result<DeltaTable, DeltaTableError> 
 /// Creates a DeltaTable from the given path and loads it with the metadata from the given version.
 /// Infers the storage backend to use from the scheme in the given table path.
 pub async fn open_table_with_version(
-    table_uri: &str,
+    table_uri: impl AsRef<str>,
     version: DeltaDataTypeVersion,
 ) -> Result<DeltaTable, DeltaTableError> {
     let table = DeltaTableBuilder::from_uri(table_uri)
@@ -1416,7 +1416,10 @@ pub async fn open_table_with_version(
 /// Creates a DeltaTable from the given path.
 /// Loads metadata from the version appropriate based on the given ISO-8601/RFC-3339 timestamp.
 /// Infers the storage backend to use from the scheme in the given table path.
-pub async fn open_table_with_ds(table_uri: &str, ds: &str) -> Result<DeltaTable, DeltaTableError> {
+pub async fn open_table_with_ds(
+    table_uri: impl AsRef<str>,
+    ds: impl AsRef<str>,
+) -> Result<DeltaTable, DeltaTableError> {
     let table = DeltaTableBuilder::from_uri(table_uri)
         .with_datestring(ds)?
         .load()

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -84,7 +84,7 @@ pub enum DeltaTableError {
     /// Error returned when reading the checkpoint failed.
     #[cfg(feature = "parquet")]
     #[error("Failed to read checkpoint: {}", .source)]
-    ParquetError {
+    Parquet {
         /// Parquet error details returned when reading the checkpoint failed.
         #[from]
         source: parquet::errors::ParquetError,
@@ -92,7 +92,7 @@ pub enum DeltaTableError {
     /// Error returned when parsing checkpoint parquet using parquet2 crate.
     #[cfg(feature = "parquet2")]
     #[error("Failed to parse parquet: {}", .source)]
-    ParquetError {
+    Parquet {
         /// Parquet error details returned when parsing the checkpoint parquet
         #[from]
         source: parquet2::error::Error,
@@ -100,7 +100,7 @@ pub enum DeltaTableError {
     /// Error returned when converting the schema in Arrow format failed.
     #[cfg(feature = "arrow")]
     #[error("Failed to convert into Arrow schema: {}", .source)]
-    ArrowError {
+    Arrow {
         /// Arrow error details returned when converting the schema in Arrow format failed
         #[from]
         source: arrow::error::ArrowError,

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -51,10 +51,10 @@ use crate::DeltaTableError;
 impl From<DeltaTableError> for DataFusionError {
     fn from(err: DeltaTableError) -> Self {
         match err {
-            DeltaTableError::ArrowError { source } => DataFusionError::ArrowError(source),
+            DeltaTableError::Arrow { source } => DataFusionError::ArrowError(source),
             DeltaTableError::Io { source } => DataFusionError::IoError(source),
             DeltaTableError::ObjectStore { source } => DataFusionError::ObjectStore(source),
-            DeltaTableError::ParquetError { source } => DataFusionError::ParquetError(source),
+            DeltaTableError::Parquet { source } => DataFusionError::ParquetError(source),
             _ => DataFusionError::External(Box::new(err)),
         }
     }
@@ -63,10 +63,10 @@ impl From<DeltaTableError> for DataFusionError {
 impl From<DataFusionError> for crate::DeltaTableError {
     fn from(err: DataFusionError) -> Self {
         match err {
-            DataFusionError::ArrowError(source) => DeltaTableError::ArrowError { source },
+            DataFusionError::ArrowError(source) => DeltaTableError::Arrow { source },
             DataFusionError::IoError(source) => DeltaTableError::Io { source },
             DataFusionError::ObjectStore(source) => DeltaTableError::ObjectStore { source },
-            DataFusionError::ParquetError(source) => DeltaTableError::ParquetError { source },
+            DataFusionError::ParquetError(source) => DeltaTableError::Parquet { source },
             _ => DeltaTableError::Generic(err.to_string()),
         }
     }

--- a/rust/src/writer/utils.rs
+++ b/rust/src/writer/utils.rs
@@ -1,5 +1,6 @@
 //! Handle JSON messages when writing to delta tables
 use crate::writer::DeltaWriterError;
+use crate::DeltaTableError;
 use arrow::{
     array::{as_primitive_array, Array},
     datatypes::{
@@ -99,52 +100,17 @@ pub(crate) fn next_data_path(
     Ok(Path::from(format!("{}/{}", partition_key, file_name)))
 }
 
-/// partition json values
-pub fn divide_by_partition_values(
-    partition_columns: &[String],
-    records: Vec<Value>,
-) -> Result<HashMap<String, Vec<Value>>, DeltaWriterError> {
-    let mut partitioned_records: HashMap<String, Vec<Value>> = HashMap::new();
-
-    for record in records {
-        let partition_value = json_to_partition_values(partition_columns, &record)?;
-        match partitioned_records.get_mut(&partition_value) {
-            Some(vec) => vec.push(record),
-            None => {
-                partitioned_records.insert(partition_value, vec![record]);
-            }
-        };
-    }
-
-    Ok(partitioned_records)
-}
-
-fn json_to_partition_values(
-    partition_columns: &[String],
-    value: &Value,
-) -> Result<String, DeltaWriterError> {
-    if let Some(obj) = value.as_object() {
-        let key: Vec<String> = partition_columns
-            .iter()
-            .map(|c| obj.get(c).unwrap_or(&Value::Null).to_string())
-            .collect();
-        return Ok(key.join("/"));
-    }
-
-    Err(DeltaWriterError::InvalidRecord(value.to_string()))
-}
-
 /// Convert a vector of json values to a RecordBatch
 pub fn record_batch_from_message(
     arrow_schema: Arc<ArrowSchema>,
     message_buffer: &[Value],
-) -> Result<RecordBatch, DeltaWriterError> {
+) -> Result<RecordBatch, DeltaTableError> {
     let mut value_iter = message_buffer.iter().map(|j| Ok(j.to_owned()));
     let options = DecoderOptions::new().with_batch_size(message_buffer.len());
     let decoder = Decoder::new(arrow_schema, options);
     decoder
         .next_batch(&mut value_iter)?
-        .ok_or(DeltaWriterError::EmptyRecordBatch)
+        .ok_or_else(|| DeltaWriterError::EmptyRecordBatch.into())
 }
 
 // very naive implementation for plucking the partition value from the first element of a column array.

--- a/rust/tests/command_optimize.rs
+++ b/rust/tests/command_optimize.rs
@@ -1,7 +1,5 @@
 #[cfg(all(feature = "arrow", feature = "parquet"))]
 mod optimize {
-    extern crate deltalake;
-
     use arrow::datatypes::Schema as ArrowSchema;
     use arrow::{
         array::{Int32Array, StringArray},
@@ -9,7 +7,7 @@ mod optimize {
         record_batch::RecordBatch,
     };
     use deltalake::optimize::{MetricDetails, Metrics};
-    use deltalake::writer::DeltaWriterError;
+    use deltalake::DeltaTableError;
     use deltalake::{
         action,
         action::Remove,
@@ -216,7 +214,7 @@ mod optimize {
         writer: &mut RecordBatchWriter,
         mut table: &mut DeltaTable,
         batch: RecordBatch,
-    ) -> Result<(), DeltaWriterError> {
+    ) -> Result<(), DeltaTableError> {
         writer.write(batch).await?;
         writer.flush_and_commit(&mut table).await?;
         Ok(())


### PR DESCRIPTION
# Description

## Update

I have been working again on the high level writer APIs. Specifically how we use data fusion and trying to move towards a structure that can more easily integrate with other query backends. These changes are fairly well contained in the `operations` module, But they do include the changes here. While mostly cosmetic so far, I was hoping to merge this PR as is, as to make review in the follow ups easier.. Right now the main focus is to end up somewhere we we can finally finish #632. 

<hr/>

This in preparation to make a pass through the `RecordBatchWriter` and some convenience around loading partitioned tables,
Publishing this already to get some feedback on the general error handling approach.  I took the same approach in the updated file and s3 object stores. Essentially the idea would be that we aim to make all module specific error (in this case the `DeltaWriterError`) private to that crate and eventually expose a single error type that contains all error we expect users to take direct action on, and a Generic error type that transports all non-surfaces mod errors. The main motivation is to simplify error handling for consumers, as we have by now some quite nested scenarios ... 

I guess there are several other alternatives to avoid some of the nesting in errors, but I personally have grown to like that approach working on object_store, and seems to me that from all alternatives that come to my mind, this is the ones that we can most easily transition to from where we are.

cc @houqp @wjones127 

# Related Issue(s)

a step towaards #118

# Documentation

<!---
Share links to useful documentation
--->
