### PR TITLE
[Python] Fix handling of null stats in write_deltalake

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -360,9 +360,11 @@ def get_file_stats_from_metadata(
                 for group in iter_groups(metadata)
             )
 
-            # I assume for now this is based on data type, and thus is
-            # consistent between groups
-            if metadata.row_group(0).column(column_idx).statistics.has_min_max:
+            # Min / max may not exist for some column types, or if all values are null
+            if any(
+                group.column(column_idx).statistics.has_min_max
+                for group in iter_groups(metadata)
+            ):
                 # Min and Max are recorded in physical type, not logical type
                 # https://stackoverflow.com/questions/66753485/decoding-parquet-min-max-statistics-for-decimal-type
                 # TODO: Add logic to decode physical type for DATE, DECIMAL

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -380,12 +380,19 @@ def get_file_stats_from_metadata(
                 ]:
                     continue
 
-                stats["minValues"][name] = min(
+                minimums = (
                     group.column(column_idx).statistics.min
                     for group in iter_groups(metadata)
                 )
-                stats["maxValues"][name] = max(
+                # If some row groups have all null values, their min and max will be null too.
+                stats["minValues"][name] = min(
+                    minimum for minimum in minimums if minimum is not None
+                )
+                maximums = (
                     group.column(column_idx).statistics.max
                     for group in iter_groups(metadata)
+                )
+                stats["maxValues"][name] = max(
+                    maximum for maximum in maximums if maximum is not None
                 )
     return stats

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -64,10 +64,26 @@ def test_roundtrip_basic(tmp_path: pathlib.Path, sample_data: pa.Table):
 
 
 def test_roundtrip_nulls(tmp_path: pathlib.Path):
-    data = pa.table({"x": pa.array([1, 2, None, None])})
+    data = pa.table({"x": pa.array([None, None, 1, 2], type=pa.int64())})
     # One row group will have values, one will be all nulls.
-    # The second will have None in min and max stats, so we need to handle that.
+    # The first will have None in min and max stats, so we need to handle that.
     write_deltalake(str(tmp_path), data, min_rows_per_group=2, max_rows_per_group=2)
+
+    delta_table = DeltaTable(str(tmp_path))
+    assert delta_table.schema().to_pyarrow() == data.schema
+
+    table = delta_table.to_pyarrow_table()
+    assert table == data
+
+    data = pa.table({"x": pa.array([None, None, None, None], type=pa.int64())})
+    # Will be all null, with two row groups
+    write_deltalake(
+        str(tmp_path),
+        data,
+        min_rows_per_group=2,
+        max_rows_per_group=2,
+        mode="overwrite",
+    )
 
     delta_table = DeltaTable(str(tmp_path))
     assert delta_table.schema().to_pyarrow() == data.schema


### PR DESCRIPTION
# Description

We were finding the file-level min and max by taking the min and max values of the row-group level ones; but we were not accounting for all-null row groups, which will not have min/max stats.

# Related Issue(s)

- fixes #763

# Documentation

<!---
Share links to useful documentation
--->
