### PR TITLE
fix: pass storage options down when getting delta table

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,8 +81,8 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       RUST_BACKTRACE: "1"
       AWS_DEFAULT_REGION: "us-east-1"
-      AWS_ACCESS_KEY_ID: test
-      AWS_SECRET_ACCESS_KEY: test
+      AWS_ACCESS_KEY_ID: deltalake
+      AWS_SECRET_ACCESS_KEY: weloverust
       AWS_ENDPOINT_URL: http://localhost:4566
       AWS_STORAGE_ALLOW_HTTP: "1"
       AZURE_USE_EMULATOR: "1"

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -93,6 +93,9 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"
+      
+      - name: Start emulated services
+        run: docker-compose up -d
 
       - name: Build and install deltalake
         run: |
@@ -104,7 +107,7 @@ jobs:
       - name: Run tests
         run: |
           source venv/bin/activate
-          make unit-test
+          python -m pytest -m 's3 and integration'
 
       - name: Test without pandas
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - PORT_WEB_UI=8080
       - DOCKER_HOST=unix:///var/run/docker.sock
       - HOST_TMP_FOLDER=${TMPDIR}
+      - AWS_ACCESS_KEY_ID=deltalake
+      - AWS_SECRET_ACCESS_KEY=weloverust
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:4566/health" ]
 

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -26,6 +26,7 @@ write_new_deltalake: Callable[
         Optional[str],
         Optional[str],
         Optional[Mapping[str, Optional[str]]],
+        Optional[Dict[str, str]],
     ],
     None,
 ]

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -196,17 +196,6 @@ def write_deltalake(
     else:  # creating a new table
         current_version = -1
 
-        # TODO: Don't allow writing to non-empty directory
-        # Blocked on: Finish filesystem implementation in fs.py
-    assert (
-        len(
-            filesystem.get_file_info(
-                pa_fs.FileSelector(table_uri, allow_not_found=True)
-            )
-        )
-        == 0
-    )
-
     if partition_by:
         partition_schema = pa.schema([schema.field(name) for name in partition_by])
         partitioning = ds.partitioning(partition_schema, flavor="hive")

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -147,6 +147,9 @@ def write_deltalake(
         else:
             schema = data.schema
 
+    if filesystem is not None:
+        raise NotImplementedError("Filesystem support is not yet implemented.  #570")
+
     if isinstance(table_or_uri, str):
         if "://" in table_or_uri:
             table_uri = table_or_uri

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -162,8 +162,8 @@ def write_deltalake(
 
     if filesystem is None:
         if table is not None:
-            storage_options = (table._storage_options or {}).update(
-                storage_options or {}
+            storage_options = dict(
+                **(table._storage_options or {}), **(storage_options or {})
             )
 
         filesystem = pa_fs.PyFileSystem(DeltaStorageHandler(table_uri, storage_options))

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -153,7 +153,7 @@ def write_deltalake(
         else:
             # Non-existant local paths are only accepted as fully-qualified URIs
             table_uri = "file://" + str(Path(table_or_uri).absolute())
-        table = try_get_deltatable(table_or_uri)
+        table = try_get_deltatable(table_or_uri, storage_options)
     else:
         table = table_or_uri
         table_uri = table._table.table_uri()
@@ -162,17 +162,11 @@ def write_deltalake(
 
     if filesystem is None:
         if table is not None:
-            filesystem = pa_fs.PyFileSystem(
-                DeltaStorageHandler(
-                    table._table.table_uri(),
-                    table._storage_options,
-                    table._table.get_py_storage_backend(),
-                )
+            storage_options = (table._storage_options or {}).update(
+                storage_options or {}
             )
-        else:
-            filesystem = pa_fs.PyFileSystem(
-                DeltaStorageHandler(table_uri, storage_options)
-            )
+
+        filesystem = pa_fs.PyFileSystem(DeltaStorageHandler(table_uri, storage_options))
 
     if table:  # already exists
         if schema != table.schema().to_pyarrow() and not (
@@ -204,7 +198,14 @@ def write_deltalake(
 
         # TODO: Don't allow writing to non-empty directory
         # Blocked on: Finish filesystem implementation in fs.py
-        # assert len(filesystem.get_file_info(pa_fs.FileSelector(table_uri, allow_not_found=True))) == 0
+    assert (
+        len(
+            filesystem.get_file_info(
+                pa_fs.FileSelector(table_uri, allow_not_found=True)
+            )
+        )
+        == 0
+    )
 
     if partition_by:
         partition_schema = pa.schema([schema.field(name) for name in partition_by])
@@ -327,9 +328,11 @@ class DeltaJSONEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def try_get_deltatable(table_uri: str) -> Optional[DeltaTable]:
+def try_get_deltatable(
+    table_uri: str, storage_options: Optional[Dict[str, str]]
+) -> Optional[DeltaTable]:
     try:
-        return DeltaTable(table_uri)
+        return DeltaTable(table_uri, storage_options=storage_options)
     except PyDeltaTableError as err:
         # TODO: There has got to be a better way...
         if "Not a Delta table" in str(err):

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -276,6 +276,7 @@ def write_deltalake(
             name,
             description,
             configuration,
+            storage_options,
         )
     else:
         table._table.create_write_transaction(

--- a/python/src/filesystem.rs
+++ b/python/src/filesystem.rs
@@ -401,7 +401,7 @@ pub struct ObjectOutputStream {
 
 impl ObjectOutputStream {
     pub async fn try_new(store: Arc<DynObjectStore>, path: Path) -> Result<Self, ObjectStoreError> {
-        let (multipart_id, writer) = store.put_multipart(&path).await.unwrap();
+        let (multipart_id, writer) = store.put_multipart(&path).await?;
         Ok(Self {
             store,
             path,

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -564,8 +564,10 @@ fn write_new_deltalake(
     name: Option<String>,
     description: Option<String>,
     configuration: Option<HashMap<String, Option<String>>>,
+    storage_options: Option<HashMap<String, String>>,
 ) -> PyResult<()> {
     let mut table = DeltaTableBuilder::from_uri(table_uri)
+        .with_storage_options(storage_options.unwrap_or_default())
         .build()
         .map_err(PyDeltaTableError::from_raw)?;
 

--- a/python/tests/pyspark_integration/test_write_to_pyspark.py
+++ b/python/tests/pyspark_integration/test_write_to_pyspark.py
@@ -80,7 +80,7 @@ def test_write_invariant(tmp_path: pathlib.Path):
     # Cannot write invalid data to the table
     invalid_data = pa.table({"c1": pa.array([6, 2], type=pa.int32())})
     with pytest.raises(
-        PyDeltaTableError, match="Invariant \(c1 > 3\) violated by value .+2"
+        PyDeltaTableError, match=r"Invariant \(c1 > 3\) violated by value .+2"
     ):
         # raise PyDeltaTableError("test")
         write_deltalake(str(tmp_path), invalid_data, mode="overwrite")

--- a/python/tests/test_fs.py
+++ b/python/tests/test_fs.py
@@ -1,9 +1,12 @@
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from pyarrow.fs import S3FileSystem
 
 from deltalake import DeltaTable
 from deltalake.fs import DeltaStorageHandler
+from deltalake.writer import write_deltalake
+from tests.conftest import s3_localstack
 
 
 @pytest.mark.s3
@@ -16,7 +19,8 @@ def test_read_files(s3_localstack):
     files = dt.file_uris()
     assert len(files) > 0
     for file in files:
-        with handler.open_input_file(file) as f_:
+        rel_path = file[len(table_path) :]
+        with handler.open_input_file(rel_path) as f_:
             table = pq.read_table(f_)
             assert isinstance(table, pa.Table)
             assert table.shape > (0, 0)
@@ -29,3 +33,70 @@ def test_read_simple_table_from_remote(s3_localstack):
     table_path = "s3://deltars/simple"
     dt = DeltaTable(table_path)
     assert dt.to_pyarrow_table().equals(pa.table({"id": [5, 7, 9]}))
+
+
+@pytest.mark.s3
+@pytest.mark.integration
+@pytest.mark.timeout(timeout=5, method="thread")
+def test_roundtrip_s3_env(s3_localstack, sample_data: pa.Table):
+    table_path = "s3://deltars/roundtrip"
+
+    # Create new table with path
+    write_deltalake(table_path, sample_data)
+    dt = DeltaTable(table_path)
+    table = dt.to_pyarrow_table()
+    assert table == sample_data
+
+    # Write with existing DeltaTable
+    write_deltalake(dt, sample_data, mode="overwrite")
+    dt.update_incremental()
+    assert dt.version == 2
+
+    table = dt.to_pyarrow_table()
+    assert table == sample_data
+
+
+@pytest.mark.skip()
+@pytest.mark.s3
+@pytest.mark.integration
+@pytest.mark.timeout(timeout=5, method="thread")
+def test_roundtrip_s3_direct(s3_localstack_creds, sample_data: pa.Table):
+    table_path = "s3://deltars/roundtrip2"
+
+    # Fails without any credentials
+    with pytest.raises(Exception):
+        # TODO: what is the default timeout?
+        write_deltalake(
+            table_path,
+            sample_data,
+            storage_options={"AWS_ENDPOINT_URL": s3_localstack_creds["endpoint_url"]},
+        )
+
+    # Can pass storage_options in directly
+    storage_opts = {
+        "AWS_ACCESS_KEY_ID": s3_localstack_creds["access_key"],
+        "AWS_SECRET_ACCESS_KEY": s3_localstack_creds["secrey_key"],
+        "AWS_ENDPOINT_URL": s3_localstack_creds["endpoint_url"],
+        "AWS_STORAGE_ALLOW_HTTP": "true",
+    }
+    write_deltalake(table_path, sample_data, storage_options=storage_opts)
+    dt = DeltaTable(table_path, storage_options=storage_opts)
+    table = dt.to_pyarrow_table()
+    assert table == sample_data
+
+    # Can pass storage_options into DeltaTable and then write
+    write_deltalake(dt, sample_data, mode="overwrite")
+    dt.update_incremental()
+    assert dt.version == 2
+    table = dt.to_pyarrow_table()
+    assert table == sample_data
+
+    # Can provide S3Filesystem from pyarrow
+    pa_s3fs = S3FileSystem(
+        access_key=s3_localstack_creds["access_key"],
+        secret_key=s3_localstack_creds["secrey_key"],
+        endpoint_override=s3_localstack_creds["endpoint_url"],
+        scheme="http",
+    )
+
+    write_deltalake(table_path, sample_data, filesystem=pa_s3fs, mode="overwrite")

--- a/python/tests/test_fs.py
+++ b/python/tests/test_fs.py
@@ -3,10 +3,9 @@ import pyarrow.parquet as pq
 import pytest
 from pyarrow.fs import S3FileSystem
 
-from deltalake import DeltaTable
+from deltalake import DeltaTable, PyDeltaTableError
 from deltalake.fs import DeltaStorageHandler
 from deltalake.writer import write_deltalake
-from tests.conftest import s3_localstack
 
 
 @pytest.mark.s3
@@ -38,25 +37,31 @@ def test_read_simple_table_from_remote(s3_localstack):
 @pytest.mark.s3
 @pytest.mark.integration
 @pytest.mark.timeout(timeout=5, method="thread")
-def test_roundtrip_s3_env(s3_localstack, sample_data: pa.Table):
+def test_roundtrip_s3_env(s3_localstack, sample_data: pa.Table, monkeypatch):
     table_path = "s3://deltars/roundtrip"
+
+    # Create new table with path
+    with pytest.raises(PyDeltaTableError, match="Atomic rename requires a LockClient"):
+        write_deltalake(table_path, sample_data)
+
+    monkeypatch.setenv("AWS_S3_ALLOW_UNSAFE_RENAME", "true")
 
     # Create new table with path
     write_deltalake(table_path, sample_data)
     dt = DeltaTable(table_path)
     table = dt.to_pyarrow_table()
     assert table == sample_data
+    assert dt.version() == 0
 
     # Write with existing DeltaTable
     write_deltalake(dt, sample_data, mode="overwrite")
     dt.update_incremental()
-    assert dt.version == 2
+    assert dt.version() == 1
 
     table = dt.to_pyarrow_table()
     assert table == sample_data
 
 
-@pytest.mark.skip()
 @pytest.mark.s3
 @pytest.mark.integration
 @pytest.mark.timeout(timeout=5, method="thread")
@@ -64,21 +69,20 @@ def test_roundtrip_s3_direct(s3_localstack_creds, sample_data: pa.Table):
     table_path = "s3://deltars/roundtrip2"
 
     # Fails without any credentials
-    with pytest.raises(Exception):
-        # TODO: what is the default timeout?
-        write_deltalake(
-            table_path,
-            sample_data,
-            storage_options={"AWS_ENDPOINT_URL": s3_localstack_creds["endpoint_url"]},
-        )
+    # with pytest.raises(PyDeltaTableError):
+    #     # TODO: what is the default timeout?
+    #     write_deltalake(
+    #         table_path,
+    #         sample_data,
+    #         storage_options={"AWS_ENDPOINT_URL": s3_localstack_creds["AWS_ENDPOINT_URL"]},
+    #     )
 
     # Can pass storage_options in directly
     storage_opts = {
-        "AWS_ACCESS_KEY_ID": s3_localstack_creds["access_key"],
-        "AWS_SECRET_ACCESS_KEY": s3_localstack_creds["secrey_key"],
-        "AWS_ENDPOINT_URL": s3_localstack_creds["endpoint_url"],
         "AWS_STORAGE_ALLOW_HTTP": "true",
+        "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
     }
+    storage_opts.update(s3_localstack_creds)
     write_deltalake(table_path, sample_data, storage_options=storage_opts)
     dt = DeltaTable(table_path, storage_options=storage_opts)
     table = dt.to_pyarrow_table()

--- a/rust/src/builder/mod.rs
+++ b/rust/src/builder/mod.rs
@@ -546,7 +546,7 @@ pub mod s3_storage_options {
     pub const AWS_REGION: &str = "AWS_REGION";
     /// The AWS_ACCESS_KEY_ID to use for S3.
     pub const AWS_ACCESS_KEY_ID: &str = "AWS_ACCESS_KEY_ID";
-    /// The AWS_SECRET_ACCESS_ID to use for S3.
+    /// The AWS_SECRET_ACCESS_KEY to use for S3.
     pub const AWS_SECRET_ACCESS_KEY: &str = "AWS_SECRET_ACCESS_KEY";
     /// The AWS_SESSION_TOKEN to use for S3.
     pub const AWS_SESSION_TOKEN: &str = "AWS_SESSION_TOKEN";

--- a/rust/src/builder/mod.rs
+++ b/rust/src/builder/mod.rs
@@ -24,9 +24,6 @@ mod azure;
 #[cfg(feature = "gcs")]
 mod google;
 
-#[cfg(any(feature = "s3", feature = "s3-rustls"))]
-const TRUTHY: [&str; 3] = ["TRUE", "1", "OK"];
-
 #[allow(dead_code)]
 #[derive(Debug, thiserror::Error)]
 enum BuilderError {
@@ -592,6 +589,10 @@ pub mod s3_storage_options {
     /// Allow http connections - mainly useful for integration tests
     pub const AWS_STORAGE_ALLOW_HTTP: &str = "AWS_STORAGE_ALLOW_HTTP";
 
+    /// If set to "true", allows creating commits without concurrent writer protection.
+    /// Only safe if there is one writer to a given table.
+    pub const AWS_S3_ALLOW_UNSAFE_RENAME: &str = "AWS_S3_ALLOW_UNSAFE_RENAME";
+
     /// The list of option keys owned by the S3 module.
     /// Option keys not contained in this list will be added to the `extra_opts`
     /// field of [crate::storage::s3::S3StorageOptions].
@@ -621,7 +622,7 @@ pub fn get_s3_builder_from_options(
 ) -> (AmazonS3Builder, S3StorageOptions) {
     let mut builder = AmazonS3Builder::new();
     if let Some(val) = str_option(&options, s3_storage_options::AWS_STORAGE_ALLOW_HTTP) {
-        if TRUTHY.contains(&val.to_uppercase().as_str()) {
+        if str_is_truthy(&val) {
             builder = builder.with_allow_http(true);
         }
     }
@@ -654,4 +655,9 @@ pub fn get_s3_builder_from_options(
 pub(crate) fn str_option(map: &HashMap<String, String>, key: &str) -> Option<String> {
     map.get(key)
         .map_or_else(|| std::env::var(key).ok(), |v| Some(v.to_owned()))
+}
+
+#[allow(dead_code)]
+pub(crate) fn str_is_truthy(val: &str) -> bool {
+    val == "1" || val.to_lowercase() == "true" || val.to_lowercase() == "on"
 }

--- a/rust/src/storage/s3.rs
+++ b/rust/src/storage/s3.rs
@@ -513,7 +513,6 @@ fn try_create_lock_client(options: &S3StorageOptions) -> Result<Option<S3LockCli
 }
 
 #[cfg(test)]
-#[cfg(not(feature = "integration_test"))]
 mod tests {
     use super::*;
 
@@ -525,6 +524,8 @@ mod tests {
     fn storage_options_default_test() {
         std::env::set_var(s3_storage_options::AWS_ENDPOINT_URL, "http://localhost");
         std::env::set_var(s3_storage_options::AWS_REGION, "us-west-1");
+        std::env::set_var(s3_storage_options::AWS_ACCESS_KEY_ID, "default_key_id");
+        std::env::set_var(s3_storage_options::AWS_SECRET_ACCESS_KEY, "default_secret_key");
         std::env::set_var(s3_storage_options::AWS_S3_LOCKING_PROVIDER, "dynamodb");
         std::env::set_var(
             s3_storage_options::AWS_S3_ASSUME_ROLE_ARN,
@@ -548,8 +549,8 @@ mod tests {
                     name: "us-west-1".to_string(),
                     endpoint: "http://localhost".to_string()
                 },
-                aws_access_key_id: Some("test".to_string()),
-                aws_secret_access_key: Some("test".to_string()),
+                aws_access_key_id: Some("default_key_id".to_string()),
+                aws_secret_access_key: Some("default_secret_key".to_string()),
                 aws_session_token: None,
                 virtual_hosted_style_request: false,
                 assume_role_arn: Some("arn:aws:iam::123456789012:role/some_role".to_string()),
@@ -572,7 +573,7 @@ mod tests {
         let options = S3StorageOptions::from_map(hashmap! {
             s3_storage_options::AWS_REGION.to_string() => "eu-west-1".to_string(),
             s3_storage_options::AWS_ACCESS_KEY_ID.to_string() => "test".to_string(),
-            s3_storage_options::AWS_SECRET_ACCESS_KEY.to_string() => "test".to_string(),
+            s3_storage_options::AWS_SECRET_ACCESS_KEY.to_string() => "test_secret".to_string(),
         });
 
         assert_eq!(
@@ -580,7 +581,7 @@ mod tests {
                 endpoint_url: None,
                 region: Region::default(),
                 aws_access_key_id: Some("test".to_string()),
-                aws_secret_access_key: Some("test".to_string()),
+                aws_secret_access_key: Some("test_secret".to_string()),
                 ..Default::default()
             },
             options
@@ -601,6 +602,8 @@ mod tests {
             s3_storage_options::AWS_S3_POOL_IDLE_TIMEOUT_SECONDS.to_string() => "1".to_string(),
             s3_storage_options::AWS_STS_POOL_IDLE_TIMEOUT_SECONDS.to_string() => "2".to_string(),
             s3_storage_options::AWS_S3_GET_INTERNAL_SERVER_ERROR_RETRIES.to_string() => "3".to_string(),
+            s3_storage_options::AWS_ACCESS_KEY_ID.to_string() => "test_id".to_string(),
+            s3_storage_options::AWS_SECRET_ACCESS_KEY.to_string() => "test_secret".to_string(),
         });
 
         assert_eq!(
@@ -610,8 +613,8 @@ mod tests {
                     name: "us-west-2".to_string(),
                     endpoint: "http://localhost:1234".to_string()
                 },
-                aws_access_key_id: Some("test".to_string()),
-                aws_secret_access_key: Some("test".to_string()),
+                aws_access_key_id: Some("test_id".to_string()),
+                aws_secret_access_key: Some("test_secret".to_string()),
                 aws_session_token: None,
                 virtual_hosted_style_request: true,
                 assume_role_arn: Some("arn:aws:iam::123456789012:role/another_role".to_string()),
@@ -621,7 +624,9 @@ mod tests {
                 s3_pool_idle_timeout: Duration::from_secs(1),
                 sts_pool_idle_timeout: Duration::from_secs(2),
                 s3_get_internal_server_error_retries: 3,
-                extra_opts: HashMap::new(),
+                extra_opts: hashmap! {
+                    s3_storage_options::AWS_S3_ADDRESSING_STYLE.to_string() => "virtual".to_string()
+                },
             },
             options
         );
@@ -632,6 +637,8 @@ mod tests {
     fn storage_options_mixed_test() {
         std::env::set_var(s3_storage_options::AWS_ENDPOINT_URL, "http://localhost");
         std::env::set_var(s3_storage_options::AWS_REGION, "us-west-1");
+        std::env::set_var(s3_storage_options::AWS_ACCESS_KEY_ID, "wrong_key_id");
+        std::env::set_var(s3_storage_options::AWS_SECRET_ACCESS_KEY, "wrong_secret_key");
         std::env::set_var(s3_storage_options::AWS_S3_LOCKING_PROVIDER, "dynamodb");
         std::env::set_var(
             s3_storage_options::AWS_S3_ASSUME_ROLE_ARN,
@@ -650,6 +657,8 @@ mod tests {
             "3",
         );
         let options = S3StorageOptions::from_map(hashmap! {
+            s3_storage_options::AWS_ACCESS_KEY_ID.to_string() => "test_id_mixed".to_string(),
+            s3_storage_options::AWS_SECRET_ACCESS_KEY.to_string() => "test_secret_mixed".to_string(),
             s3_storage_options::AWS_REGION.to_string() => "us-west-2".to_string(),
             "DYNAMO_LOCK_PARTITION_KEY_VALUE".to_string() => "my_lock".to_string(),
             "AWS_S3_GET_INTERNAL_SERVER_ERROR_RETRIES".to_string() => "3".to_string(),
@@ -662,8 +671,8 @@ mod tests {
                     name: "us-west-2".to_string(),
                     endpoint: "http://localhost".to_string()
                 },
-                aws_access_key_id: Some("test".to_string()),
-                aws_secret_access_key: Some("test".to_string()),
+                aws_access_key_id: Some("test_id_mixed".to_string()),
+                aws_secret_access_key: Some("test_secret_mixed".to_string()),
                 aws_session_token: None,
                 virtual_hosted_style_request: false,
                 assume_role_arn: Some("arn:aws:iam::123456789012:role/some_role".to_string()),

--- a/rust/src/storage/s3.rs
+++ b/rust/src/storage/s3.rs
@@ -583,6 +583,7 @@ mod tests {
                 sts_pool_idle_timeout: Duration::from_secs(10),
                 s3_get_internal_server_error_retries: 10,
                 extra_opts: HashMap::new(),
+                allow_unsafe_rename: false,
             },
             options
         );
@@ -649,6 +650,7 @@ mod tests {
                 extra_opts: hashmap! {
                     s3_storage_options::AWS_S3_ADDRESSING_STYLE.to_string() => "virtual".to_string()
                 },
+                allow_unsafe_rename: false,
             },
             options
         );
@@ -710,6 +712,7 @@ mod tests {
                 extra_opts: hashmap! {
                     "DYNAMO_LOCK_PARTITION_KEY_VALUE".to_string() => "my_lock".to_string(),
                 },
+                allow_unsafe_rename: false,
             },
             options
         );

--- a/rust/src/test_utils.rs
+++ b/rust/src/test_utils.rs
@@ -323,8 +323,8 @@ pub mod s3_cli {
             s3_storage_options::AWS_ENDPOINT_URL,
             "http://localhost:4566",
         );
-        set_env_if_not_set(s3_storage_options::AWS_ACCESS_KEY_ID, "test");
-        set_env_if_not_set(s3_storage_options::AWS_SECRET_ACCESS_KEY, "test");
+        set_env_if_not_set(s3_storage_options::AWS_ACCESS_KEY_ID, "deltalake");
+        set_env_if_not_set(s3_storage_options::AWS_SECRET_ACCESS_KEY, "weloverust");
         set_env_if_not_set("AWS_DEFAULT_REGION", "us-east-1");
         set_env_if_not_set(s3_storage_options::AWS_REGION, "us-east-1");
         set_env_if_not_set(s3_storage_options::AWS_S3_LOCKING_PROVIDER, "dynamodb");

--- a/rust/tests/common/s3.rs
+++ b/rust/tests/common/s3.rs
@@ -18,9 +18,10 @@ pub async fn setup_s3_context() -> TestContext {
 
     let region = "us-east-1".to_string();
 
-    env::set_var("AWS_ACCESS_KEY_ID", "test");
-    env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+    env::set_var("AWS_ACCESS_KEY_ID", "deltalake");
+    env::set_var("AWS_SECRET_ACCESS_KEY", "weloverust");
     env::set_var("AWS_DEFAULT_REGION", &region);
+    env::set_var("AWS_STORAGE_ALLOW_HTTP", "TRUE");
 
     cli.create_bucket(bucket_name, &endpoint);
     cli.create_table(
@@ -35,10 +36,11 @@ pub async fn setup_s3_context() -> TestContext {
     config.insert("URI".to_owned(), uri.clone());
     config.insert("AWS_ENDPOINT_URL".to_owned(), endpoint.clone());
     config.insert("AWS_REGION".to_owned(), region);
-    config.insert("AWS_ACCESS_KEY_ID".to_owned(), "test".to_owned());
-    config.insert("AWS_SECRET_ACCESS_KEY".to_owned(), "test".to_owned());
+    config.insert("AWS_ACCESS_KEY_ID".to_owned(), "deltalake".to_owned());
+    config.insert("AWS_SECRET_ACCESS_KEY".to_owned(), "weloverust".to_owned());
     config.insert("AWS_S3_LOCKING_PROVIDER".to_owned(), "dynamodb".to_owned());
     config.insert("DYNAMO_LOCK_TABLE_NAME".to_owned(), lock_table.clone());
+    config.insert("AWS_STORAGE_ALLOW_HTTP".to_owned(), "TRUE".to_string());
 
     TestContext {
         config,


### PR DESCRIPTION
# Description

We forgot to pass down storage options, so storage options were being ignored if you were passing a URI and not a DeltaTable.

This also adds a new S3 option: `AWS_S3_ALLOW_UNSAFE_RENAME` which allows using the default S3 backend without support for concurrent writers. This is an opt-in option and there is a helpful error message to provide guidance to users.

To test, I implemented integration tests that run against localstack.

# Related Issue(s)

- might be a fix for #883

# Documentation

<!---
Share links to useful documentation
--->
