### PR TITLE
remove all wildcard version pin in Cargo.toml

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -63,7 +63,7 @@ optional = true
 
 [dev-dependencies]
 criterion = "0"
-dotenv = "*"
+dotenvy = "0"
 maplit = "1"
 pretty_assertions = "1.2.1"
 rand = "0.8"

--- a/rust/src/test_utils.rs
+++ b/rust/src/test_utils.rs
@@ -25,7 +25,7 @@ impl IntegrationContext {
         // environment variables are loaded from .env files if found. Otherwise
         // default values based on the default setting of the respective emulators are set.
         #[cfg(test)]
-        dotenv::dotenv().ok();
+        dotenvy::dotenv().ok();
 
         integration.prepare_env();
 


### PR DESCRIPTION
Wildcard version pin blocks crates.io publish

Also migrate to dotenvy because dotenv is not being maintained anymore.

