### PR TITLE
Adds handling of nested partitions

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -210,7 +210,6 @@ def write_deltalake(
 
     def visitor(written_file: Any) -> None:
         path, partition_values = get_partitions_from_path(written_file.path)
-        print(written_file.path)
         stats = get_file_stats_from_metadata(written_file.metadata)
 
         # PyArrow added support for written_file.size in 9.0.0

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -210,6 +210,7 @@ def write_deltalake(
 
     def visitor(written_file: Any) -> None:
         path, partition_values = get_partitions_from_path(written_file.path)
+        print(written_file.path)
         stats = get_file_stats_from_metadata(written_file.metadata)
 
         # PyArrow added support for written_file.size in 9.0.0
@@ -345,9 +346,8 @@ def get_partitions_from_path(path: str) -> Tuple[str, Dict[str, Optional[str]]]:
     parts = path.split("/")
     parts.pop()  # remove filename
     out: Dict[str, Optional[str]] = {}
+    parts = [p for p in parts if "=" in p]
     for part in parts:
-        if part == "":
-            continue
         key, value = part.split("=", maxsplit=1)
         if value == "__HIVE_DEFAULT_PARTITION__":
             out[key] = None

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -16,7 +16,7 @@ from pyarrow.lib import RecordBatchReader
 
 from deltalake import DeltaTable, write_deltalake
 from deltalake.table import ProtocolVersions
-from deltalake.writer import DeltaTableProtocolError
+from deltalake.writer import DeltaTableProtocolError, get_partitions_from_path
 
 try:
     from pandas.testing import assert_frame_equal
@@ -496,3 +496,17 @@ def test_writer_with_options(tmp_path: pathlib.Path):
     )
 
     assert table == data
+
+
+@pytest.mark.parametrize(
+    "test_path",
+    [
+        "strings=Hannah/0-1-2.parquet",
+        "first/strings=Hannah/0-1-2.parquet",
+        "first/second/strings=Hannah/0-1-2.parquet",
+    ],
+)
+def test_get_partitions_from_path(test_path: str):
+    path, out = get_partitions_from_path(test_path)
+    assert test_path == path
+    assert out == {"strings": "Hannah"}


### PR DESCRIPTION
# Description
The python writer includes a function `get_partitions_from_path` that currently handles a path like `part=A/filename.parquet` properly.  However, it fails to handle `first_folder/second_folder/part=A/filename.parquet`.  This PR extends the function to handle these second cases properly.

This PR also adds a test for these cases.


