### PR TITLE
chore: update github actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           profile: default
           toolchain: "1.64.0" # Switch to "stable" when the 1.67.0 release of https://github.com/rust-lang/rust is published, more information: https://github.com/delta-io/delta-rs/pull/923
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: build and lint with clippy
         run: cargo clippy --features azure,datafusion,s3,gcs,glue
       - name: Spot-check build for rustls features
@@ -68,7 +68,7 @@ jobs:
           profile: default
           toolchain: "1.64.0" # Switch to "stable" when the 1.67.0 release of https://github.com/rust-lang/rust is published, more information: https://github.com/delta-io/delta-rs/pull/923
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --verbose --features datafusion,azure
 
@@ -102,7 +102,7 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Start emulated services
         run: docker-compose up -d
@@ -117,13 +117,13 @@ jobs:
   parquet2_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rs/toolchain@v1
         with:
           profile: default
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --no-default-features --features=parquet2

--- a/.github/workflows/lambda_checkpoint_build.yml
+++ b/.github/workflows/lambda_checkpoint_build.yml
@@ -2,38 +2,38 @@ name: lambda_checkpoint_build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install minimal stable with clippy and rustfmt
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: default
-        toolchain: stable
-        override: true
-    - name: Format
-      run: cargo fmt -p lambda-delta-checkpoint -- --check
+      - uses: actions/checkout@v3
+      - name: Install minimal stable with clippy and rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          override: true
+      - name: Format
+        run: cargo fmt -p lambda-delta-checkpoint -- --check
 
   build:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install minimal stable with clippy and rustfmt
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: default
-        toolchain: stable
-        override: true
-    - name: build and lint with clippy
-      run: cargo clippy -p lambda-delta-checkpoint
+      - uses: actions/checkout@v3
+      - name: Install minimal stable with clippy and rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          override: true
+      - name: build and lint with clippy
+        run: cargo clippy -p lambda-delta-checkpoint
 
   ## Temporarily disable test - the lambda isn't super useful with the current checkpoint memory pressure anyway.
   # test:
@@ -41,7 +41,7 @@ jobs:
   #     fail-fast: false
   #   runs-on: ubuntu-latest
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v3
   #   - name: Build musl
   #     uses: docker://messense/rust-musl-cross:x86_64-musl
   #     with:
@@ -62,4 +62,3 @@ jobs:
   #         -v "$(pwd)":/home/rust/src \
   #         messense/rust-musl-cross:x86_64-musl \
   #         cargo test -p lambda-delta-checkpoint
-

--- a/.github/workflows/lambda_checkpoint_release.yml
+++ b/.github/workflows/lambda_checkpoint_release.yml
@@ -2,14 +2,14 @@ name: lambda_checkpoint_release
 
 on:
   push:
-    tags: [ 'lambda-delta-checkpoint-v*' ]
+    tags: ["lambda-delta-checkpoint-v*"]
 
 jobs:
   validate-release-tag:
     name: Validate git tag
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: compare git tag with cargo metadata
         run: |
           PUSHED_TAG=${GITHUB_REF##*/}
@@ -25,19 +25,18 @@ jobs:
     runs-on: ubuntu-20.04
     name: Lambda Checkpoint release zip
     steps:
-    - uses: actions/checkout@v2
-    - name: Build musl
-      uses: docker://messense/rust-musl-cross:x86_64-musl
-      with:
-        args: cargo build -p lambda-delta-checkpoint --release
-    - name: Zip lambda bin
-      run: |
-        PUSHED_TAG=${GITHUB_REF##*/}
-        zip -j "${PUSHED_TAG}.zip" ./target/x86_64-unknown-linux-musl/release/bootstrap
-    - name: Publish artifact  
-      uses: softprops/action-gh-release@v1
-      with:
-        files: lambda-delta-checkpoint-v*.zip
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      - uses: actions/checkout@v3
+      - name: Build musl
+        uses: docker://messense/rust-musl-cross:x86_64-musl
+        with:
+          args: cargo build -p lambda-delta-checkpoint --release
+      - name: Zip lambda bin
+        run: |
+          PUSHED_TAG=${GITHUB_REF##*/}
+          zip -j "${PUSHED_TAG}.zip" ./target/x86_64-unknown-linux-musl/release/bootstrap
+      - name: Publish artifact
+        uses: softprops/action-gh-release@v1
+        with:
+          files: lambda-delta-checkpoint-v*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -38,7 +38,7 @@ jobs:
     # use the same environment we have for python release
     container: quay.io/pypa/manylinux2014_x86_64:2022-09-24-4f086d0
     steps:
-      # actions/checkout@v2 is a node action, which runs on a fairly new
+      # actions/checkout@v3 is a node action, which runs on a fairly new
       # version of node. however, manylinux environment's glibc is too old for
       # that version of the node. so we will have to use v1 instead, which is a
       # docker based action.
@@ -51,7 +51,7 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Enable manylinux Python targets
         run: |
@@ -79,7 +79,7 @@ jobs:
     name: Python Build (Python 3.10 PyArrow latest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
@@ -88,12 +88,12 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"
-      
+
       - name: Start emulated services
         run: docker-compose up -d
 
@@ -125,7 +125,7 @@ jobs:
     name: PySpark Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
@@ -134,14 +134,15 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: "zulu"
           java-version: "11"
 
       - name: Build and install deltalake
@@ -161,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3
@@ -170,7 +171,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          
+
       - name: Build and install deltalake
         run: |
           pip install virtualenv

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Validate git tag
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: compare git tag with cargo metadata
         run: |
           PUSHED_TAG=${GITHUB_REF##*/}
@@ -48,16 +48,16 @@ jobs:
     name: PyPI release on Mac universal 2
     runs-on: macos-latest
     steps:
-        - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-        - name: Publish to pypi (without sdist)
-          uses: messense/maturin-action@v1
-          env:
-            MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          with:
-            target: ${{ matrix.target }}
-            command: publish
-            args: -m python/Cargo.toml --no-sdist --universal2
+      - name: Publish to pypi (without sdist)
+        uses: messense/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        with:
+          target: ${{ matrix.target }}
+          command: publish
+          args: -m python/Cargo.toml --no-sdist --universal2
 
   release-pypi-windows:
     needs: validate-release-tag
@@ -102,12 +102,17 @@ jobs:
 
   release-docs:
     needs:
-      [validate-release-tag, release-pypi-manylinux, release-pypi-mac, release-pypi-windows]
+      [
+        validate-release-tag,
+        release-pypi-manylinux,
+        release-pypi-mac,
+        release-pypi-windows,
+      ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # fetch full history for gh-pages branch checkout
       - name: Install minimal stable with clippy and rustfmt

--- a/.github/workflows/ruby_build.yml
+++ b/.github/workflows/ruby_build.yml
@@ -2,9 +2,9 @@ name: ruby_build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 defaults:
   run:
@@ -15,30 +15,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ruby-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-        restore-keys: |
-          ruby-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          ruby-${{ runner.os }}-cargo-
-    - name: Install minimal stable with clippy and rustfmt
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: default
-        toolchain: stable
-        override: true
-    - name: Build Release for Ruby
-      run: cargo build --release
-    - name: 'Set up Ruby'
-      uses: actions/setup-ruby@v1
-    - name: 'Install Ruby Dependencies'
-      run: bundle install --path vendor/bundle
-    - name: 'Test Ruby'
-      run: bundle exec rake spec
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ruby-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ruby-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+            ruby-${{ runner.os }}-cargo-
+      - name: Install minimal stable with clippy and rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          override: true
+      - name: Build Release for Ruby
+        run: cargo build --release
+      - name: "Set up Ruby"
+        uses: actions/setup-ruby@v1
+      - name: "Install Ruby Dependencies"
+        run: bundle install --path vendor/bundle
+      - name: "Test Ruby"
+        run: bundle exec rake spec

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -2,7 +2,7 @@ name: Release to Cargo
 
 on:
   push:
-    tags: [ 'rust-v*' ]
+    tags: ["rust-v*"]
 
 defaults:
   run:
@@ -13,7 +13,7 @@ jobs:
     name: Validate git tag
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: compare git tag with cargo metadata
         run: |
           PUSHED_TAG=${GITHUB_REF##*/}
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
# Description

Update gihub actions to avoid warnings and deprecations. Unfortunately there is no updated version of `actions-rs/toolchain` (yet?), but at least some warnings will go away.

# Related Issue(s)

closes #978

# Documentation

<!---
Share links to useful documentation
--->
