### PR TITLE
Add PR autolabeling

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -1,0 +1,30 @@
+name: dev_pr
+
+# Trigger whenever a PR is changed (title as well as new / changed commits)
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  process:
+    name: Process
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Assign GitHub labels
+        if: |
+          github.event_name == 'pull_request_target' &&
+            (github.event.action == 'opened' ||
+             github.event.action == 'synchronize')
+        uses: actions/labeler@4.0.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/workflows/dev_pr/labeler.yml
+          sync-labels: true

--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -1,0 +1,47 @@
+rust:
+  - aws/**/*
+  - delta-inspect/**/*
+  - dynamodb_lock/**/*
+  - glibc_version/**/*
+  - proofs/**/*
+  - rust/**/*
+
+python:
+  - python/**/*
+
+ruby:
+  - ruby/**/*
+
+ci:
+  - .github/**.*
+
+documentation:
+  - README.adoc
+  - ./**/README.md
+  - CODE_OF_CONDUCT.md
+  - CONTRIBUTING.md
+
+aws:
+  - aws/**/*
+
+delta-checkpoint:
+  - aws/delta-checkpoint/**/*
+  
+delta-inspect:
+  - delta-inspect/**/*
+
+delta-rs-crate:
+  - rust/**/*
+
+dynamodb_lock:
+  - dynamodb_lock/**/*
+
+glibc_version:
+  - glibc_version/**/*
+
+proofs:
+  - proofs/**/*
+
+tlaplus:
+  - tlaplus/**/*
+

--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -20,6 +20,7 @@ documentation:
   - ./**/README.md
   - CODE_OF_CONDUCT.md
   - CONTRIBUTING.md
+  - python/docs/**/*
 
 aws:
   - aws/**/*


### PR DESCRIPTION
# Description
The description of the main changes of your pull request

Use [labeler](https://github.com/actions/labeler) to automatically label PRs. There are language labels, CI, documentation as well as crate-specific labels.
# Related Issue(s)
<!---
For example:

- closes #106
--->
Closes #1026 & unblocks #997.
# Documentation

<!---
Share links to useful documentation
--->
