### PR TITLE
Bump version of the Python binding to 0.6.4

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin==0.13.2"]
+requires = ["maturin==0.14.2"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
# Description
- Prepare to release the version `0.6.4` of the Python binding 
