### PR TITLE
Expose checkpoint creation for current table state in python

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -426,7 +426,7 @@ given filters.
         """
         self._table.update_incremental()
 
-    def create_checkpoint(self):
+    def create_checkpoint(self) -> None:
         self._table.create_checkpoint()
 
     def __stringify_partition_values(

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -426,6 +426,9 @@ given filters.
         """
         self._table.update_incremental()
 
+    def create_checkpoint(self):
+        self._table.create_checkpoint()
+
     def __stringify_partition_values(
         self, partition_filters: Optional[List[Tuple[str, str, Any]]]
     ) -> Optional[List[Tuple[str, str, Union[str, List[str]]]]]:

--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -1,12 +1,16 @@
 import pathlib
+
 import pyarrow as pa
+
 from deltalake import DeltaTable, write_deltalake
 
 
 def test_checkpoint(tmp_path: pathlib.Path, sample_data: pa.Table):
     tmp_table_path = tmp_path / "path" / "to" / "table"
     checkpoint_path = tmp_table_path / "_delta_log" / "_last_checkpoint"
-    last_checkpoint_path = tmp_table_path / "_delta_log" / "00000000000000000000.checkpoint.parquet"
+    last_checkpoint_path = (
+        tmp_table_path / "_delta_log" / "00000000000000000000.checkpoint.parquet"
+    )
 
     # TODO: Include decimal after fixing issue "Json error: Decimal128(5, 3) type is not supported"
     sample_data = sample_data.drop(["decimal"])

--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -1,0 +1,21 @@
+import pathlib
+import pyarrow as pa
+from deltalake import DeltaTable, write_deltalake
+
+
+def test_checkpoint(tmp_path: pathlib.Path, sample_data: pa.Table):
+    tmp_table_path = tmp_path / "path" / "to" / "table"
+    checkpoint_path = tmp_table_path / "_delta_log" / "_last_checkpoint"
+    last_checkpoint_path = tmp_table_path / "_delta_log" / "00000000000000000000.checkpoint.parquet"
+
+    # TODO: Include decimal after fixing issue "Json error: Decimal128(5, 3) type is not supported"
+    sample_data = sample_data.drop(["decimal"])
+    write_deltalake(str(tmp_table_path), sample_data)
+
+    assert not checkpoint_path.exists()
+
+    delta_table = DeltaTable(str(tmp_table_path))
+    delta_table.create_checkpoint()
+
+    assert last_checkpoint_path.exists()
+    assert checkpoint_path.exists()


### PR DESCRIPTION
# Description
Current python wrapper hasn't any functionlity to create checkpoints.
This PR exposes rust functionality which is creates checkpoint at current table version.


# Documentation
Sample of usage:
```Python
    delta_table = DeltaTable(some_path)
    # apply actions...
    delta_table.create_checkpoint()
```