### PR TITLE
feat: expose function to get table of add actions

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -443,3 +443,6 @@ given filters.
                 str_value = str(value)
             out.append((field, op, str_value))
         return out
+
+    def get_add_actions_df(self) -> pyarrow.RecordBatch:
+        return self._table.get_add_actions_df()

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -445,4 +445,58 @@ given filters.
         return out
 
     def get_add_actions_df(self, flatten: bool = False) -> pyarrow.RecordBatch:
+        """
+        Return a dataframe with all current add actions.
+
+        Add actions represent the files that currently make up the table. This
+        data is a low-level representation parsed from the transaction log.
+
+        :param flatten: whether to use a flattened schema in output (default False).
+            When False, all partition values are in a single map column,
+            `partition_values`. When True, each partition column becomes it's own
+            field, with the prefix `partition_` in the name.
+
+        :returns: a PyArrow Table containing the add action data.
+
+        Examples:
+
+        >>> from deltalake import DeltaTable, write_deltalake
+        >>> import pyarrow as pa
+        >>> data = pa.table({"x": [1, 2, 3], "y": [4, 5, 6]})
+        >>> write_deltalake("tmp", data, partition_by=["x"])
+        >>> dt = DeltaTable("tmp")
+        >>> dt.get_add_actions_df()
+        pyarrow.Table
+        path: string
+        size_bytes: int64
+        modification_time: timestamp[ms]
+        data_change: bool
+        stats: string
+        partition_values: map<string, string>
+          child 0, entries: struct<key: string not null, value: string> not null
+              child 0, key: string not null
+              child 1, value: string
+        ----
+        path: [["x=2/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet","x=3/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet","x=1/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet"]]
+        size_bytes: [[565,565,565]]
+        modification_time: [[1970-01-20 08:20:49.399,1970-01-20 08:20:49.399,1970-01-20 08:20:49.399]]
+        data_change: [[true,true,true]]
+        stats: [["{"numRecords": 1, "minValues": {"y": 5}, "maxValues": {"y": 5}, "nullCount": {"y": 0}}","{"numRecords": 1, "minValues": {"y": 6}, "maxValues": {"y": 6}, "nullCount": {"y": 0}}","{"numRecords": 1, "minValues": {"y": 4}, "maxValues": {"y": 4}, "nullCount": {"y": 0}}"]]
+        partition_values: [[keys:["x"]values:["2"],keys:["x"]values:["3"],keys:["x"]values:["1"]]]
+        >>> dt.get_add_actions_df(flatten=True)
+        pyarrow.Table
+        path: string
+        size_bytes: int64
+        modification_time: timestamp[ms]
+        data_change: bool
+        stats: string
+        partition_x: string
+        ----
+        path: [["x=2/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet","x=3/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet","x=1/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet"]]
+        size_bytes: [[565,565,565]]
+        modification_time: [[1970-01-20 08:20:49.399,1970-01-20 08:20:49.399,1970-01-20 08:20:49.399]]
+        data_change: [[true,true,true]]
+        stats: [["{"numRecords": 1, "minValues": {"y": 5}, "maxValues": {"y": 5}, "nullCount": {"y": 0}}","{"numRecords": 1, "minValues": {"y": 6}, "maxValues": {"y": 6}, "nullCount": {"y": 0}}","{"numRecords": 1, "minValues": {"y": 4}, "maxValues": {"y": 4}, "nullCount": {"y": 0}}"]]
+        partition_x: [["2","3","1"]]
+        """
         return self._table.get_add_actions_df(flatten)

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -444,5 +444,5 @@ given filters.
             out.append((field, op, str_value))
         return out
 
-    def get_add_actions_df(self) -> pyarrow.RecordBatch:
-        return self._table.get_add_actions_df()
+    def get_add_actions_df(self, flatten: bool = False) -> pyarrow.RecordBatch:
+        return self._table.get_add_actions_df(flatten)

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -444,7 +444,7 @@ given filters.
             out.append((field, op, str_value))
         return out
 
-    def get_add_actions_df(self, flatten: bool = False) -> pyarrow.RecordBatch:
+    def get_add_actions(self, flatten: bool = False) -> pyarrow.RecordBatch:
         """
         Return a dataframe with all current add actions.
 
@@ -476,4 +476,4 @@ given filters.
         1  x=3/0-91820cbf-f698-45fb-886d-5d5f5669530b-0.p...         565 1970-01-20 08:40:08.071         True            3            1             0      6      6
         2  x=1/0-91820cbf-f698-45fb-886d-5d5f5669530b-0.p...         565 1970-01-20 08:40:08.071         True            1            1             0      4      4
         """
-        return self._table.get_add_actions_df(flatten)
+        return self._table.get_add_actions(flatten)

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -453,7 +453,7 @@ given filters.
 
         :param flatten: whether to flatten the schema. Partition values columns are
           given the prefix `partition.`, statistics (null_count, min, and max) are
-          given the prefix `null_count.`, `min.`, and `max.`, and tags the 
+          given the prefix `null_count.`, `min.`, and `max.`, and tags the
           prefix `tags.`. Nested field names are concatenated with `.`.
 
         :returns: a PyArrow RecordBatch containing the add action data.

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -451,12 +451,12 @@ given filters.
         Add actions represent the files that currently make up the table. This
         data is a low-level representation parsed from the transaction log.
 
-        :param flatten: whether to use a flattened schema in output (default False).
-            When False, all partition values are in a single map column,
-            `partition_values`. When True, each partition column becomes it's own
-            field, with the prefix `partition_` in the name.
+        :param flatten: whether to flatten the schema. Partition values columns are
+          given the prefix `partition.`, statistics (null_count, min, and max) are
+          given the prefix `null_count.`, `min.`, and `max.`, and tags the 
+          prefix `tags.`. Nested field names are concatenated with `.`.
 
-        :returns: a PyArrow Table containing the add action data.
+        :returns: a PyArrow RecordBatch containing the add action data.
 
         Examples:
 
@@ -465,38 +465,15 @@ given filters.
         >>> data = pa.table({"x": [1, 2, 3], "y": [4, 5, 6]})
         >>> write_deltalake("tmp", data, partition_by=["x"])
         >>> dt = DeltaTable("tmp")
-        >>> dt.get_add_actions_df()
-        pyarrow.Table
-        path: string
-        size_bytes: int64
-        modification_time: timestamp[ms]
-        data_change: bool
-        stats: string
-        partition_values: map<string, string>
-          child 0, entries: struct<key: string not null, value: string> not null
-              child 0, key: string not null
-              child 1, value: string
-        ----
-        path: [["x=2/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet","x=3/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet","x=1/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet"]]
-        size_bytes: [[565,565,565]]
-        modification_time: [[1970-01-20 08:20:49.399,1970-01-20 08:20:49.399,1970-01-20 08:20:49.399]]
-        data_change: [[true,true,true]]
-        stats: [["{"numRecords": 1, "minValues": {"y": 5}, "maxValues": {"y": 5}, "nullCount": {"y": 0}}","{"numRecords": 1, "minValues": {"y": 6}, "maxValues": {"y": 6}, "nullCount": {"y": 0}}","{"numRecords": 1, "minValues": {"y": 4}, "maxValues": {"y": 4}, "nullCount": {"y": 0}}"]]
-        partition_values: [[keys:["x"]values:["2"],keys:["x"]values:["3"],keys:["x"]values:["1"]]]
-        >>> dt.get_add_actions_df(flatten=True)
-        pyarrow.Table
-        path: string
-        size_bytes: int64
-        modification_time: timestamp[ms]
-        data_change: bool
-        stats: string
-        partition_x: string
-        ----
-        path: [["x=2/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet","x=3/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet","x=1/0-6e6952dd-ed03-4488-810e-ebe76a1a1200-0.parquet"]]
-        size_bytes: [[565,565,565]]
-        modification_time: [[1970-01-20 08:20:49.399,1970-01-20 08:20:49.399,1970-01-20 08:20:49.399]]
-        data_change: [[true,true,true]]
-        stats: [["{"numRecords": 1, "minValues": {"y": 5}, "maxValues": {"y": 5}, "nullCount": {"y": 0}}","{"numRecords": 1, "minValues": {"y": 6}, "maxValues": {"y": 6}, "nullCount": {"y": 0}}","{"numRecords": 1, "minValues": {"y": 4}, "maxValues": {"y": 4}, "nullCount": {"y": 0}}"]]
-        partition_x: [["2","3","1"]]
+        >>> dt.get_add_actions_df().to_pandas()
+                                                                path  size_bytes       modification_time  data_change partition_values  num_records null_count       min       max
+        0  x=2/0-91820cbf-f698-45fb-886d-5d5f5669530b-0.p...         565 1970-01-20 08:40:08.071         True         {'x': 2}            1   {'y': 0}  {'y': 5}  {'y': 5}
+        1  x=3/0-91820cbf-f698-45fb-886d-5d5f5669530b-0.p...         565 1970-01-20 08:40:08.071         True         {'x': 3}            1   {'y': 0}  {'y': 6}  {'y': 6}
+        2  x=1/0-91820cbf-f698-45fb-886d-5d5f5669530b-0.p...         565 1970-01-20 08:40:08.071         True         {'x': 1}            1   {'y': 0}  {'y': 4}  {'y': 4}
+        >>> dt.get_add_actions_df(flatten=True).to_pandas()
+                                                                path  size_bytes       modification_time  data_change  partition.x  num_records  null_count.y  min.y  max.y
+        0  x=2/0-91820cbf-f698-45fb-886d-5d5f5669530b-0.p...         565 1970-01-20 08:40:08.071         True            2            1             0      5      5
+        1  x=3/0-91820cbf-f698-45fb-886d-5d5f5669530b-0.p...         565 1970-01-20 08:40:08.071         True            3            1             0      6      6
+        2  x=1/0-91820cbf-f698-45fb-886d-5d5f5669530b-0.p...         565 1970-01-20 08:40:08.071         True            1            1             0      4      4
         """
-        return self._table.get_add_actions_df(flatten, parse_stats)
+        return self._table.get_add_actions_df(flatten)

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -499,4 +499,4 @@ given filters.
         stats: [["{"numRecords": 1, "minValues": {"y": 5}, "maxValues": {"y": 5}, "nullCount": {"y": 0}}","{"numRecords": 1, "minValues": {"y": 6}, "maxValues": {"y": 6}, "nullCount": {"y": 0}}","{"numRecords": 1, "minValues": {"y": 4}, "maxValues": {"y": 4}, "nullCount": {"y": 0}}"]]
         partition_x: [["2","3","1"]]
         """
-        return self._table.get_add_actions_df(flatten)
+        return self._table.get_add_actions_df(flatten, parse_stats)

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -458,7 +458,7 @@ impl RawDeltaTable {
         Ok(PyArrowType(
             self._table
                 .get_state()
-                .add_actions_table()
+                .add_actions_table(flatten)
                 .map_err(PyDeltaTableError::from_arrow)?,
         ))
     }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -454,7 +454,7 @@ impl RawDeltaTable {
         Ok(())
     }
 
-    pub fn get_add_actions_df(&self) -> PyResult<PyArrowType<RecordBatch>> {
+    pub fn get_add_actions(&self, flatten: bool) -> PyResult<PyArrowType<RecordBatch>> {
         Ok(PyArrowType(
             self._table
                 .get_state()

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -459,7 +459,7 @@ impl RawDeltaTable {
             self._table
                 .get_state()
                 .add_actions_table(flatten)
-                .map_err(PyDeltaTableError::from_arrow)?,
+                .map_err(PyDeltaTableError::from_raw)?,
         ))
     }
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -453,6 +453,15 @@ impl RawDeltaTable {
 
         Ok(())
     }
+
+    pub fn get_add_actions_df(&self) -> PyResult<PyArrowType<RecordBatch>> {
+        Ok(PyArrowType(
+            self._table
+                .get_state()
+                .add_actions_table()
+                .map_err(PyDeltaTableError::from_arrow)?,
+        ))
+    }
 }
 
 fn convert_partition_filters<'a>(

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -269,6 +269,45 @@ def test_history_partitioned_table_metadata():
     }
 
 
+@pytest.mark.parametrize("flatten", [True, False])
+def test_add_actions_table(flatten: bool):
+    table_path = "../rust/tests/data/delta-0.8.0-partitioned"
+    dt = DeltaTable(table_path)
+    actions_df = dt.get_add_actions_df(flatten)
+    # RecordBatch doesn't have a sort_by method yet
+    actions_df = pa.Table.from_batches([actions_df]).sort_by("path").to_batches()[0]
+
+    assert actions_df.num_rows == 6
+    assert actions_df["path"] == pa.array(
+        [
+            "year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet",
+            "year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet",
+            "year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet",
+            "year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet",
+            "year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet",
+            "year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet",
+        ]
+    )
+    assert actions_df["size_bytes"] == pa.array([414, 414, 414, 407, 414, 414])
+    assert actions_df["data_change"] == pa.array([True] * 6)
+    assert actions_df["modification_time"] == pa.array(
+        [1615555646000] * 6, type=pa.timestamp("ms")
+    )
+
+    if flatten:
+        partition_year = actions_df["partition_year"]
+        partition_month = actions_df["partition_month"]
+        partition_day = actions_df["partition_day"]
+    else:
+        partition_year = actions_df["partition_values"].field("year")
+        partition_month = actions_df["partition_values"].field("month")
+        partition_day = actions_df["partition_values"].field("day")
+
+    assert partition_year == pa.array(["2020"] * 3 + ["2021"] * 3)
+    assert partition_month == pa.array(["1", "2", "2", "12", "12", "4"])
+    assert partition_day == pa.array(["1", "3", "5", "20", "4", "5"])
+
+
 def assert_correct_files(dt: DeltaTable, partition_filters, expected_paths):
     assert dt.files(partition_filters) == expected_paths
     absolute_paths = [os.path.join(dt.table_uri, path) for path in expected_paths]

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -273,7 +273,7 @@ def test_history_partitioned_table_metadata():
 def test_add_actions_table(flatten: bool):
     table_path = "../rust/tests/data/delta-0.8.0-partitioned"
     dt = DeltaTable(table_path)
-    actions_df = dt.get_add_actions_df(flatten)
+    actions_df = dt.get_add_actions(flatten)
     # RecordBatch doesn't have a sort_by method yet
     actions_df = pa.Table.from_batches([actions_df]).sort_by("path").to_batches()[0]
 

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -295,9 +295,9 @@ def test_add_actions_table(flatten: bool):
     )
 
     if flatten:
-        partition_year = actions_df["partition_year"]
-        partition_month = actions_df["partition_month"]
-        partition_day = actions_df["partition_day"]
+        partition_year = actions_df["partition.year"]
+        partition_month = actions_df["partition.month"]
+        partition_day = actions_df["partition.day"]
     else:
         partition_year = actions_df["partition_values"].field("year")
         partition_month = actions_df["partition_values"].field("month")

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
 cfg-if = "1"
 errno = "0.2"
 futures = "0.3"
+itertools = "0.10"
 lazy_static = "1"
 log = "0"
 libc = ">=0.2.90, <1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { version = "1", features = ["macros", "rt", "parking_lot"] }
 regex = "1"
 uuid = { version = "1", features = ["serde", "v4"] }
 url = "2.3"
+num = { version = "0.4", default-features = false, features = ["std"] }
 
 # S3 lock client
 rusoto_core = { version = "0.48", default-features = false, optional = true }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -36,7 +36,6 @@ tokio = { version = "1", features = ["macros", "rt", "parking_lot"] }
 regex = "1"
 uuid = { version = "1", features = ["serde", "v4"] }
 url = "2.3"
-num = { version = "0.4", default-features = false, features = ["std"] }
 
 # S3 lock client
 rusoto_core = { version = "0.48", default-features = false, optional = true }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -92,6 +92,9 @@ pub mod table_properties;
 pub mod table_state;
 pub mod time_utils;
 
+#[cfg(all(feature = "arrow"))]
+pub mod table_state_arrow;
+
 #[cfg(all(feature = "arrow", feature = "parquet"))]
 pub mod checkpoints;
 #[cfg(all(feature = "arrow", feature = "parquet"))]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -70,6 +70,7 @@
 
 #![deny(warnings)]
 #![deny(missing_docs)]
+#![allow(rustdoc::invalid_html_tags)]
 
 #[cfg(all(feature = "parquet", feature = "parquet2"))]
 compile_error!(

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -388,14 +388,11 @@ impl DeltaTableState {
         &self,
         flatten: bool,
     ) -> Result<arrow::record_batch::RecordBatch, DeltaTableError> {
-        // TODO: test this thoroughly in Rust
         let mut paths = arrow::array::StringBuilder::with_capacity(
             self.files.len(),
             self.files.iter().map(|add| add.path.len()).sum(),
         );
         let mut size = arrow::array::Int64Builder::with_capacity(self.files.len());
-        // let mut partition_keys = arrow::array::StringArray::with_capacity()
-        // let partition_values = arrow::array::MapBuilder::with_capacity(None, , key_builder, value_builder, capacity)
         let mut mod_time =
             arrow::array::TimestampMillisecondBuilder::with_capacity(self.files.len());
         let mut data_change = arrow::array::BooleanBuilder::with_capacity(self.files.len());
@@ -412,8 +409,9 @@ impl DeltaTableState {
             size.append_value(action.size);
             mod_time.append_value(action.modification_time);
             data_change.append_value(action.data_change);
-            if let Some(action_stats) = &action.stats {
-                stats.append_value(action_stats);
+
+            if let Some(action_stats) = &action.get_stats()? {
+                stats.append_value(serde_json::to_string(action_stats)?);
             } else {
                 stats.append_null();
             }

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -379,6 +379,8 @@ impl DeltaTableState {
         Ok(actions)
     }
 }
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -493,12 +493,15 @@ impl DeltaTableState {
                 .into_iter()
                 .zip(metadata.partition_columns.iter())
                 .map(|(datatype, name)| arrow::datatypes::Field::new(name, datatype, true));
-            let arr = arrow::array::StructArray::from(
-                fields
-                    .zip(partition_columns.into_iter())
-                    .collect::<Vec<_>>(),
-            );
-            vec![(Cow::Borrowed("partition_values"), Arc::new(arr))]
+            let field_arrays = fields
+                .zip(partition_columns.into_iter())
+                .collect::<Vec<_>>();
+            if field_arrays.is_empty() {
+                vec![]
+            } else {
+                let arr = Arc::new(arrow::array::StructArray::from(field_arrays));
+                vec![(Cow::Borrowed("partition_values"), arr)]
+            }
         };
 
         arrays.extend(partition_columns.into_iter());

--- a/rust/src/table_state_arrow.rs
+++ b/rust/src/table_state_arrow.rs
@@ -1,5 +1,5 @@
 //! Methods to get Delta Table state in Arrow structures
-//! 
+//!
 //! See [crate::table_state::DeltaTableState].
 
 use crate::action::{ColumnCountStat, ColumnValueStat, Stats};
@@ -24,24 +24,24 @@ use std::sync::Arc;
 
 impl DeltaTableState {
     /// Get an [arrow::record_batch::RecordBatch] containing add action data.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `flatten` - whether to flatten the schema. Partition values columns are
     ///   given the prefix `partition.`, statistics (null_count, min, and max) are
-    ///   given the prefix `null_count.`, `min.`, and `max.`, and tags the 
+    ///   given the prefix `null_count.`, `min.`, and `max.`, and tags the
     ///   prefix `tags.`. Nested field names are concatenated with `.`.
-    /// 
+    ///
     /// # Data schema
-    /// 
+    ///
     /// Each row represents a file that is a part of the selected tables state.
-    /// 
+    ///
     /// * `path` (String): relative or absolute to a file.
     /// * `size_bytes` (Int64): size of file in bytes.
     /// * `modification_time` (Millisecond Timestamp): time the file was created.
     /// * `data_change` (Boolean): false if data represents data moved from other files
     ///   in the same transaction.
-    /// * `partition.{partition column name}` (matches column type): value of 
+    /// * `partition.{partition column name}` (matches column type): value of
     ///   partition the file corresponds to.
     /// * `null_count.{col_name}` (Int64): number of null values for column in
     ///   this file.

--- a/rust/src/table_state_arrow.rs
+++ b/rust/src/table_state_arrow.rs
@@ -1,4 +1,6 @@
 //! Methods to get Delta Table state in Arrow structures
+//! 
+//! See [crate::table_state::DeltaTableState].
 
 use crate::action::{ColumnCountStat, ColumnValueStat, Stats};
 use crate::table_state::DeltaTableState;
@@ -21,7 +23,33 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 impl DeltaTableState {
-    /// Get the add actions as a RecordBatch
+    /// Get an [arrow::record_batch::RecordBatch] containing add action data.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `flatten` - whether to flatten the schema. Partition values columns are
+    ///   given the prefix `partition.`, statistics (null_count, min, and max) are
+    ///   given the prefix `null_count.`, `min.`, and `max.`, and tags the 
+    ///   prefix `tags.`. Nested field names are concatenated with `.`.
+    /// 
+    /// # Data schema
+    /// 
+    /// Each row represents a file that is a part of the selected tables state.
+    /// 
+    /// * `path` (String): relative or absolute to a file.
+    /// * `size_bytes` (Int64): size of file in bytes.
+    /// * `modification_time` (Millisecond Timestamp): time the file was created.
+    /// * `data_change` (Boolean): false if data represents data moved from other files
+    ///   in the same transaction.
+    /// * `partition.{partition column name}` (matches column type): value of 
+    ///   partition the file corresponds to.
+    /// * `null_count.{col_name}` (Int64): number of null values for column in
+    ///   this file.
+    /// * `min.{col_name}` (matches column type): minimum value of column in file
+    ///   (if available).
+    /// * `max.{col_name}` (matches column type): maximum value of column in file
+    ///   (if available).
+    /// * `tag.{tag_key}` (String): value of a metadata tag for the file.
     pub fn add_actions_table(
         &self,
         flatten: bool,
@@ -160,7 +188,7 @@ impl DeltaTableState {
                 .into_iter()
                 .zip(metadata.partition_columns.iter())
                 .map(|(array, name)| {
-                    let name: Cow<str> = Cow::Owned(format!("partition_{}", name));
+                    let name: Cow<str> = Cow::Owned(format!("partition.{}", name));
                     (name, array)
                 })
                 .collect()

--- a/rust/tests/add_actions_test.rs
+++ b/rust/tests/add_actions_test.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "arrow")]
 
-use arrow::array::{self, ArrayRef};
+use arrow::array::{self, ArrayRef, StringArray};
 use arrow::compute::sort_to_indices;
 use arrow::datatypes::{DataType, Field};
 use arrow::record_batch::RecordBatch;
@@ -123,10 +123,124 @@ async fn test_add_action_table() {
     assert_eq!(expected, actions);
 
     // test table with stats
-    // let path = "./tests/data/delta-0.8.0";
-    // let mut table = deltalake::open_table(path).await.unwrap();
+    let path = "./tests/data/delta-0.8.0";
+    let table = deltalake::open_table(path).await.unwrap();
+    let actions = table.get_state().add_actions_table(true).unwrap();
+    let actions = sort_batch_by(&actions, "path").unwrap();
+
+    let expected_columns: Vec<(&str, ArrayRef)> = vec![
+        ("path", Arc::new(array::StringArray::from(vec![
+            "part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet",
+            "part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet",
+        ]))),
+        ("size_bytes", Arc::new(array::Int64Array::from(vec![440, 440]))),
+        ("modification_time", Arc::new(arrow::array::TimestampMillisecondArray::from(vec![
+            1615043776000, 1615043767000
+        ]))),
+        ("data_change", Arc::new(array::BooleanArray::from(vec![true, true]))),
+        ("stats", Arc::new(array::StringArray::from(vec![
+            "{\"numRecords\":2,\"minValues\":{\"value\":2},\"maxValues\":{\"value\":4},\"nullCount\":{\"value\":0}}",
+            "{\"numRecords\":2,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":2},\"nullCount\":{\"value\":0}}",
+        ]))),
+    ];
+    let expected = RecordBatch::try_from_iter(expected_columns.clone()).unwrap();
+
+    assert_eq!(expected, actions);
 
     // test table with no json stats
-    // let path = "./tests/data/delta-1.2.1-only-struct-stats";
-    // let mut table = deltalake::open_table(path).await.unwrap();
+    let path = "./tests/data/delta-1.2.1-only-struct-stats";
+    let table = deltalake::open_table(path).await.unwrap();
+
+    let actions = table.get_state().add_actions_table(true).unwrap();
+    let actions = sort_batch_by(&actions, "path").unwrap();
+
+    let stats_col_index = actions.schema().column_with_name("stats").unwrap().0;
+    let result_stats: &StringArray = actions
+        .column(stats_col_index)
+        .as_any()
+        .downcast_ref()
+        .unwrap();
+    let actions = actions
+        .project(
+            &(0..actions.num_columns())
+                .into_iter()
+                .filter(|i| i != &stats_col_index)
+                .collect::<Vec<usize>>(),
+        )
+        .unwrap();
+
+    let expected_columns: Vec<(&str, ArrayRef)> = vec![
+        (
+            "path",
+            Arc::new(array::StringArray::from(vec![
+                "part-00000-1c2d1a32-02dc-484f-87ff-4328ea56045d-c000.snappy.parquet",
+                "part-00000-28925d3a-bdf2-411e-bca9-b067444cbcb0-c000.snappy.parquet",
+                "part-00000-6630b7c4-0aca-405b-be86-68a812f2e4c8-c000.snappy.parquet",
+                "part-00000-74151571-7ec6-4bd6-9293-b5daab2ce667-c000.snappy.parquet",
+                "part-00000-7a509247-4f58-4453-9202-51d75dee59af-c000.snappy.parquet",
+                "part-00000-8e0aefe1-6645-4601-ac29-68cba64023b5-c000.snappy.parquet",
+                "part-00000-b26ba634-874c-45b0-a7ff-2f0395a53966-c000.snappy.parquet",
+                "part-00000-c4c8caec-299d-42a4-b50c-5a4bf724c037-c000.snappy.parquet",
+                "part-00000-ce300400-58ff-4b8f-8ba9-49422fdf9f2e-c000.snappy.parquet",
+                "part-00000-e1262b3e-2959-4910-aea9-4eaf92f0c68c-c000.snappy.parquet",
+                "part-00000-e8e3753f-e2f6-4c9f-98f9-8f3d346727ba-c000.snappy.parquet",
+                "part-00000-f73ff835-0571-4d67-ac43-4fbf948bfb9b-c000.snappy.parquet",
+            ])),
+        ),
+        (
+            "size_bytes",
+            Arc::new(array::Int64Array::from(vec![
+                5488, 5489, 5489, 5489, 5489, 5489, 5489, 5489, 5489, 5489, 5489, 5731,
+            ])),
+        ),
+        (
+            "modification_time",
+            Arc::new(arrow::array::TimestampMillisecondArray::from(vec![
+                1666652376000,
+                1666652374000,
+                1666652378000,
+                1666652377000,
+                1666652373000,
+                1666652385000,
+                1666652375000,
+                1666652379000,
+                1666652382000,
+                1666652386000,
+                1666652380000,
+                1666652383000,
+            ])),
+        ),
+        (
+            "data_change",
+            Arc::new(array::BooleanArray::from(vec![
+                false, false, false, false, false, true, false, false, false, true, false, false,
+            ])),
+        ),
+    ];
+    let expected = RecordBatch::try_from_iter(expected_columns.clone()).unwrap();
+
+    assert_eq!(expected, actions);
+
+    // For stats in checkpoints, the serialization order isn't deterministic, so we can't compare with strings
+    let expected_stats = vec![
+        "{\"numRecords\":1,\"minValues\":{\"struct\":{\"struct_element\":\"struct_value\"},\"double\":1.234,\"decimal\":-5.678,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"timestamp\":\"2022-10-24T22:59:36.177Z\",\"string\":\"string\",\"integer\":3,\"date\":\"2022-10-24\"},\"maxValues\":{\"timestamp\":\"2022-10-24T22:59:36.177Z\",\"integer\":3,\"struct\":{\"struct_element\":\"struct_value\"},\"double\":1.234,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"string\":\"string\",\"date\":\"2022-10-24\",\"decimal\":-5.678},\"nullCount\":{\"struct\":{\"struct_element\":0},\"double\":0,\"array\":0,\"integer\":0,\"date\":0,\"map\":0,\"struct_of_array_of_map\":{\"struct_element\":0},\"boolean\":0,\"null\":1,\"decimal\":0,\"binary\":0,\"timestamp\":0,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"string\":0}}",
+        "{\"numRecords\":1,\"minValues\":{\"integer\":1,\"timestamp\":\"2022-10-24T22:59:34.067Z\",\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"struct\":{\"struct_element\":\"struct_value\"},\"string\":\"string\",\"double\":1.234,\"date\":\"2022-10-24\",\"decimal\":-5.678},\"maxValues\":{\"decimal\":-5.678,\"timestamp\":\"2022-10-24T22:59:34.067Z\",\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"integer\":1,\"double\":1.234,\"string\":\"string\",\"struct\":{\"struct_element\":\"struct_value\"},\"date\":\"2022-10-24\"},\"nullCount\":{\"boolean\":0,\"string\":0,\"struct\":{\"struct_element\":0},\"map\":0,\"double\":0,\"array\":0,\"null\":1,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"binary\":0,\"decimal\":0,\"date\":0,\"timestamp\":0,\"struct_of_array_of_map\":{\"struct_element\":0},\"integer\":0}}",
+        "{\"numRecords\":1,\"minValues\":{\"integer\":5,\"decimal\":-5.678,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"string\":\"string\",\"timestamp\":\"2022-10-24T22:59:38.358Z\",\"double\":1.234,\"date\":\"2022-10-24\",\"struct\":{\"struct_element\":\"struct_value\"}},\"maxValues\":{\"timestamp\":\"2022-10-24T22:59:38.358Z\",\"integer\":5,\"decimal\":-5.678,\"date\":\"2022-10-24\",\"string\":\"string\",\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"double\":1.234,\"struct\":{\"struct_element\":\"struct_value\"}},\"nullCount\":{\"null\":1,\"struct_of_array_of_map\":{\"struct_element\":0},\"binary\":0,\"string\":0,\"double\":0,\"integer\":0,\"date\":0,\"timestamp\":0,\"map\":0,\"array\":0,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"decimal\":0,\"struct\":{\"struct_element\":0},\"boolean\":0}}",
+        "{\"numRecords\":1,\"minValues\":{\"string\":\"string\",\"double\":1.234,\"integer\":4,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"timestamp\":\"2022-10-24T22:59:37.235Z\",\"date\":\"2022-10-24\",\"decimal\":-5.678,\"struct\":{\"struct_element\":\"struct_value\"}},\"maxValues\":{\"timestamp\":\"2022-10-24T22:59:37.235Z\",\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"date\":\"2022-10-24\",\"string\":\"string\",\"struct\":{\"struct_element\":\"struct_value\"},\"double\":1.234,\"integer\":4,\"decimal\":-5.678},\"nullCount\":{\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"struct_of_array_of_map\":{\"struct_element\":0},\"binary\":0,\"map\":0,\"string\":0,\"double\":0,\"date\":0,\"null\":1,\"integer\":0,\"boolean\":0,\"decimal\":0,\"timestamp\":0,\"struct\":{\"struct_element\":0},\"array\":0}}",
+        "{\"numRecords\":1,\"minValues\":{\"struct\":{\"struct_element\":\"struct_value\"},\"decimal\":-5.678,\"timestamp\":\"2022-10-24T22:59:32.846Z\",\"string\":\"string\",\"integer\":0,\"double\":1.234,\"date\":\"2022-10-24\",\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}}},\"maxValues\":{\"string\":\"string\",\"struct\":{\"struct_element\":\"struct_value\"},\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"date\":\"2022-10-24\",\"decimal\":-5.678,\"integer\":0,\"double\":1.234,\"timestamp\":\"2022-10-24T22:59:32.846Z\"},\"nullCount\":{\"timestamp\":0,\"struct\":{\"struct_element\":0},\"double\":0,\"binary\":0,\"string\":0,\"boolean\":0,\"decimal\":0,\"null\":1,\"integer\":0,\"array\":0,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"struct_of_array_of_map\":{\"struct_element\":0},\"date\":0,\"map\":0}}",
+        "{\"numRecords\":1,\"minValues\":{\"struct\":{\"struct_element\":\"struct_value\"},\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"date\":\"2022-10-24\",\"timestamp\":\"2022-10-24T22:59:44.639Z\",\"double\":1.234,\"integer\":10,\"string\":\"string\",\"decimal\":-5.678},\"maxValues\":{\"struct\":{\"struct_element\":\"struct_value\"},\"date\":\"2022-10-24\",\"integer\":10,\"decimal\":-5.678,\"string\":\"string\",\"double\":1.234,\"timestamp\":\"2022-10-24T22:59:44.639Z\",\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}}},\"nullCount\":{\"binary\":0,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"timestamp\":0,\"boolean\":0,\"string\":0,\"struct_of_array_of_map\":{\"struct_element\":0},\"map\":0,\"null\":1,\"decimal\":0,\"array\":0,\"struct\":{\"struct_element\":0},\"double\":0,\"integer\":0,\"date\":0}}",
+        "{\"numRecords\":1,\"minValues\":{\"date\":\"2022-10-24\",\"timestamp\":\"2022-10-24T22:59:35.117Z\",\"integer\":2,\"struct\":{\"struct_element\":\"struct_value\"},\"decimal\":-5.678,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"string\":\"string\",\"double\":1.234},\"maxValues\":{\"integer\":2,\"timestamp\":\"2022-10-24T22:59:35.117Z\",\"struct\":{\"struct_element\":\"struct_value\"},\"decimal\":-5.678,\"double\":1.234,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"date\":\"2022-10-24\",\"string\":\"string\"},\"nullCount\":{\"struct\":{\"struct_element\":0},\"double\":0,\"map\":0,\"array\":0,\"boolean\":0,\"integer\":0,\"date\":0,\"binary\":0,\"decimal\":0,\"string\":0,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"struct_of_array_of_map\":{\"struct_element\":0},\"null\":1,\"timestamp\":0}}",
+        "{\"numRecords\":1,\"minValues\":{\"timestamp\":\"2022-10-24T22:59:39.489Z\",\"string\":\"string\",\"struct\":{\"struct_element\":\"struct_value\"},\"date\":\"2022-10-24\",\"integer\":6,\"double\":1.234,\"decimal\":-5.678,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}}},\"maxValues\":{\"timestamp\":\"2022-10-24T22:59:39.489Z\",\"decimal\":-5.678,\"integer\":6,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"string\":\"string\",\"struct\":{\"struct_element\":\"struct_value\"},\"date\":\"2022-10-24\",\"double\":1.234},\"nullCount\":{\"double\":0,\"decimal\":0,\"boolean\":0,\"struct\":{\"struct_element\":0},\"date\":0,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"timestamp\":0,\"array\":0,\"binary\":0,\"map\":0,\"null\":1,\"struct_of_array_of_map\":{\"struct_element\":0},\"string\":0,\"integer\":0}}",
+        "{\"numRecords\":1,\"minValues\":{\"timestamp\":\"2022-10-24T22:59:41.637Z\",\"decimal\":-5.678,\"date\":\"2022-10-24\",\"integer\":8,\"string\":\"string\",\"double\":1.234,\"struct\":{\"struct_element\":\"struct_value\"},\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}}},\"maxValues\":{\"date\":\"2022-10-24\",\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"decimal\":-5.678,\"double\":1.234,\"integer\":8,\"timestamp\":\"2022-10-24T22:59:41.637Z\",\"string\":\"string\",\"struct\":{\"struct_element\":\"struct_value\"}},\"nullCount\":{\"array\":0,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"timestamp\":0,\"string\":0,\"struct_of_array_of_map\":{\"struct_element\":0},\"map\":0,\"integer\":0,\"binary\":0,\"double\":0,\"null\":1,\"date\":0,\"decimal\":0,\"boolean\":0,\"struct\":{\"struct_element\":0}}}",
+        "{\"numRecords\":1,\"minValues\":{\"timestamp\":\"2022-10-24T22:59:46.083Z\",\"date\":\"2022-10-24\",\"struct\":{\"struct_element\":\"struct_value\"},\"integer\":11,\"string\":\"string\",\"double\":1.234,\"decimal\":-5.678,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}}},\"maxValues\":{\"decimal\":-5.678,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"date\":\"2022-10-24\",\"timestamp\":\"2022-10-24T22:59:46.083Z\",\"string\":\"string\",\"struct\":{\"struct_element\":\"struct_value\"},\"double\":1.234,\"integer\":11},\"nullCount\":{\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"binary\":0,\"date\":0,\"double\":0,\"map\":0,\"null\":1,\"struct_of_array_of_map\":{\"struct_element\":0},\"string\":0,\"boolean\":0,\"integer\":0,\"struct\":{\"struct_element\":0},\"decimal\":0,\"timestamp\":0,\"array\":0}}",
+        "{\"numRecords\":1,\"minValues\":{\"date\":\"2022-10-24\",\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"decimal\":-5.678,\"timestamp\":\"2022-10-24T22:59:40.572Z\",\"struct\":{\"struct_element\":\"struct_value\"},\"string\":\"string\",\"integer\":7,\"double\":1.234},\"maxValues\":{\"integer\":7,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"struct\":{\"struct_element\":\"struct_value\"},\"double\":1.234,\"decimal\":-5.678,\"string\":\"string\",\"timestamp\":\"2022-10-24T22:59:40.572Z\",\"date\":\"2022-10-24\"},\"nullCount\":{\"double\":0,\"binary\":0,\"boolean\":0,\"timestamp\":0,\"array\":0,\"null\":1,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"struct\":{\"struct_element\":0},\"struct_of_array_of_map\":{\"struct_element\":0},\"map\":0,\"integer\":0,\"date\":0,\"string\":0,\"decimal\":0}}",
+        "{\"numRecords\":1,\"minValues\":{\"double\":1.234,\"string\":\"string\",\"date\":\"2022-10-24\",\"struct\":{\"struct_element\":\"struct_value\"},\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"timestamp\":\"2022-10-24T22:59:42.908Z\",\"integer\":9,\"decimal\":-5.678,\"new_column\":0},\"maxValues\":{\"date\":\"2022-10-24\",\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":\"nested_struct_value\"}},\"decimal\":-5.678,\"integer\":9,\"double\":1.234,\"string\":\"string\",\"struct\":{\"struct_element\":\"struct_value\"},\"timestamp\":\"2022-10-24T22:59:42.908Z\",\"new_column\":0},\"nullCount\":{\"double\":0,\"new_column\":0,\"struct_of_array_of_map\":{\"struct_element\":0},\"date\":0,\"map\":0,\"decimal\":0,\"null\":1,\"timestamp\":0,\"struct\":{\"struct_element\":0},\"boolean\":0,\"nested_struct\":{\"struct_element\":{\"nested_struct_element\":0}},\"binary\":0,\"integer\":0,\"array\":0,\"string\":0}}",
+    ];
+
+    for (maybe_result_stat, expected_stat) in result_stats.iter().zip(expected_stats.into_iter()) {
+        let result_value: serde_json::Value =
+            serde_json::from_str(maybe_result_stat.unwrap()).unwrap();
+        let expected_value: serde_json::Value = serde_json::from_str(expected_stat).unwrap();
+        assert_eq!(result_value, expected_value);
+    }
 }

--- a/rust/tests/add_actions_test.rs
+++ b/rust/tests/add_actions_test.rs
@@ -43,7 +43,7 @@ async fn test_with_partitions() {
             1627990384000, 1627990384000
         ]))),
         ("data_change", Arc::new(array::BooleanArray::from(vec![true, true]))),
-        ("partition_k", Arc::new(array::StringArray::from(vec![Some("A"), None]))),
+        ("partition.k", Arc::new(array::StringArray::from(vec![Some("A"), None]))),
     ];
     let expected = RecordBatch::try_from_iter(expected_columns.clone()).unwrap();
 

--- a/rust/tests/add_actions_test.rs
+++ b/rust/tests/add_actions_test.rs
@@ -321,6 +321,14 @@ async fn test_only_struct_stats() {
             "null_count.struct_of_array_of_map.struct_element",
             Arc::new(array::Int64Array::from(vec![0])),
         ),
+        (
+            "tags.INSERTION_TIME",
+            Arc::new(array::StringArray::from(vec!["1666652373000000"])),
+        ),
+        (
+            "tags.OPTIMIZE_TARGET_SIZE",
+            Arc::new(array::StringArray::from(vec!["268435456"])),
+        ),
     ];
     let expected = RecordBatch::try_from_iter(expected_columns.clone()).unwrap();
 
@@ -400,6 +408,16 @@ async fn test_only_struct_stats() {
             .downcast_ref::<array::Int64Array>()
             .unwrap(),
         &array::Int64Array::from(vec![0])
+    );
+
+    assert_eq!(
+        actions
+            .get_field_at_path(&vec!["tags", "OPTIMIZE_TARGET_SIZE"])
+            .unwrap()
+            .as_any()
+            .downcast_ref::<array::StringArray>()
+            .unwrap(),
+        &array::StringArray::from(vec!["268435456"])
     );
 }
 

--- a/rust/tests/add_actions_test.rs
+++ b/rust/tests/add_actions_test.rs
@@ -1,0 +1,132 @@
+#![cfg(feature = "arrow")]
+
+use arrow::array::{self, ArrayRef};
+use arrow::compute::sort_to_indices;
+use arrow::datatypes::{DataType, Field};
+use arrow::record_batch::RecordBatch;
+use std::sync::Arc;
+
+fn sort_batch_by(batch: &RecordBatch, column: &str) -> arrow::error::Result<RecordBatch> {
+    let sort_column = batch.column(batch.schema().column_with_name(column).unwrap().0);
+    let sort_indices = sort_to_indices(sort_column, None, None)?;
+    let schema = batch.schema();
+    let sorted_columns: Vec<(&String, ArrayRef)> = schema
+        .fields()
+        .iter()
+        .zip(batch.columns().iter())
+        .map(|(field, column)| {
+            Ok((
+                field.name(),
+                arrow::compute::take(column, &sort_indices, None)?,
+            ))
+        })
+        .collect::<arrow::error::Result<_>>()?;
+    RecordBatch::try_from_iter(sorted_columns)
+}
+
+#[tokio::test]
+async fn test_add_action_table() {
+    // test table with partitions
+    let path = "./tests/data/delta-0.8.0-null-partition";
+    let table = deltalake::open_table(path).await.unwrap();
+    let actions = table.get_state().add_actions_table(true).unwrap();
+    let actions = sort_batch_by(&actions, "path").unwrap();
+
+    let mut expected_columns: Vec<(&str, ArrayRef)> = vec![
+        ("path", Arc::new(array::StringArray::from(vec![
+            "k=A/part-00000-b1f1dbbb-70bc-4970-893f-9bb772bf246e.c000.snappy.parquet",
+            "k=__HIVE_DEFAULT_PARTITION__/part-00001-8474ac85-360b-4f58-b3ea-23990c71b932.c000.snappy.parquet"
+        ]))),
+        ("size_bytes", Arc::new(array::Int64Array::from(vec![460, 460]))),
+        ("modification_time", Arc::new(arrow::array::TimestampMillisecondArray::from(vec![
+            1627990384000, 1627990384000
+        ]))),
+        ("data_change", Arc::new(array::BooleanArray::from(vec![true, true]))),
+        ("stats", Arc::new(array::StringArray::from(vec![None, None]))),
+        ("partition_k", Arc::new(array::StringArray::from(vec![Some("A"), None]))),
+    ];
+    let expected = RecordBatch::try_from_iter(expected_columns.clone()).unwrap();
+
+    assert_eq!(expected, actions);
+
+    let actions = table.get_state().add_actions_table(false).unwrap();
+    let actions = sort_batch_by(&actions, "path").unwrap();
+
+    expected_columns[5] = (
+        "partition_values",
+        Arc::new(array::StructArray::from(vec![(
+            Field::new("k", DataType::Utf8, true),
+            Arc::new(array::StringArray::from(vec![Some("A"), None])) as ArrayRef,
+        )])),
+    );
+    let expected = RecordBatch::try_from_iter(expected_columns).unwrap();
+
+    assert_eq!(expected, actions);
+
+    // test table without partitions
+    let path = "./tests/data/simple_table";
+    let table = deltalake::open_table(path).await.unwrap();
+
+    let actions = table.get_state().add_actions_table(true).unwrap();
+    let actions = sort_batch_by(&actions, "path").unwrap();
+
+    let expected_columns: Vec<(&str, ArrayRef)> = vec![
+        (
+            "path",
+            Arc::new(array::StringArray::from(vec![
+                "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet",
+                "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
+                "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
+                "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
+                "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
+            ])),
+        ),
+        (
+            "size_bytes",
+            Arc::new(array::Int64Array::from(vec![262, 262, 429, 429, 429])),
+        ),
+        (
+            "modification_time",
+            Arc::new(arrow::array::TimestampMillisecondArray::from(vec![
+                1587968626000,
+                1587968602000,
+                1587968602000,
+                1587968602000,
+                1587968602000,
+            ])),
+        ),
+        (
+            "data_change",
+            Arc::new(array::BooleanArray::from(vec![
+                true, true, true, true, true,
+            ])),
+        ),
+        (
+            "stats",
+            Arc::new(array::StringArray::from(vec![None, None, None, None, None])),
+        ),
+    ];
+    let expected = RecordBatch::try_from_iter(expected_columns.clone()).unwrap();
+
+    assert_eq!(expected, actions);
+
+    let actions = table.get_state().add_actions_table(false).unwrap();
+    let actions = sort_batch_by(&actions, "path").unwrap();
+
+    // For now, this column is ignored.
+    // expected_columns.push((
+    //     "partition_values",
+    //     new_null_array(&DataType::Struct(vec![]), 5),
+    // ));
+    let expected = RecordBatch::try_from_iter(expected_columns.clone()).unwrap();
+
+    assert_eq!(expected, actions);
+
+    // test table with stats
+    // let path = "./tests/data/delta-0.8.0";
+    // let mut table = deltalake::open_table(path).await.unwrap();
+
+    // test table with no json stats
+    // let path = "./tests/data/delta-1.2.1-only-struct-stats";
+    // let mut table = deltalake::open_table(path).await.unwrap();
+}


### PR DESCRIPTION
# Description

Exposes function to get a dataframe of add actions for selected version of the table. 

TODO:

 * [x] add unit tests
 * [x] write user guide
 * [x] handle partition columns
 * [x] handle stats
 * [x] handle tags
 * [x] add a `flatten` option

# Related Issue(s)

- closes #1031

# Documentation

<!---
Share links to useful documentation
--->
