### PR TITLE
pin glic_version version in dep to unblock creates.io release

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -73,7 +73,7 @@ tempfile = "3"
 utime = "0.3"
 
 [build-dependencies]
-glibc_version = { path = "../glibc_version" }
+glibc_version = { path = "../glibc_version", version = "0.1" }
 
 [features]
 default = ["arrow", "parquet"]


### PR DESCRIPTION
# Description

all dependency versions need to be pinned in order to release to creates.io