### PR TITLE
feat: improve storage location handling

### DIFF
--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -350,8 +350,8 @@ pub(crate) fn str_option(map: &HashMap<String, String>, key: &str) -> Option<Str
 pub(crate) fn ensure_table_uri(table_uri: impl AsRef<str>) -> DeltaResult<Url> {
     let table_uri = table_uri.as_ref();
     if let Ok(path) = std::fs::canonicalize(table_uri) {
-        return Ok(Url::from_directory_path(path)
-            .map_err(|_| DeltaTableError::InvalidTableLocation(table_uri.to_string()))?);
+        return Url::from_directory_path(path)
+            .map_err(|_| DeltaTableError::InvalidTableLocation(table_uri.to_string()));
     }
     if let Ok(url) = Url::parse(table_uri) {
         return Ok(url);

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -220,7 +220,10 @@ impl DeltaTableBuilder {
     /// Build a delta storage backend for the given config
     pub fn build_storage(self) -> DeltaResult<ObjectStoreRef> {
         match self.options.storage_backend {
-            Some((storage, location)) => Ok(Arc::new(DeltaObjectStore::new(storage, location))),
+            Some((storage, location)) => Ok(Arc::new(DeltaObjectStore::new(
+                storage,
+                ensure_table_uri(location.as_str())?,
+            ))),
             None => {
                 let location = ensure_table_uri(&self.options.table_uri)?;
                 Ok(Arc::new(DeltaObjectStore::try_new(
@@ -389,7 +392,9 @@ mod tests {
         assert_eq!("file:///", uri.as_str());
         let uri = ensure_table_uri("memory://").unwrap();
         assert_eq!("memory://", uri.as_str());
-        let uri = ensure_table_uri("s3://tests/data/delta-0.8.0//").unwrap();
+        let uri = ensure_table_uri("s3://tests/data/delta-0.8.0/").unwrap();
+        assert_eq!("s3://tests/data/delta-0.8.0", uri.as_str());
+        let _uri = ensure_table_uri("s3://tests/data/delta-0.8.0//").unwrap();
         assert_eq!("s3://tests/data/delta-0.8.0", uri.as_str())
     }
 }

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -5,25 +5,13 @@ use std::sync::Arc;
 
 use crate::delta::{DeltaResult, DeltaTable, DeltaTableError};
 use crate::schema::DeltaDataTypeVersion;
-use crate::storage::config::{StorageLocation, StorageOptions};
-use crate::storage::file::FileStorageBackend;
+use crate::storage::config::StorageOptions;
 use crate::storage::{DeltaObjectStore, ObjectStoreRef};
 
 use chrono::{DateTime, FixedOffset, Utc};
-use object_store::memory::InMemory;
-use object_store::path::Path;
-use object_store::{DynObjectStore, Error as ObjectStoreError, Result as ObjectStoreResult};
+use object_store::DynObjectStore;
 use serde::{Deserialize, Serialize};
 use url::Url;
-
-#[cfg(any(feature = "s3", feature = "s3-rustls"))]
-use crate::storage::s3::{S3StorageBackend, S3StorageOptions};
-#[cfg(any(feature = "s3", feature = "s3-rustls"))]
-use object_store::aws::AmazonS3Builder;
-#[cfg(feature = "azure")]
-use object_store::azure::MicrosoftAzureBuilder;
-#[cfg(feature = "gcs")]
-use object_store::gcp::GoogleCloudStorageBuilder;
 
 #[allow(dead_code)]
 #[derive(Debug, thiserror::Error)]
@@ -38,6 +26,8 @@ enum BuilderError {
     Decode(String),
     #[error("Delta-rs must be build with feature '{feature}' to support url: {url}.")]
     MissingFeature { feature: &'static str, url: String },
+    #[error("Failed to parse table uri")]
+    TableUri(#[from] url::ParseError),
 }
 
 impl From<BuilderError> for DeltaTableError {
@@ -98,7 +88,7 @@ pub struct DeltaTableLoadOptions {
     /// table root uri
     pub table_uri: String,
     /// backend to access storage system
-    pub storage_backend: Option<(Arc<DynObjectStore>, Path)>,
+    pub storage_backend: Option<(Arc<DynObjectStore>, Url)>,
     /// specify the version we are going to load: a time stamp, a version, or just the newest
     /// available version
     pub version: DeltaVersion,
@@ -168,7 +158,7 @@ impl DeltaTableBuilder {
     }
 
     /// specify the timestamp given as ISO-8601/RFC-3339 timestamp
-    pub fn with_datestring(self, date_string: impl AsRef<str>) -> Result<Self, DeltaTableError> {
+    pub fn with_datestring(self, date_string: impl AsRef<str>) -> DeltaResult<Self> {
         let datetime = DateTime::<Utc>::from(DateTime::<FixedOffset>::parse_from_rfc3339(
             date_string.as_ref(),
         )?);
@@ -183,13 +173,14 @@ impl DeltaTableBuilder {
 
     /// Set the storage backend.
     ///
-    /// `table_root` denotes the [object_store::path::Path] within the store to the root of the delta.
-    /// This is required since we cannot infer the relative location of the table from the `table_uri`
-    /// For non-standard object store implementations.
-    ///
     /// If a backend is not provided then it is derived from `table_uri`.
-    pub fn with_storage_backend(mut self, storage: Arc<DynObjectStore>, table_root: &Path) -> Self {
-        self.options.storage_backend = Some((storage, table_root.clone()));
+    ///
+    /// # Arguments
+    ///
+    /// * `storage` - A shared reference to an [`ObjectStore`](object_store::ObjectStore) with "/" pointing at delta table root (i.e. where `_delta_log` is located).
+    /// * `location` - A url corresponding to the storagle location of `storage`.
+    pub fn with_storage_backend(mut self, storage: Arc<DynObjectStore>, location: Url) -> Self {
+        self.options.storage_backend = Some((storage, location));
         self
     }
 
@@ -214,53 +205,46 @@ impl DeltaTableBuilder {
         self
     }
 
-    /// Build a delta storage backend for the given config
-    pub fn build_storage(self) -> Result<ObjectStoreRef, DeltaTableError> {
-        let (storage, storage_url) = match self.options.storage_backend {
-            // Some(storage) => storage,
-            None => get_storage_backend(
-                &self.options.table_uri,
-                self.storage_options,
-                self.allow_http,
-            )?,
-            _ => todo!(),
+    /// Storage options for configuring backend object store
+    pub fn storage_options(&self) -> StorageOptions {
+        let mut storage_options = self.storage_options.clone().unwrap_or_default();
+        if let Some(allow) = self.allow_http {
+            storage_options.insert(
+                "allow_http".into(),
+                if allow { "true" } else { "false" }.into(),
+            );
         };
-        let object_store = Arc::new(DeltaObjectStore::new(storage_url, storage));
-        Ok(object_store)
+        storage_options.into()
+    }
+
+    /// Build a delta storage backend for the given config
+    pub fn build_storage(self) -> DeltaResult<ObjectStoreRef> {
+        match self.options.storage_backend {
+            Some((storage, location)) => Ok(Arc::new(DeltaObjectStore::new(storage, location))),
+            None => {
+                let location = ensure_table_uri(&self.options.table_uri)?;
+                Ok(Arc::new(DeltaObjectStore::try_new(
+                    location,
+                    self.storage_options(),
+                )?))
+            }
+        }
     }
 
     /// Build the [`DeltaTable`] from specified options.
     ///
     /// This will not load the log, i.e. the table is not initialized. To get an initialized
     /// table use the `load` function
-    pub fn build(self) -> Result<DeltaTable, DeltaTableError> {
-        let (storage, storage_url) = match self.options.storage_backend {
-            Some((store, path)) => {
-                let mut uri = self.options.table_uri + path.as_ref();
-                if !uri.contains(':') {
-                    uri = format!("file://{}", uri);
-                }
-                let url = Url::parse(uri.as_str())
-                    .map_err(|_| DeltaTableError::Generic(format!("Can't parse uri: {}", uri)))?;
-                let url = StorageLocation::new(url);
-                (store, url)
-            }
-            None => get_storage_backend(
-                &self.options.table_uri,
-                self.storage_options,
-                self.allow_http,
-            )?,
-        };
+    pub fn build(self) -> DeltaResult<DeltaTable> {
         let config = DeltaTableConfig {
             require_tombstones: self.options.require_tombstones,
             require_files: self.options.require_files,
         };
-        let object_store = Arc::new(DeltaObjectStore::new(storage_url, storage));
-        Ok(DeltaTable::new(object_store, config))
+        Ok(DeltaTable::new(self.build_storage()?, config))
     }
 
     /// Build the [`DeltaTable`] and load its state
-    pub async fn load(self) -> Result<DeltaTable, DeltaTableError> {
+    pub async fn load(self) -> DeltaResult<DeltaTable> {
         let version = self.options.version.clone();
         let mut table = self.build()?;
         match version {
@@ -269,132 +253,6 @@ impl DeltaTableBuilder {
             DeltaVersion::Timestamp(ts) => table.load_with_datetime(ts).await?,
         }
         Ok(table)
-    }
-}
-
-enum ObjectStoreKind {
-    Local,
-    InMemory,
-    S3,
-    Google,
-    Azure,
-}
-
-impl ObjectStoreKind {
-    pub fn parse_url(url: &Url) -> ObjectStoreResult<Self> {
-        match url.scheme() {
-            "file" => Ok(ObjectStoreKind::Local),
-            "memory" => Ok(ObjectStoreKind::InMemory),
-            "az" | "abfs" | "abfss" | "azure" | "wasb" | "adl" => Ok(ObjectStoreKind::Azure),
-            "s3" | "s3a" => Ok(ObjectStoreKind::S3),
-            "gs" => Ok(ObjectStoreKind::Google),
-            "https" => {
-                let host = url.host_str().unwrap_or_default();
-                if host.contains("amazonaws.com") {
-                    Ok(ObjectStoreKind::S3)
-                } else if host.contains("dfs.core.windows.net")
-                    || host.contains("blob.core.windows.net")
-                {
-                    Ok(ObjectStoreKind::Azure)
-                } else {
-                    Err(ObjectStoreError::NotImplemented)
-                }
-            }
-            _ => Err(ObjectStoreError::NotImplemented),
-        }
-    }
-}
-
-/// Create a new storage backend used in Delta table
-pub(crate) fn get_storage_backend(
-    table_uri: impl AsRef<str>,
-    // annotation needed for some feature builds
-    #[allow(unused_variables)] options: Option<HashMap<String, String>>,
-    #[allow(unused_variables)] allow_http: Option<bool>,
-) -> DeltaResult<(Arc<DynObjectStore>, StorageLocation)> {
-    let storage_url = StorageLocation::parse(table_uri)?;
-    let mut options = options.unwrap_or_default();
-    if let Some(allow) = allow_http {
-        options.insert(
-            "allow_http".into(),
-            if allow { "true" } else { "false" }.into(),
-        );
-    }
-    let _options = StorageOptions::new(options);
-
-    match ObjectStoreKind::parse_url(&storage_url.url)? {
-        ObjectStoreKind::Local => Ok((Arc::new(FileStorageBackend::new()), storage_url)),
-        ObjectStoreKind::InMemory => Ok((Arc::new(InMemory::new()), storage_url)),
-        #[cfg(any(feature = "s3", feature = "s3-rustls"))]
-        ObjectStoreKind::S3 => {
-            let store = AmazonS3Builder::new()
-                .with_url(storage_url.as_ref())
-                .try_with_options(&_options.as_s3_options())?
-                .with_allow_http(_options.allow_http())
-                .build()
-                .or_else(|_| {
-                    AmazonS3Builder::from_env()
-                        .with_url(storage_url.as_ref())
-                        .try_with_options(&_options.as_s3_options())?
-                        .with_allow_http(_options.allow_http())
-                        .build()
-                })?;
-            Ok((
-                Arc::new(S3StorageBackend::try_new(
-                    Arc::new(store),
-                    S3StorageOptions::from_map(&_options.0),
-                )?),
-                storage_url,
-            ))
-        }
-        #[cfg(not(any(feature = "s3", feature = "s3-rustls")))]
-        ObjectStoreKind::S3 => Err(BuilderError::MissingFeature {
-            feature: "s3",
-            url: storage_url.as_ref().into(),
-        }
-        .into()),
-        #[cfg(feature = "azure")]
-        ObjectStoreKind::Azure => {
-            let store = MicrosoftAzureBuilder::new()
-                .with_url(storage_url.as_ref())
-                .try_with_options(&_options.as_azure_options())?
-                .with_allow_http(_options.allow_http())
-                .build()
-                .or_else(|_| {
-                    MicrosoftAzureBuilder::from_env()
-                        .with_url(storage_url.as_ref())
-                        .try_with_options(&_options.as_azure_options())?
-                        .with_allow_http(_options.allow_http())
-                        .build()
-                })?;
-            Ok((Arc::new(store), storage_url))
-        }
-        #[cfg(not(feature = "azure"))]
-        ObjectStoreKind::Azure => Err(BuilderError::MissingFeature {
-            feature: "azure",
-            url: storage_url.as_ref().into(),
-        }
-        .into()),
-        #[cfg(feature = "gcs")]
-        ObjectStoreKind::Google => {
-            let store = GoogleCloudStorageBuilder::new()
-                .with_url(storage_url.as_ref())
-                .try_with_options(&_options.as_gcs_options())?
-                .build()
-                .or_else(|_| {
-                    GoogleCloudStorageBuilder::from_env()
-                        .with_url(storage_url.as_ref())
-                        .try_with_options(&_options.as_gcs_options())?
-                        .build()
-                })?;
-            Ok((Arc::new(store), storage_url))
-        }
-        #[cfg(not(feature = "gcs"))]
-        ObjectStoreKind::Google => Err(BuilderError::MissingFeature {
-            feature: "gcs",
-            url: storage_url.as_ref().into(),
-        }
-        .into()),
     }
 }
 
@@ -432,7 +290,7 @@ pub mod s3_storage_options {
     /// Hence, the `connection closed before message completed` could occur.
     /// To avoid that, the default value of this setting is 15 seconds if it's not set otherwise.
     pub const AWS_S3_POOL_IDLE_TIMEOUT_SECONDS: &str = "AWS_S3_POOL_IDLE_TIMEOUT_SECONDS";
-    /// The `pool_idle_timeout` for the as3_storage_optionsws sts client. See
+    /// The `pool_idle_timeout` for the as3_storage_options sts client. See
     /// the reasoning in `AWS_S3_POOL_IDLE_TIMEOUT_SECONDS`.
     pub const AWS_STS_POOL_IDLE_TIMEOUT_SECONDS: &str = "AWS_STS_POOL_IDLE_TIMEOUT_SECONDS";
     /// The number of retries for S3 GET requests failed with 500 Internal Server Error.
@@ -487,4 +345,38 @@ pub mod s3_storage_options {
 pub(crate) fn str_option(map: &HashMap<String, String>, key: &str) -> Option<String> {
     map.get(key)
         .map_or_else(|| std::env::var(key).ok(), |v| Some(v.to_owned()))
+}
+
+pub(crate) fn ensure_table_uri(table_uri: impl AsRef<str>) -> DeltaResult<Url> {
+    let table_uri = table_uri.as_ref();
+    if let Ok(path) = std::fs::canonicalize(table_uri) {
+        return Ok(Url::from_directory_path(path)
+            .map_err(|_| DeltaTableError::InvalidTableLocation(table_uri.to_string()))?);
+    }
+    if let Ok(url) = Url::parse(table_uri) {
+        return Ok(url);
+    }
+    // The table uri still might be a relative paths that does not exist.
+    std::fs::create_dir_all(table_uri)
+        .map_err(|_| DeltaTableError::InvalidTableLocation(table_uri.to_string()))?;
+    let path = std::fs::canonicalize(table_uri)
+        .map_err(|_| DeltaTableError::InvalidTableLocation(table_uri.to_string()))?;
+    Url::from_directory_path(path)
+        .map_err(|_| DeltaTableError::InvalidTableLocation(table_uri.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ensure_table_uri() {
+        // parse an exisiting relative directory
+        let uri = ensure_table_uri(".");
+        assert!(uri.is_ok());
+        let _uri = ensure_table_uri("./nonexistent");
+        assert!(uri.is_ok());
+        let uri = ensure_table_uri("s3://container/path");
+        assert!(uri.is_ok());
+    }
 }

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1535,20 +1535,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn normalize_table_uri() {
-        for table_uri in [
-            "file:///tests/data/delta-0.8.0/",
-            "file:///tests/data/delta-0.8.0//",
-            "file:///tests/data/delta-0.8.0",
-        ]
-        .iter()
-        {
-            let table = DeltaTableBuilder::from_uri(table_uri).build().unwrap();
-            assert_eq!(table.table_uri(), "/tests/data/delta-0.8.0");
-        }
-    }
-
     async fn create_test_table() -> (DeltaTableMetaData, Protocol, DeltaTable, TempDir) {
         // Setup
         let test_schema = Schema::new(vec![

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -199,6 +199,17 @@ pub enum DeltaTableError {
     /// Error returned when user attempts to commit actions that don't belong to the next version.
     #[error("Delta transaction failed, version {0} does not follow {1}")]
     VersionMismatch(DeltaDataTypeVersion, DeltaDataTypeVersion),
+    /// A Feature is missing to perform operation
+    #[error("Delta-rs must be build with feature '{feature}' to support loading from: {url}.")]
+    MissingFeature {
+        /// Name of the missiing feature
+        feature: &'static str,
+        /// Storage location url
+        url: String,
+    },
+    /// A Feature is missing to perform operation
+    #[error("Cannot infer storage location from: {0}")]
+    InvalidTableLocation(String),
     /// Generic Delta Table error
     #[error("Generic DeltaTable error: {0}")]
     Generic(String),

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1522,16 +1522,30 @@ mod tests {
 
     #[cfg(any(feature = "s3", feature = "s3-rustls"))]
     #[test]
-    fn normalize_table_uri() {
+    fn normalize_table_uri_s3() {
         for table_uri in [
             "s3://tests/data/delta-0.8.0/",
-            // "s3://tests/data/delta-0.8.0//",
+            "s3://tests/data/delta-0.8.0//",
             "s3://tests/data/delta-0.8.0",
         ]
         .iter()
         {
             let table = DeltaTableBuilder::from_uri(table_uri).build().unwrap();
             assert_eq!(table.table_uri(), "s3://tests/data/delta-0.8.0");
+        }
+    }
+
+    #[test]
+    fn normalize_table_uri() {
+        for table_uri in [
+            "file:///tests/data/delta-0.8.0/",
+            "file:///tests/data/delta-0.8.0//",
+            "file:///tests/data/delta-0.8.0",
+        ]
+        .iter()
+        {
+            let table = DeltaTableBuilder::from_uri(table_uri).build().unwrap();
+            assert_eq!(table.table_uri(), "/tests/data/delta-0.8.0");
         }
     }
 

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1523,6 +1523,7 @@ mod tests {
     #[cfg(any(feature = "s3", feature = "s3-rustls"))]
     #[test]
     fn normalize_table_uri_s3() {
+        std::env::set_var("AWS_DEFAULT_REGION", "us-east-1");
         for table_uri in [
             "s3://tests/data/delta-0.8.0/",
             "s3://tests/data/delta-0.8.0//",

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -56,6 +56,7 @@ use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use object_store::{path::Path, ObjectMeta};
 use url::Url;
 
+use crate::builder::ensure_table_uri;
 use crate::Invariant;
 use crate::{action, open_table, open_table_with_storage_options};
 use crate::{schema, DeltaTableBuilder};
@@ -410,13 +411,11 @@ impl TableProvider for DeltaTable {
                 filters,
             )
             .await?;
-        let mut url = self.table_uri();
-        if url.ends_with(':') {
-            url += "//"; // table_uri() trims slashes from `memory://` so add them back
-        }
-        let delta_scan = DeltaScan { url, parquet_scan };
 
-        Ok(Arc::new(delta_scan))
+        Ok(Arc::new(DeltaScan {
+            url: ensure_table_uri(&self.table_uri())?.as_str().into(),
+            parquet_scan,
+        }))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -467,15 +466,19 @@ impl ExecutionPlan for DeltaScan {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
-        let url = self.url.as_str();
-        let url = ListingTableUrl::parse(url)?;
-        let storage = context.runtime_env().object_store_registry.get_by_url(url);
-        let mut table = DeltaTableBuilder::from_uri(self.url.clone());
+        let df_url = ListingTableUrl::parse(self.url.as_str())?;
+        let storage = context
+            .runtime_env()
+            .object_store_registry
+            .get_by_url(df_url);
+        let mut table = DeltaTableBuilder::from_uri(&self.url);
         if let Ok(storage) = storage {
             // When running in ballista, the store will be deserialized and re-created
             // When testing with a MemoryStore, it will already be present and we should re-use it
-            let path = &Path::parse("")?;
-            table = table.with_storage_backend(storage, path);
+            table = table.with_storage_backend(
+                storage,
+                Url::parse(&self.url).map_err(|err| DataFusionError::Internal(err.to_string()))?,
+            );
         }
         let table = table.build()?;
         register_store(&table, context.runtime_env());

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -413,7 +413,7 @@ impl TableProvider for DeltaTable {
             .await?;
 
         Ok(Arc::new(DeltaScan {
-            url: ensure_table_uri(&self.table_uri())?.as_str().into(),
+            url: ensure_table_uri(self.table_uri())?.as_str().into(),
             parquet_scan,
         }))
     }
@@ -1006,8 +1006,8 @@ mod tests {
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
             vec![
-                Arc::new(arrow::array::StringArray::from_slice(&["a", "b", "c", "d"])),
-                Arc::new(arrow::array::Int32Array::from_slice(&[1, 10, 10, 100])),
+                Arc::new(arrow::array::StringArray::from_slice(["a", "b", "c", "d"])),
+                Arc::new(arrow::array::Int32Array::from_slice([1, 10, 10, 100])),
             ],
         )
         .unwrap();

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -314,6 +314,7 @@ mod tests {
     use crate::operations::DeltaOps;
     use crate::table_properties::APPEND_ONLY;
     use crate::writer::test_utils::get_delta_schema;
+    use rand::distributions::{Alphanumeric, DistString};
 
     #[tokio::test]
     async fn test_create() {
@@ -332,8 +333,8 @@ mod tests {
     #[tokio::test]
     async fn test_create_local_relative_path() {
         let table_schema = get_delta_schema();
-
-        let table = DeltaOps::try_from_uri("./table")
+        let name = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+        let table = DeltaOps::try_from_uri(format!("./{}", name))
             .await
             .unwrap()
             .create()
@@ -348,8 +349,9 @@ mod tests {
     #[tokio::test]
     async fn test_create_table_local_path() {
         let schema = get_delta_schema();
+        let name = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
         let table = CreateBuilder::new()
-            .with_location("./new-table")
+            .with_location(format!("./{}", name))
             .with_columns(schema.get_fields().clone())
             .await
             .unwrap();

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -1,20 +1,18 @@
 //! Command for creating a new delta table
 // https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use crate::{DeltaTableBuilder, DeltaTableMetaData};
-
 use super::transaction::commit;
 use super::{MAX_SUPPORTED_READER_VERSION, MAX_SUPPORTED_WRITER_VERSION};
 use crate::action::{Action, DeltaOperation, MetaData, Protocol, SaveMode};
+use crate::builder::ensure_table_uri;
 use crate::schema::{SchemaDataType, SchemaField, SchemaTypeStruct};
-use crate::storage::config::StorageLocation;
 use crate::storage::DeltaObjectStore;
 use crate::{DeltaResult, DeltaTable, DeltaTableError};
+use crate::{DeltaTableBuilder, DeltaTableMetaData};
 
 use futures::future::BoxFuture;
 use serde_json::{Map, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 #[derive(thiserror::Error, Debug)]
 enum CreateError {
@@ -209,20 +207,20 @@ impl CreateBuilder {
             return Err(CreateError::MissingSchema.into());
         }
 
-        let (table, storage_url) = if let Some(object_store) = self.object_store {
-            let storage_url = StorageLocation::parse(object_store.root_uri())?;
+        let (storage_url, table) = if let Some(object_store) = self.object_store {
             (
+                ensure_table_uri(object_store.root_uri())?
+                    .as_str()
+                    .to_string(),
                 DeltaTable::new(object_store, Default::default()),
-                storage_url,
             )
         } else {
-            let storage_url =
-                StorageLocation::parse(self.location.ok_or(CreateError::MissingLocation)?)?;
+            let storage_url = ensure_table_uri(self.location.ok_or(CreateError::MissingLocation)?)?;
             (
+                storage_url.as_str().to_string(),
                 DeltaTableBuilder::from_uri(&storage_url)
                     .with_storage_options(self.storage_options.unwrap_or_default())
                     .build()?,
-                storage_url,
             )
         };
 
@@ -253,7 +251,7 @@ impl CreateBuilder {
         let operation = DeltaOperation::Create {
             mode: self.mode.clone(),
             metadata: metadata.clone(),
-            location: storage_url.to_string(),
+            location: storage_url,
             protocol: protocol.clone(),
         };
 
@@ -322,6 +320,22 @@ mod tests {
         let table_schema = get_delta_schema();
 
         let table = DeltaOps::new_in_memory()
+            .create()
+            .with_columns(table_schema.get_fields().clone())
+            .with_save_mode(SaveMode::Ignore)
+            .await
+            .unwrap();
+        assert_eq!(table.version(), 0);
+        assert_eq!(table.get_metadata().unwrap().schema, table_schema)
+    }
+
+    #[tokio::test]
+    async fn test_create_local_relative_path() {
+        let table_schema = get_delta_schema();
+
+        let table = DeltaOps::try_from_uri("./table")
+            .await
+            .unwrap()
             .create()
             .with_columns(table_schema.get_fields().clone())
             .with_save_mode(SaveMode::Ignore)

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -346,6 +346,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_table_local_path() {
+        let schema = get_delta_schema();
+        let table = CreateBuilder::new()
+            .with_location("./new-table")
+            .with_columns(schema.get_fields().clone())
+            .await
+            .unwrap();
+        assert_eq!(table.version(), 0);
+    }
+
+    #[tokio::test]
     async fn test_create_table_metadata() {
         let schema = get_delta_schema();
         let table = CreateBuilder::new()

--- a/rust/src/operations/load.rs
+++ b/rust/src/operations/load.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::storage::DeltaObjectStore;
-use crate::{DeltaResult, DeltaTable};
+use crate::{DeltaResult, DeltaTable, DeltaTableError};
 
 use datafusion::datasource::TableProvider;
 use datafusion::execution::context::{SessionContext, TaskContext};
@@ -77,8 +77,10 @@ impl std::future::IntoFuture for LoadBuilder {
 
         Box::pin(async move {
             let object_store = this.object_store.unwrap();
-            let scheme = object_store.root_uri(); // underlying store, i.e. `memory:`
-            let scheme = scheme.trim_end_matches(':');
+            let url = url::Url::parse(&object_store.root_uri())
+                .map_err(|_| DeltaTableError::InvalidTableLocation(object_store.root_uri()))?;
+            let scheme = url.scheme();
+
             let store = object_store.storage_backend().clone();
             let mut table = DeltaTable::new(object_store, Default::default());
             table.load().await?;

--- a/rust/src/operations/load.rs
+++ b/rust/src/operations/load.rs
@@ -79,8 +79,6 @@ impl std::future::IntoFuture for LoadBuilder {
             let object_store = this.object_store.unwrap();
             let url = url::Url::parse(&object_store.root_uri())
                 .map_err(|_| DeltaTableError::InvalidTableLocation(object_store.root_uri()))?;
-            let scheme = url.scheme();
-
             let store = object_store.storage_backend().clone();
             let mut table = DeltaTable::new(object_store, Default::default());
             table.load().await?;
@@ -88,7 +86,7 @@ impl std::future::IntoFuture for LoadBuilder {
             let ctx = SessionContext::new();
             ctx.state()
                 .runtime_env
-                .register_object_store(scheme, "", store);
+                .register_object_store(url.scheme(), "", store);
             let scan_plan = table.scan(&ctx.state(), None, &[], None).await?;
             let plan = CoalescePartitionsExec::new(scan_plan);
             let task_ctx = Arc::new(TaskContext::from(&ctx.state()));

--- a/rust/src/operations/transaction.rs
+++ b/rust/src/operations/transaction.rs
@@ -159,7 +159,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_commits_writes_file() {
-        let metadata = get_delta_metadata(&vec![]);
+        let metadata = get_delta_metadata(&[]);
         let operation = DeltaOperation::Create {
             mode: SaveMode::Append,
             location: "memory://".into(),

--- a/rust/src/storage/config.rs
+++ b/rust/src/storage/config.rs
@@ -206,8 +206,7 @@ impl ObjectStoreKind {
             ObjectStoreKind::S3 => Err(DeltaTableError::MissingFeature {
                 feature: "s3",
                 url: storage_url.as_ref().into(),
-            }
-            .into()),
+            }),
             #[cfg(feature = "azure")]
             ObjectStoreKind::Azure => {
                 let store = MicrosoftAzureBuilder::new()
@@ -228,8 +227,7 @@ impl ObjectStoreKind {
             ObjectStoreKind::Azure => Err(DeltaTableError::MissingFeature {
                 feature: "azure",
                 url: storage_url.as_ref().into(),
-            }
-            .into()),
+            }),
             #[cfg(feature = "gcs")]
             ObjectStoreKind::Google => {
                 let store = GoogleCloudStorageBuilder::new()
@@ -248,8 +246,7 @@ impl ObjectStoreKind {
             ObjectStoreKind::Google => Err(DeltaTableError::MissingFeature {
                 feature: "gcs",
                 url: storage_url.as_ref().into(),
-            }
-            .into()),
+            }),
         }
     }
 }

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -159,8 +159,6 @@ impl DeltaObjectStore {
             }
             _ => format!("{}/{}", self.location.as_ref(), location.as_ref()),
         }
-        .trim_end_matches('/')
-        .into()
     }
 
     /// Deletes object by `paths`.

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -159,6 +159,8 @@ impl DeltaObjectStore {
             }
             _ => format!("{}/{}", self.location.as_ref(), location.as_ref()),
         }
+        .trim_end_matches('/')
+        .into()
     }
 
     /// Deletes object by `paths`.

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -82,7 +82,8 @@ impl DeltaObjectStore {
     ///
     /// # Arguments
     ///
-    /// * `location` -
+    /// * `location` - A url pointing to the root of the delta table.
+    /// * `options` - Options passed to underlying builders. See [`with_storage_options`](crate::builder::DeltaTableBuilder::with_storage_options)
     pub fn try_new(location: Url, options: impl Into<StorageOptions> + Clone) -> DeltaResult<Self> {
         let prefix = Path::from(location.path());
         let root_store =

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -4,27 +4,33 @@ pub mod config;
 pub mod file;
 pub mod utils;
 
-#[cfg(any(feature = "s3", feature = "s3-rustls"))]
-pub mod s3;
+use self::config::{ObjectStoreKind, StorageOptions};
+use crate::DeltaResult;
 
-use crate::storage::config::StorageLocation;
 use bytes::Bytes;
-use futures::{stream::BoxStream, StreamExt, TryStreamExt};
+use futures::{stream::BoxStream, StreamExt};
 use lazy_static::lazy_static;
-pub use object_store::{
-    path::{Path, DELIMITER},
-    DynObjectStore, Error as ObjectStoreError, GetResult, ListResult, MultipartId, ObjectMeta,
-    ObjectStore, Result as ObjectStoreResult,
-};
+use serde::de::{Error, SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashMap;
+use std::fmt;
 use std::ops::Range;
 use std::sync::Arc;
 use tokio::io::AsyncWrite;
+use url::Url;
 
-use crate::get_storage_backend;
+#[cfg(any(feature = "s3", feature = "s3-rustls"))]
+pub mod s3;
+
 #[cfg(feature = "datafusion")]
 use datafusion::datasource::object_store::ObjectStoreUrl;
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+pub use object_store::path::{Path, DELIMITER};
+pub use object_store::{
+    DynObjectStore, Error as ObjectStoreError, GetResult, ListResult, MultipartId, ObjectMeta,
+    ObjectStore, Result as ObjectStoreResult,
+};
 
 lazy_static! {
     static ref DELTA_LOG_PATH: Path = Path::from("_delta_log");
@@ -43,37 +49,11 @@ pub type ObjectStoreRef = Arc<DeltaObjectStore>;
 /// All [Path] are reported relative to the table root.
 #[derive(Debug, Clone)]
 pub struct DeltaObjectStore {
-    storage: Arc<DynObjectStore>,
-    location: StorageLocation,
-}
-
-impl Serialize for DeltaObjectStore {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.location.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for DeltaObjectStore {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let config = StorageLocation::deserialize(deserializer)?;
-        let (storage, storage_url) = get_storage_backend(
-            config.clone(),
-            None,       // TODO: config options
-            Some(true), // TODO: this isn't preserved after builder stage
-        )
-        .map_err(|_| D::Error::missing_field("storage"))?;
-        let storage = Arc::new(DeltaObjectStore::new(storage_url, storage));
-        Ok(DeltaObjectStore {
-            storage,
-            location: config,
-        })
-    }
+    storage: Arc<dyn ObjectStore>,
+    location: Url,
+    options: StorageOptions,
+    #[allow(unused)]
+    prefix: Path,
 }
 
 impl std::fmt::Display for DeltaObjectStore {
@@ -83,12 +63,41 @@ impl std::fmt::Display for DeltaObjectStore {
 }
 
 impl DeltaObjectStore {
-    /// Create new DeltaObjectStore
-    pub fn new(storage_url: StorageLocation, storage: Arc<DynObjectStore>) -> Self {
+    /// Create a new instance of [`DeltaObjectStore`]
+    ///
+    /// # Arguemnts
+    ///
+    /// * `storage` - A shared reference to an [`ObjectStore`](object_store::ObjectStore) with "/" pointing at delta table root (i.e. where `_delta_log` is located).
+    /// * `location` - A url corresponding to the storagle location of `storage`.
+    pub fn new(storage: Arc<DynObjectStore>, location: Url) -> Self {
         Self {
             storage,
-            location: storage_url,
+            location,
+            prefix: Path::from("/"),
+            options: HashMap::new().into(),
         }
+    }
+
+    /// Try creating a new instance of [`DeltaObjectStore`]
+    ///
+    /// # Arguments
+    ///
+    /// * `location` -
+    pub fn try_new(location: Url, options: impl Into<StorageOptions> + Clone) -> DeltaResult<Self> {
+        let prefix = Path::from(location.path());
+        let root_store =
+            ObjectStoreKind::parse_url(&location)?.into_impl(location.as_ref(), options.clone())?;
+        let storage = if prefix != Path::from("/") {
+            root_store.into_prefix(prefix.clone())
+        } else {
+            root_store.into_store()
+        };
+        Ok(Self {
+            storage,
+            location,
+            prefix,
+            options: options.into(),
+        })
     }
 
     /// Get a reference to the underlying storage backend
@@ -96,9 +105,14 @@ impl DeltaObjectStore {
         self.storage.clone()
     }
 
+    /// Storage options used to intialize storage backend
+    pub fn storage_options(&self) -> &StorageOptions {
+        &self.options
+    }
+
     /// Get fully qualified uri for table root
     pub fn root_uri(&self) -> String {
-        self.location.to_uri(&Path::from(""))
+        self.to_uri(&Path::from(""))
     }
 
     #[cfg(feature = "datafusion")]
@@ -110,8 +124,7 @@ impl DeltaObjectStore {
             "delta-rs://{}",
             // NOTE We need to also replace colons, but its fine, since it just needs
             // to be a unique-ish identifier for the object store in datafusion
-            self.location
-                .prefix
+            self.prefix
                 .as_ref()
                 .replace(DELIMITER, "-")
                 .replace(':', "-")
@@ -126,7 +139,26 @@ impl DeltaObjectStore {
 
     /// [Path] to Delta log
     pub fn to_uri(&self, location: &Path) -> String {
-        self.location.to_uri(location)
+        match self.location.scheme() {
+            "file" => {
+                #[cfg(windows)]
+                let uri = format!(
+                    "{}/{}",
+                    self.location.as_ref().trim_end_matches('/'),
+                    location.as_ref()
+                )
+                .replace("file:///", "");
+                #[cfg(unix)]
+                let uri = format!(
+                    "{}/{}",
+                    self.location.as_ref().trim_end_matches('/'),
+                    location.as_ref()
+                )
+                .replace("file://", "");
+                uri
+            }
+            _ => format!("{}/{}", self.location.as_ref(), location.as_ref()),
+        }
     }
 
     /// Deletes object by `paths`.
@@ -161,40 +193,28 @@ impl DeltaObjectStore {
 impl ObjectStore for DeltaObjectStore {
     /// Save the provided bytes to the specified location.
     async fn put(&self, location: &Path, bytes: Bytes) -> ObjectStoreResult<()> {
-        let full_path = self.location.full_path(location);
-        self.storage.put(&full_path, bytes).await
+        self.storage.put(location, bytes).await
     }
 
     /// Return the bytes that are stored at the specified location.
     async fn get(&self, location: &Path) -> ObjectStoreResult<GetResult> {
-        let full_path = self.location.full_path(location);
-        self.storage.get(&full_path).await
+        self.storage.get(location).await
     }
 
     /// Return the bytes that are stored at the specified location
     /// in the given byte range
     async fn get_range(&self, location: &Path, range: Range<usize>) -> ObjectStoreResult<Bytes> {
-        let full_path = self.location.full_path(location);
-        object_store::ObjectStore::get_range(self.storage.as_ref(), &full_path, range).await
+        self.storage.get_range(location, range).await
     }
 
     /// Return the metadata for the specified location
     async fn head(&self, location: &Path) -> ObjectStoreResult<ObjectMeta> {
-        let full_path = self.location.full_path(location);
-        self.storage.head(&full_path).await.map(|meta| ObjectMeta {
-            last_modified: meta.last_modified,
-            size: meta.size,
-            location: self
-                .location
-                .strip_prefix(&meta.location)
-                .unwrap_or(meta.location),
-        })
+        self.storage.head(location).await
     }
 
     /// Delete the object at the specified location.
     async fn delete(&self, location: &Path) -> ObjectStoreResult<()> {
-        let full_path = self.location.full_path(location);
-        self.storage.delete(&full_path).await
+        self.storage.delete(location).await
     }
 
     /// List all the objects with the given prefix.
@@ -205,22 +225,7 @@ impl ObjectStore for DeltaObjectStore {
         &self,
         prefix: Option<&Path>,
     ) -> ObjectStoreResult<BoxStream<'_, ObjectStoreResult<ObjectMeta>>> {
-        let prefix = prefix.map(|p| self.location.full_path(p));
-        Ok(self
-            .storage
-            .list(Some(
-                &prefix.unwrap_or_else(|| self.location.prefix.clone()),
-            ))
-            .await?
-            .map_ok(|meta| ObjectMeta {
-                last_modified: meta.last_modified,
-                size: meta.size,
-                location: self
-                    .location
-                    .strip_prefix(&meta.location)
-                    .unwrap_or(meta.location),
-            })
-            .boxed())
+        self.storage.list(prefix).await
     }
 
     /// List objects with the given prefix and an implementation specific
@@ -230,68 +235,35 @@ impl ObjectStore for DeltaObjectStore {
     /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
     /// `foo/bar_baz/x`.
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> ObjectStoreResult<ListResult> {
-        let prefix = prefix.map(|p| self.location.full_path(p));
-        self.storage
-            .list_with_delimiter(Some(
-                &prefix.unwrap_or_else(|| self.location.prefix.clone()),
-            ))
-            .await
-            .map(|lst| ListResult {
-                common_prefixes: lst
-                    .common_prefixes
-                    .iter()
-                    .map(|p| self.location.strip_prefix(p).unwrap_or_else(|| p.clone()))
-                    .collect(),
-                objects: lst
-                    .objects
-                    .iter()
-                    .map(|meta| ObjectMeta {
-                        last_modified: meta.last_modified,
-                        size: meta.size,
-                        location: self
-                            .location
-                            .strip_prefix(&meta.location)
-                            .unwrap_or_else(|| meta.location.clone()),
-                    })
-                    .collect(),
-            })
+        self.storage.list_with_delimiter(prefix).await
     }
 
     /// Copy an object from one path to another in the same object store.
     ///
     /// If there exists an object at the destination, it will be overwritten.
     async fn copy(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-        let full_from = self.location.full_path(from);
-        let full_to = self.location.full_path(to);
-        self.storage.copy(&full_from, &full_to).await
+        self.storage.copy(from, to).await
     }
 
     /// Copy an object from one path to another, only if destination is empty.
     ///
     /// Will return an error if the destination already has an object.
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-        let full_from = self.location.full_path(from);
-        let full_to = self.location.full_path(to);
-        self.storage.copy_if_not_exists(&full_from, &full_to).await
+        self.storage.copy_if_not_exists(from, to).await
     }
 
     /// Move an object from one path to another in the same object store.
     ///
     /// Will return an error if the destination already has an object.
     async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-        let full_from = self.location.full_path(from);
-        let full_to = self.location.full_path(to);
-        self.storage
-            .rename_if_not_exists(&full_from, &full_to)
-            .await
+        self.storage.rename_if_not_exists(from, to).await
     }
 
     async fn put_multipart(
         &self,
         location: &Path,
     ) -> ObjectStoreResult<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
-        let full_path = self.location.full_path(location);
-        self.storage.put_multipart(&full_path).await
+        self.storage.put_multipart(location).await
     }
 
     async fn abort_multipart(
@@ -299,7 +271,53 @@ impl ObjectStore for DeltaObjectStore {
         location: &Path,
         multipart_id: &MultipartId,
     ) -> ObjectStoreResult<()> {
-        let full_path = self.location.full_path(location);
-        self.storage.abort_multipart(&full_path, multipart_id).await
+        self.storage.abort_multipart(location, multipart_id).await
+    }
+}
+
+impl Serialize for DeltaObjectStore {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(None)?;
+        seq.serialize_element(&self.location.to_string())?;
+        seq.serialize_element(&self.options.0)?;
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for DeltaObjectStore {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct DeltaObjectStoreVisitor {}
+
+        impl<'de> Visitor<'de> for DeltaObjectStoreVisitor {
+            type Value = DeltaObjectStore;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct DeltaObjectStore")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let location_str: String = seq
+                    .next_element()?
+                    .ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                let options: HashMap<String, String> = seq
+                    .next_element()?
+                    .ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                let location = Url::parse(&location_str).unwrap();
+                let table = DeltaObjectStore::try_new(location, options)
+                    .map_err(|_| A::Error::custom("Failed deserializing DeltaObjectStore"))?;
+                Ok(table)
+            }
+        }
+
+        deserializer.deserialize_seq(DeltaObjectStoreVisitor {})
     }
 }

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -157,7 +157,13 @@ impl DeltaObjectStore {
                 .replace("file://", "");
                 uri
             }
-            _ => format!("{}/{}", self.location.as_ref(), location.as_ref()),
+            _ => {
+                if location.as_ref().is_empty() || location.as_ref() == "/" {
+                    format!("{}", self.location.as_ref())
+                } else {
+                    format!("{}/{}", self.location.as_ref(), location.as_ref())
+                }
+            }
         }
     }
 

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -159,7 +159,7 @@ impl DeltaObjectStore {
             }
             _ => {
                 if location.as_ref().is_empty() || location.as_ref() == "/" {
-                    format!("{}", self.location.as_ref())
+                    self.location.as_ref().to_string()
                 } else {
                     format!("{}/{}", self.location.as_ref(), location.as_ref())
                 }

--- a/rust/src/storage/s3.rs
+++ b/rust/src/storage/s3.rs
@@ -1,6 +1,6 @@
 //! AWS S3 storage backend.
 
-use super::config::str_is_truthy;
+use super::utils::str_is_truthy;
 use crate::builder::{s3_storage_options, str_option};
 use bytes::Bytes;
 use dynamodb_lock::{DynamoError, LockClient, LockItem, DEFAULT_MAX_RETRY_ACQUIRE_LOCK_ATTEMPTS};

--- a/rust/src/storage/utils.rs
+++ b/rust/src/storage/utils.rs
@@ -56,3 +56,11 @@ pub async fn flatten_list_stream(
         .try_collect::<Vec<Path>>()
         .await
 }
+
+pub(crate) fn str_is_truthy(val: &str) -> bool {
+    val.eq_ignore_ascii_case("1")
+        | val.eq_ignore_ascii_case("true")
+        | val.eq_ignore_ascii_case("on")
+        | val.eq_ignore_ascii_case("yes")
+        | val.eq_ignore_ascii_case("y")
+}

--- a/rust/tests/add_actions_test.rs
+++ b/rust/tests/add_actions_test.rs
@@ -353,12 +353,10 @@ async fn test_only_struct_stats() {
 
     assert_eq!(
         actions
-            .get_field_at_path(&vec![
-                "null_count",
+            .get_field_at_path(&["null_count",
                 "nested_struct",
                 "struct_element",
-                "nested_struct_element"
-            ])
+                "nested_struct_element"])
             .unwrap()
             .as_any()
             .downcast_ref::<array::Int64Array>()
@@ -368,12 +366,10 @@ async fn test_only_struct_stats() {
 
     assert_eq!(
         actions
-            .get_field_at_path(&vec![
-                "min",
+            .get_field_at_path(&["min",
                 "nested_struct",
                 "struct_element",
-                "nested_struct_element"
-            ])
+                "nested_struct_element"])
             .unwrap()
             .as_any()
             .downcast_ref::<array::StringArray>()
@@ -383,12 +379,10 @@ async fn test_only_struct_stats() {
 
     assert_eq!(
         actions
-            .get_field_at_path(&vec![
-                "max",
+            .get_field_at_path(&["max",
                 "nested_struct",
                 "struct_element",
-                "nested_struct_element"
-            ])
+                "nested_struct_element"])
             .unwrap()
             .as_any()
             .downcast_ref::<array::StringArray>()
@@ -398,11 +392,9 @@ async fn test_only_struct_stats() {
 
     assert_eq!(
         actions
-            .get_field_at_path(&vec![
-                "null_count",
+            .get_field_at_path(&["null_count",
                 "struct_of_array_of_map",
-                "struct_element"
-            ])
+                "struct_element"])
             .unwrap()
             .as_any()
             .downcast_ref::<array::Int64Array>()
@@ -412,7 +404,7 @@ async fn test_only_struct_stats() {
 
     assert_eq!(
         actions
-            .get_field_at_path(&vec!["tags", "OPTIMIZE_TARGET_SIZE"])
+            .get_field_at_path(&["tags", "OPTIMIZE_TARGET_SIZE"])
             .unwrap()
             .as_any()
             .downcast_ref::<array::StringArray>()

--- a/rust/tests/add_actions_test.rs
+++ b/rust/tests/add_actions_test.rs
@@ -353,10 +353,12 @@ async fn test_only_struct_stats() {
 
     assert_eq!(
         actions
-            .get_field_at_path(&["null_count",
+            .get_field_at_path(&[
+                "null_count",
                 "nested_struct",
                 "struct_element",
-                "nested_struct_element"])
+                "nested_struct_element"
+            ])
             .unwrap()
             .as_any()
             .downcast_ref::<array::Int64Array>()
@@ -366,10 +368,12 @@ async fn test_only_struct_stats() {
 
     assert_eq!(
         actions
-            .get_field_at_path(&["min",
+            .get_field_at_path(&[
+                "min",
                 "nested_struct",
                 "struct_element",
-                "nested_struct_element"])
+                "nested_struct_element"
+            ])
             .unwrap()
             .as_any()
             .downcast_ref::<array::StringArray>()
@@ -379,10 +383,12 @@ async fn test_only_struct_stats() {
 
     assert_eq!(
         actions
-            .get_field_at_path(&["max",
+            .get_field_at_path(&[
+                "max",
                 "nested_struct",
                 "struct_element",
-                "nested_struct_element"])
+                "nested_struct_element"
+            ])
             .unwrap()
             .as_any()
             .downcast_ref::<array::StringArray>()
@@ -392,9 +398,7 @@ async fn test_only_struct_stats() {
 
     assert_eq!(
         actions
-            .get_field_at_path(&["null_count",
-                "struct_of_array_of_map",
-                "struct_element"])
+            .get_field_at_path(&["null_count", "struct_of_array_of_map", "struct_element"])
             .unwrap()
             .as_any()
             .downcast_ref::<array::Int64Array>()

--- a/rust/tests/checkpoint_writer.rs
+++ b/rust/tests/checkpoint_writer.rs
@@ -109,7 +109,7 @@ mod delete_expired_delta_log_in_checkpoint {
         let set_file_last_modified = |version: usize, last_modified_millis: i64| {
             let last_modified_secs = last_modified_millis / 1000;
             let path = format!("{}/_delta_log/{:020}.json", &table_path, version);
-            utime::set_file_times(&path, last_modified_secs, last_modified_secs).unwrap();
+            utime::set_file_times(path, last_modified_secs, last_modified_secs).unwrap();
         };
 
         // create 2 commits

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -61,7 +61,7 @@ async fn prepare_table(
     let table_dir = tempfile::tempdir().unwrap();
     let table_path = table_dir.path();
     let table_uri = table_path.to_str().unwrap().to_string();
-    let table_schema: Schema = batches[0].schema().clone().try_into().unwrap();
+    let table_schema: Schema = batches[0].schema().try_into().unwrap();
 
     let mut table = DeltaOps::try_from_uri(table_uri)
         .await

--- a/rust/tests/fs_common/mod.rs
+++ b/rust/tests/fs_common/mod.rs
@@ -15,7 +15,7 @@ pub fn cleanup_dir_except<P: AsRef<Path>>(path: P, ignore_files: Vec<String>) {
         let name = d.path().file_name().unwrap().to_str().unwrap().to_string();
 
         if !ignore_files.contains(&name) && !name.starts_with('.') {
-            fs::remove_file(&path).unwrap();
+            fs::remove_file(path).unwrap();
         }
     }
 }


### PR DESCRIPTION
# Description

This PR contains some improvements and refactoring for handling storage locations.

- Removes the `StorageLocation` struct (a left-over from previous clean up)
- allows for creating tables using local file paths (including relative)
- persists options during serialization (this will not work for custom storage backends, but still extends what the previous approach could do)
- adopts `PrefixObjectStore` from upstream crate in favour of maintaining that logic here. 
- run `cargo clippy --fix` on `/rust`

# Related Issue(s)

Closes #998

# Documentation

<!---
Share links to useful documentation
--->
