### PR TITLE
Add missing documentation metadata to Cargo.toml

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,6 +7,9 @@ homepage = "https://github.com/delta-io/delta.rs"
 license = "Apache-2.0"
 keywords = ["deltalake", "delta", "datalake"]
 description = "Native Delta Lake implementation in Rust"
+documentation = "https://docs.rs/deltalake"
+repository = "https://github.com/delta-io/delta.rs"
+readme = "README.md"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# Description

Add missing metadata fields to `Cargo.toml`:
- `documentation`
- `repository`
- `readme`

This helps to provide more information on certain `crates.io` pages.

# Related Issue(s)

Closes #1076
