### PR TITLE
Refactoring of the Github Action python release

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -23,23 +23,14 @@ jobs:
             exit 1
           fi
 
-  release-pypi-mac-windows:
+  release-pypi-mac:
     needs: validate-release-tag
-    name: PyPI release Mac & Windows
+    name: PyPI release on Mac
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macOS-11
-          - windows-2019
-        include:
-          - target: x86_64-apple-darwin
-            os: macOS-11
-          - target: aarch64-apple-darwin
-            os: macOS-11
-          - target: x86_64-pc-windows-msvc
-            os: windows-2019
-    runs-on: ${{ matrix.os }}
+        target: [x86_64-apple-darwin, aarch64-apple-darwin]
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
 
@@ -49,6 +40,22 @@ jobs:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         with:
           target: ${{ matrix.target }}
+          command: publish
+          args: -m python/Cargo.toml --no-sdist
+
+  release-pypi-windows:
+    needs: validate-release-tag
+    name: PyPI release on Windows
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Publish to pypi (without sdist)
+        uses: messense/maturin-action@main
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        with:
+          target: x86_64-pc-windows-msvc
           command: publish
           args: -m python/Cargo.toml --no-sdist
 


### PR DESCRIPTION
# Description
- Split Windows and Mac Github Action runners when releasing a new version of the Python binding
- Provide `x86_64` and `aarch64` wheels for Mac

# Related Issue(s)
- related to #808