### PR TITLE
bump rust core version to 0.5.0

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake"
-version = "0.4.1"
+version = "0.5.0"
 rust-version = "1.64"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta.rs"


### PR DESCRIPTION
# Description

It's been a long time since our last crates.io release!

Should make version pinning a little bit easier for https://github.com/pola-rs/polars/issues/2858

# Related Issue(s)

Closes https://github.com/delta-io/delta-rs/issues/480.

# Documentation

<!---
Share links to useful documentation
--->
