### PR TITLE
Add TableProviderFactory and test for SQL to register tables dynamically at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-proto"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7956c5e25c01554bf36105db462382a4d9798b6331072a812408a84a5cf8cdfc"
+dependencies = [
+ "arrow",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "pbjson-build",
+ "prost",
+ "prost-build",
+]
+
+[[package]]
 name = "datafusion-row"
 version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,12 +901,13 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-proto",
  "dotenv",
  "dynamodb_lock",
  "errno",
  "fs_extra",
  "futures",
- "glibc_version 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glibc_version",
  "lazy_static",
  "libc",
  "log",
@@ -1102,6 +1118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flatbuffers"
 version = "22.9.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,15 +1298,6 @@ dependencies = [
 [[package]]
 name = "glibc_version"
 version = "0.1.2"
-dependencies = [
- "regex",
-]
-
-[[package]]
-name = "glibc_version"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803ff7635f1ab4e2c064b68a0c60da917d3d18dc8d086130f689d62ce4f1c33e"
 dependencies = [
  "regex",
 ]
@@ -1834,6 +1847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "multiversion"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,10 +2189,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
+name = "pbjson-build"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdbb7b706f2afc610f3853550cdbbf6372fd324824a087806bd4480ea4996e24"
+dependencies = [
+ "heck",
+ "itertools",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pin-project"
@@ -2306,6 +2347,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -3571,6 +3665,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/glibc_version/src/lib.rs
+++ b/glibc_version/src/lib.rs
@@ -26,7 +26,7 @@ mod imp {
     // glibc version is taken from std/sys/unix/os.rs
     pub fn get_version() -> Result<Version, String> {
         let output = Command::new("ldd")
-            .args(&["--version"])
+            .args(["--version"])
             .output()
             .expect("failed to execute ldd");
         let output_str = std::str::from_utf8(&output.stdout).unwrap();

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,9 +46,10 @@ rusoto_dynamodb = { version = "0.48", default-features = false, optional = true 
 rusoto_glue = { version = "0.48", default-features = false, optional = true }
 
 # Datafusion
-datafusion = { version = "14", optional = true }
-datafusion-expr = { version = "14", optional = true }
-datafusion-common = { version = "14", optional = true }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4a67d0d2613d8c4b323e0dd5a6afe1eb1115c7ba", optional = true }
+datafusion-expr = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4a67d0d2613d8c4b323e0dd5a6afe1eb1115c7ba", optional = true }
+datafusion-common = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4a67d0d2613d8c4b323e0dd5a6afe1eb1115c7ba", optional = true }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4a67d0d2613d8c4b323e0dd5a6afe1eb1115c7ba", optional = true }
 
 # NOTE dependencies only for integration tests
 fs_extra = { version = "1.2.0", optional = true }
@@ -72,7 +73,7 @@ tempfile = "3"
 utime = "0.3"
 
 [build-dependencies]
-glibc_version = "0"
+glibc_version = { path = "../glibc_version" }
 
 [features]
 default = ["arrow", "parquet"]
@@ -80,6 +81,7 @@ datafusion-ext = [
     "datafusion",
     "datafusion-expr",
     "datafusion-common",
+    "datafusion-proto",
     "arrow",
     "parquet",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,10 +46,10 @@ rusoto_dynamodb = { version = "0.48", default-features = false, optional = true 
 rusoto_glue = { version = "0.48", default-features = false, optional = true }
 
 # Datafusion
-datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4a67d0d2613d8c4b323e0dd5a6afe1eb1115c7ba", optional = true }
-datafusion-expr = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4a67d0d2613d8c4b323e0dd5a6afe1eb1115c7ba", optional = true }
-datafusion-common = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4a67d0d2613d8c4b323e0dd5a6afe1eb1115c7ba", optional = true }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4a67d0d2613d8c4b323e0dd5a6afe1eb1115c7ba", optional = true }
+datafusion = { version = "14", optional = true }
+datafusion-expr = { version = "14", optional = true }
+datafusion-common = { version = "14", optional = true }
+datafusion-proto = { version = "14", optional = true }
 
 # NOTE dependencies only for integration tests
 fs_extra = { version = "1.2.0", optional = true }

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -5,7 +5,9 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
+use std::fmt::Formatter;
 use std::io::{BufRead, BufReader, Cursor};
+use std::sync::Arc;
 use std::{cmp::max, cmp::Ordering, collections::HashSet};
 
 use super::action;
@@ -24,7 +26,9 @@ use lazy_static::lazy_static;
 use log::debug;
 use object_store::{path::Path, Error as ObjectStoreError, ObjectStore};
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::de::{Error, SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Map, Value};
 use uuid::Uuid;
 
@@ -429,6 +433,70 @@ pub struct DeltaTable {
     version_timestamp: HashMap<DeltaDataTypeVersion, i64>,
 }
 
+impl Serialize for DeltaTable {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(None)?;
+        seq.serialize_element(&self.state)?;
+        seq.serialize_element(&self.config)?;
+        seq.serialize_element(self.storage.as_ref())?;
+        seq.serialize_element(&self.last_check_point)?;
+        seq.serialize_element(&self.version_timestamp)?;
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for DeltaTable {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct DeltaTableVisitor {}
+
+        impl<'de> Visitor<'de> for DeltaTableVisitor {
+            type Value = DeltaTable;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                formatter.write_str("struct DeltaTable")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let state = seq
+                    .next_element()?
+                    .ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                let config = seq
+                    .next_element()?
+                    .ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                let storage = seq
+                    .next_element()?
+                    .ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                let last_check_point = seq
+                    .next_element()?
+                    .ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                let version_timestamp = seq
+                    .next_element()?
+                    .ok_or_else(|| A::Error::invalid_length(0, &self))?;
+
+                let table = DeltaTable {
+                    state,
+                    config,
+                    storage: Arc::new(storage),
+                    last_check_point,
+                    version_timestamp,
+                };
+                Ok(table)
+            }
+        }
+
+        deserializer.deserialize_seq(DeltaTableVisitor {})
+    }
+}
+
 impl DeltaTable {
     /// Create a new Delta Table struct without loading any data from backing storage.
     ///
@@ -449,7 +517,7 @@ impl DeltaTable {
         self.storage.clone()
     }
 
-    /// The
+    /// The URI of the underlying data
     pub fn table_uri(&self) -> String {
         self.storage.root_uri()
     }
@@ -1449,10 +1517,19 @@ pub fn crate_version() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::action::Protocol;
     use crate::builder::DeltaTableBuilder;
     use pretty_assertions::assert_eq;
     use std::io::{BufRead, BufReader};
     use std::{collections::HashMap, fs::File, path::Path};
+
+    #[tokio::test]
+    async fn table_round_trip() {
+        let (_, _, dt) = create_test_table().await;
+        let bytes = serde_json::to_vec(&dt).unwrap();
+        let actual: DeltaTable = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(actual.version(), dt.version());
+    }
 
     #[cfg(any(feature = "s3", feature = "s3-rustls"))]
     #[test]
@@ -1469,8 +1546,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_create_delta_table() {
+    async fn create_test_table() -> (DeltaTableMetaData, Protocol, DeltaTable) {
         // Setup
         let test_schema = Schema::new(vec![
             SchemaField::new(
@@ -1522,6 +1598,12 @@ mod tests {
         dt.create(delta_md.clone(), protocol.clone(), Some(commit_info), None)
             .await
             .unwrap();
+        (delta_md, protocol, dt)
+    }
+
+    #[tokio::test]
+    async fn test_create_delta_table() {
+        let (delta_md, protocol, dt) = create_test_table().await;
 
         // Validation
         // assert DeltaTable version is now 0 and no data files have been added

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -23,28 +23,37 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fmt::Debug;
 use std::sync::Arc;
 
-use crate::action;
-use crate::schema;
+use crate::{action, open_table};
+use crate::{schema, DeltaTableBuilder};
 use crate::{DeltaTable, DeltaTableError};
 
 use arrow::array::ArrayRef;
 use arrow::compute::{cast_with_options, CastOptions};
-use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, TimeUnit};
+use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, SchemaRef, TimeUnit};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use chrono::{DateTime, NaiveDateTime, Utc};
+use datafusion::datasource::datasource::TableProviderFactory;
 use datafusion::datasource::file_format::{parquet::ParquetFormat, FileFormat};
 use datafusion::datasource::{listing::PartitionedFile, MemTable, TableProvider, TableType};
-use datafusion::execution::context::{SessionContext, SessionState};
+use datafusion::execution::context::{SessionContext, SessionState, TaskContext};
+use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::execution::FunctionRegistry;
+use datafusion::optimizer::utils::conjunction;
+use datafusion::physical_expr::PhysicalSortExpr;
 use datafusion::optimizer::utils::conjunction;
 use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
 use datafusion::physical_plan::file_format::FileScanConfig;
-use datafusion::physical_plan::{ColumnStatistics, ExecutionPlan, Statistics};
+use datafusion::physical_plan::{
+    ColumnStatistics, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
+};
 use datafusion_common::scalar::ScalarValue;
 use datafusion_common::{Column, DataFusionError, Result as DataFusionResult};
-use datafusion_expr::Expr;
+use datafusion_expr::{Expr, Extension, LogicalPlan};
+use datafusion_proto::logical_plan::{LogicalExtensionCodec, PhysicalExtensionCodec};
 use object_store::{path::Path, ObjectMeta};
 use url::Url;
 
@@ -295,6 +304,18 @@ impl PruningStatistics for DeltaTable {
     }
 }
 
+// each delta table must register a specific object store, since paths are internally
+// handled relative to the table root.
+fn register_store(table: &DeltaTable, env: Arc<RuntimeEnv>) {
+    let object_store_url = table.storage.object_store_url();
+    let url: &Url = object_store_url.as_ref();
+    env.register_object_store(
+        url.scheme(),
+        url.host_str().unwrap_or_default(),
+        table.object_store(),
+    );
+}
+
 #[async_trait]
 impl TableProvider for DeltaTable {
     fn schema(&self) -> Arc<ArrowSchema> {
@@ -319,15 +340,7 @@ impl TableProvider for DeltaTable {
             DeltaTable::schema(self).unwrap(),
         )?);
 
-        // each delta table must register a specific object store, since paths are internally
-        // handled relative to the table root.
-        let object_store_url = self.storage.object_store_url();
-        let url: &Url = object_store_url.as_ref();
-        session.runtime_env.register_object_store(
-            url.scheme(),
-            url.host_str().unwrap_or_default(),
-            self.object_store(),
-        );
+        register_store(self, session.runtime_env.clone());
 
         // TODO we group files together by their partition values. If the table is partitioned
         // and partitions are somewhat evenly distributed, probably not the worst choice ...
@@ -370,10 +383,10 @@ impl TableProvider for DeltaTable {
                 .cloned()
                 .collect(),
         ));
-        ParquetFormat::default()
+        let parquet_scan = ParquetFormat::default()
             .create_physical_plan(
                 FileScanConfig {
-                    object_store_url,
+                    object_store_url: self.storage.object_store_url(),
                     file_schema,
                     file_groups: file_groups.into_values().collect(),
                     statistics: self.datafusion_table_statistics(),
@@ -384,11 +397,70 @@ impl TableProvider for DeltaTable {
                 },
                 filters,
             )
-            .await
+            .await?;
+        let delta_scan = DeltaScan {
+            url: self.table_uri(),
+            parquet_scan,
+        };
+
+        Ok(Arc::new(delta_scan))
     }
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+// TODO: this will likely also need to perform column mapping later when we support reader protocol v2
+/// A wrapper for parquet scans that installs the required ObjectStore
+#[derive(Debug)]
+pub struct DeltaScan {
+    /// The URL of the ObjectStore root
+    pub url: String,
+    /// The parquet scan to wrap
+    pub parquet_scan: Arc<dyn ExecutionPlan>,
+}
+
+impl ExecutionPlan for DeltaScan {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.parquet_scan.schema()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        self.parquet_scan.output_partitioning()
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        self.parquet_scan.output_ordering()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.parquet_scan.clone()]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        ExecutionPlan::with_new_children(self.parquet_scan.clone(), children)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let table = DeltaTableBuilder::from_uri(self.url.clone()).build()?;
+        register_store(&table, context.runtime_env());
+        self.parquet_scan.execute(partition, context)
+    }
+
+    fn statistics(&self) -> Statistics {
+        self.parquet_scan.statistics()
     }
 }
 
@@ -676,6 +748,98 @@ impl DeltaDataChecker {
         } else {
             Ok(())
         }
+    }
+}
+
+/// A codec for deltalake physical plans
+#[derive(Debug)]
+pub struct DeltaPhysicalCodec {}
+
+impl PhysicalExtensionCodec for DeltaPhysicalCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[Arc<dyn ExecutionPlan>],
+        _registry: &dyn FunctionRegistry,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        let url: String = serde_json::from_reader(buf)
+            .map_err(|_| DataFusionError::Internal("Unable to decode DeltaScan".to_string()))?;
+        let delta_scan = DeltaScan {
+            url,
+            parquet_scan: (*inputs)[0].clone(),
+        };
+        Ok(Arc::new(delta_scan))
+    }
+
+    fn try_encode(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+        buf: &mut Vec<u8>,
+    ) -> Result<(), DataFusionError> {
+        let delta_scan = node
+            .as_any()
+            .downcast_ref::<DeltaScan>()
+            .ok_or_else(|| DataFusionError::Internal("Not a delta scan!".to_string()))?;
+        serde_json::to_writer(buf, delta_scan.url.as_str())
+            .map_err(|_| DataFusionError::Internal("Unable to encode delta scan!".to_string()))?;
+        Ok(())
+    }
+}
+
+/// Does serde on DeltaTables
+#[derive(Debug)]
+pub struct DeltaLogicalCodec {}
+
+impl LogicalExtensionCodec for DeltaLogicalCodec {
+    fn try_decode(
+        &self,
+        _buf: &[u8],
+        _inputs: &[LogicalPlan],
+        _ctx: &SessionContext,
+    ) -> Result<Extension, DataFusionError> {
+        todo!("DeltaLogicalCodec")
+    }
+
+    fn try_encode(&self, _node: &Extension, _buf: &mut Vec<u8>) -> Result<(), DataFusionError> {
+        todo!("DeltaLogicalCodec")
+    }
+
+    fn try_decode_table_provider(
+        &self,
+        buf: &[u8],
+        _schema: SchemaRef,
+        _ctx: &SessionContext,
+    ) -> Result<Arc<dyn TableProvider>, DataFusionError> {
+        let provider: DeltaTable = serde_json::from_slice(buf)
+            .map_err(|_| DataFusionError::Internal("Error encoding delta table".to_string()))?;
+        Ok(Arc::new(provider))
+    }
+
+    fn try_encode_table_provider(
+        &self,
+        node: Arc<dyn TableProvider>,
+        mut buf: &mut Vec<u8>,
+    ) -> Result<(), DataFusionError> {
+        let table = node
+            .as_ref()
+            .as_any()
+            .downcast_ref::<DeltaTable>()
+            .ok_or_else(|| {
+                DataFusionError::Internal("Can't encode non-delta tables".to_string())
+            })?;
+        serde_json::to_writer(&mut buf, table)
+            .map_err(|_| DataFusionError::Internal("Error encoding delta table".to_string()))
+    }
+}
+
+/// Responsible for creating deltatables
+pub struct DeltaTableFactory {}
+
+#[async_trait]
+impl TableProviderFactory for DeltaTableFactory {
+    async fn create(&self, url: &str) -> datafusion::error::Result<Arc<dyn TableProvider>> {
+        let provider = open_table(url).await.unwrap();
+        Ok(Arc::new(provider))
     }
 }
 

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -26,10 +26,6 @@ use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use crate::{action, open_table};
-use crate::{schema, DeltaTableBuilder};
-use crate::{DeltaTable, DeltaTableError};
-
 use arrow::array::ArrayRef;
 use arrow::compute::{cast_with_options, CastOptions};
 use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, SchemaRef, TimeUnit};
@@ -43,8 +39,8 @@ use datafusion::execution::context::{SessionContext, SessionState, TaskContext};
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::execution::FunctionRegistry;
 use datafusion::optimizer::utils::conjunction;
-use datafusion::physical_expr::PhysicalSortExpr;
 use datafusion::optimizer::utils::conjunction;
+use datafusion::physical_expr::PhysicalSortExpr;
 use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
 use datafusion::physical_plan::file_format::FileScanConfig;
 use datafusion::physical_plan::{
@@ -58,6 +54,9 @@ use object_store::{path::Path, ObjectMeta};
 use url::Url;
 
 use crate::Invariant;
+use crate::{action, open_table};
+use crate::{schema, DeltaTableBuilder};
+use crate::{DeltaTable, DeltaTableError};
 
 impl From<DeltaTableError> for DataFusionError {
     fn from(err: DeltaTableError) -> Self {
@@ -845,12 +844,13 @@ impl TableProviderFactory for DeltaTableFactory {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use arrow::array::StructArray;
     use arrow::datatypes::{DataType, Field, Schema};
     use chrono::{TimeZone, Utc};
     use datafusion::from_slice::FromSlice;
     use serde_json::json;
+
+    use super::*;
 
     // test deserialization of serialized partition values.
     // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#partition-value-serialization

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -39,7 +39,6 @@ use datafusion::execution::context::{SessionContext, SessionState, TaskContext};
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::execution::FunctionRegistry;
 use datafusion::optimizer::utils::conjunction;
-use datafusion::optimizer::utils::conjunction;
 use datafusion::physical_expr::PhysicalSortExpr;
 use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
 use datafusion::physical_plan::file_format::FileScanConfig;

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -1,10 +1,8 @@
 #![cfg(feature = "datafusion-ext")]
+
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
-
-use deltalake::action::SaveMode;
-use deltalake::{operations::DeltaOps, DeltaTable, Schema};
 
 use arrow::array::*;
 use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
@@ -20,7 +18,10 @@ use datafusion::prelude::SessionConfig;
 use datafusion_common::scalar::ScalarValue;
 use datafusion_common::{Column, DataFusionError, Result};
 use datafusion_expr::Expr;
+
+use deltalake::action::SaveMode;
 use deltalake::delta_datafusion::DeltaTableFactory;
+use deltalake::{operations::DeltaOps, DeltaTable, Schema};
 
 fn get_scanned_files(node: &dyn ExecutionPlan) -> HashSet<Label> {
     node.metrics()

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "datafusion-ext")]
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "datafusion-ext")]
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use deltalake::action::SaveMode;
@@ -8,14 +9,18 @@ use deltalake::{operations::DeltaOps, DeltaTable, Schema};
 use arrow::array::*;
 use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
 use arrow::record_batch::RecordBatch;
+use datafusion::datasource::datasource::TableProviderFactory;
 use datafusion::datasource::TableProvider;
 use datafusion::execution::context::{SessionContext, TaskContext};
+use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::{common, file_format::ParquetExec, metrics::Label};
 use datafusion::physical_plan::{visit_execution_plan, ExecutionPlan, ExecutionPlanVisitor};
+use datafusion::prelude::SessionConfig;
 use datafusion_common::scalar::ScalarValue;
 use datafusion_common::{Column, DataFusionError, Result};
 use datafusion_expr::Expr;
+use deltalake::delta_datafusion::DeltaTableFactory;
 
 fn get_scanned_files(node: &dyn ExecutionPlan) -> HashSet<Label> {
     node.metrics()
@@ -75,6 +80,42 @@ async fn prepare_table(
     }
 
     (table_dir, Arc::new(table))
+}
+
+#[tokio::test]
+async fn test_datafusion_sql_registration() -> Result<()> {
+    let mut table_factories: HashMap<String, Arc<dyn TableProviderFactory>> = HashMap::new();
+    table_factories.insert("deltatable".to_string(), Arc::new(DeltaTableFactory {}));
+    let cfg = RuntimeConfig::new().with_table_factories(table_factories);
+    let env = RuntimeEnv::new(cfg).unwrap();
+    let ses = SessionConfig::new();
+    let ctx = SessionContext::with_config_rt(ses, Arc::new(env));
+
+    let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    d.push("tests/data/delta-0.8.0-partitioned");
+    let sql = format!(
+        "CREATE EXTERNAL TABLE demo STORED AS DELTATABLE LOCATION '{}'",
+        d.to_str().unwrap()
+    );
+    let _ = ctx
+        .sql(sql.as_str())
+        .await
+        .expect("Failed to register table!");
+
+    let batches = ctx
+        .sql("SELECT CAST( day as int ) as my_day FROM demo WHERE CAST( year as int ) > 2020 ORDER BY CAST( day as int ) ASC")
+        .await?
+        .collect()
+        .await?;
+
+    let batch = &batches[0];
+
+    assert_eq!(
+        batch.column(0).as_ref(),
+        Arc::new(Int32Array::from(vec![4, 5, 20, 20])).as_ref(),
+    );
+
+    Ok(())
 }
 
 #[tokio::test]

--- a/rust/tests/integration_object_store.rs
+++ b/rust/tests/integration_object_store.rs
@@ -4,10 +4,7 @@ use bytes::Bytes;
 use deltalake::storage::utils::flatten_list_stream;
 use deltalake::test_utils::{IntegrationContext, StorageIntegration, TestResult};
 use deltalake::DeltaTableBuilder;
-use futures::TryStreamExt;
-use object_store::{
-    path::Path, DynObjectStore, Error as ObjectStoreError, Result as ObjectStoreResult,
-};
+use object_store::{path::Path, DynObjectStore, Error as ObjectStoreError};
 use serial_test::serial;
 
 #[tokio::test]


### PR DESCRIPTION
# Description

Use (hopefully soon-to-be-merged) Datafusion functionality to allow dynamic (i.e. SQL-based) registration of deltalake tables at runtime.

# Related Issue(s)
- closes #891

# Documentation

- TBD