### PR TITLE
ci: Merge several automatically generated labels

### DIFF
--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -6,10 +6,10 @@ rust:
   - proofs/**/*
   - rust/**/*
 
-python:
+binding/python:
   - python/**/*
 
-ruby:
+binding/ruby:
   - ruby/**/*
 
 ci:
@@ -22,7 +22,7 @@ documentation:
   - CONTRIBUTING.md
   - python/docs/**/*
 
-aws:
+storage/aws:
   - aws/**/*
 
 delta-checkpoint:
@@ -31,7 +31,7 @@ delta-checkpoint:
 delta-inspect:
   - delta-inspect/**/*
 
-delta-rs-crate:
+binding/rust:
   - rust/**/*
 
 dynamodb_lock:


### PR DESCRIPTION
# Description
The description of the main changes of your pull request

Several issue and PR labels are merged at the suggestion of @wjones127:
`delta-rs-crate` -> `binding/rust`
`python` -> `binding/python`
`ruby` -> `binding/ruby`
`aws` -> `storage/aws`

Note that we will still have a `rust` label for anything that changes any of the Rust crates outside Python & Ruby bindings. Also `storage/gcp` and `storage/azure` labels do not get automatically added.

If the new labels are acceptable I will file another PR to relabel old issues and PRs.

# Related Issue(s)
Closes #1051.
# Documentation

<!---
Share links to useful documentation
--->
