### PR TITLE
fix: datafusion predicate pushdown and dependencies

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 name = "deltalake._internal"
 
 [dependencies]
-arrow-schema = { version = "28", features = ["serde"] }
+arrow-schema = { version = "29", features = ["serde"] }
 chrono = "0"
 env_logger = "0"
 futures = "0.3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ description = "Native Delta Lake implementation in Rust"
 edition = "2021"
 
 [dependencies]
-arrow = { version = "28", optional = true }
+arrow = { version = "29", optional = true }
 async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
@@ -26,7 +26,7 @@ num-traits = "0.2.15"
 object_store = "0.5.3"
 once_cell = "1.16.0"
 parking_lot = "0.12"
-parquet = { version = "28", features = ["async"], optional = true }
+parquet = { version = "29", features = ["async"], optional = true }
 parquet2 = { version = "0.17", optional = true }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
@@ -47,10 +47,10 @@ rusoto_dynamodb = { version = "0.48", default-features = false, optional = true 
 rusoto_glue = { version = "0.48", default-features = false, optional = true }
 
 # Datafusion
-datafusion = { version = "15", optional = true }
-datafusion-expr = { version = "15", optional = true }
-datafusion-common = { version = "15", optional = true }
-datafusion-proto = { version = "15", optional = true }
+datafusion = { version = "16", optional = true }
+datafusion-expr = { version = "16", optional = true }
+datafusion-common = { version = "16", optional = true }
+datafusion-proto = { version = "16", optional = true }
 
 # NOTE dependencies only for integration tests
 fs_extra = { version = "1.2.0", optional = true }

--- a/rust/src/delta_arrow.rs
+++ b/rust/src/delta_arrow.rs
@@ -459,7 +459,7 @@ pub(crate) fn delta_log_schema_for_table(
             .for_each(|f| max_min_schema_for_fields(&mut max_min_vec, f));
 
         stats_parsed_fields.extend(
-            ["minValues", "maxValues"].iter().map(|name| {
+            ["minValues", "maxValues"].into_iter().map(|name| {
                 ArrowField::new(name, ArrowDataType::Struct(max_min_vec.clone()), true)
             }),
         );

--- a/rust/src/operations/load.rs
+++ b/rust/src/operations/load.rs
@@ -85,7 +85,7 @@ impl std::future::IntoFuture for LoadBuilder {
 
             let ctx = SessionContext::new();
             ctx.state()
-                .runtime_env
+                .runtime_env()
                 .register_object_store(url.scheme(), "", store);
             let scan_plan = table.scan(&ctx.state(), None, &[], None).await?;
             let plan = CoalescePartitionsExec::new(scan_plan);

--- a/rust/src/table_state_arrow.rs
+++ b/rust/src/table_state_arrow.rs
@@ -402,7 +402,7 @@ impl DeltaTableState {
                     .flat_map(|sub_field| {
                         if let Some(values) = getter(sub_field) {
                             let field = Field::new(
-                                sub_field
+                                *sub_field
                                     .path
                                     .last()
                                     .expect("paths must have at least one element"),


### PR DESCRIPTION
# Description

Update datafusion to version 16 and arrow to corresponding version 29. This also fixes a logical error in predicate pushdown and implements missing methods on `TableProvider`, specifically also the one telling datafusion that predicate pushdown is supported :).

Turns out, our tests already cover that predicates are working correctly, when actually being used.

# Related Issue(s)

closes #1063
closes #1064

# Documentation

<!---
Share links to useful documentation
--->
