### PR TITLE
feat: improve write perfromance of `DeltaFileSystemHandler`

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -27,6 +27,7 @@ use pyo3::types::PyType;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryFrom;
+use std::sync::Arc;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -394,10 +395,11 @@ impl RawDeltaTable {
         Ok(())
     }
 
-    pub fn get_py_storage_backend(&self) -> filesystem::DeltaFileSystemHandler {
-        filesystem::DeltaFileSystemHandler {
+    pub fn get_py_storage_backend(&self) -> PyResult<filesystem::DeltaFileSystemHandler> {
+        Ok(filesystem::DeltaFileSystemHandler {
             inner: self._table.object_store(),
-        }
+            rt: Arc::new(rt()?),
+        })
     }
 }
 

--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -1,20 +1,15 @@
-use std::future::Future;
 use std::sync::Arc;
 
 use deltalake::storage::{ListResult, ObjectStore, ObjectStoreError, ObjectStoreResult, Path};
 use futures::future::{join_all, BoxFuture, FutureExt};
 use futures::StreamExt;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use tokio::runtime::Runtime;
 
-/// Utility to collect rust futures with GIL released
-pub fn wait_for_future<F: Future>(py: Python, f: F) -> F::Output
-where
-    F: Send,
-    F::Output: Send,
-{
-    let rt = Runtime::new().unwrap();
-    py.allow_threads(|| rt.block_on(f))
+#[inline]
+pub fn rt() -> PyResult<tokio::runtime::Runtime> {
+    Runtime::new().map_err(|_| PyRuntimeError::new_err("Couldn't start a new tokio runtime."))
 }
 
 /// walk the "directory" tree along common prefixes in object store


### PR DESCRIPTION
# Description

This PR builds in top of the changes to handling the runtime in #933. In my local tests this fixed #915. Additionally, I added the runtime as a property on the fs handler to avoid re-creating it on every call. In some non-representative tests with a large number of very small partitions it cut the runtime in about half.

cc @wjones127 

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
