### PR TITLE
Added without_files flag to DeltaTable constructor

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -77,7 +77,7 @@ class DeltaTable:
         table_uri: str,
         version: Optional[int] = None,
         storage_options: Optional[Dict[str, str]] = None,
-        without_files: Optional[bool] = None
+        without_files: bool = False
     ):
         """
         Create the Delta Table from a path with an optional version.

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -77,6 +77,7 @@ class DeltaTable:
         table_uri: str,
         version: Optional[int] = None,
         storage_options: Optional[Dict[str, str]] = None,
+        without_files: Optional[bool] = None
     ):
         """
         Create the Delta Table from a path with an optional version.
@@ -89,7 +90,7 @@ class DeltaTable:
         """
         self._storage_options = storage_options
         self._table = RawDeltaTable(
-            table_uri, version=version, storage_options=storage_options
+            table_uri, version=version, storage_options=storage_options, without_files=without_files
         )
         self._metadata = Metadata(self._table)
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -87,6 +87,9 @@ class DeltaTable:
         :param table_uri: the path of the DeltaTable
         :param version: version of the DeltaTable
         :param storage_options: a dictionary of the options to use for the storage backend
+        :param without_files: If True, will load table without tracking files.
+                              Some append-only applications might have no need of tracking any files. So, the
+                              DeltaTable will be loaded with a significant memory reduction.
         """
         self._storage_options = storage_options
         self._table = RawDeltaTable(

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -77,7 +77,7 @@ class DeltaTable:
         table_uri: str,
         version: Optional[int] = None,
         storage_options: Optional[Dict[str, str]] = None,
-        without_files: bool = False
+        without_files: bool = False,
     ):
         """
         Create the Delta Table from a path with an optional version.
@@ -93,7 +93,10 @@ class DeltaTable:
         """
         self._storage_options = storage_options
         self._table = RawDeltaTable(
-            table_uri, version=version, storage_options=storage_options, without_files=without_files
+            table_uri,
+            version=version,
+            storage_options=storage_options,
+            without_files=without_files,
         )
         self._metadata = Metadata(self._table)
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -106,7 +106,7 @@ impl RawDeltaTable {
         table_uri: &str,
         version: Option<deltalake::DeltaDataTypeLong>,
         storage_options: Option<HashMap<String, String>>,
-        without_files: bool
+        without_files: bool,
     ) -> PyResult<Self> {
         let mut builder = deltalake::DeltaTableBuilder::from_uri(table_uri);
         if let Some(storage_options) = storage_options {

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -106,7 +106,7 @@ impl RawDeltaTable {
         table_uri: &str,
         version: Option<deltalake::DeltaDataTypeLong>,
         storage_options: Option<HashMap<String, String>>,
-        without_files: Option<bool>
+        without_files: bool
     ) -> PyResult<Self> {
         let mut builder = deltalake::DeltaTableBuilder::from_uri(table_uri);
         if let Some(storage_options) = storage_options {
@@ -116,7 +116,7 @@ impl RawDeltaTable {
             builder = builder.with_version(version)
         }
 
-        if without_files.unwrap_or(false) {
+        if without_files {
             builder = builder.without_files()
         }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -106,6 +106,7 @@ impl RawDeltaTable {
         table_uri: &str,
         version: Option<deltalake::DeltaDataTypeLong>,
         storage_options: Option<HashMap<String, String>>,
+        without_files: Option<bool>
     ) -> PyResult<Self> {
         let mut builder = deltalake::DeltaTableBuilder::from_uri(table_uri);
         if let Some(storage_options) = storage_options {
@@ -114,6 +115,11 @@ impl RawDeltaTable {
         if let Some(version) = version {
             builder = builder.with_version(version)
         }
+
+        if without_files.unwrap_or(false) {
+            builder = builder.without_files()
+        }
+
         let table = rt()?
             .block_on(builder.load())
             .map_err(PyDeltaTableError::from_raw)?;


### PR DESCRIPTION
# Description
Added _without_files_ flag to DeltaTable constructor. If the flag is set it will be called method _without_files_ in the **DeltaTableBuilder**. And this allows users to control memory usage. Some append-only applications might have no need of tracking any files.


# Documentation
Indicates whether DeltaTable should not track files. This defaults to "false" (files are tracked). Some append-only applications might have no need of tracking any files. So, DeltaTable will be loaded with significant memory reduction.
