### PR TITLE
Handle pandas timestamps

### DIFF
--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -1,7 +1,40 @@
-from typing import Union
+from typing import Tuple, Union
+
+import pandas as pd
+import pyarrow as pa
 
 from ._internal import ArrayType, Field, MapType, PrimitiveType, Schema, StructType
 
 # Can't implement inheritance (see note in src/schema.rs), so this is next
 # best thing.
 DataType = Union["PrimitiveType", "MapType", "StructType", "ArrayType"]
+
+
+def delta_arrow_schema_from_pandas(
+    data: pd.DataFrame,
+) -> Tuple[pd.DataFrame, pa.Schema]:
+    """ "
+    Infers the schema for the delta table from the Pandas DataFrame.
+    Necessary because of issues such as:  https://github.com/delta-io/delta-rs/issues/686
+
+    :param data: Data to write.
+    :returns A Pyarrow Table and the inferred schema for the Delta Table
+    """
+
+    table = pa.Table.from_pandas(data)
+    _schema = table.schema
+    schema_out = []
+    for _field in _schema:
+        if isinstance(_field.type, pa.TimestampType):
+            f = pa.field(
+                name=_field.name,
+                type=pa.timestamp("us"),
+                nullable=_field.nullable,
+                metadata=_field.metadata,
+            )
+            schema_out.append(f)
+        else:
+            schema_out.append(_field)
+    schema = pa.schema(schema_out, metadata=_schema.metadata)
+    data = pa.Table.from_pandas(data, schema=schema)
+    return data, schema

--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -12,7 +12,7 @@ DataType = Union["PrimitiveType", "MapType", "StructType", "ArrayType"]
 
 def delta_arrow_schema_from_pandas(
     data: pd.DataFrame,
-) -> Tuple[pd.DataFrame, pa.Schema]:
+) -> Tuple[pa.Table, pa.Schema]:
     """ "
     Infers the schema for the delta table from the Pandas DataFrame.
     Necessary because of issues such as:  https://github.com/delta-io/delta-rs/issues/686

--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -35,6 +35,6 @@ def delta_arrow_schema_from_pandas(
             schema_out.append(f)
         else:
             schema_out.append(field)
-    schema = pa.schema(schema_out, metadata=_schema.metadata)
+    schema = pa.schema(schema_out, metadata=schema.metadata)
     data = pa.Table.from_pandas(data, schema=schema)
     return data, schema

--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -1,7 +1,9 @@
-from typing import Tuple, Union
+from typing import Tuple, Union, TYPE_CHECKING
 
-import pandas as pd
 import pyarrow as pa
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 from ._internal import ArrayType, Field, MapType, PrimitiveType, Schema, StructType
 
@@ -11,7 +13,7 @@ DataType = Union["PrimitiveType", "MapType", "StructType", "ArrayType"]
 
 
 def delta_arrow_schema_from_pandas(
-    data: pd.DataFrame,
+    data: "pd.DataFrame",
 ) -> Tuple[pa.Table, pa.Schema]:
     """
     Infers the schema for the delta table from the Pandas DataFrame.

--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple, Union
 
 import pyarrow as pa
 

--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -13,7 +13,7 @@ DataType = Union["PrimitiveType", "MapType", "StructType", "ArrayType"]
 def delta_arrow_schema_from_pandas(
     data: pd.DataFrame,
 ) -> Tuple[pa.Table, pa.Schema]:
-    """ "
+    """
     Infers the schema for the delta table from the Pandas DataFrame.
     Necessary because of issues such as:  https://github.com/delta-io/delta-rs/issues/686
 

--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -22,19 +22,19 @@ def delta_arrow_schema_from_pandas(
     """
 
     table = pa.Table.from_pandas(data)
-    _schema = table.schema
+    schema = table.schema
     schema_out = []
-    for _field in _schema:
-        if isinstance(_field.type, pa.TimestampType):
+    for field in schema:
+        if isinstance(field.type, pa.TimestampType):
             f = pa.field(
-                name=_field.name,
+                name=field.name,
                 type=pa.timestamp("us"),
-                nullable=_field.nullable,
-                metadata=_field.metadata,
+                nullable=field.nullable,
+                metadata=field.metadata,
             )
             schema_out.append(f)
         else:
-            schema_out.append(_field)
+            schema_out.append(field)
     schema = pa.schema(schema_out, metadata=_schema.metadata)
     data = pa.Table.from_pandas(data, schema=schema)
     return data, schema

--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -18,7 +18,7 @@ def delta_arrow_schema_from_pandas(
     Necessary because of issues such as:  https://github.com/delta-io/delta-rs/issues/686
 
     :param data: Data to write.
-    :returns A Pyarrow Table and the inferred schema for the Delta Table
+    :return: A PyArrow Table and the inferred schema for the Delta Table
     """
 
     table = pa.Table.from_pandas(data)

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -141,7 +141,7 @@ def write_deltalake(
             _schema = _data.schema
             schema_out = []
             for _field in _schema:
-                # handles https://github.com/delta-io/delta-rs/issues/686
+                # partially handles https://github.com/delta-io/delta-rs/issues/686
                 if isinstance(_field.type, pa.lib.TimestampType):
                     f = pa.field(
                         name=_field.name,

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -75,7 +75,7 @@ def delta_arrow_schema_from_pandas(
     _schema = table.schema
     schema_out = []
     for _field in _schema:
-        if isinstance(_field.type, pa.lib.TimestampType):
+        if isinstance(_field.type, pa.TimestampType):
             f = pa.field(
                 name=_field.name,
                 type=pa.timestamp("us"),

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -60,7 +60,7 @@ class AddAction:
     stats: str
 
 
-def _delta_arrow_schema_from_pandas(
+def delta_arrow_schema_from_pandas(
     data: pd.DataFrame,
 ) -> Tuple[pd.DataFrame, pa.Schema]:
     """ "
@@ -167,7 +167,7 @@ def write_deltalake(
         if schema is not None:
             data = pa.Table.from_pandas(data, schema=schema)
         else:
-            data, schema = _delta_arrow_schema_from_pandas(data)
+            data, schema = delta_arrow_schema_from_pandas(data)
 
     if schema is None:
         if isinstance(data, RecordBatchReader):

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -135,7 +135,7 @@ def write_deltalake(
 
     if _has_pandas and isinstance(data, pd.DataFrame):
         if schema is not None:
-            data = pa.Table.from_panda(data, schema=schema)
+            data = pa.Table.from_pandas(data, schema=schema)
         else:
             _data = pa.Table.from_pandas(data)
             _schema = _data.schema

--- a/python/stubs/pyarrow/__init__.pyi
+++ b/python/stubs/pyarrow/__init__.pyi
@@ -23,6 +23,8 @@ float16: Any
 float32: Any
 float64: Any
 dictionary: Any
+timestamp: Any
+TimestampType: Any
 
 py_buffer: Callable[[bytes], Any]
 NativeFile: Any

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -275,9 +275,8 @@ def test_fails_wrong_partitioning(existing_table: DeltaTable, sample_data: pa.Ta
 def test_write_pandas(tmp_path: pathlib.Path, sample_data: pa.Table):
     # When timestamp is converted to Pandas, it gets casted to ns resolution,
     # but Delta Lake schemas only support us resolution.
-    sample_pandas = sample_data.to_pandas().drop(["timestamp"], axis=1)
+    sample_pandas = sample_data.to_pandas()
     write_deltalake(str(tmp_path), sample_pandas)
-
     delta_table = DeltaTable(str(tmp_path))
     df = delta_table.to_pandas()
     assert_frame_equal(df, sample_pandas)

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -272,11 +272,16 @@ def test_fails_wrong_partitioning(existing_table: DeltaTable, sample_data: pa.Ta
 
 
 @pytest.mark.pandas
-def test_write_pandas(tmp_path: pathlib.Path, sample_data: pa.Table):
+@pytest.mark.parametrize("schema_provided", [True, False])
+def test_write_pandas(tmp_path: pathlib.Path, sample_data: pa.Table, schema_provided):
     # When timestamp is converted to Pandas, it gets casted to ns resolution,
     # but Delta Lake schemas only support us resolution.
     sample_pandas = sample_data.to_pandas()
-    write_deltalake(str(tmp_path), sample_pandas)
+    if schema_provided is True:
+        schema = sample_data.schema
+    else:
+        schema = None
+    write_deltalake(str(tmp_path), sample_pandas, schema=schema)
     delta_table = DeltaTable(str(tmp_path))
     df = delta_table.to_pandas()
     assert_frame_equal(df, sample_pandas)


### PR DESCRIPTION
# Description
As described in #686 some pandas datatypes are not converted to a format that is compatible with delta lake.  This handles the instance of timestamps, which are stored with `ns` resolution in Pandas.  Here, if is a schema is not provided, we specify converting the timestamps to `us` resolution.

We also update `python/tests/test_writer.py::test_write_pandas` to reflect this change.

# Related Issue(s)
#685 


