### PR TITLE
fix: azure sas key url encoding

### DIFF
--- a/rust/src/builder/azure.rs
+++ b/rust/src/builder/azure.rs
@@ -5,6 +5,7 @@ use crate::DeltaResult;
 
 use object_store::azure::MicrosoftAzureBuilder;
 use once_cell::sync::Lazy;
+use percent_encoding::percent_decode_str;
 
 #[derive(PartialEq, Eq)]
 enum AzureConfigKey {
@@ -220,6 +221,9 @@ fn parse_boolean(term: &str) -> Option<bool> {
 }
 
 fn split_sas(sas: &str) -> Result<Vec<(String, String)>, BuilderError> {
+    let sas = percent_decode_str(sas)
+        .decode_utf8()
+        .map_err(|err| BuilderError::Decode(err.to_string()))?;
     let kv_str_pairs = sas
         .trim_start_matches('?')
         .split('&')

--- a/rust/src/builder/mod.rs
+++ b/rust/src/builder/mod.rs
@@ -37,7 +37,7 @@ enum BuilderError {
     Required(String),
     #[error("Failed to find valid credential.")]
     MissingCredential,
-    #[error("Failed to decode sas key. {0}")]
+    #[error("Failed to decode SAS key: {0}\nSAS keys must be percent-encoded. They come encoded in the Azure portal and Azure Storage Explorer.")]
     Decode(String),
 }
 

--- a/rust/src/builder/mod.rs
+++ b/rust/src/builder/mod.rs
@@ -37,6 +37,8 @@ enum BuilderError {
     Required(String),
     #[error("Failed to find valid credential.")]
     MissingCredential,
+    #[error("Failed to decode sas key. {0}")]
+    Decode(String),
 }
 
 impl From<BuilderError> for DeltaTableError {


### PR DESCRIPTION
# Description

The object store crate encode the sas key values internally. When passing in an already encoded sas key, they would get double encoded. Since sas keys acquired from the azure portal and azure storage explorer are encoded, and this is "ususally" how a user would get them we decode them before passign them to object store.

I was not completely sure what the desired bahvior should be, alternatively we could update the documentation, to show a sas keys from the portal should be handled.

```py
import deltalake
from urllib.parse import unquote

storage_options = dict(account_name=storage_account, sas_token=unquote(sas))
dt = deltalake.DeltaTable(azure_uri, storage_options=storage_options)
```

# Related Issue(s)

closes #910

# Documentation

<!---
Share links to useful documentation
--->
