### PR TITLE
docs: add simple operations example

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,3 +111,7 @@ integration_test = ["fs_extra", "tempdir"]
 [[bench]]
 name = "read_checkpoint"
 harness = false
+
+[[example]]
+name = "basic_operations"
+required-features = ["datafusion-ext"]

--- a/rust/examples/basic_operations.rs
+++ b/rust/examples/basic_operations.rs
@@ -1,0 +1,73 @@
+use arrow::{
+    array::{Int32Array, StringArray},
+    datatypes::{DataType, Field, Schema as ArrowSchema},
+    record_batch::RecordBatch,
+};
+use deltalake::operations::collect_sendable_stream;
+use deltalake::{action::SaveMode, DeltaOps, SchemaDataType, SchemaField};
+use std::sync::Arc;
+
+fn get_table_columns() -> Vec<SchemaField> {
+    vec![
+        SchemaField::new(
+            String::from("int"),
+            SchemaDataType::primitive(String::from("integer")),
+            false,
+            Default::default(),
+        ),
+        SchemaField::new(
+            String::from("string"),
+            SchemaDataType::primitive(String::from("string")),
+            true,
+            Default::default(),
+        ),
+    ]
+}
+
+fn get_table_batches() -> Vec<RecordBatch> {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("int", DataType::Int32, false),
+        Field::new("string", DataType::Utf8, true),
+    ]));
+
+    let int_values = Int32Array::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    let str_values = StringArray::from(vec!["A", "B", "A", "B", "A", "A", "A", "B", "B", "A", "A"]);
+
+    vec![RecordBatch::try_new(schema, vec![Arc::new(int_values), Arc::new(str_values)]).unwrap()]
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), deltalake::DeltaTableError> {
+    // create a delta operations client pointing at an un-initialized im memory location
+    // in a productive environment this would be created with "try_new" and point at
+    // a real storage location.
+    let ops = DeltaOps::new_in_memory();
+
+    // the operations module uses a builder pattern that allows specifying several options
+    // on how the command behaves.
+    let table = ops
+        .create()
+        .with_columns(get_table_columns())
+        .with_table_name("my_table")
+        .with_comment("A table to show how delta-rs works")
+        .await?;
+
+    assert_eq!(table.version(), 0);
+
+    let table = DeltaOps(table).write(get_table_batches()).await?;
+
+    assert_eq!(table.version(), 1);
+
+    // setting options allows us to e.g. overwrite the table rather then appending to it.
+    let table = DeltaOps(table)
+        .write(get_table_batches())
+        .with_save_mode(SaveMode::Overwrite)
+        .await?;
+
+    assert_eq!(table.version(), 2);
+
+    let (_table, stream) = DeltaOps(table).load().await?;
+    let _data = collect_sendable_stream(stream).await?;
+
+    Ok(())
+}

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -11,7 +11,6 @@ use crate::action::{Action, DeltaOperation, MetaData, Protocol, SaveMode};
 use crate::builder::StorageUrl;
 use crate::schema::{SchemaDataType, SchemaField, SchemaTypeStruct};
 use crate::storage::DeltaObjectStore;
-use crate::table_properties::APPEND_ONLY;
 use crate::{DeltaResult, DeltaTable, DeltaTableError};
 
 use futures::future::BoxFuture;
@@ -312,6 +311,7 @@ impl std::future::IntoFuture for CreateBuilder {
 mod tests {
     use super::*;
     use crate::operations::DeltaOps;
+    use crate::table_properties::APPEND_ONLY;
     use crate::writer::test_utils::get_delta_schema;
 
     #[tokio::test]

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -170,7 +170,10 @@ impl CreateBuilder {
         self
     }
 
-    /// Append custom (application specific) metadata to created table
+    /// Append custom (application-specific) metadata to the commit.
+    ///
+    /// This might include provenance information such as an id of the
+    /// user that made the commit or the program that created it.
     pub fn with_metadata(mut self, metadata: Map<String, Value>) -> Self {
         self.metadata = Some(metadata);
         self

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -166,6 +166,9 @@ impl CreateBuilder {
     }
 
     /// Specify additional actions to be added to the commit.
+    ///
+    /// This method is mainly meant for internal use. Manually adding inconsistent
+    /// actions to a create operation may have undesired effects - use with caution.
     pub fn with_actions(mut self, actions: impl IntoIterator<Item = Action>) -> Self {
         self.actions.extend(actions);
         self

--- a/rust/src/operations/load.rs
+++ b/rust/src/operations/load.rs
@@ -25,6 +25,7 @@ impl Default for LoadBuilder {
 }
 
 impl LoadBuilder {
+    /// Create a new [`LoadBuilder`]
     pub fn new() -> Self {
         Self {
             location: None,

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -1,4 +1,11 @@
-//! High level delta commands that can be executed against a delta table
+//! High level operations API to interact with Delta tables
+//!
+//! At the heart of the high level operations APIs is the [`DeltaOps`] struct,
+//! which consumes a [`DeltaTable`] and exposes methods to attain builders for
+//! several high level operations. The specific builder structs allow fine-tuning
+//! the operations' behaviors and will return an updated table potentially in conjunction
+//! with a [data stream][datafusion::physical_plan::SendableRecordBatchStream],
+//! if the operation returns data as well.
 
 use self::create::CreateBuilder;
 use crate::builder::DeltaTableBuilder;
@@ -85,7 +92,7 @@ impl DeltaOps {
         CreateBuilder::default().with_object_store(self.0.object_store())
     }
 
-    /// Write data to Delta table
+    /// Load data from a DeltaTable
     #[cfg(feature = "datafusion-ext")]
     #[must_use]
     pub fn load(self) -> LoadBuilder {

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -54,7 +54,7 @@ impl DeltaOps {
     /// Create a new [`DeltaOps`] instance, backed by an un-initialized in memory table
     ///
     /// Using this will not persist any changes beyond the lifetime of the table object.
-    /// THe main purpose of in-memory tables is for use in testing.
+    /// The main purpose of in-memory tables is for use in testing.
     ///
     /// ```
     /// use deltalake::DeltaOps;
@@ -95,7 +95,7 @@ impl DeltaOps {
     /// Write data to Delta table
     #[cfg(feature = "datafusion-ext")]
     #[must_use]
-    pub fn write(self, batches: Vec<RecordBatch>) -> WriteBuilder {
+    pub fn write(self, batches: impl IntoIterator<Item = RecordBatch>) -> WriteBuilder {
         WriteBuilder::default()
             .with_input_batches(batches)
             .with_object_store(self.0.object_store())

--- a/rust/src/operations/writer.rs
+++ b/rust/src/operations/writer.rs
@@ -333,7 +333,7 @@ impl PartitionWriter {
     }
 
     async fn flush_arrow_writer(&mut self) -> DeltaResult<()> {
-        // replace counter / buffers adn close the current writer
+        // replace counter / buffers and close the current writer
         let (writer, buffer) = self.replace_arrow_buffer(vec![])?;
         let null_counts = std::mem::take(&mut self.null_counts);
         let metadata = writer.close()?;

--- a/rust/src/table_properties.rs
+++ b/rust/src/table_properties.rs
@@ -67,5 +67,3 @@ pub const SET_TRANSACTION_RETENTION_DURATION: &str = "delta.setTransactionRetent
 pub const TARGET_FILE_SIZE: &str = "delta.targetFileSize";
 /// The target file size in bytes or higher units for file tuning. For example, 104857600 (bytes) or 100mb.
 pub const TUNE_FILE_SIZES_FOR_REWRITES: &str = "delta.tuneFileSizesForRewrites";
-/// Invariants defined on the table
-pub const INVARIANTS: &str = "delta.invariants";

--- a/rust/src/table_properties.rs
+++ b/rust/src/table_properties.rs
@@ -67,3 +67,5 @@ pub const SET_TRANSACTION_RETENTION_DURATION: &str = "delta.setTransactionRetent
 pub const TARGET_FILE_SIZE: &str = "delta.targetFileSize";
 /// The target file size in bytes or higher units for file tuning. For example, 104857600 (bytes) or 100mb.
 pub const TUNE_FILE_SIZES_FOR_REWRITES: &str = "delta.tuneFileSizesForRewrites";
+/// Invariants defined on the table
+pub const INVARIANTS: &str = "delta.invariants";


### PR DESCRIPTION
# Description

Adding a simple example how to use operations APIs to create and work with delta tables and some minor documentation tweaks.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
