### PR TITLE
feat: enable passing storage options to Delta table builder via DataFusion's CREATE EXTERNAL TABLE

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1482,6 +1482,19 @@ pub async fn open_table(table_uri: impl AsRef<str>) -> Result<DeltaTable, DeltaT
     Ok(table)
 }
 
+/// Same as `open_table`, but also accepts storage options to aid in building the table for a deduced
+/// `StorageService`.
+pub async fn open_table_with_storage_options(
+    table_uri: impl AsRef<str>,
+    storage_options: HashMap<String, String>,
+) -> Result<DeltaTable, DeltaTableError> {
+    let table = DeltaTableBuilder::from_uri(table_uri)
+        .with_storage_options(storage_options)
+        .load()
+        .await?;
+    Ok(table)
+}
+
 /// Creates a DeltaTable from the given path and loads it with the metadata from the given version.
 /// Infers the storage backend to use from the scheme in the given table path.
 pub async fn open_table_with_version(

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -57,7 +57,7 @@ use object_store::{path::Path, ObjectMeta};
 use url::Url;
 
 use crate::Invariant;
-use crate::{action, open_table};
+use crate::{action, open_table, open_table_with_storage_options};
 use crate::{schema, DeltaTableBuilder};
 use crate::{DeltaTable, DeltaTableError};
 
@@ -866,7 +866,11 @@ impl TableProviderFactory for DeltaTableFactory {
         _ctx: &SessionState,
         cmd: &CreateExternalTable,
     ) -> datafusion::error::Result<Arc<dyn TableProvider>> {
-        let provider = open_table(cmd.to_owned().location).await.unwrap();
+        let provider = if cmd.options.is_empty() {
+            open_table(cmd.to_owned().location).await?
+        } else {
+            open_table_with_storage_options(cmd.to_owned().location, cmd.to_owned().options).await?
+        };
         Ok(Arc::new(provider))
     }
 }

--- a/rust/src/test_utils.rs
+++ b/rust/src/test_utils.rs
@@ -434,22 +434,3 @@ pub mod gs_cli {
         set_env_if_not_set("GOOGLE_ENDPOINT_URL", "http://localhost:4443/storage/v1/b");
     }
 }
-
-pub mod datafusion {
-    use crate::delta_datafusion::DeltaTableFactory;
-    use datafusion::datasource::datasource::TableProviderFactory;
-    use datafusion::execution::context::SessionContext;
-    use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
-    use datafusion::prelude::SessionConfig;
-    use std::collections::HashMap;
-    use std::sync::Arc;
-
-    pub fn context_with_delta_table_factory() -> SessionContext {
-        let mut table_factories: HashMap<String, Arc<dyn TableProviderFactory>> = HashMap::new();
-        table_factories.insert("DELTATABLE".to_string(), Arc::new(DeltaTableFactory {}));
-        let cfg = RuntimeConfig::new().with_table_factories(table_factories);
-        let env = RuntimeEnv::new(cfg).unwrap();
-        let ses = SessionConfig::new();
-        SessionContext::with_config_rt(ses, Arc::new(env))
-    }
-}

--- a/rust/tests/common/datafusion.rs
+++ b/rust/tests/common/datafusion.rs
@@ -1,0 +1,16 @@
+use datafusion::datasource::datasource::TableProviderFactory;
+use datafusion::execution::context::SessionContext;
+use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
+use datafusion::prelude::SessionConfig;
+use deltalake::delta_datafusion::DeltaTableFactory;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub fn context_with_delta_table_factory() -> SessionContext {
+    let mut table_factories: HashMap<String, Arc<dyn TableProviderFactory>> = HashMap::new();
+    table_factories.insert("DELTATABLE".to_string(), Arc::new(DeltaTableFactory {}));
+    let cfg = RuntimeConfig::new().with_table_factories(table_factories);
+    let env = RuntimeEnv::new(cfg).unwrap();
+    let ses = SessionConfig::new();
+    SessionContext::with_config_rt(ses, Arc::new(env))
+}

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -1,4 +1,5 @@
-#![deny(warnings)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
 
 use bytes::Bytes;
 use deltalake::action::{self, Add, Remove};
@@ -15,6 +16,8 @@ use tempdir::TempDir;
 #[cfg(feature = "azure")]
 pub mod adls;
 pub mod clock;
+#[cfg(feature = "datafusion-ext")]
+pub mod datafusion;
 #[cfg(any(feature = "s3", feature = "s3-rustls"))]
 pub mod s3;
 pub mod schemas;

--- a/rust/tests/integration_datafusion.rs
+++ b/rust/tests/integration_datafusion.rs
@@ -1,10 +1,10 @@
 #![cfg(all(feature = "integration_test", feature = "datafusion-ext"))]
 
 use arrow::array::Int64Array;
-use datafusion::execution::context::SessionContext;
-use deltalake::test_utils::{IntegrationContext, StorageIntegration, TestResult, TestTables};
-use deltalake::DeltaTableBuilder;
-use maplit::hashmap;
+use deltalake::test_utils::{
+    datafusion::context_with_delta_table_factory, IntegrationContext, StorageIntegration,
+    TestResult, TestTables,
+};
 use serial_test::serial;
 use std::sync::Arc;
 
@@ -47,16 +47,27 @@ async fn test_datafusion(storage: StorageIntegration) -> TestResult {
 async fn simple_query(context: &IntegrationContext) -> TestResult {
     let table_uri = context.uri_for_table(TestTables::Simple);
 
-    let table = DeltaTableBuilder::from_uri(table_uri)
-        .with_allow_http(true)
-        .with_storage_options(hashmap! {
-            "DYNAMO_LOCK_OWNER_NAME".to_string() => "s3::deltars/simple".to_string(),
-        })
-        .load()
-        .await?;
+    let dynamo_lock_option = "'DYNAMO_LOCK_OWNER_NAME' 's3::deltars/simple'".to_string();
+    let options = match context.integration {
+        StorageIntegration::Amazon => format!("'AWS_STORAGE_ALLOW_HTTP' '1', {dynamo_lock_option}"),
+        StorageIntegration::Microsoft => {
+            format!("'AZURE_STORAGE_ALLOW_HTTP' '1', {dynamo_lock_option}")
+        }
+        _ => dynamo_lock_option,
+    };
 
-    let ctx = SessionContext::new();
-    ctx.register_table("demo", Arc::new(table))?;
+    let sql = format!(
+        "CREATE EXTERNAL TABLE demo \
+        STORED AS DELTATABLE \
+        OPTIONS ({options}) \
+        LOCATION '{table_uri}'",
+    );
+
+    let ctx = context_with_delta_table_factory();
+    let _ = ctx
+        .sql(sql.as_str())
+        .await
+        .expect("Failed to register table!");
 
     let batches = ctx
         .sql("SELECT id FROM demo WHERE id > 5 ORDER BY id ASC")

--- a/rust/tests/integration_datafusion.rs
+++ b/rust/tests/integration_datafusion.rs
@@ -1,12 +1,12 @@
 #![cfg(all(feature = "integration_test", feature = "datafusion-ext"))]
 
 use arrow::array::Int64Array;
-use deltalake::test_utils::{
-    datafusion::context_with_delta_table_factory, IntegrationContext, StorageIntegration,
-    TestResult, TestTables,
-};
+use common::datafusion::context_with_delta_table_factory;
+use deltalake::test_utils::{IntegrationContext, StorageIntegration, TestResult, TestTables};
 use serial_test::serial;
 use std::sync::Arc;
+
+mod common;
 
 #[tokio::test]
 #[serial]


### PR DESCRIPTION
# Description
We've recently added Delta table support to [Seafowl](https://github.com/splitgraph/seafowl) using delta-rs, which utilizes the new `OPTIONS` clause in sqlparser/DataFusion. It allows propagating a set of key/values down to the `DeltaTableBuilder`, which in turn can use those to instantiate a corresponding object store client. This means someone can now define a delta table without relying on env vars as:
```sql
CREATE EXTERNAL TABLE my_delta
STORED AS DELTATABLE
OPTIONS ('AWS_ACCESS_KEY_ID' 'secret', 'AWS_SECRET_ACCESS_KEY' 'also_secret', 'AWS_REGION' 'eu-west-3') 
LOCATION 's3://my-bucket/my-delta-table/'
```

I've also changed the existing datafusion integration tests to use this approach to exercise it.

I'm not sure whether it makes sense to merge this PR upstream, but opening this PR just in case it does.

# Related Issue(s)
Didn't find any related issues.

# Documentation