### PR TITLE
Datafusion-imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,8 @@ dependencies = [
  "chrono",
  "criterion",
  "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
  "dotenv",
  "dynamodb_lock",
  "errno",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ object_store = "0.5.0"
 once_cell = "1.12.0"
 parquet = { version = "22", features = ["async"], optional = true }
 parquet2 = { version = "0.16", optional = true }
-parquet-format = "~4.0.0"
+parquet-format = { version = "~4.0.0" }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -44,17 +44,44 @@ rusoto_dynamodb = { version = "0.48", default-features = false, optional = true 
 # Glue
 rusoto_glue = { version = "0.48", default-features = false, optional = true }
 
+# Datafusion
+datafusion = { version = "12", optional = true }
+datafusion-expr = { version = "12", optional = true }
+datafusion-common = { version = "12", optional = true }
+
 # NOTE dependencies only for integration tests
 fs_extra = { version = "1.2.0", optional = true }
 tempdir = { version = "0", optional = true }
 
-[dependencies.datafusion]
-version = "12"
+[dependencies.dynamodb_lock]
+path = "../dynamodb_lock"
+version = "0"
+default-features = false
 optional = true
+
+[dev-dependencies]
+criterion = "0"
+dotenv = "*"
+maplit = "1"
+pretty_assertions = "1.2.1"
+rand = "0.8"
+serial_test = "0"
+tempdir = "0"
+tempfile = "3"
+utime = "0.3"
+
+[build-dependencies]
+glibc_version = "0"
 
 [features]
 default = ["arrow", "parquet"]
-datafusion-ext = ["datafusion"]
+datafusion-ext = [
+    "datafusion",
+    "datafusion-expr",
+    "datafusion-common",
+    "arrow",
+    "parquet",
+]
 azure = ["object_store/azure"]
 gcs = ["object_store/gcp"]
 s3 = [
@@ -77,26 +104,6 @@ glue = ["s3", "rusoto_glue"]
 python = ["arrow/pyarrow"]
 # used only for integration testing
 integration_test = ["fs_extra", "tempdir"]
-
-[build-dependencies]
-glibc_version = "0"
-
-[dependencies.dynamodb_lock]
-path = "../dynamodb_lock"
-version = "0"
-default-features = false
-optional = true
-
-[dev-dependencies]
-criterion = "0"
-dotenv = "*"
-maplit = "1"
-pretty_assertions = "1.3.0"
-rand = "0.8"
-serial_test = "0"
-tempdir = "0"
-tempfile = "3"
-utime = "0.3"
 
 [[bench]]
 name = "read_checkpoint"

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -481,10 +481,7 @@ fn to_correct_scalar_value(
     }
 }
 
-fn correct_scalar_value_type(
-    value: ScalarValue,
-    field_dt: &ArrowDataType,
-) -> Option<ScalarValue> {
+fn correct_scalar_value_type(value: ScalarValue, field_dt: &ArrowDataType) -> Option<ScalarValue> {
     match field_dt {
         ArrowDataType::Int64 => {
             let raw_value = i64::try_from(value).ok()?;
@@ -561,10 +558,7 @@ fn correct_scalar_value_type(
     }
 }
 
-fn left_larger_than_right(
-    left: ScalarValue,
-    right: ScalarValue,
-) -> Option<bool> {
+fn left_larger_than_right(left: ScalarValue, right: ScalarValue) -> Option<bool> {
     match left {
         ScalarValue::Float64(Some(v)) => {
             let f_right = f64::try_from(right).ok()?;

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -12,10 +12,9 @@ use crate::{
     DeltaTableBuilder, DeltaTableMetaData,
 };
 
+use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use core::any::Any;
-use arrow::datatypes::SchemaRef;
-use datafusion_common::{DataFusionError, Result as DataFusionResult};
 use datafusion::{
     execution::context::TaskContext,
     physical_plan::{
@@ -26,6 +25,7 @@ use datafusion::{
         Distribution, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
     },
 };
+use datafusion_common::{DataFusionError, Result as DataFusionResult};
 use futures::{TryFutureExt, TryStreamExt};
 
 /// Command for creating new delta table

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -1,5 +1,7 @@
 //! Command for creating a new delta table
 // https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+use std::sync::Arc;
+
 use super::{
     to_datafusion_err,
     transaction::{serialize_actions, OPERATION_SCHEMA},
@@ -9,11 +11,12 @@ use crate::{
     action::{Action, DeltaOperation, MetaData, Protocol, SaveMode},
     DeltaTableBuilder, DeltaTableMetaData,
 };
+
 use async_trait::async_trait;
 use core::any::Any;
+use arrow::datatypes::SchemaRef;
+use datafusion_common::{DataFusionError, Result as DataFusionResult};
 use datafusion::{
-    arrow::datatypes::SchemaRef,
-    error::{DataFusionError, Result as DataFusionResult},
     execution::context::TaskContext,
     physical_plan::{
         common::{compute_record_batch_statistics, SizedRecordBatchStream},
@@ -24,7 +27,6 @@ use datafusion::{
     },
 };
 use futures::{TryFutureExt, TryStreamExt};
-use std::sync::Arc;
 
 /// Command for creating new delta table
 pub struct CreateCommand {

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -16,11 +16,11 @@ use crate::{
 };
 
 use arrow::{datatypes::SchemaRef as ArrowSchemaRef, error::ArrowError, record_batch::RecordBatch};
-use datafusion_common::DataFusionError;
 use datafusion::{
     physical_plan::{collect, memory::MemoryExec, ExecutionPlan},
     prelude::SessionContext,
 };
+use datafusion_common::DataFusionError;
 
 pub mod create;
 pub mod transaction;

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -1,6 +1,11 @@
 //! High level delta commands that can be executed against a delta table
 // TODO
 // - rename to delta operations
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::fmt::Debug;
+use std::sync::Arc;
+
 use crate::{
     action::{DeltaOperation, Protocol, SaveMode},
     builder::DeltaTableBuilder,
@@ -9,16 +14,13 @@ use crate::{
     writer::{record_batch::divide_by_partition_values, utils::PartitionPath},
     DeltaTable, DeltaTableError, DeltaTableMetaData,
 };
+
 use arrow::{datatypes::SchemaRef as ArrowSchemaRef, error::ArrowError, record_batch::RecordBatch};
+use datafusion_common::DataFusionError;
 use datafusion::{
-    error::DataFusionError,
     physical_plan::{collect, memory::MemoryExec, ExecutionPlan},
     prelude::SessionContext,
 };
-use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::fmt::Debug;
-use std::sync::Arc;
 
 pub mod create;
 pub mod transaction;

--- a/rust/src/operations/transaction.rs
+++ b/rust/src/operations/transaction.rs
@@ -1,17 +1,17 @@
 //! Wrapper Execution plan to handle distributed operations
+use core::any::Any;
+use std::sync::Arc;
+
 use super::*;
 use crate::action::Action;
 use crate::schema::DeltaDataTypeVersion;
-use core::any::Any;
+
+use arrow::array::StringArray;
+use arrow::datatypes::{
+    DataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
+};
+use arrow::record_batch::RecordBatch;
 use datafusion::{
-    arrow::{
-        array::StringArray,
-        datatypes::{
-            DataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
-        },
-        record_batch::RecordBatch,
-    },
-    error::Result as DataFusionResult,
     execution::context::TaskContext,
     physical_plan::{
         coalesce_partitions::CoalescePartitionsExec, common::compute_record_batch_statistics,
@@ -19,9 +19,9 @@ use datafusion::{
         Distribution, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
     },
 };
+use datafusion_common::Result as DataFusionResult;
 use futures::{TryFutureExt, TryStreamExt};
 use lazy_static::lazy_static;
-use std::sync::Arc;
 
 lazy_static! {
     /// Schema expected for plans wrapped by transaction

--- a/rust/src/operations/write.rs
+++ b/rust/src/operations/write.rs
@@ -16,20 +16,22 @@
 //! replace data that matches a predicate.
 
 // https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+use core::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use super::{
     create::CreateCommand,
     transaction::{serialize_actions, OPERATION_SCHEMA},
     *,
 };
-use crate::{
-    action::{Action, Add, Remove, SaveMode},
-    writer::{DeltaWriter, RecordBatchWriter},
-    Schema,
-};
-use core::any::Any;
+use crate::action::{Action, Add, Remove, SaveMode};
+use crate::writer::{DeltaWriter, RecordBatchWriter};
+use crate::Schema;
+
+use arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use datafusion::{
-    arrow::datatypes::SchemaRef as ArrowSchemaRef,
-    error::Result as DataFusionResult,
     execution::context::TaskContext,
     physical_plan::{
         common::{
@@ -42,10 +44,8 @@ use datafusion::{
         SendableRecordBatchStream, Statistics,
     },
 };
+use datafusion_common::Result as DataFusionResult;
 use futures::{TryFutureExt, TryStreamExt};
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 const MAX_SUPPORTED_WRITER_VERSION: i32 = 1;
 

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -154,6 +154,15 @@ impl DeltaObjectStore {
         }
         Ok(())
     }
+
+    /// Check if the location is a delta table location
+    pub async fn is_delta_table_location(&self) -> ObjectStoreResult<bool> {
+        match self.head(self.log_path()).await {
+            Ok(_) => Ok(true),
+            Err(ObjectStoreError::NotFound { .. }) => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
 }
 
 #[async_trait::async_trait]

--- a/rust/tests/command_optimize.rs
+++ b/rust/tests/command_optimize.rs
@@ -1,504 +1,503 @@
-#[cfg(all(feature = "arrow", feature = "parquet"))]
-mod optimize {
-    use arrow::datatypes::Schema as ArrowSchema;
-    use arrow::{
-        array::{Int32Array, StringArray},
-        datatypes::{DataType, Field},
-        record_batch::RecordBatch,
-    };
-    use deltalake::optimize::{MetricDetails, Metrics};
-    use deltalake::DeltaTableError;
-    use deltalake::{
-        action,
-        action::Remove,
-        builder::DeltaTableBuilder,
-        optimize::{create_merge_plan, Optimize},
-        writer::{DeltaWriter, RecordBatchWriter},
-        DeltaTableMetaData, PartitionFilter,
-    };
-    use deltalake::{DeltaTable, Schema, SchemaDataType, SchemaField};
-    use rand::prelude::*;
-    use serde_json::{json, Map, Value};
-    use std::time::SystemTime;
-    use std::time::UNIX_EPOCH;
-    use std::{collections::HashMap, error::Error, sync::Arc};
-    use tempdir::TempDir;
+#![cfg(all(feature = "arrow", feature = "parquet"))]
 
-    struct Context {
-        pub tmp_dir: TempDir,
-        pub table: DeltaTable,
-    }
+use arrow::datatypes::Schema as ArrowSchema;
+use arrow::{
+    array::{Int32Array, StringArray},
+    datatypes::{DataType, Field},
+    record_batch::RecordBatch,
+};
+use deltalake::optimize::{MetricDetails, Metrics};
+use deltalake::DeltaTableError;
+use deltalake::{
+    action,
+    action::Remove,
+    builder::DeltaTableBuilder,
+    optimize::{create_merge_plan, Optimize},
+    writer::{DeltaWriter, RecordBatchWriter},
+    DeltaTableMetaData, PartitionFilter,
+};
+use deltalake::{DeltaTable, Schema, SchemaDataType, SchemaField};
+use rand::prelude::*;
+use serde_json::{json, Map, Value};
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+use std::{collections::HashMap, error::Error, sync::Arc};
+use tempdir::TempDir;
 
-    async fn setup_test(partitioned: bool) -> Result<Context, Box<dyn Error>> {
-        let schema = Schema::new(vec![
-            SchemaField::new(
-                "x".to_owned(),
-                SchemaDataType::primitive("integer".to_owned()),
-                false,
-                HashMap::new(),
-            ),
-            SchemaField::new(
-                "y".to_owned(),
-                SchemaDataType::primitive("integer".to_owned()),
-                false,
-                HashMap::new(),
-            ),
-            SchemaField::new(
-                "date".to_owned(),
-                SchemaDataType::primitive("string".to_owned()),
-                false,
-                HashMap::new(),
-            ),
-        ]);
+struct Context {
+    pub tmp_dir: TempDir,
+    pub table: DeltaTable,
+}
 
-        let p = if partitioned {
-            vec!["date".to_owned()]
-        } else {
-            vec![]
-        };
-
-        let table_meta = DeltaTableMetaData::new(
-            Some("opt_table".to_owned()),
-            Some("Table for optimize tests".to_owned()),
-            None,
-            schema.clone(),
-            p,
+async fn setup_test(partitioned: bool) -> Result<Context, Box<dyn Error>> {
+    let schema = Schema::new(vec![
+        SchemaField::new(
+            "x".to_owned(),
+            SchemaDataType::primitive("integer".to_owned()),
+            false,
             HashMap::new(),
-        );
+        ),
+        SchemaField::new(
+            "y".to_owned(),
+            SchemaDataType::primitive("integer".to_owned()),
+            false,
+            HashMap::new(),
+        ),
+        SchemaField::new(
+            "date".to_owned(),
+            SchemaDataType::primitive("string".to_owned()),
+            false,
+            HashMap::new(),
+        ),
+    ]);
 
-        let tmp_dir = tempdir::TempDir::new("opt_table").unwrap();
-        let p = tmp_dir.path().to_str().to_owned().unwrap();
-        let mut dt = DeltaTableBuilder::from_uri(p).build()?;
+    let p = if partitioned {
+        vec!["date".to_owned()]
+    } else {
+        vec![]
+    };
 
-        let mut commit_info = Map::<String, Value>::new();
+    let table_meta = DeltaTableMetaData::new(
+        Some("opt_table".to_owned()),
+        Some("Table for optimize tests".to_owned()),
+        None,
+        schema.clone(),
+        p,
+        HashMap::new(),
+    );
 
-        let protocol = action::Protocol {
-            min_reader_version: 1,
-            min_writer_version: 2,
-        };
+    let tmp_dir = tempdir::TempDir::new("opt_table").unwrap();
+    let p = tmp_dir.path().to_str().to_owned().unwrap();
+    let mut dt = DeltaTableBuilder::from_uri(p).build()?;
 
-        commit_info.insert(
-            "operation".to_string(),
-            serde_json::Value::String("CREATE TABLE".to_string()),
-        );
-        let _res = dt
-            .create(
-                table_meta.clone(),
-                protocol.clone(),
-                Some(commit_info),
-                None,
-            )
-            .await?;
+    let mut commit_info = Map::<String, Value>::new();
 
-        Ok(Context { tmp_dir, table: dt })
+    let protocol = action::Protocol {
+        min_reader_version: 1,
+        min_writer_version: 2,
+    };
+
+    commit_info.insert(
+        "operation".to_string(),
+        serde_json::Value::String("CREATE TABLE".to_string()),
+    );
+    let _res = dt
+        .create(
+            table_meta.clone(),
+            protocol.clone(),
+            Some(commit_info),
+            None,
+        )
+        .await?;
+
+    Ok(Context { tmp_dir, table: dt })
+}
+
+fn generate_random_batch<T: Into<String>>(
+    rows: usize,
+    partition: T,
+) -> Result<RecordBatch, Box<dyn Error>> {
+    let mut x_vec: Vec<i32> = Vec::with_capacity(rows);
+    let mut y_vec: Vec<i32> = Vec::with_capacity(rows);
+    let mut date_vec = Vec::with_capacity(rows);
+    let mut rng = rand::thread_rng();
+    let s = partition.into();
+
+    for _ in 0..rows {
+        x_vec.push(rng.gen());
+        y_vec.push(rng.gen());
+        date_vec.push(s.clone());
     }
 
-    fn generate_random_batch<T: Into<String>>(
-        rows: usize,
-        partition: T,
-    ) -> Result<RecordBatch, Box<dyn Error>> {
-        let mut x_vec: Vec<i32> = Vec::with_capacity(rows);
-        let mut y_vec: Vec<i32> = Vec::with_capacity(rows);
-        let mut date_vec = Vec::with_capacity(rows);
-        let mut rng = rand::thread_rng();
-        let s = partition.into();
+    let x_array = Int32Array::from(x_vec);
+    let y_array = Int32Array::from(y_vec);
+    let date_array = StringArray::from(date_vec);
 
-        for _ in 0..rows {
-            x_vec.push(rng.gen());
-            y_vec.push(rng.gen());
-            date_vec.push(s.clone());
-        }
+    Ok(RecordBatch::try_new(
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("x", DataType::Int32, false),
+            Field::new("y", DataType::Int32, false),
+            Field::new("date", DataType::Utf8, false),
+        ])),
+        vec![Arc::new(x_array), Arc::new(y_array), Arc::new(date_array)],
+    )?)
+}
 
-        let x_array = Int32Array::from(x_vec);
-        let y_array = Int32Array::from(y_vec);
-        let date_array = StringArray::from(date_vec);
+fn tuples_to_batch<T: Into<String>>(
+    tuples: Vec<(i32, i32)>,
+    partition: T,
+) -> Result<RecordBatch, Box<dyn Error>> {
+    let mut x_vec: Vec<i32> = Vec::new();
+    let mut y_vec: Vec<i32> = Vec::new();
+    let mut date_vec = Vec::new();
+    let s = partition.into();
 
-        Ok(RecordBatch::try_new(
-            Arc::new(ArrowSchema::new(vec![
-                Field::new("x", DataType::Int32, false),
-                Field::new("y", DataType::Int32, false),
-                Field::new("date", DataType::Utf8, false),
-            ])),
-            vec![Arc::new(x_array), Arc::new(y_array), Arc::new(date_array)],
-        )?)
+    for t in tuples {
+        x_vec.push(t.0);
+        y_vec.push(t.1);
+        date_vec.push(s.clone());
     }
 
-    fn tuples_to_batch<T: Into<String>>(
-        tuples: Vec<(i32, i32)>,
-        partition: T,
-    ) -> Result<RecordBatch, Box<dyn Error>> {
-        let mut x_vec: Vec<i32> = Vec::new();
-        let mut y_vec: Vec<i32> = Vec::new();
-        let mut date_vec = Vec::new();
-        let s = partition.into();
+    let x_array = Int32Array::from(x_vec);
+    let y_array = Int32Array::from(y_vec);
+    let date_array = StringArray::from(date_vec);
 
-        for t in tuples {
-            x_vec.push(t.0);
-            y_vec.push(t.1);
-            date_vec.push(s.clone());
-        }
+    Ok(RecordBatch::try_new(
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("x", DataType::Int32, false),
+            Field::new("y", DataType::Int32, false),
+            Field::new("date", DataType::Utf8, false),
+        ])),
+        vec![Arc::new(x_array), Arc::new(y_array), Arc::new(date_array)],
+    )?)
+}
 
-        let x_array = Int32Array::from(x_vec);
-        let y_array = Int32Array::from(y_vec);
-        let date_array = StringArray::from(date_vec);
+fn records_for_size(size: usize) -> usize {
+    //12 bytes to account of overhead
+    size / 12
+}
 
-        Ok(RecordBatch::try_new(
-            Arc::new(ArrowSchema::new(vec![
-                Field::new("x", DataType::Int32, false),
-                Field::new("y", DataType::Int32, false),
-                Field::new("date", DataType::Utf8, false),
-            ])),
-            vec![Arc::new(x_array), Arc::new(y_array), Arc::new(date_array)],
-        )?)
-    }
+#[tokio::test]
+async fn test_optimize_non_partitioned_table() -> Result<(), Box<dyn Error>> {
+    let context = setup_test(false).await?;
+    let mut dt = context.table;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
 
-    fn records_for_size(size: usize) -> usize {
-        //12 bytes to account of overhead
-        size / 12
-    }
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(1, 2), (1, 3), (1, 4)], "2022-05-22")?,
+    )
+    .await?;
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(2, 1), (2, 3), (2, 3)], "2022-05-23")?,
+    )
+    .await?;
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(3, 1), (3, 3), (3, 3)], "2022-05-22")?,
+    )
+    .await?;
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(4, 1), (4, 3), (4, 3)], "2022-05-23")?,
+    )
+    .await?;
+    write(
+        &mut writer,
+        &mut dt,
+        generate_random_batch(records_for_size(4_000_000), "2022-05-22")?,
+    )
+    .await?;
 
-    #[tokio::test]
-    async fn test_optimize_non_partitioned_table() -> Result<(), Box<dyn Error>> {
-        let context = setup_test(false).await?;
-        let mut dt = context.table;
-        let mut writer = RecordBatchWriter::for_table(&dt)?;
+    let version = dt.version();
+    assert_eq!(dt.get_state().files().len(), 5);
 
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(1, 2), (1, 3), (1, 4)], "2022-05-22")?,
-        )
-        .await?;
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(2, 1), (2, 3), (2, 3)], "2022-05-23")?,
-        )
-        .await?;
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(3, 1), (3, 3), (3, 3)], "2022-05-22")?,
-        )
-        .await?;
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(4, 1), (4, 3), (4, 3)], "2022-05-23")?,
-        )
-        .await?;
-        write(
-            &mut writer,
-            &mut dt,
-            generate_random_batch(records_for_size(4_000_000), "2022-05-22")?,
-        )
-        .await?;
+    let optimize = Optimize::default().target_size(2_000_000);
+    let metrics = optimize.execute(&mut dt).await?;
 
-        let version = dt.version();
-        assert_eq!(dt.get_state().files().len(), 5);
+    assert_eq!(version + 1, dt.version());
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 4);
+    assert_eq!(metrics.total_considered_files, 5);
+    assert_eq!(metrics.partitions_optimized, 1);
+    assert_eq!(dt.get_state().files().len(), 2);
 
-        let optimize = Optimize::default().target_size(2_000_000);
-        let metrics = optimize.execute(&mut dt).await?;
+    Ok(())
+}
 
-        assert_eq!(version + 1, dt.version());
-        assert_eq!(metrics.num_files_added, 1);
-        assert_eq!(metrics.num_files_removed, 4);
-        assert_eq!(metrics.total_considered_files, 5);
-        assert_eq!(metrics.partitions_optimized, 1);
-        assert_eq!(dt.get_state().files().len(), 2);
+async fn write(
+    writer: &mut RecordBatchWriter,
+    mut table: &mut DeltaTable,
+    batch: RecordBatch,
+) -> Result<(), DeltaTableError> {
+    writer.write(batch).await?;
+    writer.flush_and_commit(&mut table).await?;
+    Ok(())
+}
 
-        Ok(())
-    }
+#[tokio::test]
+async fn test_optimize_with_partitions() -> Result<(), Box<dyn Error>> {
+    let context = setup_test(true).await?;
+    let mut dt = context.table;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
 
-    async fn write(
-        writer: &mut RecordBatchWriter,
-        mut table: &mut DeltaTable,
-        batch: RecordBatch,
-    ) -> Result<(), DeltaTableError> {
-        writer.write(batch).await?;
-        writer.flush_and_commit(&mut table).await?;
-        Ok(())
-    }
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(1, 2), (1, 3), (1, 4)], "2022-05-22")?,
+    )
+    .await?;
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(2, 1), (2, 3), (2, 3)], "2022-05-23")?,
+    )
+    .await?;
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(3, 1), (3, 3), (3, 3)], "2022-05-22")?,
+    )
+    .await?;
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(4, 1), (4, 3), (4, 3)], "2022-05-23")?,
+    )
+    .await?;
 
-    #[tokio::test]
-    async fn test_optimize_with_partitions() -> Result<(), Box<dyn Error>> {
-        let context = setup_test(true).await?;
-        let mut dt = context.table;
-        let mut writer = RecordBatchWriter::for_table(&dt)?;
+    let version = dt.version();
+    let mut filter = vec![];
+    filter.push(PartitionFilter::try_from(("date", "=", "2022-05-22"))?);
 
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(1, 2), (1, 3), (1, 4)], "2022-05-22")?,
-        )
-        .await?;
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(2, 1), (2, 3), (2, 3)], "2022-05-23")?,
-        )
-        .await?;
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(3, 1), (3, 3), (3, 3)], "2022-05-22")?,
-        )
-        .await?;
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(4, 1), (4, 3), (4, 3)], "2022-05-23")?,
-        )
-        .await?;
+    let optimize = Optimize::default().filter(&filter);
+    let metrics = optimize.execute(&mut dt).await?;
 
-        let version = dt.version();
-        let mut filter = vec![];
-        filter.push(PartitionFilter::try_from(("date", "=", "2022-05-22"))?);
+    assert_eq!(version + 1, dt.version());
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 2);
+    assert_eq!(dt.get_state().files().len(), 3);
 
-        let optimize = Optimize::default().filter(&filter);
-        let metrics = optimize.execute(&mut dt).await?;
+    Ok(())
+}
 
-        assert_eq!(version + 1, dt.version());
-        assert_eq!(metrics.num_files_added, 1);
-        assert_eq!(metrics.num_files_removed, 2);
-        assert_eq!(dt.get_state().files().len(), 3);
+#[tokio::test]
+#[ignore]
+/// Validate that optimize fails when a remove action occurs
+async fn test_conflict_for_remove_actions() -> Result<(), Box<dyn Error>> {
+    let context = setup_test(true).await?;
+    let mut dt = context.table;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
 
-        Ok(())
-    }
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(1, 2), (1, 3), (1, 4)], "2022-05-22")?,
+    )
+    .await?;
 
-    #[tokio::test]
-    #[ignore]
-    /// Validate that optimize fails when a remove action occurs
-    async fn test_conflict_for_remove_actions() -> Result<(), Box<dyn Error>> {
-        let context = setup_test(true).await?;
-        let mut dt = context.table;
-        let mut writer = RecordBatchWriter::for_table(&dt)?;
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(2, 2), (2, 3), (2, 4)], "2022-05-22")?,
+    )
+    .await?;
 
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(1, 2), (1, 3), (1, 4)], "2022-05-22")?,
-        )
-        .await?;
+    let version = dt.version();
 
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(2, 2), (2, 3), (2, 4)], "2022-05-22")?,
-        )
-        .await?;
+    //create the merge plan, remove a file, and execute the plan.
+    let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
+    let plan = create_merge_plan(&mut dt, &filter, None)?;
 
-        let version = dt.version();
+    let uri = context.tmp_dir.path().to_str().to_owned().unwrap();
+    let mut other_dt = deltalake::open_table(uri).await?;
+    let add = &other_dt.get_state().files()[0];
+    let remove = Remove {
+        path: add.path.clone(),
+        deletion_timestamp: Some(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as i64,
+        ),
+        data_change: true,
+        extended_file_metadata: None,
+        size: Some(add.size),
+        partition_values: Some(add.partition_values.clone()),
+        tags: Some(HashMap::new()),
+    };
 
-        //create the merge plan, remove a file, and execute the plan.
-        let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
-        let plan = create_merge_plan(&mut dt, &filter, None)?;
+    let mut transaction = other_dt.create_transaction(None);
+    transaction.add_action(action::Action::remove(remove));
+    transaction.commit(None, None).await?;
 
-        let uri = context.tmp_dir.path().to_str().to_owned().unwrap();
-        let mut other_dt = deltalake::open_table(uri).await?;
-        let add = &other_dt.get_state().files()[0];
-        let remove = Remove {
-            path: add.path.clone(),
-            deletion_timestamp: Some(
-                SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis() as i64,
-            ),
-            data_change: true,
-            extended_file_metadata: None,
-            size: Some(add.size),
-            partition_values: Some(add.partition_values.clone()),
-            tags: Some(HashMap::new()),
-        };
+    let maybe_metrics = plan.execute(&mut dt).await;
+    assert!(maybe_metrics.is_err());
+    assert_eq!(dt.version(), version + 1);
+    Ok(())
+}
 
-        let mut transaction = other_dt.create_transaction(None);
-        transaction.add_action(action::Action::remove(remove));
-        transaction.commit(None, None).await?;
+#[tokio::test]
+/// Validate that optimize succeeds when only add actions occur for a optimized partition
+async fn test_no_conflict_for_append_actions() -> Result<(), Box<dyn Error>> {
+    let context = setup_test(true).await?;
+    let mut dt = context.table;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
 
-        let maybe_metrics = plan.execute(&mut dt).await;
-        assert!(maybe_metrics.is_err());
-        assert_eq!(dt.version(), version + 1);
-        Ok(())
-    }
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(1, 2), (1, 3), (1, 4)], "2022-05-22")?,
+    )
+    .await?;
 
-    #[tokio::test]
-    /// Validate that optimize succeeds when only add actions occur for a optimized partition
-    async fn test_no_conflict_for_append_actions() -> Result<(), Box<dyn Error>> {
-        let context = setup_test(true).await?;
-        let mut dt = context.table;
-        let mut writer = RecordBatchWriter::for_table(&dt)?;
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(2, 2), (2, 3), (2, 4)], "2022-05-22")?,
+    )
+    .await?;
 
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(1, 2), (1, 3), (1, 4)], "2022-05-22")?,
-        )
-        .await?;
+    let version = dt.version();
 
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(2, 2), (2, 3), (2, 4)], "2022-05-22")?,
-        )
-        .await?;
+    //create the merge plan, remove a file, and execute the plan.
+    let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
+    let plan = create_merge_plan(&mut dt, &filter, None)?;
 
-        let version = dt.version();
+    let uri = context.tmp_dir.path().to_str().to_owned().unwrap();
+    let mut other_dt = deltalake::open_table(uri).await?;
+    let mut writer = RecordBatchWriter::for_table(&other_dt)?;
+    write(
+        &mut writer,
+        &mut other_dt,
+        tuples_to_batch(vec![(3, 2), (3, 3), (3, 4)], "2022-05-22")?,
+    )
+    .await?;
 
-        //create the merge plan, remove a file, and execute the plan.
-        let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
-        let plan = create_merge_plan(&mut dt, &filter, None)?;
+    let metrics = plan.execute(&mut dt).await?;
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 2);
+    assert_eq!(dt.version(), version + 2);
+    Ok(())
+}
 
-        let uri = context.tmp_dir.path().to_str().to_owned().unwrap();
-        let mut other_dt = deltalake::open_table(uri).await?;
-        let mut writer = RecordBatchWriter::for_table(&other_dt)?;
-        write(
-            &mut writer,
-            &mut other_dt,
-            tuples_to_batch(vec![(3, 2), (3, 3), (3, 4)], "2022-05-22")?,
-        )
-        .await?;
+#[tokio::test]
+#[ignore]
+/// Validate that bin packing is idempotent.
+async fn test_idempotent() -> Result<(), Box<dyn Error>> {
+    //TODO: Compression makes it hard to get the target file size...
+    //Maybe just commit files with a known size
+    let context = setup_test(true).await?;
+    let mut dt = context.table;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
 
-        let metrics = plan.execute(&mut dt).await?;
-        assert_eq!(metrics.num_files_added, 1);
-        assert_eq!(metrics.num_files_removed, 2);
-        assert_eq!(dt.version(), version + 2);
-        Ok(())
-    }
+    write(
+        &mut writer,
+        &mut dt,
+        generate_random_batch(records_for_size(6_000_000), "2022-05-22")?,
+    )
+    .await?;
+    write(
+        &mut writer,
+        &mut dt,
+        generate_random_batch(records_for_size(9_000_000), "2022-05-22")?,
+    )
+    .await?;
+    write(
+        &mut writer,
+        &mut dt,
+        generate_random_batch(records_for_size(2_000_000), "2022-05-22")?,
+    )
+    .await?;
 
-    #[tokio::test]
-    #[ignore]
-    /// Validate that bin packing is idempotent.
-    async fn test_idempotent() -> Result<(), Box<dyn Error>> {
-        //TODO: Compression makes it hard to get the target file size...
-        //Maybe just commit files with a known size
-        let context = setup_test(true).await?;
-        let mut dt = context.table;
-        let mut writer = RecordBatchWriter::for_table(&dt)?;
+    let version = dt.version();
 
-        write(
-            &mut writer,
-            &mut dt,
-            generate_random_batch(records_for_size(6_000_000), "2022-05-22")?,
-        )
-        .await?;
-        write(
-            &mut writer,
-            &mut dt,
-            generate_random_batch(records_for_size(9_000_000), "2022-05-22")?,
-        )
-        .await?;
-        write(
-            &mut writer,
-            &mut dt,
-            generate_random_batch(records_for_size(2_000_000), "2022-05-22")?,
-        )
-        .await?;
+    let mut filter = vec![];
+    filter.push(PartitionFilter::try_from(("date", "=", "2022-05-22"))?);
 
-        let version = dt.version();
+    let optimize = Optimize::default().filter(&filter).target_size(10_000_000);
+    let metrics = optimize.execute(&mut dt).await?;
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 2);
+    assert_eq!(dt.version(), version + 1);
 
-        let mut filter = vec![];
-        filter.push(PartitionFilter::try_from(("date", "=", "2022-05-22"))?);
+    let metrics = optimize.execute(&mut dt).await?;
 
-        let optimize = Optimize::default().filter(&filter).target_size(10_000_000);
-        let metrics = optimize.execute(&mut dt).await?;
-        assert_eq!(metrics.num_files_added, 1);
-        assert_eq!(metrics.num_files_removed, 2);
-        assert_eq!(dt.version(), version + 1);
+    assert_eq!(metrics.num_files_added, 0);
+    assert_eq!(metrics.num_files_removed, 0);
+    assert_eq!(dt.version(), version + 1);
 
-        let metrics = optimize.execute(&mut dt).await?;
+    Ok(())
+}
 
-        assert_eq!(metrics.num_files_added, 0);
-        assert_eq!(metrics.num_files_removed, 0);
-        assert_eq!(dt.version(), version + 1);
+#[tokio::test]
+/// Validate Metrics when no files are optimized
+async fn test_idempotent_metrics() -> Result<(), Box<dyn Error>> {
+    let context = setup_test(true).await?;
+    let mut dt = context.table;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
 
-        Ok(())
-    }
+    write(
+        &mut writer,
+        &mut dt,
+        generate_random_batch(records_for_size(1_000_000), "2022-05-22")?,
+    )
+    .await?;
 
-    #[tokio::test]
-    /// Validate Metrics when no files are optimized
-    async fn test_idempotent_metrics() -> Result<(), Box<dyn Error>> {
-        let context = setup_test(true).await?;
-        let mut dt = context.table;
-        let mut writer = RecordBatchWriter::for_table(&dt)?;
+    let version = dt.version();
+    let optimize = Optimize::default().target_size(10_000_000);
+    let metrics = optimize.execute(&mut dt).await?;
 
-        write(
-            &mut writer,
-            &mut dt,
-            generate_random_batch(records_for_size(1_000_000), "2022-05-22")?,
-        )
-        .await?;
+    let mut expected_metric_details = MetricDetails::default();
+    expected_metric_details.min = 0;
+    expected_metric_details.max = 0;
+    expected_metric_details.avg = 0.0;
+    expected_metric_details.total_files = 0;
+    expected_metric_details.total_size = 0;
 
-        let version = dt.version();
-        let optimize = Optimize::default().target_size(10_000_000);
-        let metrics = optimize.execute(&mut dt).await?;
+    let mut expected = Metrics::default();
+    expected.num_files_added = 0;
+    expected.num_files_removed = 0;
+    expected.partitions_optimized = 0;
+    expected.num_batches = 0;
+    expected.total_considered_files = 1;
+    expected.total_files_skipped = 1;
+    expected.preserve_insertion_order = true;
+    expected.files_added = expected_metric_details.clone();
+    expected.files_removed = expected_metric_details.clone();
 
-        let mut expected_metric_details = MetricDetails::default();
-        expected_metric_details.min = 0;
-        expected_metric_details.max = 0;
-        expected_metric_details.avg = 0.0;
-        expected_metric_details.total_files = 0;
-        expected_metric_details.total_size = 0;
+    assert_eq!(expected, metrics);
+    assert_eq!(version, dt.version());
+    Ok(())
+}
 
-        let mut expected = Metrics::default();
-        expected.num_files_added = 0;
-        expected.num_files_removed = 0;
-        expected.partitions_optimized = 0;
-        expected.num_batches = 0;
-        expected.total_considered_files = 1;
-        expected.total_files_skipped = 1;
-        expected.preserve_insertion_order = true;
-        expected.files_added = expected_metric_details.clone();
-        expected.files_removed = expected_metric_details.clone();
+#[tokio::test]
+/// Validate operation data and metadata was written
+async fn test_commit_info() -> Result<(), Box<dyn Error>> {
+    let context = setup_test(true).await?;
+    let mut dt = context.table;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
 
-        assert_eq!(expected, metrics);
-        assert_eq!(version, dt.version());
-        Ok(())
-    }
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(1, 2), (1, 3), (1, 4)], "2022-05-22")?,
+    )
+    .await?;
 
-    #[tokio::test]
-    /// Validate operation data and metadata was written
-    async fn test_commit_info() -> Result<(), Box<dyn Error>> {
-        let context = setup_test(true).await?;
-        let mut dt = context.table;
-        let mut writer = RecordBatchWriter::for_table(&dt)?;
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(2, 2), (2, 3), (2, 4)], "2022-05-22")?,
+    )
+    .await?;
 
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(1, 2), (1, 3), (1, 4)], "2022-05-22")?,
-        )
-        .await?;
+    let version = dt.version();
 
-        write(
-            &mut writer,
-            &mut dt,
-            tuples_to_batch(vec![(2, 2), (2, 3), (2, 4)], "2022-05-22")?,
-        )
-        .await?;
+    let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
 
-        let version = dt.version();
+    let optimize = Optimize::default().target_size(2_000_000).filter(&filter);
+    let metrics = optimize.execute(&mut dt).await?;
 
-        let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
+    let commit_info = dt.history(None).await?;
+    let last_commit = &commit_info[commit_info.len() - 1];
 
-        let optimize = Optimize::default().target_size(2_000_000).filter(&filter);
-        let metrics = optimize.execute(&mut dt).await?;
+    let commit_metrics =
+        serde_json::from_value::<Metrics>(last_commit["operationMetrics"].clone())?;
 
-        let commit_info = dt.history(None).await?;
-        let last_commit = &commit_info[commit_info.len() - 1];
+    assert_eq!(commit_metrics, metrics);
+    assert_eq!(last_commit["readVersion"], json!(version));
+    assert_eq!(
+        last_commit["operationParameters"]["targetSize"],
+        json!(2_000_000)
+    );
+    // TODO: Requires a string representation for PartitionFilter
+    assert_eq!(last_commit["operationParameters"]["predicate"], Value::Null);
 
-        let commit_metrics =
-            serde_json::from_value::<Metrics>(last_commit["operationMetrics"].clone())?;
-
-        assert_eq!(commit_metrics, metrics);
-        assert_eq!(last_commit["readVersion"], json!(version));
-        assert_eq!(
-            last_commit["operationParameters"]["targetSize"],
-            json!(2_000_000)
-        );
-        // TODO: Requires a string representation for PartitionFilter
-        assert_eq!(last_commit["operationParameters"]["predicate"], Value::Null);
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/rust/tests/integration_datafusion.rs
+++ b/rust/tests/integration_datafusion.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "integration_test", feature = "datafusion-ext"))]
 
-use datafusion::arrow::array::Int64Array;
+use arrow::array::Int64Array;
 use datafusion::execution::context::SessionContext;
 use deltalake::test_utils::{IntegrationContext, StorageIntegration, TestResult, TestTables};
 use deltalake::DeltaTableBuilder;

--- a/rust/tests/integration_object_store.rs
+++ b/rust/tests/integration_object_store.rs
@@ -1,10 +1,9 @@
 #![cfg(feature = "integration_test")]
 
 use bytes::Bytes;
-use deltalake::{
-    test_utils::{IntegrationContext, StorageIntegration, TestResult},
-    DeltaTableBuilder,
-};
+use deltalake::storage::utils::flatten_list_stream;
+use deltalake::test_utils::{IntegrationContext, StorageIntegration, TestResult};
+use deltalake::DeltaTableBuilder;
 use futures::TryStreamExt;
 use object_store::{
     path::Path, DynObjectStore, Error as ObjectStoreError, Result as ObjectStoreResult,
@@ -411,16 +410,4 @@ async fn delete_fixtures(storage: &DynObjectStore) -> TestResult {
         let _ = storage.delete(f).await?;
     }
     Ok(())
-}
-
-async fn flatten_list_stream(
-    storage: &DynObjectStore,
-    prefix: Option<&Path>,
-) -> ObjectStoreResult<Vec<Path>> {
-    storage
-        .list(prefix)
-        .await?
-        .map_ok(|meta| meta.location)
-        .try_collect::<Vec<Path>>()
-        .await
 }


### PR DESCRIPTION
# Description

Going forward we may introduce a dependency on `datafusion_expr`, or other sub crates, to use for handling predicates etc. AFAIK, the datafusion crate is also going to deprecate re-exports of some of these sub-crates. To be prepared for this, we refactor the imports in `delta-rs` to import from the sub-crates.

As a drive-by I also consolidated some helper functions in `storage::utils`. 

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
