### PR TITLE
Add invariant enforcement support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,9 +1848,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.21.0+1.1.1p"
+version = "111.22.0+1.1.1q"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0a8313729211913936f1b95ca47a5fc7f2e04cd658c115388287f8a8361008"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,9 +1848,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.21.0+1.1.1p"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "6d0a8313729211913936f1b95ca47a5fc7f2e04cd658c115388287f8a8361008"
 dependencies = [
  "cc",
 ]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -36,4 +36,4 @@ features = ["extension-module", "abi3", "abi3-py37"]
 [dependencies.deltalake]
 path = "../rust"
 version = "0"
-features = ["s3", "azure", "glue", "gcs", "python"]
+features = ["s3", "azure", "glue", "gcs", "python", "datafusion-ext"]

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Callable, Dict, List, Mapping, Optional, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -118,6 +118,7 @@ class StructType:
 class Schema:
     def __init__(self, fields: List[Field]) -> None: ...
     fields: List[Field]
+    invariants: List[Tuple[str, str]]
 
     def to_json(self) -> str: ...
     @staticmethod
@@ -212,3 +213,7 @@ class DeltaFileSystemHandler:
         self, path: str, metadata: dict[str, str] | None = None
     ) -> ObjectOutputStream:
         """Open an output stream for sequential writing."""
+
+class DeltaDataChecker:
+    def __init__(self, invariants: List[Tuple[str, str]]) -> None: ...
+    def check_batch(self, batch: pa.RecordBatch) -> None: ...

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -8,14 +8,16 @@ use chrono::{DateTime, FixedOffset, Utc};
 use deltalake::action::{
     self, Action, ColumnCountStat, ColumnValueStat, DeltaOperation, SaveMode, Stats,
 };
+use deltalake::arrow::record_batch::RecordBatch;
 use deltalake::arrow::{self, datatypes::Schema as ArrowSchema};
 use deltalake::builder::DeltaTableBuilder;
+use deltalake::delta_datafusion::DeltaDataChecker;
 use deltalake::partitions::PartitionFilter;
 use deltalake::DeltaDataTypeLong;
 use deltalake::DeltaDataTypeTimestamp;
 use deltalake::DeltaTableMetaData;
 use deltalake::DeltaTransactionOptions;
-use deltalake::Schema;
+use deltalake::{Invariant, Schema};
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyValueError;
@@ -585,6 +587,34 @@ fn write_new_deltalake(
     Ok(())
 }
 
+#[pyclass(name = "DeltaDataChecker", text_signature = "(invariants)")]
+struct PyDeltaDataChecker {
+    inner: DeltaDataChecker,
+}
+
+#[pymethods]
+impl PyDeltaDataChecker {
+    #[new]
+    fn new(invariants: Vec<(String, String)>) -> Self {
+        let invariants: Vec<Invariant> = invariants
+            .into_iter()
+            .map(|(field_name, invariant_sql)| Invariant {
+                field_name,
+                invariant_sql,
+            })
+            .collect();
+        Self {
+            inner: DeltaDataChecker::new(invariants),
+        }
+    }
+
+    fn check_batch(&self, batch: RecordBatch) -> PyResult<()> {
+        self.inner
+            .check_batch(&batch)
+            .map_err(PyDeltaTableError::from_raw)
+    }
+}
+
 #[pymodule]
 // module name need to match project name
 fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
@@ -594,6 +624,7 @@ fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(pyo3::wrap_pyfunction!(write_new_deltalake, m)?)?;
     m.add_class::<RawDeltaTable>()?;
     m.add_class::<RawDeltaTableMetaData>()?;
+    m.add_class::<PyDeltaDataChecker>()?;
     m.add("PyDeltaTableError", py.get_type::<PyDeltaTableError>())?;
     // There are issues with submodules, so we will expose them flat for now
     // See also: https://github.com/PyO3/pyo3/issues/759

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -1064,4 +1064,22 @@ impl PySchema {
             Err(PyTypeError::new_err("Type is not a struct"))
         }
     }
+
+    /// The list of invariants on the table.
+    ///
+    /// :rtype: List[Tuple[str, str]]
+    /// :return: a tuple of strings for each invariant. The first string is the
+    /// field path and the second is the SQL of the invariant.
+    #[getter]
+    fn invariants(self_: PyRef<'_, Self>) -> PyResult<Vec<(String, String)>> {
+        let super_ = self_.as_ref();
+        let invariants = super_
+            .inner_type
+            .get_invariants()
+            .map_err(|err| PyException::new_err(err.to_string()))?;
+        Ok(invariants
+            .into_iter()
+            .map(|invariant| (invariant.field_name, invariant.invariant_sql))
+            .collect())
+    }
 }

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -1069,7 +1069,7 @@ impl PySchema {
     ///
     /// :rtype: List[Tuple[str, str]]
     /// :return: a tuple of strings for each invariant. The first string is the
-    /// field path and the second is the SQL of the invariant.
+    ///          field path and the second is the SQL of the invariant.
     #[getter]
     fn invariants(self_: PyRef<'_, Self>) -> PyResult<Vec<(String, String)>> {
         let super_ = self_.as_ref();

--- a/python/tests/pyspark_integration/test_write_to_pyspark.py
+++ b/python/tests/pyspark_integration/test_write_to_pyspark.py
@@ -1,0 +1,107 @@
+"""Tests that deltalake(delta-rs) can write to tables written by PySpark"""
+import pathlib
+
+import pyarrow as pa
+import pytest
+
+from deltalake import write_deltalake
+from deltalake.deltalake import PyDeltaTableError
+
+from .utils import assert_spark_read_equal, get_spark
+
+try:
+    from pandas.testing import assert_frame_equal
+except ModuleNotFoundError:
+    _has_pandas = False
+else:
+    _has_pandas = True
+
+
+try:
+    import delta
+    import delta.pip_utils
+    import delta.tables
+    import pyspark
+
+    spark = get_spark()
+except ModuleNotFoundError:
+    pass
+
+
+@pytest.mark.pyspark
+@pytest.mark.integration
+def test_write_basic(tmp_path: pathlib.Path, sample_data: pa.Table):
+    # Write table in Spark
+    spark = get_spark()
+    schema = pyspark.sql.types.StructType(
+        [
+            pyspark.sql.types.StructField(
+                "c1",
+                dataType=pyspark.sql.types.IntegerType(),
+                nullable=True,
+            )
+        ]
+    )
+    spark.createDataFrame([(4,)], schema=schema).write.save(
+        str(tmp_path),
+        mode="append",
+        format="delta",
+    )
+    # Overwrite table in deltalake
+    data = pa.table({"c1": pa.array([5, 6], type=pa.int32())})
+    write_deltalake(str(tmp_path), data, mode="overwrite")
+
+    # Read table in Spark
+    assert_spark_read_equal(data, str(tmp_path))
+
+
+@pytest.mark.pyspark
+@pytest.mark.integration
+def test_write_invariant(tmp_path: pathlib.Path):
+    # Write table in Spark with invariant
+    spark = get_spark()
+
+    schema = pyspark.sql.types.StructType(
+        [
+            pyspark.sql.types.StructField(
+                "c1",
+                dataType=pyspark.sql.types.IntegerType(),
+                nullable=True,
+                metadata={
+                    "delta.invariants": '{"expression": { "expression": "c1 > 3"} }'
+                },
+            )
+        ]
+    )
+
+    delta.tables.DeltaTable.create(spark).location(str(tmp_path)).addColumns(
+        schema
+    ).execute()
+
+    spark.createDataFrame([(4,)], schema=schema).write.save(
+        str(tmp_path),
+        mode="append",
+        format="delta",
+    )
+
+    # Cannot write invalid data to the table
+    invalid_data = pa.table({"c1": pa.array([6, 2], type=pa.int32())})
+    with pytest.raises(
+        PyDeltaTableError, match="Invariant (c1 > 3) violated by value .+2"
+    ):
+        write_deltalake(str(tmp_path), invalid_data, mode="overwrite")
+
+    # Can write valid data to the table
+    valid_data = pa.table({"c1": pa.array([5, 6], type=pa.int32())})
+    write_deltalake(str(tmp_path), valid_data, mode="append")
+
+    expected = pa.table({"c1": pa.array([4, 5, 6], type=pa.int32())})
+    assert_spark_read_equal(expected, str(tmp_path))
+
+
+@pytest.mark.pyspark
+@pytest.mark.integration
+def test_checks_min_writer_version():
+    # Write table in Spark with constraint
+    # assert we fail to write any data to it
+    pass

--- a/python/tests/pyspark_integration/test_write_to_pyspark.py
+++ b/python/tests/pyspark_integration/test_write_to_pyspark.py
@@ -112,10 +112,10 @@ def test_checks_min_writer_version(tmp_path: pathlib.Path):
     )
 
     # Add a constraint upgrades the minWriterProtocol
-    spark.sql(f"ALTER TABLE delta.{str(tmp_path)} ADD CONSTRAINT x CHECK c1 > 2")
+    spark.sql(f"ALTER TABLE delta.`{str(tmp_path)}` ADD CONSTRAINT x CHECK (c1 > 2)")
 
     with pytest.raises(
-        PyDeltaTableError, match="The table's min_writer_version is 3 but"
+        PyDeltaTableError, match="This table's min_writer_version is 3, but"
     ):
-        valid_data = pa.table({"c1": pa.array([5, 6], type=pa.int32())})
+        valid_data = pa.table({"c1": pa.array([5, 6])})
         write_deltalake(str(tmp_path), valid_data, mode="append")

--- a/python/tests/pyspark_integration/utils.py
+++ b/python/tests/pyspark_integration/utils.py
@@ -1,0 +1,49 @@
+from typing import List
+
+import pyarrow as pa
+
+try:
+    import delta
+    import delta.pip_utils
+    import delta.tables
+    import pyspark
+except ModuleNotFoundError:
+    pass
+
+try:
+    from pandas.testing import assert_frame_equal
+except ModuleNotFoundError:
+    _has_pandas = False
+else:
+    _has_pandas = True
+
+
+def get_spark():
+    builder = (
+        pyspark.sql.SparkSession.builder.appName("MyApp")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+    )
+    return delta.pip_utils.configure_spark_with_delta_pip(builder).getOrCreate()
+
+
+def assert_spark_read_equal(
+    expected: pa.Table, uri: str, sort_by: List[str] = ["int32"]
+):
+    spark = get_spark()
+    df = spark.read.format("delta").load(uri)
+
+    # Spark and pyarrow don't convert these types to the same Pandas values
+    incompatible_types = ["timestamp", "struct"]
+
+    assert_frame_equal(
+        df.toPandas()
+        .sort_values(sort_by, ignore_index=True)
+        .drop(incompatible_types, axis="columns"),
+        expected.to_pandas()
+        .sort_values(sort_by, ignore_index=True)
+        .drop(incompatible_types, axis="columns"),
+    )

--- a/python/tests/pyspark_integration/utils.py
+++ b/python/tests/pyspark_integration/utils.py
@@ -42,8 +42,8 @@ def assert_spark_read_equal(
     assert_frame_equal(
         df.toPandas()
         .sort_values(sort_by, ignore_index=True)
-        .drop(incompatible_types, axis="columns"),
+        .drop(incompatible_types, axis="columns", errors="ignore"),
         expected.to_pandas()
         .sort_values(sort_by, ignore_index=True)
-        .drop(incompatible_types, axis="columns"),
+        .drop(incompatible_types, axis="columns", errors="ignore"),
     )

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -420,7 +420,7 @@ def test_writer_null_stats(tmp_path: pathlib.Path):
 
 
 def test_writer_fails_on_protocol(existing_table: DeltaTable, sample_data: pa.Table):
-    existing_table.protocol = Mock(return_value=ProtocolVersions(1, 2))
+    existing_table.protocol = Mock(return_value=ProtocolVersions(1, 3))
     with pytest.raises(DeltaTableProtocolError):
         write_deltalake(existing_table, sample_data, mode="overwrite")
 

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -141,6 +141,12 @@ pub enum DeltaTableError {
         #[from]
         source: action::ActionError,
     },
+    /// Error returned when attempting to write bad data to the table
+    #[error("Attempted to write invalid data to the table: {:#?}", violations)]
+    InvalidData {
+        /// Action error details returned of the invalid action.
+        violations: Vec<String>,
+    },
     /// Error returned when it is not a DeltaTable.
     #[error("Not a Delta table: {0}")]
     NotATable(String),

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -603,6 +603,18 @@ fn left_larger_than_right(left: ScalarValue, right: ScalarValue) -> Option<bool>
     }
 }
 
+fn enforce_invariants(
+    record_batch: RecordBatch,
+    invariants: &Vec<(String, String)>,
+) -> Result<(), DeltaTableError> {
+    let ctx = SessionContext::new();
+    // TODO: How does one query a record batch in data fusion??
+    for invariant in invariants.iter() {
+        let sql = format!("SELECT {} FROM data WHERE {} LIMIT 1", name, invariant);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -47,10 +47,6 @@ use datafusion_expr::{combine_filters, Expr};
 use object_store::{path::Path, ObjectMeta};
 use url::Url;
 
-use crate::action;
-use crate::delta;
-use crate::schema;
-use crate::DeltaTableError;
 use crate::Invariant;
 
 impl From<DeltaTableError> for DataFusionError {

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -654,7 +654,7 @@ impl DeltaDataChecker {
                 invariant.field_name, invariant.invariant_sql
             );
 
-            let dfs: Vec<RecordBatch> =  self.ctx.sql(&sql).await?.collect().await?;
+            let dfs: Vec<RecordBatch> = self.ctx.sql(&sql).await?.collect().await?;
             if !dfs.is_empty() && dfs[0].num_rows() > 0 {
                 let value = format!("{:?}", dfs[0].column(0));
                 let msg = format!(

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -33,7 +33,7 @@ pub struct Invariant {
 impl Invariant {
     /// Create a new invariant
     pub fn new(field_name: &str, invariant_sql: &str) -> Self {
-        Invariant {
+        Self {
             field_name: field_name.to_string(),
             invariant_sql: invariant_sql.to_string(),
         }

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -22,7 +22,7 @@ static ARRAY_TAG: &str = "array";
 static MAP_TAG: &str = "map";
 
 /// An invariant for a column that is enforced on all writes to a Delta table.
-#[derive(PartialEq, Debug, Default, Clone)]
+#[derive(Eq, PartialEq, Debug, Default, Clone)]
 pub struct Invariant {
     /// The full path to the field.
     pub field_name: String,


### PR DESCRIPTION
# Description

Adds support to retrieve invariants from the Delta schema and also a struct `DeltaDataChecker` to use DataFusion to check them and report useful errors.

This also hooks it up to the Python bindings, allowing `write_deltalake()` to support Writer Protocol V2.

I looked briefly at the Rust writer, but then realized we don't want to introduce a dependency on DataFusion. We should discuss how we want to design that API. I suspect we'll turn DeltaDataChecker into a trait, so we can have a DataFusion one available but also allow other engines to implement it themselves if they don't wish to use DataFusion.

# Related Issue(s)

- closes #592
- closes #575

# Documentation

https://github.com/delta-io/delta/blob/master/PROTOCOL.md#column-invariants
