### PR TITLE
fix truncating signature on SAS

### DIFF
--- a/python/tests/test_fs.py
+++ b/python/tests/test_fs.py
@@ -1,3 +1,5 @@
+import urllib
+
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
@@ -198,6 +200,22 @@ def test_roundtrip_azure_direct(azurite_creds, sample_data: pa.Table):
 @pytest.mark.timeout(timeout=5, method="thread")
 def test_roundtrip_azure_sas(azurite_sas_creds, sample_data: pa.Table):
     table_path = "az://deltars/roundtrip3"
+
+    write_deltalake(table_path, sample_data, storage_options=azurite_sas_creds)
+    dt = DeltaTable(table_path, storage_options=azurite_sas_creds)
+    table = dt.to_pyarrow_table()
+    assert table == sample_data
+    assert dt.version() == 0
+
+
+@pytest.mark.azure
+@pytest.mark.integration
+@pytest.mark.timeout(timeout=5, method="thread")
+def test_roundtrip_azure_decoded_sas(azurite_sas_creds, sample_data: pa.Table):
+    table_path = "az://deltars/roundtrip4"
+    azurite_sas_creds["SAS_TOKEN"] = urllib.parse.unquote(
+        azurite_sas_creds["SAS_TOKEN"]
+    )
 
     write_deltalake(table_path, sample_data, storage_options=azurite_sas_creds)
     dt = DeltaTable(table_path, storage_options=azurite_sas_creds)

--- a/rust/src/builder/azure.rs
+++ b/rust/src/builder/azure.rs
@@ -226,11 +226,10 @@ fn split_sas(sas: &str) -> Result<Vec<(String, String)>, BuilderError> {
         .filter(|s| !s.chars().all(char::is_whitespace));
     let mut pairs = Vec::new();
     for kv_pair_str in kv_str_pairs {
-        let kv = kv_pair_str.trim().split_once('=');
-        let (k, v) = match kv {
-            None => return Err(BuilderError::MissingCredential),
-            Some(kv) => kv,
-        };
+        let (k, v) = kv_pair_str
+            .trim()
+            .split_once('=')
+            .ok_or(BuilderError::MissingCredential)?;
         pairs.push((k.into(), v.into()))
     }
     Ok(pairs)

--- a/rust/src/builder/azure.rs
+++ b/rust/src/builder/azure.rs
@@ -226,16 +226,10 @@ fn split_sas(sas: &str) -> Result<Vec<(String, String)>, BuilderError> {
         .filter(|s| !s.chars().all(char::is_whitespace));
     let mut pairs = Vec::new();
     for kv_pair_str in kv_str_pairs {
-        let mut kv = kv_pair_str.trim().split('=');
-        let k = match kv.next().filter(|k| !k.chars().all(char::is_whitespace)) {
-            None => {
-                return Err(BuilderError::MissingCredential);
-            }
-            Some(k) => k,
-        };
-        let v = match kv.next().filter(|k| !k.chars().all(char::is_whitespace)) {
+        let kv = kv_pair_str.trim().split_once('=');
+        let (k, v) = match kv {
             None => return Err(BuilderError::MissingCredential),
-            Some(v) => v,
+            Some(kv) => kv,
         };
         pairs.push((k.into(), v.into()))
     }


### PR DESCRIPTION
# Description
This fixes the truncation of Azure SAS signatures ending in "=", i.e. when using non-url-encoded SAS tokens.

# Related Issue(s)
<!---
For example:

- closes #1003
--->
closes #1003 
