### PR TITLE
prepare python release `0.6.1`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-11
-          - macOS-10.15
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,7 +56,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-11
-          - macOS-10.15
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -2,7 +2,7 @@ name: Release to PyPI
 
 on:
   push:
-    tags: [ 'python-v*' ]
+    tags: ["python-v*"]
 
 defaults:
   run:
@@ -30,12 +30,11 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macOS-10.15
           - macOS-11
           - windows-2019
         include:
           - target: x86_64-apple-darwin
-            os: macOS-10.15
+            os: macOS-11
           - target: aarch64-apple-darwin
             os: macOS-11
           - target: x86_64-pc-windows-msvc
@@ -58,64 +57,65 @@ jobs:
     name: PyPI release manylinux
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-        - name: Publish manylinux to pypi x86_64 (with sdist)
-          uses: messense/maturin-action@main
-          env:
-            MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          with:
-            target: x86_64-unknown-linux-gnu
-            command: publish
-            args: -m python/Cargo.toml
+      - name: Publish manylinux to pypi x86_64 (with sdist)
+        uses: messense/maturin-action@main
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        with:
+          target: x86_64-unknown-linux-gnu
+          command: publish
+          args: -m python/Cargo.toml
 
-        - name: Publish manylinux to pypi aarch64 (without sdist)
-          uses: messense/maturin-action@main
-          env:
-            MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          with:
-            target: aarch64-unknown-linux-gnu
-            command: publish
-            args: -m python/Cargo.toml --no-sdist
+      - name: Publish manylinux to pypi aarch64 (without sdist)
+        uses: messense/maturin-action@main
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        with:
+          target: aarch64-unknown-linux-gnu
+          command: publish
+          args: -m python/Cargo.toml --no-sdist
 
   release-docs:
-    needs: [validate-release-tag, release-pypi-manylinux, release-pypi-mac-windows]
+    needs:
+      [validate-release-tag, release-pypi-manylinux, release-pypi-mac-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0  # fetch full history for gh-pages branch checkout
-    - name: Install minimal stable with clippy and rustfmt
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: default
-        toolchain: stable
-        override: true
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # fetch full history for gh-pages branch checkout
+      - name: Install minimal stable with clippy and rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          override: true
 
-    - name: Build and install deltalake
-      run: |
-        make install MATURIN_EXTRA_ARGS="--manylinux off"
+      - name: Build and install deltalake
+        run: |
+          make install MATURIN_EXTRA_ARGS="--manylinux off"
 
-    - name: Build Sphinx documentation
-      run: |
-        make build-documentation
-        mv docs/build ~/build
+      - name: Build Sphinx documentation
+        run: |
+          make build-documentation
+          mv docs/build ~/build
 
-        echo "Configuring git..."
-        git config --global user.name 'Github Action'
-        git config --global user.email 'deltars@users.noreply.github.com'
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+          echo "Configuring git..."
+          git config --global user.name 'Github Action'
+          git config --global user.email 'deltars@users.noreply.github.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
 
-        echo "Commit to gh-pages branch..."
-        git reset --hard HEAD
-        git clean -d -fx .
-        git checkout gh-pages
-        cd ..
-        cp -avr ~/build/html/.  ./python
-        PUSHED_TAG=${GITHUB_REF##*/}
-        git status
-        git add ./python
-        git commit -m "doc update for tag `${PUSHED_TAG}`"
-        git push origin gh-pages
+          echo "Commit to gh-pages branch..."
+          git reset --hard HEAD
+          git clean -d -fx .
+          git checkout gh-pages
+          cd ..
+          cp -avr ~/build/html/.  ./python
+          PUSHED_TAG=${GITHUB_REF##*/}
+          git status
+          git add ./python
+          git commit -m "doc update for tag `${PUSHED_TAG}`"
+          git push origin gh-pages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,11 +685,11 @@ dependencies = [
 
 [[package]]
 name = "deltalake-python"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "deltalake",
- "env_logger 0.9.0",
+ "env_logger",
  "lazy_static",
  "pyo3",
  "regex",
@@ -803,20 +803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime 2.1.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -1170,12 +1157,6 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -2007,7 +1988,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "log",
 ]
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"

--- a/python/Makefile
+++ b/python/Makefile
@@ -2,7 +2,7 @@
 
 VENV := venv
 MATURIN_VERSION := $(shell awk -F '[ ="]+' '$$1 == "requires" { print $$4 }' pyproject.toml)
-PACKAGE_VERSION := $(shell cargo pkgid | cut -d\# -f2 | cut -d: -f2)
+PACKAGE_VERSION := $(shell grep version Cargo.toml | head -n 1 | awk '{print $$3}' | tr -d '"' )
 
 .PHONY: setup-venv
 setup-venv: ## Setup the virtualenv

--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -39,18 +39,18 @@ Configuration is defined for specific backends - `s3 options`_, `azure options`_
 The configuration can also be provided via the environment, and the basic service provider is derived from the URL
 being used. We try to support many of the well-known formats to identify basic service properties.
 
-__S3__:
+**S3**:
 
   * s3://<bucket>/<path>
   * s3a://<bucket>/<path>
 
-__Azure__:
+**Azure**:
 
   * az://<container>/<path>
   * adl://<container>/<path>
   * abfs://<container>/<path>
 
-__GCS__:
+**GCS**:
 
   * gs://<bucket>/<path>
 
@@ -70,18 +70,8 @@ For AWS Glue catalog, use AWS environment variables to authenticate.
     >>> dt.to_pyarrow_table().to_pydict()
     {'id': [5, 7, 9, 5, 6, 7, 8, 9]}
 
-Besides local filesystems, the following backends are supported:
-
-* AWS S3, detected by the prefix ``s3://``. AWS credentials can be specified using
-  environment variables in the same way as the CLI.
-* Azure Data Lake Storage Gen 2, detected by the prefix ``adls2://``. Note that
-  `specific instructions`_ must be followed to setup the Azure Storage Account.
-* Google Cloud Storage, detected by the prefix ``gs://``.
-
-.. _`specific instructions`: https://github.com/delta-io/delta-rs/blob/main/docs/ADLSGen2-HOWTO.md
 .. _`s3 options`: https://github.com/delta-io/delta-rs/blob/17999d24a58fb4c98c6280b9e57842c346b4603a/rust/src/builder.rs#L423-L491
 .. _`azure options`: https://github.com/delta-io/delta-rs/blob/17999d24a58fb4c98c6280b9e57842c346b4603a/rust/src/builder.rs#L524-L539
-
 
 Time Travel
 ~~~~~~~~~~~


### PR DESCRIPTION
# Description

Prepare the release of python version `0.6.1`, to mitigate the regression regarding path handling.
I tested it against real azure, azurite and localstack. Prettier made this PR a bit less pretty, but the following a re the relevant changes.

- update python version 
- remove macos-10.15 from test matrix, add macos-11
- update python makefile, since somehow version parsing broke, which in turn broke the docs build.
- update docs relating to table uris.

# Related Issue(s)

closes #785 (i guess we'll see in ci :) ... but i could repro and fix it locally)

# Documentation

<!---
Share links to useful documentation
--->
