### PR TITLE
feat: improve storage configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "object_store",
+ "once_cell",
  "parquet",
  "parquet-format",
  "parquet2",

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, Mapping
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -16,7 +16,19 @@ rust_core_version: Callable[[], str]
 
 class PyDeltaTableError(BaseException): ...
 
-write_new_deltalake: Callable[[str, pa.Schema, List[AddAction], str, List[str]], None]
+write_new_deltalake: Callable[
+    [
+        str,
+        pa.Schema,
+        List[AddAction],
+        str,
+        List[str],
+        Optional[str],
+        Optional[str],
+        Optional[Mapping[str, Optional[str]]],
+    ],
+    None,
+]
 
 # Can't implement inheritance (see note in src/schema.rs), so this is next
 # best thing.

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Callable, Dict, List, Optional, Union, Mapping
+from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
 if sys.version_info >= (3, 8):
     from typing import Literal

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -253,7 +253,7 @@ def write_deltalake(
     )
 
     if table is None:
-        _write_new_deltalake(  # type: ignore[call-arg]
+        _write_new_deltalake(
             table_uri,
             schema,
             add_actions,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,6 +22,7 @@ libc = ">=0.2.90, <1"
 num-bigint = "0.4"
 num-traits = "0.2.15"
 object_store = "0.5.0"
+once_cell = "1.12.0"
 parquet = { version = "22", features = ["async"], optional = true }
 parquet2 = { version = "0.16", optional = true }
 parquet-format = "~4.0.0"

--- a/rust/src/builder/azure.rs
+++ b/rust/src/builder/azure.rs
@@ -209,14 +209,8 @@ impl AzureConfig {
 
 fn parse_boolean(term: &str) -> Option<bool> {
     match term.to_lowercase().as_str() {
-        "true" => Some(true),
-        "1" => Some(true),
-        "yes" => Some(true),
-        "y" => Some(true),
-        "false" => Some(false),
-        "0" => Some(false),
-        "no" => Some(false),
-        "n" => Some(false),
+        "true" | "1" | "yes" | "y" => Some(true),
+        "false" | "0" | "no" | "n" => Some(false),
         _ => None,
     }
 }

--- a/rust/src/builder/azure.rs
+++ b/rust/src/builder/azure.rs
@@ -1,0 +1,245 @@
+use std::collections::HashMap;
+
+use super::BuilderError;
+use crate::DeltaResult;
+
+use object_store::azure::MicrosoftAzureBuilder;
+use once_cell::sync::Lazy;
+
+#[derive(PartialEq, Eq)]
+enum AzureConfigKey {
+    AccountKey,
+    AccountName,
+    ClientId,
+    ClientSecret,
+    AuthorityId,
+    SasKey,
+    UseEmulator,
+    AllowHttp,
+}
+
+impl AzureConfigKey {
+    fn get_from_env(&self) -> Option<String> {
+        for (key, value) in ALIAS_MAP.iter() {
+            if value == self {
+                if let Ok(val) = std::env::var(key.to_ascii_uppercase()) {
+                    return Some(val);
+                }
+            }
+        }
+        None
+    }
+}
+
+static ALIAS_MAP: Lazy<HashMap<&'static str, AzureConfigKey>> = Lazy::new(|| {
+    HashMap::from([
+        // access key
+        ("azure_storage_account_key", AzureConfigKey::AccountKey),
+        ("azure_storage_access_key", AzureConfigKey::AccountKey),
+        ("azure_storage_master_key", AzureConfigKey::AccountKey),
+        ("azure_storage_key", AzureConfigKey::AccountKey),
+        ("account_key", AzureConfigKey::AccountKey),
+        ("access_key", AzureConfigKey::AccountKey),
+        // sas key
+        ("azure_storage_sas_token", AzureConfigKey::SasKey),
+        ("azure_storage_sas_key", AzureConfigKey::SasKey),
+        ("sas_token", AzureConfigKey::SasKey),
+        ("sas_key", AzureConfigKey::SasKey),
+        // account name
+        ("azure_storage_account_name", AzureConfigKey::AccountName),
+        ("account_name", AzureConfigKey::AccountName),
+        // client id
+        ("azure_storage_client_id", AzureConfigKey::ClientId),
+        ("azure_client_id", AzureConfigKey::ClientId),
+        ("client_id", AzureConfigKey::ClientId),
+        // authority id
+        ("azure_storage_tenant_id", AzureConfigKey::AuthorityId),
+        ("azure_storage_authority_id", AzureConfigKey::AuthorityId),
+        ("azure_tenant_id", AzureConfigKey::AuthorityId),
+        ("azure_authority_id", AzureConfigKey::AuthorityId),
+        ("tenant_id", AzureConfigKey::AuthorityId),
+        ("authority_id", AzureConfigKey::AuthorityId),
+        // use emulator
+        ("azure_storage_use_emulator", AzureConfigKey::UseEmulator),
+        ("object_store_use_emulator", AzureConfigKey::UseEmulator),
+        ("use_emulator", AzureConfigKey::UseEmulator),
+        // AllowHttp
+        ("azure_storage_allow_http", AzureConfigKey::AllowHttp),
+        ("object_store_allow_http", AzureConfigKey::AllowHttp),
+        ("allow_http", AzureConfigKey::AllowHttp),
+    ])
+});
+
+pub struct AzureConfig {
+    account_key: Option<String>,
+    account_name: Option<String>,
+    client_id: Option<String>,
+    client_secret: Option<String>,
+    authority_id: Option<String>,
+    sas_key: Option<String>,
+    use_emulator: Option<bool>,
+    allow_http: Option<bool>,
+}
+
+impl AzureConfig {
+    fn new(options: &HashMap<String, String>) -> Self {
+        let mut account_key = None;
+        let mut account_name = None;
+        let mut client_id = None;
+        let mut client_secret = None;
+        let mut authority_id = None;
+        let mut sas_key = None;
+        let mut use_emulator = None;
+        let mut allow_http = None;
+
+        for (raw, value) in options {
+            if let Some(key) = ALIAS_MAP.get(&*raw.to_ascii_lowercase()) {
+                match key {
+                    AzureConfigKey::AccountKey => account_key = Some(value.clone()),
+                    AzureConfigKey::AccountName => account_name = Some(value.clone()),
+                    AzureConfigKey::ClientId => client_id = Some(value.clone()),
+                    AzureConfigKey::ClientSecret => client_secret = Some(value.clone()),
+                    AzureConfigKey::AuthorityId => authority_id = Some(value.clone()),
+                    AzureConfigKey::SasKey => sas_key = Some(value.clone()),
+                    AzureConfigKey::UseEmulator => use_emulator = parse_boolean(value),
+                    AzureConfigKey::AllowHttp => allow_http = parse_boolean(value),
+                }
+            }
+        }
+
+        Self {
+            account_key,
+            account_name,
+            client_id,
+            client_secret,
+            authority_id,
+            sas_key,
+            use_emulator,
+            allow_http,
+        }
+    }
+
+    /// Check all options if a valid builder can be generated, if not, check if configuration
+    /// can be read from the environment.
+    pub fn get_builder(options: &HashMap<String, String>) -> DeltaResult<MicrosoftAzureBuilder> {
+        let config = Self::new(options);
+
+        let mut builder = MicrosoftAzureBuilder::default();
+        if let Some(account) = config.account_name {
+            builder = builder.with_account(account);
+        } else {
+            builder = builder.with_account(
+                AzureConfigKey::AccountName
+                    .get_from_env()
+                    .ok_or_else(|| BuilderError::Required("AZURE_STORAGE_ACCOUNT".into()))?,
+            );
+        }
+
+        if let Some(use_emulator) = config.use_emulator {
+            builder = builder.with_use_emulator(use_emulator);
+        } else if let Some(val) = AzureConfigKey::UseEmulator.get_from_env() {
+            if let Some(use_emulator) = parse_boolean(&val) {
+                builder = builder.with_use_emulator(use_emulator);
+            }
+        }
+
+        let allow_http = config.allow_http.map(Some).unwrap_or_else(|| {
+            AzureConfigKey::AllowHttp
+                .get_from_env()
+                .and_then(|val| parse_boolean(&val))
+        });
+        if let Some(allow) = allow_http {
+            builder = builder.with_allow_http(allow);
+        }
+
+        if let Some(key) = config.account_key {
+            builder = builder.with_access_key(key);
+            return Ok(builder);
+        }
+
+        if let Some(sas) = config.sas_key {
+            let query_pairs = split_sas(&sas)?;
+            builder = builder.with_sas_authorization(query_pairs);
+            return Ok(builder);
+        }
+
+        if let (Some(client_id), Some(client_secret), Some(tenant_id)) = (
+            config.client_id.clone(),
+            config.client_secret.clone(),
+            config.authority_id.clone(),
+        ) {
+            builder = builder.with_client_secret_authorization(client_id, client_secret, tenant_id);
+            return Ok(builder);
+        }
+
+        if let Some(key) = AzureConfigKey::AccountKey.get_from_env() {
+            builder = builder.with_access_key(key);
+            return Ok(builder);
+        }
+
+        let client_id = config
+            .client_id
+            .map(Some)
+            .unwrap_or_else(|| AzureConfigKey::ClientId.get_from_env());
+        let client_secret = config
+            .client_secret
+            .map(Some)
+            .unwrap_or_else(|| AzureConfigKey::ClientSecret.get_from_env());
+        let authority_id = config
+            .authority_id
+            .map(Some)
+            .unwrap_or_else(|| AzureConfigKey::AuthorityId.get_from_env());
+
+        if let (Some(client_id), Some(client_secret), Some(tenant_id)) =
+            (client_id, client_secret, authority_id)
+        {
+            builder = builder.with_client_secret_authorization(client_id, client_secret, tenant_id);
+            return Ok(builder);
+        }
+
+        if let Some(sas) = AzureConfigKey::SasKey.get_from_env() {
+            let query_pairs = split_sas(&sas)?;
+            builder = builder.with_sas_authorization(query_pairs);
+            return Ok(builder);
+        }
+
+        Err(BuilderError::MissingCredential.into())
+    }
+}
+
+fn parse_boolean(term: &str) -> Option<bool> {
+    match term.to_lowercase().as_str() {
+        "true" => Some(true),
+        "1" => Some(true),
+        "yes" => Some(true),
+        "y" => Some(true),
+        "false" => Some(false),
+        "0" => Some(false),
+        "no" => Some(false),
+        "n" => Some(false),
+        _ => None,
+    }
+}
+
+fn split_sas(sas: &str) -> Result<Vec<(String, String)>, BuilderError> {
+    let kv_str_pairs = sas
+        .trim_start_matches('?')
+        .split('&')
+        .filter(|s| !s.chars().all(char::is_whitespace));
+    let mut pairs = Vec::new();
+    for kv_pair_str in kv_str_pairs {
+        let mut kv = kv_pair_str.trim().split('=');
+        let k = match kv.next().filter(|k| !k.chars().all(char::is_whitespace)) {
+            None => {
+                return Err(BuilderError::MissingCredential);
+            }
+            Some(k) => k,
+        };
+        let v = match kv.next().filter(|k| !k.chars().all(char::is_whitespace)) {
+            None => return Err(BuilderError::MissingCredential),
+            Some(v) => v,
+        };
+        pairs.push((k.into(), v.into()))
+    }
+    Ok(pairs)
+}

--- a/rust/src/builder/google.rs
+++ b/rust/src/builder/google.rs
@@ -1,0 +1,69 @@
+use std::collections::HashMap;
+
+use super::BuilderError;
+use crate::DeltaResult;
+
+use object_store::gcp::GoogleCloudStorageBuilder;
+use once_cell::sync::Lazy;
+
+#[derive(PartialEq, Eq)]
+enum GoogleConfigKey {
+    ServiceAccount,
+}
+
+impl GoogleConfigKey {
+    fn get_from_env(&self) -> Option<String> {
+        for (key, value) in ALIAS_MAP.iter() {
+            if value == self {
+                if let Ok(val) = std::env::var(key.to_ascii_uppercase()) {
+                    return Some(val);
+                }
+            }
+        }
+        None
+    }
+}
+
+static ALIAS_MAP: Lazy<HashMap<&'static str, GoogleConfigKey>> = Lazy::new(|| {
+    HashMap::from([
+        // service account
+        ("google_service_account", GoogleConfigKey::ServiceAccount),
+        ("service_account", GoogleConfigKey::ServiceAccount),
+    ])
+});
+
+pub struct GoogleConfig {
+    service_account: Option<String>,
+}
+
+impl GoogleConfig {
+    fn new(options: &HashMap<String, String>) -> Self {
+        let mut service_account = None;
+
+        for (raw, value) in options {
+            if let Some(key) = ALIAS_MAP.get(&*raw.to_ascii_lowercase()) {
+                match key {
+                    GoogleConfigKey::ServiceAccount => service_account = Some(value.clone()),
+                }
+            }
+        }
+
+        Self { service_account }
+    }
+
+    /// Check all options if a valid builder can be generated, if not, check if configuration
+    /// can be read from the environment.
+    pub fn get_builder(
+        options: &HashMap<String, String>,
+    ) -> DeltaResult<GoogleCloudStorageBuilder> {
+        let config = Self::new(options);
+        let service_account = if let Some(account) = config.service_account {
+            account
+        } else {
+            GoogleConfigKey::ServiceAccount
+                .get_from_env()
+                .ok_or_else(|| BuilderError::MissingCredential)?
+        };
+        Ok(GoogleCloudStorageBuilder::default().with_service_account_path(service_account))
+    }
+}

--- a/rust/src/builder/google.rs
+++ b/rust/src/builder/google.rs
@@ -62,7 +62,7 @@ impl GoogleConfig {
         } else {
             GoogleConfigKey::ServiceAccount
                 .get_from_env()
-                .ok_or_else(|| BuilderError::MissingCredential)?
+                .ok_or(BuilderError::MissingCredential)?
         };
         Ok(GoogleCloudStorageBuilder::default().with_service_account_path(service_account))
     }

--- a/rust/src/builder/mod.rs
+++ b/rust/src/builder/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use crate::delta::{DeltaResult, DeltaTable, DeltaTableError};
 use crate::schema::DeltaDataTypeVersion;
 use crate::storage::file::FileStorageBackend;
-use crate::storage::DeltaObjectStore;
+use crate::storage::{DeltaObjectStore, ObjectStoreRef};
 
 use chrono::{DateTime, FixedOffset, Utc};
 use object_store::memory::InMemory;
@@ -210,7 +210,7 @@ impl DeltaTableBuilder {
     }
 
     /// Build a delta storage backend for the given config
-    pub fn build_storage(self) -> Result<Arc<DeltaObjectStore>, DeltaTableError> {
+    pub fn build_storage(self) -> Result<ObjectStoreRef, DeltaTableError> {
         let (storage, storage_url) = match self.options.storage_backend {
             // Some(storage) => storage,
             None => get_storage_backend(

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -2,6 +2,11 @@
 
 // Reference: https://github.com/delta-io/delta/blob/master/PROTOCOL.md
 //
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::fmt;
+use std::io::{BufRead, BufReader, Cursor};
+use std::{cmp::max, cmp::Ordering, collections::HashSet};
 
 use super::action;
 use super::action::{Action, DeltaOperation};
@@ -9,25 +14,21 @@ use super::partitions::{DeltaTablePartition, PartitionFilter};
 use super::schema::*;
 use super::table_state::DeltaTableState;
 use crate::action::{Add, Stats};
-pub use crate::builder::{DeltaTableBuilder, DeltaTableConfig, DeltaVersion};
 use crate::delta_config::DeltaConfigError;
-use crate::storage::DeltaObjectStore;
+use crate::storage::{DeltaObjectStore, ObjectStoreRef};
 use crate::vacuum::{Vacuum, VacuumError};
+
 use chrono::{DateTime, Duration, Utc};
 use futures::StreamExt;
 use lazy_static::lazy_static;
 use log::debug;
-use object_store::{path::Path, Error as ObjectStoreError, ObjectStore};
+use object_store::{path::Path, Error as ObjectStoreError};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::fmt;
-use std::io::{BufRead, BufReader, Cursor};
-use std::sync::Arc;
-use std::{cmp::max, cmp::Ordering, collections::HashSet};
 use uuid::Uuid;
+
+pub use crate::builder::{DeltaTableBuilder, DeltaTableConfig, DeltaVersion};
 
 /// Metadata for a checkpoint file
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Copy)]
@@ -412,7 +413,7 @@ pub struct DeltaTable {
     pub config: DeltaTableConfig,
     // metadata
     // application_transactions
-    pub(crate) storage: Arc<DeltaObjectStore>,
+    pub(crate) storage: ObjectStoreRef,
 
     last_check_point: Option<CheckPoint>,
     version_timestamp: HashMap<DeltaDataTypeVersion, i64>,
@@ -423,7 +424,7 @@ impl DeltaTable {
     ///
     /// NOTE: This is for advanced users. If you don't know why you need to use this method, please
     /// call one of the `open_table` helper methods instead.
-    pub fn new(storage: Arc<DeltaObjectStore>, config: DeltaTableConfig) -> Self {
+    pub fn new(storage: ObjectStoreRef, config: DeltaTableConfig) -> Self {
         Self {
             state: DeltaTableState::with_version(-1),
             storage,
@@ -434,7 +435,7 @@ impl DeltaTable {
     }
 
     /// get a shared reference to the delta object store
-    pub fn object_store(&self) -> Arc<DeltaObjectStore> {
+    pub fn object_store(&self) -> ObjectStoreRef {
         self.storage.clone()
     }
 
@@ -997,7 +998,7 @@ impl DeltaTable {
         self.state.min_writer_version()
     }
 
-    /// Vacuum the delta table seee [`Vacuum`] for more info
+    /// Vacuum the delta table see [`Vacuum`] for more info
     pub async fn vacuum(
         &mut self,
         retention_hours: Option<u64>,
@@ -1271,7 +1272,7 @@ impl<'a> DeltaTransaction<'a> {
 
         // TODO: calculate isolation level to use when checking for conflicts.
         // Leaving conflict checking unimplemented for now to get the "single writer" implementation off the ground.
-        // Leaving some commmented code in place as a guidepost for the future.
+        // Leaving some commented code in place as a guidepost for the future.
 
         // let no_data_changed = actions.iter().all(|a| match a {
         //     Action::add(x) => !x.dataChange,

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -15,14 +15,14 @@ use super::schema::*;
 use super::table_state::DeltaTableState;
 use crate::action::{Add, Stats};
 use crate::delta_config::DeltaConfigError;
-use crate::storage::{DeltaObjectStore, ObjectStoreRef};
+use crate::storage::ObjectStoreRef;
 use crate::vacuum::{Vacuum, VacuumError};
 
 use chrono::{DateTime, Duration, Utc};
 use futures::StreamExt;
 use lazy_static::lazy_static;
 use log::debug;
-use object_store::{path::Path, Error as ObjectStoreError};
+use object_store::{path::Path, Error as ObjectStoreError, ObjectStore};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -57,6 +57,9 @@ impl PartialEq for CheckPoint {
 
 impl Eq for CheckPoint {}
 
+/// A result returned by delta-rs
+pub type DeltaResult<T> = Result<T, DeltaTableError>;
+
 /// Delta Table specific error
 #[derive(thiserror::Error, Debug)]
 pub enum DeltaTableError {

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -26,6 +26,9 @@ lazy_static! {
     static ref DELTA_LOG_PATH: Path = Path::from("_delta_log");
 }
 
+/// Sharable reference to [`DeltaObjectStore`]
+pub type ObjectStoreRef = Arc<DeltaObjectStore>;
+
 /// Configuration for a DeltaObjectStore
 #[derive(Debug, Clone)]
 struct DeltaObjectStoreConfig {

--- a/rust/src/test_utils.rs
+++ b/rust/src/test_utils.rs
@@ -233,7 +233,6 @@ fn set_env_if_not_set(key: impl AsRef<str>, value: impl AsRef<str>) {
 /// small wrapper around az cli
 pub mod az_cli {
     use super::set_env_if_not_set;
-    use crate::builder::azure_storage_options;
     use std::process::{Command, ExitStatus};
 
     /// Create a new bucket
@@ -268,12 +267,9 @@ pub mod az_cli {
 
     /// prepare_env
     pub fn prepare_env() {
-        set_env_if_not_set(azure_storage_options::AZURE_STORAGE_USE_EMULATOR, "1");
-        set_env_if_not_set(
-            azure_storage_options::AZURE_STORAGE_ACCOUNT_NAME,
-            "devstoreaccount1",
-        );
-        set_env_if_not_set(azure_storage_options::AZURE_STORAGE_ACCOUNT_KEY, "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==");
+        set_env_if_not_set("AZURE_STORAGE_USE_EMULATOR", "1");
+        set_env_if_not_set("AZURE_STORAGE_ACCOUNT_NAME", "devstoreaccount1");
+        set_env_if_not_set("AZURE_STORAGE_ACCOUNT_KEY", "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==");
         set_env_if_not_set(
             "AZURE_STORAGE_CONNECTION_STRING",
             "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;"
@@ -435,10 +431,6 @@ pub mod gs_cli {
             .spawn()
             .expect("curl command is installed");
         child.wait()
-    }
-
-    pub fn upload_table(_src: &str, _dst: &str) -> std::io::Result<ExitStatus> {
-        todo!()
     }
 
     /// prepare_env

--- a/rust/src/test_utils.rs
+++ b/rust/src/test_utils.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code, missing_docs)]
-use crate::builder::gcp_storage_options;
 use crate::storage::utils::copy_table;
 use crate::DeltaTableBuilder;
 use chrono::Utc;
@@ -43,11 +42,7 @@ impl IntegrationContext {
             let account_path = tmp_dir.path().join("gcs.json");
             std::fs::write(&account_path, serde_json::to_vec(&token)?)?;
             set_env_if_not_set(
-                gcp_storage_options::SERVICE_ACCOUNT,
-                account_path.as_path().to_str().unwrap(),
-            );
-            set_env_if_not_set(
-                gcp_storage_options::GOOGLE_SERVICE_ACCOUNT,
+                "GOOGLE_SERVICE_ACCOUNT",
                 account_path.as_path().to_str().unwrap(),
             );
         }

--- a/rust/src/writer/json.rs
+++ b/rust/src/writer/json.rs
@@ -1,20 +1,20 @@
 //! Main writer API to write json messages to delta table
-use super::{
-    stats::{apply_null_counts, create_add, NullCounts},
-    utils::{
-        arrow_schema_without_partitions, next_data_path, record_batch_from_message,
-        record_batch_without_partitions, stringified_partition_value,
-    },
-    DeltaWriter, DeltaWriterError,
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::sync::Arc;
+
+use super::stats::{apply_null_counts, create_add, NullCounts};
+use super::utils::{
+    arrow_schema_without_partitions, next_data_path, record_batch_from_message,
+    record_batch_without_partitions, stringified_partition_value,
 };
+use super::{DeltaWriter, DeltaWriterError};
 use crate::builder::DeltaTableBuilder;
-use crate::DeltaTableError;
-use crate::{action::Add, DeltaTable, DeltaTableMetaData, Schema};
+use crate::{action::Add, DeltaTable, DeltaTableError, DeltaTableMetaData, Schema};
 use crate::{storage::DeltaObjectStore, writer::utils::ShareableBuffer};
-use arrow::{
-    datatypes::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef},
-    record_batch::*,
-};
+
+use arrow::datatypes::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
+use arrow::record_batch::*;
 use bytes::Bytes;
 use log::{info, warn};
 use object_store::ObjectStore;
@@ -23,9 +23,6 @@ use parquet::{
     file::properties::WriterProperties,
 };
 use serde_json::Value;
-use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::sync::Arc;
 
 type BadValue = (Value, ParquetError);
 

--- a/rust/src/writer/mod.rs
+++ b/rust/src/writer/mod.rs
@@ -11,19 +11,18 @@ mod stats;
 pub mod test_utils;
 pub mod utils;
 
-use crate::{
-    action::{Action, Add, ColumnCountStat, Stats},
-    delta::DeltaTable,
-    DeltaDataTypeVersion, DeltaTableError,
-};
+use crate::action::{Action, Add, ColumnCountStat, Stats};
+use crate::delta::DeltaTable;
+use crate::{DeltaDataTypeVersion, DeltaTableError};
+
 use arrow::{datatypes::SchemaRef, datatypes::*, error::ArrowError};
 use async_trait::async_trait;
-pub use json::JsonWriter;
 use object_store::Error as ObjectStoreError;
 use parquet::{basic::LogicalType, errors::ParquetError};
-pub use record_batch::RecordBatchWriter;
 use serde_json::Value;
-use std::sync::Arc;
+
+pub use json::JsonWriter;
+pub use record_batch::RecordBatchWriter;
 
 /// Enum representing an error when calling [`DeltaWriter`].
 #[derive(thiserror::Error, Debug)]
@@ -38,7 +37,7 @@ pub(crate) enum DeltaWriterError {
         /// The record batch schema.
         record_batch_schema: SchemaRef,
         /// The schema of the target delta table.
-        expected_schema: Arc<arrow::datatypes::Schema>,
+        expected_schema: SchemaRef,
     },
 
     /// An Arrow RecordBatch could not be created from the JSON buffer.

--- a/rust/tests/common/adls.rs
+++ b/rust/tests/common/adls.rs
@@ -2,7 +2,6 @@ use super::TestContext;
 use chrono::Utc;
 use rand::Rng;
 use std::collections::HashMap;
-use std::process::Command;
 
 pub struct AzureGen2 {
     account_name: String,
@@ -54,7 +53,6 @@ pub async fn setup_azure_gen2_context() -> TestContext {
 }
 
 pub mod az_cli {
-    use deltalake::builder::azure_storage_options;
     use std::process::{Command, ExitStatus};
 
     /// Create a new bucket
@@ -82,14 +80,6 @@ pub mod az_cli {
                 "-n",
                 container_name.as_ref(),
             ])
-            .spawn()
-            .expect("az command is installed");
-        child.wait()
-    }
-
-    pub fn upload_table(src: &str, dst: &str) -> std::io::Result<ExitStatus> {
-        let mut child = Command::new("az")
-            .args(["storage", "blob", "upload-batch", "-d", dst, "-s", src])
             .spawn()
             .expect("az command is installed");
         child.wait()

--- a/rust/tests/common/adls.rs
+++ b/rust/tests/common/adls.rs
@@ -37,7 +37,7 @@ pub async fn setup_azure_gen2_context() -> TestContext {
         storage_account_name.clone(),
     );
     config.insert(
-        "AZRUE_STORAGE_ACCOUNT_KEY".to_string(),
+        "AZURE_STORAGE_ACCOUNT_KEY".to_string(),
         storage_account_key.clone(),
     );
 

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -38,7 +38,7 @@ impl TestContext {
         let backend_ref = backend.as_ref().map(|s| s.as_str());
         let context = match backend_ref {
             Ok("LOCALFS") | Err(std::env::VarError::NotPresent) => setup_local_context().await,
-            #[cfg(feature = "azure2")]
+            #[cfg(feature = "azure")]
             Ok("AZURE_GEN2") => adls::setup_azure_gen2_context().await,
             #[cfg(any(feature = "s3", feature = "s3-rustls"))]
             Ok("S3_LOCAL_STACK") => s3::setup_s3_context().await,


### PR DESCRIPTION
# Description

This PR mainly improves the handling of configuration - hopefully. In essence we get closed to the options usually used in fsspec or the azure sdk, while retaining the current key names and the option to configure via the environment.

Previously I also believe that in cases where an applicable environment variable was defined, it may have taken precedence over alternative configuration passed to the Delta table.

For testing purposed the in-memory store can now also be used as a backend to delta tables. (I am working on updating the operations, and bringing in changes piece-by-piece to keep PR size reasonable).

For now I left out migrating the S3 config, as it has a bit more logic in it. Also since the currently documented way is still supported, I have not yet updated the documentation. I plant to do both in a follow up PR,

# Related Issue(s)

closes #766

# Documentation

<!---
Share links to useful documentation
--->
