### PR TITLE
feat: integrate `object_store` for read/write with pyarrow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "chrono",
  "deltalake",
  "env_logger",
+ "futures",
  "lazy_static",
  "pyo3",
  "regex",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -14,15 +14,17 @@ name = "deltalake"
 crate-type = ["cdylib"]
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread"] }
+chrono = "0"
 env_logger = "0"
+futures = "0.3"
+lazy_static = "1"
+regex = "1"
+serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread"] }
+
 # reqwest is pulled in by azure sdk, but not used by python binding itself
 # for binary wheel best practice, statically link openssl
 reqwest = { version = "*", features = ["native-tls-vendored"] }
-serde_json = "1"
-chrono = "0"
-regex = "1"
-lazy_static = "1"
 
 [dependencies.pyo3]
 version = "0.16"

--- a/python/deltalake/deltalake.pyi
+++ b/python/deltalake/deltalake.pyi
@@ -7,12 +7,12 @@ else:
     from typing_extensions import Literal
 
 import pyarrow as pa
+import pyarrow.fs as fs
 
 from deltalake.writer import AddAction
 
 RawDeltaTable: Any
 rust_core_version: Callable[[], str]
-DeltaStorageFsBackend: Any
 
 class PyDeltaTableError(BaseException): ...
 
@@ -113,3 +113,90 @@ class Schema:
     def to_pyarrow(self) -> pa.Schema: ...
     @staticmethod
     def from_pyarrow(type: pa.Schema) -> "Schema": ...
+
+class ObjectInputFile:
+    @property
+    def closed(self) -> bool: ...
+    @property
+    def mode(self) -> str: ...
+    def isatty(self) -> bool: ...
+    def readable(self) -> bool: ...
+    def seekable(self) -> bool: ...
+    def tell(self) -> int: ...
+    def size(self) -> int: ...
+    def seek(self, position: int, whence: int = 0) -> int: ...
+    def read(self, nbytes: int) -> bytes: ...
+
+class ObjectOutputStream:
+    @property
+    def closed(self) -> bool: ...
+    @property
+    def mode(self) -> str: ...
+    def isatty(self) -> bool: ...
+    def readable(self) -> bool: ...
+    def seekable(self) -> bool: ...
+    def writable(self) -> bool: ...
+    def tell(self) -> int: ...
+    def size(self) -> int: ...
+    def seek(self, position: int, whence: int = 0) -> int: ...
+    def read(self, nbytes: int) -> bytes: ...
+    def write(self, data: bytes) -> int: ...
+
+class DeltaFileSystemHandler:
+    """Implementation of pyarrow.fs.FileSystemHandler for use with pyarrow.fs.PyFileSystem"""
+
+    def __init__(self, root: str, options: dict[str, str] | None = None) -> None: ...
+    def get_type_name(self) -> str: ...
+    def copy_file(self, src: str, dst: str) -> None:
+        """Copy a file.
+
+        If the destination exists and is a directory, an error is returned. Otherwise, it is replaced.
+        """
+    def create_dir(self, path: str, recursive: bool = True) -> None:
+        """Create a directory and subdirectories.
+
+        This function succeeds if the directory already exists.
+        """
+    def delete_dir(self, path: str) -> None:
+        """Delete a directory and its contents, recursively."""
+    def delete_file(self, path: str) -> None:
+        """Delete a file."""
+    def equals(self, other) -> bool: ...
+    def delete_dir_contents(
+        self, path: str, *, accept_root_dir: bool = False, missing_dir_ok: bool = False
+    ) -> None:
+        """Delete a directory's contents, recursively.
+
+        Like delete_dir, but doesn't delete the directory itself.
+        """
+    def delete_root_dir_contents(self) -> None:
+        """Delete the root directory contents, recursively."""
+    def get_file_info(self, paths: list[str]) -> list[fs.FileInfo]:
+        """Get info for the given files.
+
+        A non-existing or unreachable file returns a FileStat object and has a FileType of value NotFound.
+        An exception indicates a truly exceptional condition (low-level I/O error, etc.).
+        """
+    def get_file_info_selector(
+        self, base_dir: str, allow_not_found: bool = False, recursive: bool = False
+    ) -> list[fs.FileInfo]:
+        """Get info for the given files.
+
+        A non-existing or unreachable file returns a FileStat object and has a FileType of value NotFound.
+        An exception indicates a truly exceptional condition (low-level I/O error, etc.).
+        """
+    def move_file(self, src: str, dest: str) -> None:
+        """Move / rename a file or directory.
+
+        If the destination exists: - if it is a non-empty directory, an error is returned - otherwise,
+        if it has the same type as the source, it is replaced - otherwise, behavior is
+        unspecified (implementation-dependent).
+        """
+    def normalize_path(self, path: str) -> str:
+        """Normalize filesystem path."""
+    def open_input_file(self, path: str) -> ObjectInputFile:
+        """Open an input file for random access reading."""
+    def open_output_stream(
+        self, path: str, metadata: dict[str, str] | None = None
+    ) -> ObjectOutputStream:
+        """Open an output stream for sequential writing."""

--- a/python/deltalake/deltalake.pyi
+++ b/python/deltalake/deltalake.pyi
@@ -161,7 +161,7 @@ class DeltaFileSystemHandler:
         """Delete a directory and its contents, recursively."""
     def delete_file(self, path: str) -> None:
         """Delete a file."""
-    def equals(self, other) -> bool: ...
+    def equals(self, other: Any) -> bool: ...
     def delete_dir_contents(
         self, path: str, *, accept_root_dir: bool = False, missing_dir_ok: bool = False
     ) -> None:

--- a/python/deltalake/fs.py
+++ b/python/deltalake/fs.py
@@ -15,7 +15,7 @@ class DeltaStorageHandler(FileSystemHandler):
         self,
         table_uri: str,
         options: Optional[Dict[str, str]] = None,
-        backend: Optional[DeltaFileSystemHandler] = None,
+        backend: Optional[Any] = None,
     ) -> None:
         self._storage = backend or DeltaFileSystemHandler(table_uri, options)
 
@@ -71,7 +71,7 @@ class DeltaStorageHandler(FileSystemHandler):
         :param path: The path of the new directory.
         :param recursive: Create nested directories as well.
         """
-        return self._storage.create_dir(path, recursive)
+        self._storage.create_dir(path, recursive)
 
     def delete_dir(self, path: str) -> None:
         """
@@ -79,7 +79,7 @@ class DeltaStorageHandler(FileSystemHandler):
 
         :param path: The path of the directory to be deleted.
         """
-        return self._storage.delete_dir(path)
+        self._storage.delete_dir(path)
 
     def delete_dir_contents(self, path: str) -> None:
         """
@@ -89,7 +89,7 @@ class DeltaStorageHandler(FileSystemHandler):
 
         :param path: The path of the directory to be deleted.
         """
-        return self._storage.delete_dir_contents(path)
+        self._storage.delete_dir_contents(path)
 
     def delete_root_dir_contents(self) -> None:
         """
@@ -97,7 +97,7 @@ class DeltaStorageHandler(FileSystemHandler):
 
         Like delete_dir_contents, but for the root directory (path is empty or “/”)
         """
-        return self._storage.delete_root_dir_contents()
+        self._storage.delete_root_dir_contents()
 
     def delete_file(self, path: str) -> None:
         """
@@ -105,7 +105,7 @@ class DeltaStorageHandler(FileSystemHandler):
 
         :param path: The path of the file to be deleted.
         """
-        return self._storage.delete_file(path)
+        self._storage.delete_file(path)
 
     def move(self, src: str, dest: str) -> None:
         """
@@ -118,7 +118,7 @@ class DeltaStorageHandler(FileSystemHandler):
         :param src: The path of the file or the directory to be moved.
         :param dest: The destination path where the file or directory is moved to.
         """
-        return self._storage.move_file(src, dest)
+        self._storage.move_file(src, dest)
 
     def copy_file(self, src: str, dest: str) -> None:
         """
@@ -130,7 +130,7 @@ class DeltaStorageHandler(FileSystemHandler):
         :param src: The path of the file to be copied from.
         :param dest: The destination path where the file is copied to.
         """
-        return self._storage.copy_file(src, dest)
+        self._storage.copy_file(src, dest)
 
     def open_input_stream(self, path: str) -> pa.NativeFile:
         """

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -156,7 +156,18 @@ def write_deltalake(
     __enforce_append_only(table=table, configuration=configuration, mode=mode)
 
     if filesystem is None:
-        filesystem = pa_fs.PyFileSystem(DeltaStorageHandler(table_uri, storage_options))
+        if table is not None:
+            filesystem = pa_fs.PyFileSystem(
+                DeltaStorageHandler(
+                    table._table.table_uri(),
+                    table._storage_options,
+                    table._table.get_py_storage_backend(),
+                )
+            )
+        else:
+            filesystem = pa_fs.PyFileSystem(
+                DeltaStorageHandler(table_uri, storage_options)
+            )
 
     if table:  # already exists
         if schema != table.schema().to_pyarrow() and not (

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -206,7 +206,7 @@ def write_deltalake(
         if PYARROW_MAJOR_VERSION >= 9:
             size = written_file.size
         else:
-            size = filesystem.get_file_info([path])[0].size
+            size = filesystem.get_file_info([path])[0].size  # type: ignore
 
         add_actions.append(
             AddAction(

--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -73,6 +73,43 @@ For AWS Glue catalog, use AWS environment variables to authenticate.
 .. _`s3 options`: https://github.com/delta-io/delta-rs/blob/17999d24a58fb4c98c6280b9e57842c346b4603a/rust/src/builder.rs#L423-L491
 .. _`azure options`: https://github.com/delta-io/delta-rs/blob/17999d24a58fb4c98c6280b9e57842c346b4603a/rust/src/builder.rs#L524-L539
 
+Custom Storage Backends
+~~~~~~~~~~~~~~~~~~~~~~~
+
+While delta always needs its internal storage backend to work and be properly configured, in order to manage the delta log,
+it may sometime be advantageous - and is common practice in the arrow world - to customize the storage interface used for
+reading the bulk data. 
+
+`deltalake` will work with any storage compliant with `pyarrow.fs.FileSystem`, however the root of the filesystem has
+to be adjusted to point at the root of the Delta table. We can achieve this by wrapping the custom filesystem into
+a `pyarrow.fs.SubTreeFileSystem`.
+
+.. code-block:: python
+
+    import pyarrow.fs as fs
+    from deltalake import DeltaTable
+    
+    path = "<path/to/table>"
+    filesystem = fs.SubTreeFileSystem(path, fs.LocalFileSystem())
+    
+    dt = DeltaTable(path)
+    ds = dt.to_pyarrow_dataset(filesystem=filesystem)
+
+When using the pyarrow factory method for file systems, the normalized path is provided
+on creation. In case of S3 this would look something like.
+
+.. code-block:: python
+
+    import pyarrow.fs as fs
+    from deltalake import DeltaTable
+
+    table_uri = "s3://<bucket>/<path>"
+    raw_fs, normalized_path = fs.FileSystem.from_uri(table_uri)
+    filesystem = fs.SubTreeFileSystem(normalized_path, raw_fs)
+
+    dt = DeltaTable(table_uri)
+    ds = dt.to_pyarrow_dataset(filesystem=filesystem)
+
 Time Travel
 ~~~~~~~~~~~
 

--- a/python/src/filesystem.rs
+++ b/python/src/filesystem.rs
@@ -36,7 +36,7 @@ impl DeltaFileSystemHandler {
     fn normalize_path(&self, path: String) -> PyResult<String> {
         let suffix = if path.ends_with('/') { "/" } else { "" };
         let path = Path::parse(path).unwrap();
-        Ok(format!("{}{}", path.to_string(), suffix))
+        Ok(format!("{}{}", path, suffix))
     }
 
     fn copy_file(&self, src: String, dest: String, py: Python) -> PyResult<()> {

--- a/python/src/filesystem.rs
+++ b/python/src/filesystem.rs
@@ -1,0 +1,527 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::utils::{delete_dir, wait_for_future, walk_tree};
+use crate::PyDeltaTableError;
+
+use deltalake::storage::{DynObjectStore, ListResult, MultipartId, ObjectStoreError, Path};
+use deltalake::DeltaTableBuilder;
+use pyo3::exceptions::{PyIOError, PyNotImplementedError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{IntoPyDict, PyBytes};
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+#[pyclass(subclass)]
+#[derive(Debug, Clone)]
+pub struct DeltaFileSystemHandler {
+    pub(crate) inner: Arc<DynObjectStore>,
+}
+
+#[pymethods]
+impl DeltaFileSystemHandler {
+    #[new]
+    #[args(options = "None")]
+    fn new(table_uri: &str, options: Option<HashMap<String, String>>) -> PyResult<Self> {
+        let storage = DeltaTableBuilder::from_uri(table_uri)
+            .with_storage_options(options.unwrap_or_default())
+            .build_storage()
+            .map_err(PyDeltaTableError::from_raw)?;
+        Ok(Self { inner: storage })
+    }
+
+    fn get_type_name(&self) -> String {
+        "object-store".into()
+    }
+
+    fn normalize_path(&self, path: String) -> PyResult<String> {
+        let suffix = if path.ends_with('/') { "/" } else { "" };
+        let path = Path::parse(path).unwrap();
+        Ok(format!("{}{}", path.to_string(), suffix))
+    }
+
+    fn copy_file(&self, src: String, dest: String, py: Python) -> PyResult<()> {
+        let from_path = Path::from(src);
+        let to_path = Path::from(dest);
+        wait_for_future(py, self.inner.copy(&from_path, &to_path))
+            .map_err(PyDeltaTableError::from_object_store)?;
+        Ok(())
+    }
+
+    fn create_dir(&self, _path: String, _recursive: bool) -> PyResult<()> {
+        // TODO creating a dir should be a no-op with object_store, right?
+        Ok(())
+    }
+
+    fn delete_dir(&self, path: String, py: Python) -> PyResult<()> {
+        let path = Path::from(path);
+        wait_for_future(py, delete_dir(self.inner.as_ref(), &path))
+            .map_err(PyDeltaTableError::from_object_store)?;
+        Ok(())
+    }
+
+    fn delete_file(&self, path: String, py: Python) -> PyResult<()> {
+        let path = Path::from(path);
+        wait_for_future(py, self.inner.delete(&path))
+            .map_err(PyDeltaTableError::from_object_store)?;
+        Ok(())
+    }
+
+    fn equals(&self, other: &DeltaFileSystemHandler) -> PyResult<bool> {
+        Ok(format!("{:?}", self) == format!("{:?}", other))
+    }
+
+    fn get_file_info<'py>(&self, paths: Vec<String>, py: Python<'py>) -> PyResult<Vec<&'py PyAny>> {
+        let fs = PyModule::import(py, "pyarrow.fs")?;
+        let file_types = fs.getattr("FileType")?;
+
+        let to_file_info = |loc: String, type_: &PyAny, kwargs: HashMap<&str, i64>| {
+            fs.call_method("FileInfo", (loc, type_), Some(kwargs.into_py_dict(py)))
+        };
+
+        let mut infos = Vec::new();
+        for file_path in paths {
+            let path = Path::from(file_path);
+            let listed = wait_for_future(py, self.inner.list_with_delimiter(Some(&path)))
+                .map_err(PyDeltaTableError::from_object_store)?;
+
+            // TODO is there a better way to figure out if we are in a directory?
+            if listed.objects.is_empty() && listed.common_prefixes.is_empty() {
+                let maybe_meta = wait_for_future(py, self.inner.head(&path));
+                match maybe_meta {
+                    Ok(meta) => {
+                        let kwargs = HashMap::from([
+                            ("size", meta.size as i64),
+                            ("mtime_ns", meta.last_modified.timestamp_nanos()),
+                        ]);
+                        infos.push(to_file_info(
+                            meta.location.to_string(),
+                            file_types.getattr("File")?,
+                            kwargs,
+                        )?);
+                    }
+                    Err(ObjectStoreError::NotFound { .. }) => {
+                        infos.push(to_file_info(
+                            path.to_string(),
+                            file_types.getattr("NotFound")?,
+                            HashMap::new(),
+                        )?);
+                    }
+                    Err(err) => {
+                        return Err(PyDeltaTableError::from_object_store(err));
+                    }
+                }
+            } else {
+                infos.push(to_file_info(
+                    path.to_string(),
+                    file_types.getattr("Directory")?,
+                    HashMap::new(),
+                )?);
+            }
+        }
+
+        Ok(infos)
+    }
+
+    #[args(allow_not_found = "false", recursive = "false")]
+    fn get_file_info_selector<'py>(
+        &self,
+        base_dir: String,
+        allow_not_found: bool,
+        recursive: bool,
+        py: Python<'py>,
+    ) -> PyResult<Vec<&'py PyAny>> {
+        let fs = PyModule::import(py, "pyarrow.fs")?;
+        let file_types = fs.getattr("FileType")?;
+
+        let to_file_info = |loc: String, type_: &PyAny, kwargs: HashMap<&str, i64>| {
+            fs.call_method("FileInfo", (loc, type_), Some(kwargs.into_py_dict(py)))
+        };
+
+        let path = Path::from(base_dir);
+        let list_result =
+            match wait_for_future(py, walk_tree(self.inner.clone(), &path, recursive)) {
+                Ok(res) => Ok(res),
+                Err(ObjectStoreError::NotFound { path, source }) => {
+                    if allow_not_found {
+                        Ok(ListResult {
+                            common_prefixes: vec![],
+                            objects: vec![],
+                        })
+                    } else {
+                        Err(ObjectStoreError::NotFound { path, source })
+                    }
+                }
+                Err(err) => Err(err),
+            }
+            .map_err(PyDeltaTableError::from_object_store)?;
+
+        let mut infos = vec![];
+        infos.extend(
+            list_result
+                .common_prefixes
+                .into_iter()
+                .map(|p| {
+                    to_file_info(
+                        p.to_string(),
+                        file_types.getattr("Directory")?,
+                        HashMap::new(),
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+        infos.extend(
+            list_result
+                .objects
+                .into_iter()
+                .map(|meta| {
+                    let kwargs = HashMap::from([
+                        ("size", meta.size as i64),
+                        ("mtime_ns", meta.last_modified.timestamp_nanos()),
+                    ]);
+                    to_file_info(
+                        meta.location.to_string(),
+                        file_types.getattr("File")?,
+                        kwargs,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+
+        Ok(infos)
+    }
+
+    fn move_file(&self, src: String, dest: String, py: Python) -> PyResult<()> {
+        let from_path = Path::from(src);
+        let to_path = Path::from(dest);
+        // TODO check the if not exists semantics
+        wait_for_future(py, self.inner.rename(&from_path, &to_path))
+            .map_err(PyDeltaTableError::from_object_store)?;
+        Ok(())
+    }
+
+    fn open_input_file(&self, path: String, py: Python) -> PyResult<ObjectInputFile> {
+        let path = Path::from(path);
+        let file = wait_for_future(py, ObjectInputFile::try_new(self.inner.clone(), path))
+            .map_err(PyDeltaTableError::from_object_store)?;
+        Ok(file)
+    }
+
+    #[args(metadata = "None")]
+    fn open_output_stream(
+        &self,
+        path: String,
+        #[allow(unused)] metadata: Option<HashMap<String, String>>,
+        py: Python,
+    ) -> PyResult<ObjectOutputStream> {
+        let path = Path::from(path);
+        let file = wait_for_future(py, ObjectOutputStream::try_new(self.inner.clone(), path))
+            .map_err(PyDeltaTableError::from_object_store)?;
+        Ok(file)
+    }
+}
+
+// TODO the C++ implementation track an internal lock on all random access files, DO we need this here?
+// TODO add buffer to store data ...
+#[pyclass(weakref)]
+#[derive(Debug, Clone)]
+pub struct ObjectInputFile {
+    store: Arc<DynObjectStore>,
+    path: Path,
+    content_length: i64,
+    #[pyo3(get)]
+    closed: bool,
+    pos: i64,
+    #[pyo3(get)]
+    mode: String,
+}
+
+impl ObjectInputFile {
+    pub async fn try_new(store: Arc<DynObjectStore>, path: Path) -> Result<Self, ObjectStoreError> {
+        // Issue a HEAD Object to get the content-length and ensure any
+        // errors (e.g. file not found) don't wait until the first read() call.
+        let meta = store.head(&path).await?;
+        let content_length = meta.size as i64;
+        // TODO make sure content length is valid
+        // https://github.com/apache/arrow/blob/f184255cbb9bf911ea2a04910f711e1a924b12b8/cpp/src/arrow/filesystem/s3fs.cc#L1083
+        Ok(Self {
+            store,
+            path,
+            content_length,
+            closed: false,
+            pos: 0,
+            mode: "rb".into(),
+        })
+    }
+
+    fn check_closed(&self) -> PyResult<()> {
+        if self.closed {
+            return Err(PyIOError::new_err("Operation on closed stream"));
+        }
+
+        Ok(())
+    }
+
+    fn check_position(&self, position: i64, action: &str) -> PyResult<()> {
+        if position < 0 {
+            return Err(PyIOError::new_err(format!(
+                "Cannot {} for negative position.",
+                action
+            )));
+        }
+        if position > self.content_length {
+            return Err(PyIOError::new_err(format!(
+                "Cannot {} past end of file.",
+                action
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[pymethods]
+impl ObjectInputFile {
+    fn close(&mut self) -> PyResult<()> {
+        self.closed = true;
+        Ok(())
+    }
+
+    fn isatty(&self) -> PyResult<bool> {
+        Ok(false)
+    }
+
+    fn readable(&self) -> PyResult<bool> {
+        Ok(true)
+    }
+
+    fn seekable(&self) -> PyResult<bool> {
+        Ok(true)
+    }
+
+    fn writable(&self) -> PyResult<bool> {
+        Ok(false)
+    }
+
+    fn tell(&self) -> PyResult<i64> {
+        self.check_closed()?;
+        Ok(self.pos)
+    }
+
+    fn size(&self) -> PyResult<i64> {
+        self.check_closed()?;
+        Ok(self.content_length)
+    }
+
+    #[args(whence = "0")]
+    fn seek(&mut self, offset: i64, whence: i64) -> PyResult<i64> {
+        self.check_closed()?;
+        self.check_position(offset, "seek")?;
+        match whence {
+            // reference is start of the stream (the default); offset should be zero or positive
+            0 => {
+                self.pos = offset;
+            }
+            // reference is current stream position; offset may be negative
+            1 => {
+                self.pos += offset;
+            }
+            // reference is  end of the stream; offset is usually negative
+            2 => {
+                self.pos = self.content_length as i64 - offset;
+            }
+            _ => {
+                return Err(PyValueError::new_err(
+                    "'whence' must be between  0 <= whence <= 2.",
+                ));
+            }
+        }
+        Ok(self.pos)
+    }
+
+    #[args(nbytes = "None")]
+    fn read<'py>(&mut self, nbytes: Option<i64>, py: Python<'py>) -> PyResult<&'py PyBytes> {
+        self.check_closed()?;
+        let range = match nbytes {
+            Some(len) => {
+                let end = i64::min(self.pos + len, self.content_length) as usize;
+                std::ops::Range {
+                    start: self.pos as usize,
+                    end,
+                }
+            }
+            _ => std::ops::Range {
+                start: self.pos as usize,
+                end: self.content_length as usize,
+            },
+        };
+        let nbytes = (range.end - range.start) as i64;
+        self.pos += nbytes;
+        let obj = if nbytes > 0 {
+            wait_for_future(py, self.store.get_range(&self.path, range))
+                .map_err(PyDeltaTableError::from_object_store)?
+                .to_vec()
+        } else {
+            Vec::new()
+        };
+        Ok(PyBytes::new(py, &obj))
+    }
+
+    fn fileno(&self) -> PyResult<()> {
+        Err(PyNotImplementedError::new_err("'fileno' not implemented"))
+    }
+
+    fn truncate(&self) -> PyResult<()> {
+        Err(PyNotImplementedError::new_err("'truncate' not implemented"))
+    }
+
+    fn readline(&self, _size: Option<i64>) -> PyResult<()> {
+        Err(PyNotImplementedError::new_err("'readline' not implemented"))
+    }
+
+    fn readlines(&self, _hint: Option<i64>) -> PyResult<()> {
+        Err(PyNotImplementedError::new_err(
+            "'readlines' not implemented",
+        ))
+    }
+}
+
+// TODO the C++ implementation track an internal lock on all random access files, DO we need this here?
+// TODO add buffer to store data ...
+#[pyclass(weakref)]
+pub struct ObjectOutputStream {
+    store: Arc<DynObjectStore>,
+    path: Path,
+    writer: Box<dyn AsyncWrite + Send + Unpin>,
+    multipart_id: MultipartId,
+    pos: i64,
+    #[pyo3(get)]
+    closed: bool,
+    #[pyo3(get)]
+    mode: String,
+}
+
+impl ObjectOutputStream {
+    pub async fn try_new(store: Arc<DynObjectStore>, path: Path) -> Result<Self, ObjectStoreError> {
+        let (multipart_id, writer) = store.put_multipart(&path).await.unwrap();
+        Ok(Self {
+            store,
+            path,
+            writer,
+            multipart_id,
+            pos: 0,
+            closed: false,
+            mode: "wb".into(),
+        })
+    }
+
+    fn check_closed(&self) -> PyResult<()> {
+        if self.closed {
+            return Err(PyIOError::new_err("Operation on closed stream"));
+        }
+
+        Ok(())
+    }
+}
+
+#[pymethods]
+impl ObjectOutputStream {
+    fn close(&mut self, py: Python) -> PyResult<()> {
+        self.closed = true;
+        match wait_for_future(py, self.writer.shutdown()) {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                wait_for_future(
+                    py,
+                    self.store.abort_multipart(&self.path, &self.multipart_id),
+                )
+                .map_err(PyDeltaTableError::from_object_store)?;
+                Err(PyDeltaTableError::from_io(err))
+            }
+        }
+    }
+
+    fn isatty(&self) -> PyResult<bool> {
+        Ok(false)
+    }
+
+    fn readable(&self) -> PyResult<bool> {
+        Ok(false)
+    }
+
+    fn seekable(&self) -> PyResult<bool> {
+        Ok(false)
+    }
+
+    fn writable(&self) -> PyResult<bool> {
+        Ok(true)
+    }
+
+    fn tell(&self) -> PyResult<i64> {
+        self.check_closed()?;
+        Ok(self.pos)
+    }
+
+    fn size(&self) -> PyResult<i64> {
+        self.check_closed()?;
+        Err(PyNotImplementedError::new_err("'size' not implemented"))
+    }
+
+    #[args(whence = "0")]
+    fn seek(&mut self, _offset: i64, _whence: i64) -> PyResult<i64> {
+        self.check_closed()?;
+        Err(PyNotImplementedError::new_err("'seek' not implemented"))
+    }
+
+    #[args(nbytes = "None")]
+    fn read(&mut self, _nbytes: Option<i64>) -> PyResult<()> {
+        self.check_closed()?;
+        Err(PyNotImplementedError::new_err("'read' not implemented"))
+    }
+
+    fn write(&mut self, data: Vec<u8>, py: Python) -> PyResult<i64> {
+        self.check_closed()?;
+        let len = data.len() as i64;
+        match wait_for_future(py, self.writer.write_all(&data)) {
+            Ok(_) => Ok(len),
+            Err(err) => {
+                wait_for_future(
+                    py,
+                    self.store.abort_multipart(&self.path, &self.multipart_id),
+                )
+                .map_err(PyDeltaTableError::from_object_store)?;
+                Err(PyDeltaTableError::from_io(err))
+            }
+        }
+    }
+
+    fn flush(&mut self, py: Python) -> PyResult<()> {
+        match wait_for_future(py, self.writer.flush()) {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                wait_for_future(
+                    py,
+                    self.store.abort_multipart(&self.path, &self.multipart_id),
+                )
+                .map_err(PyDeltaTableError::from_object_store)?;
+                Err(PyDeltaTableError::from_io(err))
+            }
+        }
+    }
+
+    fn fileno(&self) -> PyResult<()> {
+        Err(PyNotImplementedError::new_err("'fileno' not implemented"))
+    }
+
+    fn truncate(&self) -> PyResult<()> {
+        Err(PyNotImplementedError::new_err("'truncate' not implemented"))
+    }
+
+    fn readline(&self, _size: Option<i64>) -> PyResult<()> {
+        Err(PyNotImplementedError::new_err("'readline' not implemented"))
+    }
+
+    fn readlines(&self, _hint: Option<i64>) -> PyResult<()> {
+        Err(PyNotImplementedError::new_err(
+            "'readlines' not implemented",
+        ))
+    }
+}

--- a/python/src/filesystem.rs
+++ b/python/src/filesystem.rs
@@ -326,7 +326,7 @@ impl ObjectInputFile {
             }
             // reference is  end of the stream; offset is usually negative
             2 => {
-                self.pos = self.content_length as i64 - offset;
+                self.pos = self.content_length as i64 + offset;
             }
             _ => {
                 return Err(PyValueError::new_err(

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -1,6 +1,5 @@
 extern crate pyo3;
 
-use crate::pyo3::types::IntoPyDict;
 use deltalake::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
 };
@@ -11,6 +10,7 @@ use deltalake::schema::{
 use lazy_static::lazy_static;
 use pyo3::exceptions::{PyException, PyNotImplementedError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::types::IntoPyDict;
 use pyo3::{PyRef, PyResult};
 use regex::Regex;
 use std::collections::HashMap;

--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -1,0 +1,88 @@
+use std::future::Future;
+use std::sync::Arc;
+
+use deltalake::storage::{ListResult, ObjectStore, ObjectStoreError, ObjectStoreResult, Path};
+use futures::future::{join_all, BoxFuture, FutureExt};
+use futures::StreamExt;
+use pyo3::prelude::*;
+use tokio::runtime::Runtime;
+
+/// Utility to collect rust futures with GIL released
+pub fn wait_for_future<F: Future>(py: Python, f: F) -> F::Output
+where
+    F: Send,
+    F::Output: Send,
+{
+    let rt = Runtime::new().unwrap();
+    py.allow_threads(|| rt.block_on(f))
+}
+
+/// walk the "directory" tree along common prefixes in object store
+pub async fn walk_tree(
+    storage: Arc<dyn ObjectStore>,
+    path: &Path,
+    recursive: bool,
+) -> ObjectStoreResult<ListResult> {
+    list_with_delimiter_recursive(storage, [path.clone()], recursive).await
+}
+
+fn list_with_delimiter_recursive(
+    storage: Arc<dyn ObjectStore>,
+    paths: impl IntoIterator<Item = Path>,
+    recursive: bool,
+) -> BoxFuture<'static, ObjectStoreResult<ListResult>> {
+    let mut tasks = vec![];
+    for path in paths {
+        let store = storage.clone();
+        let prefix = path.clone();
+        let handle =
+            tokio::task::spawn(async move { store.list_with_delimiter(Some(&prefix)).await });
+        tasks.push(handle);
+    }
+
+    async move {
+        let mut results = join_all(tasks)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| ObjectStoreError::JoinError { source: err })?
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .fold(
+                ListResult {
+                    common_prefixes: vec![],
+                    objects: vec![],
+                },
+                |mut acc, res| {
+                    acc.common_prefixes.extend(res.common_prefixes);
+                    acc.objects.extend(res.objects);
+                    acc
+                },
+            );
+
+        if recursive && !results.common_prefixes.is_empty() {
+            let more_result = list_with_delimiter_recursive(
+                storage.clone(),
+                results.common_prefixes.clone(),
+                recursive,
+            )
+            .await?;
+            results.common_prefixes.extend(more_result.common_prefixes);
+            results.objects.extend(more_result.objects);
+        }
+
+        Ok(results)
+    }
+    .boxed()
+}
+
+pub async fn delete_dir(storage: &dyn ObjectStore, prefix: &Path) -> ObjectStoreResult<()> {
+    // TODO batch delete would be really useful now...
+    let mut stream = storage.list(Some(prefix)).await?;
+    while let Some(maybe_meta) = stream.next().await {
+        let meta = maybe_meta?;
+        storage.delete(&meta.location).await?;
+    }
+    Ok(())
+}

--- a/python/stubs/pyarrow/__init__.pyi
+++ b/python/stubs/pyarrow/__init__.pyi
@@ -25,3 +25,4 @@ float64: Any
 py_buffer: Callable[[bytes], Any]
 NativeFile: Any
 BufferReader: Any
+PythonFile: Any

--- a/python/tests/test_file_system_handler.py
+++ b/python/tests/test_file_system_handler.py
@@ -1,0 +1,169 @@
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.dataset as ds
+import pyarrow.fs as fs
+import pyarrow.parquet as pq
+import pytest
+
+from deltalake.fs import DeltaStorageHandler
+
+
+@pytest.fixture
+def file_systems(tmp_path: Path):
+    store = fs.PyFileSystem(DeltaStorageHandler(str(tmp_path.absolute())))
+    arrow_fs = fs.SubTreeFileSystem(str(tmp_path.absolute()), fs.LocalFileSystem())
+    return (store, arrow_fs)
+
+
+@pytest.fixture
+def table_data():
+    return pa.Table.from_arrays(
+        [pa.array([1, 2, 3]), pa.array(["a", "b", "c"])], names=["int", "str"]
+    )
+
+
+def test_file_info(file_systems, table_data):
+    store, arrow_fs = file_systems
+    file_path = "table.parquet"
+
+    pq.write_table(table_data, file_path, filesystem=arrow_fs)
+
+    info = store.get_file_info(file_path)
+    arrow_info = arrow_fs.get_file_info(file_path)
+
+    assert type(info) == type(arrow_info)
+    assert info.path == arrow_info.path
+    assert info.type == arrow_info.type
+    assert info.size == arrow_info.size
+    assert info.mtime_ns == arrow_info.mtime_ns
+    assert info.mtime == arrow_info.mtime
+
+
+def test_get_file_info_selector(file_systems):
+    store, arrow_fs = file_systems
+    table = pa.table({"a": range(10), "b": np.random.randn(10), "c": [1, 2] * 5})
+    partitioning = ds.partitioning(pa.schema([("c", pa.int64())]), flavor="hive")
+    ds.write_dataset(
+        table,
+        "/",
+        partitioning=partitioning,
+        format="parquet",
+        filesystem=arrow_fs,
+    )
+
+    selector = fs.FileSelector("/", recursive=True)
+    infos = store.get_file_info(selector)
+    arrow_infos = arrow_fs.get_file_info(selector)
+
+    assert Counter([i.type for i in infos]) == Counter([i.type for i in arrow_infos])
+
+
+def test_open_input_file(file_systems, table_data):
+    store, arrow_fs = file_systems
+    file_path = "table.parquet"
+
+    pq.write_table(table_data, file_path, filesystem=arrow_fs)
+
+    file = store.open_input_file(file_path)
+    arrow_file = arrow_fs.open_input_file(file_path)
+
+    # Check the metadata
+    assert file.mode == arrow_file.mode
+    assert file.closed == arrow_file.closed
+    assert file.size() == arrow_file.size()
+    assert file.isatty() == arrow_file.isatty()
+    assert file.readable() == arrow_file.readable()
+    assert file.seekable() == arrow_file.seekable()
+
+    # Check reading the same content
+    assert file.read() == arrow_file.read()
+    # Check subsequent read (should return no data anymore)
+    assert file.read() == arrow_file.read()
+    assert file.read() == b""
+
+    file = store.open_input_file(file_path)
+    arrow_file = arrow_fs.open_input_file(file_path)
+
+    # Check seeking works as expected
+    assert file.tell() == arrow_file.tell()
+    assert file.seek(2) == arrow_file.seek(2)
+    assert file.tell() == arrow_file.tell()
+    assert file.tell() == 2
+
+    # check reading works as expected
+    assert file.read(10) == arrow_file.read(10)
+    assert file.read1(10) == arrow_file.read1(10)
+    assert file.read_at(10, 0) == arrow_file.read_at(10, 0)
+
+
+def test_read_table(file_systems, table_data):
+    store, arrow_fs = file_systems
+    file_path = "table.parquet"
+
+    pq.write_table(table_data, file_path, filesystem=arrow_fs)
+
+    table = pq.read_table(file_path, filesystem=store)
+    arrow_table = pq.read_table(file_path, filesystem=arrow_fs)
+
+    assert isinstance(table, pa.Table)
+    assert table.equals(arrow_table)
+
+
+def test_read_dataset(file_systems):
+    store, arrow_fs = file_systems
+    table = pa.table({"a": range(10), "b": np.random.randn(10), "c": [1, 2] * 5})
+
+    pq.write_table(table.slice(0, 5), "data1.parquet", filesystem=arrow_fs)
+    pq.write_table(table.slice(5, 10), "data2.parquet", filesystem=arrow_fs)
+
+    dataset = ds.dataset("/", format="parquet", filesystem=store)
+    ds_table = dataset.to_table()
+
+    assert table.schema == dataset.schema
+    assert table.equals(ds_table)
+
+
+def test_write_table(file_systems):
+    store, _ = file_systems
+    table = pa.table({"a": range(10), "b": np.random.randn(10), "c": [1, 2] * 5})
+
+    pq.write_table(table.slice(0, 5), "data1.parquet", filesystem=store)
+    pq.write_table(table.slice(5, 10), "data2.parquet", filesystem=store)
+
+    dataset = ds.dataset("/", format="parquet", filesystem=store)
+    ds_table = dataset.to_table()
+
+    assert table.schema == ds_table.schema
+    assert table.equals(ds_table)
+
+
+def test_write_partitioned_dataset(file_systems):
+    store, arrow_fs = file_systems
+    table = pa.table({"a": range(10), "b": np.random.randn(10), "c": [1, 2] * 5})
+
+    partitioning = ds.partitioning(pa.schema([("c", pa.int64())]), flavor="hive")
+    ds.write_dataset(
+        table,
+        "/",
+        partitioning=partitioning,
+        format="parquet",
+        filesystem=store,
+    )
+
+    dataset = ds.dataset(
+        "/", format="parquet", filesystem=arrow_fs, partitioning=partitioning
+    )
+    ds_table = dataset.to_table().select(["a", "b", "c"])
+
+    dataset = ds.dataset(
+        "/", format="parquet", filesystem=store, partitioning=partitioning
+    )
+    ds_table2 = dataset.to_table().select(["a", "b", "c"])
+
+    assert table.schema == ds_table.schema
+    assert table.schema == ds_table2.schema
+    assert table.shape == ds_table.shape
+    assert table.shape == ds_table2.shape

--- a/python/tests/test_fs.py
+++ b/python/tests/test_fs.py
@@ -3,15 +3,7 @@ import pyarrow.parquet as pq
 import pytest
 
 from deltalake import DeltaTable
-from deltalake.deltalake import DeltaStorageFsBackend
 from deltalake.fs import DeltaStorageHandler
-
-
-def test_normalize_path():
-    backend = DeltaStorageFsBackend(".")
-    assert backend.normalize_path("s3://foo/bar") == "s3://foo/bar"
-    assert backend.normalize_path("s3://foo/bar/") == "s3://foo/bar"
-    assert backend.normalize_path("/foo/bar//") == "/foo/bar"
 
 
 @pytest.mark.s3

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -16,7 +16,7 @@ import pyarrow as pa
 import pyarrow.dataset as ds
 import pytest
 from pyarrow.dataset import ParquetReadOptions
-from pyarrow.fs import LocalFileSystem
+from pyarrow.fs import LocalFileSystem, SubTreeFileSystem
 
 from deltalake import DeltaTable
 
@@ -250,32 +250,32 @@ def test_get_files_partitioned_table():
     ).as_posix()
     partition_filters = [("day", "=", "3")]
     assert dt.files_by_partitions(partition_filters=partition_filters) == [
-        f"{table_path}/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet"
+        f"year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet"
     ]
     partition_filters = [("day", "!=", "3")]
     assert dt.files_by_partitions(partition_filters=partition_filters) == [
-        f"{table_path}/year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet",
-        f"{table_path}/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet",
-        f"{table_path}/year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet",
-        f"{table_path}/year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet",
-        f"{table_path}/year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet",
+        f"year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet",
+        f"year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet",
+        f"year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet",
+        f"year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet",
+        f"year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet",
     ]
     partition_filters = [("day", "in", ["3", "20"])]
     assert dt.files_by_partitions(partition_filters=partition_filters) == [
-        f"{table_path}/year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet",
-        f"{table_path}/year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet",
+        f"year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet",
+        f"year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet",
     ]
     partition_filters = [("day", "not in", ["3", "20"])]
     assert dt.files_by_partitions(partition_filters=partition_filters) == [
-        f"{table_path}/year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet",
-        f"{table_path}/year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet",
-        f"{table_path}/year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet",
-        f"{table_path}/year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet",
+        f"year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet",
+        f"year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet",
+        f"year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet",
+        f"year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet",
     ]
     partition_filters = [("day", "not in", ["3", "20"]), ("year", "=", "2021")]
     assert dt.files_by_partitions(partition_filters=partition_filters) == [
-        f"{table_path}/year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet",
-        f"{table_path}/year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet",
+        f"year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet",
+        f"year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet",
     ]
     partition_filters = [("invalid_operation", "=>", "3")]
     with pytest.raises(Exception) as exception:
@@ -321,7 +321,7 @@ def test_delta_table_to_pandas():
 def test_delta_table_with_filesystem():
     table_path = "../rust/tests/data/simple_table"
     dt = DeltaTable(table_path)
-    filesystem = LocalFileSystem()
+    filesystem = SubTreeFileSystem(table_path, LocalFileSystem())
     assert dt.to_pandas(filesystem=filesystem).equals(pd.DataFrame({"id": [5, 7, 9]}))
 
 

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -10,7 +10,7 @@ use crate::builder::StorageUrl;
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use lazy_static::lazy_static;
-use object_store::{
+pub use object_store::{
     path::{Path, DELIMITER},
     DynObjectStore, Error as ObjectStoreError, GetResult, ListResult, MultipartId, ObjectMeta,
     ObjectStore, Result as ObjectStoreResult,


### PR DESCRIPTION
# Description

This PR embraces the object store crate also on the python side and at least for the current test base supports reading and writing using the dataset and other pyarrow APIs. Thanks to @wjones127 's mutipart upload in object_store, implementing the write functionality was actually quite straigt forward. We now implement `ObjectInputFile` and `ObjectOutputStream`, which - if wrapped in `pyarrow.PythonFile` will work with the arrow ecosystem (so far ;))

There was on bigger and breaking deign decision, but I hope people agree :).

Essatially I just accepted, that working exclusively with the relative delta paths makes life much more convenient.. As such rather then adding and removing paths prefixes all the time, I thought it would be reasonable to as users to wrap their own filesystems in a `pyarrow.fs.SubTreeFileSystems`, which points at the table root..

```py
import pyarrow.fs as fs
from deltalake import DeltaTable

path = "<path/to/table>"
filesystem = fs.SubTreeFileSystem(path, fs.LocalFileSystem())

dt = DeltaTable(path)
ds = dt.to_pyarrow_dataset(filesystem=filesystem)
```

Of course the hope is to eventually be at comparable (or higher :)) performance then the c++ file systems. Then there would be little reason (I guess) to still provide a "custom" file system at all.

# Related Issue(s)

closes (at least to some degree) #570 
closes #574
closes #696
closes  #689
towards #542

# Documentation

<!---
Share links to useful documentation
--->
