### PR TITLE
Bump Python binding version to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "deltalake-python"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "deltalake",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"


### PR DESCRIPTION
# Description
- Bump Python binding version to `0.6.2` for a new release

