### PR TITLE
Loosen version requirement for maturin

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 
 VENV := venv
-MATURIN_VERSION := $(shell awk -F '[ ="]+' '$$1 == "requires" { print $$4 }' pyproject.toml)
+MATURIN_VERSION := $(shell grep 'requires =' pyproject.toml | cut -d= -f2- | tr -d '[ "]')
 PACKAGE_VERSION := $(shell grep version Cargo.toml | head -n 1 | awk '{print $$3}' | tr -d '"' )
 
 .PHONY: setup-venv
@@ -12,7 +12,7 @@ setup-venv: ## Setup the virtualenv
 .PHONY: setup
 setup: ## Setup the requirements
 	$(info --- Setup dependencies ---)
-	pip install maturin==$(MATURIN_VERSION)
+	pip install "$(MATURIN_VERSION)"
 
 .PHONY: build
 build: setup ## Build Python binding of delta-rs

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin==0.14.2"]
+requires = ["maturin>=0.14,<0.15"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
# Description

This loosen the version requirement for maturin when building the python package.

# Related Issue(s)

- closes #1004
<!---
For example:

- closes #106
--->

# Documentation

Using an exact version can be excessively restrictive, for example preventing the use of the latest (but still compatible) version of maturin. Especially when packaging for rolling-releases distributions (like Archlinux), being able to build with the latest version would be beneficial.
<!---
Share links to useful documentation
--->
