### PR TITLE
Bump version of the Python binding to 0.6.3

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"


### PR DESCRIPTION
# Description
- Prepare the release of the Python version `0.6.3` binding 
