### PR TITLE
Allow for reading columns as dictionaries using to_pyarrow_dataset

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -334,9 +334,12 @@ class DeltaTable:
             )
         ]
 
-        return FileSystemDataset(
-            fragments, self.schema().to_pyarrow(), format, filesystem
-        )
+        if parquet_read_options is not None and parquet_read_options.dictionary_columns:
+            schema = pyarrow.unify_schemas([f.physical_schema for f in fragments])
+        else:
+            schema = self.schema().to_pyarrow()
+
+        return FileSystemDataset(fragments, schema, format, filesystem)
 
     def to_pyarrow_table(
         self,

--- a/python/stubs/pyarrow/__init__.pyi
+++ b/python/stubs/pyarrow/__init__.pyi
@@ -10,7 +10,6 @@ ListType: Any
 StructType: Any
 MapType: Any
 schema: Any
-unify_schemas: Any
 map_: Any
 list_: Any
 field: Any
@@ -19,9 +18,11 @@ type_for_alias: Any
 date32: Any
 date64: Any
 decimal128: Any
+int32: Any
 float16: Any
 float32: Any
 float64: Any
+dictionary: Any
 
 py_buffer: Callable[[bytes], Any]
 NativeFile: Any

--- a/python/stubs/pyarrow/__init__.pyi
+++ b/python/stubs/pyarrow/__init__.pyi
@@ -10,6 +10,7 @@ ListType: Any
 StructType: Any
 MapType: Any
 schema: Any
+unify_schemas: Any
 map_: Any
 list_: Any
 field: Any

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -160,6 +160,21 @@ def test_read_table_with_column_subset():
     )
 
 
+def test_read_table_as_category():
+    table_path = "../rust/tests/data/delta-0.8.0-partitioned"
+    dt = DeltaTable(table_path)
+
+    assert dt.schema().to_pyarrow().field("value").type == pa.string()
+
+    read_options = ds.ParquetReadOptions(dictionary_columns={"value"})
+
+    data = dt.to_pyarrow_dataset(parquet_read_options=read_options).to_table(
+        columns=["value"]
+    )
+
+    assert data.schema.field("value").type == pa.dictionary(pa.int32(), pa.string())
+
+
 def test_read_table_with_filter():
     table_path = "../rust/tests/data/delta-0.8.0-partitioned"
     dt = DeltaTable(table_path)

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -168,11 +168,10 @@ def test_read_table_as_category():
 
     read_options = ds.ParquetReadOptions(dictionary_columns={"value"})
 
-    data = dt.to_pyarrow_dataset(parquet_read_options=read_options).to_table(
-        columns=["value"]
-    )
+    data = dt.to_pyarrow_dataset(parquet_read_options=read_options).to_table()
 
     assert data.schema.field("value").type == pa.dictionary(pa.int32(), pa.string())
+    assert data.schema.field("day").type == pa.string()
 
 
 def test_read_table_with_filter():


### PR DESCRIPTION
# Description
When passing `parquet_read_options` to `to_pyarrow_dataset` it is now possible to use `dictionary_columns` to control which columns should be dictionary encoded as they are read.

# Related Issue(s)
- closes #938 
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
