### PR TITLE
Re-allow writing to non-existant local paths

### DIFF
--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -40,6 +40,9 @@ def test_handle_existing(tmp_path: pathlib.Path, sample_data: pa.Table):
 
 
 def test_roundtrip_basic(tmp_path: pathlib.Path, sample_data: pa.Table):
+    # Check we can create the subdirectory
+    tmp_path = tmp_path / "path" / "to" / "table"
+
     write_deltalake(str(tmp_path), sample_data)
 
     assert ("0" * 20 + ".json") in os.listdir(tmp_path / "_delta_log")


### PR DESCRIPTION
# Description

We were always testing writing to directories that already existed, and the recent object store changes caused a regression that made it not support writing to local directories that don't already exist.

# Related Issue(s)

- closes #777

# Documentation

<!---
Share links to useful documentation
--->
