### PR TITLE
fix: get azure client secret from config

### DIFF
--- a/rust/src/builder/azure.rs
+++ b/rust/src/builder/azure.rs
@@ -52,6 +52,10 @@ static ALIAS_MAP: Lazy<HashMap<&'static str, AzureConfigKey>> = Lazy::new(|| {
         ("azure_storage_client_id", AzureConfigKey::ClientId),
         ("azure_client_id", AzureConfigKey::ClientId),
         ("client_id", AzureConfigKey::ClientId),
+        // client secret
+        ("azure_storage_client_secret", AzureConfigKey::ClientSecret),
+        ("azure_client_secret", AzureConfigKey::ClientSecret),
+        ("client_secret", AzureConfigKey::ClientSecret),
         // authority id
         ("azure_storage_tenant_id", AzureConfigKey::AuthorityId),
         ("azure_storage_authority_id", AzureConfigKey::AuthorityId),


### PR DESCRIPTION
# Description
When updating the parsing for azure configuration, the client secret got lost, This should fix that. 

# Related Issue(s)

closes #977

# Documentation

<!---
Share links to useful documentation
--->
