### PR TITLE
hotfix: python object store paths

### DIFF
--- a/python/deltalake/fs.py
+++ b/python/deltalake/fs.py
@@ -11,8 +11,13 @@ class DeltaStorageHandler(FileSystemHandler):
     DeltaStorageHander is a concrete implementations of a PyArrow FileSystemHandler.
     """
 
-    def __init__(self, table_uri: str) -> None:
-        self._storage = DeltaStorageFsBackend(table_uri)
+    def __init__(
+        self,
+        table_uri: str,
+        options: Optional[Dict[str, str]] = None,
+        backend: Any = None,
+    ) -> None:
+        self._storage = backend or DeltaStorageFsBackend(table_uri, options)
 
     def __eq__(self, other: Any) -> bool:
         return NotImplemented

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -87,6 +87,7 @@ class DeltaTable:
         :param version: version of the DeltaTable
         :param storage_options: a dictionary of the options to use for the storage backend
         """
+        self._storage_options = storage_options
         self._table = RawDeltaTable(
             table_uri, version=version, storage_options=storage_options
         )
@@ -292,7 +293,11 @@ class DeltaTable:
         """
         if not filesystem:
             filesystem = pa_fs.PyFileSystem(
-                DeltaStorageHandler(self._table.table_uri())
+                DeltaStorageHandler(
+                    self._table.table_uri(),
+                    self._storage_options,
+                    self._table.get_py_storage_backend(),
+                )
             )
 
         format = ParquetFileFormat(read_options=parquet_read_options)

--- a/python/tests/pyspark_integration/test_writer_readable.py
+++ b/python/tests/pyspark_integration/test_writer_readable.py
@@ -24,11 +24,12 @@ def get_spark():
             "org.apache.spark.sql.delta.catalog.DeltaCatalog",
         )
     )
-    return delta.configure_spark_with_delta_pip(builder).getOrCreate()
+    return delta.pip_utils.configure_spark_with_delta_pip(builder).getOrCreate()
 
 
 try:
     import delta
+    import delta.pip_utils
     import delta.tables
     import pyspark
 

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -366,6 +366,11 @@ impl StorageUrl {
         self.url.host_str()
     }
 
+    /// Returns the path prefix relative to location root
+    pub fn prefix(&self) -> Path {
+        self.prefix.clone()
+    }
+
     /// Returns this [`StorageUrl`] as a string
     pub fn as_str(&self) -> &str {
         self.as_ref()


### PR DESCRIPTION
# Description

After the migration to `object_store`, the pyarrow integration broke when using remote storages. The root cause is that paths are handled a bit differently by object_store, and these differences were not accounted for in all scenarios.

Specifically, when using the `DeltaStorageFsBackend`, we are passing in the full path including cloud prefixes - e.g. `s3://<bucket>/<path>`. Object store now expects paths relative the the object store root. For remote stores, the root is always the bucket level, for local it can be anywhere, but we make sure its always the file system root. (note the `DeltaObjectStore` wrapping the backend is always rooted in the table root).

Since recently we have a new struct `StorageUrl`, which encapsulates all the logic of url parsing specific to our object store.

While there is an effort to properly integrate storages, so we have seamless interop between delta-rs and the pyarrow world, spearheaded by @wjones127, I think we should deploy an hotfix, to remedy the immediate issues users are experiencing.

The following changes are included.

- We pass any string passed to `head_obj` and `get_obj` through the `StorageUrl` to extract the proper path for the storage backend. THe term prefix is admittedly misleading here :)
- When possible we create the Storage backend from the table, to have consistency in terms of storage options
- There is a (mostly redundant) Path to initialize the storage backend with options now, this is mainly useful for testing / experimentation.

P.S. for me the import of `configure_spark_with_delta_pip`, did not work, so updated it.

# Related Issue(s)

should close after feedback: #786,  #600, #778

# Documentation

<!---
Share links to useful documentation
--->
