### PR TITLE
add test for left_larger_than_right

### DIFF
--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -1023,8 +1023,8 @@ mod tests {
                 ScalarValue::Float32(Some(2.0)),
             ),
         ];
-        for (smaller_val, larger_val) in incorrect_reference_pairs {
-            assert_eq!(left_larger_than_right(larger_val, smaller_val), None);
+        for (left, right) in incorrect_reference_pairs {
+            assert_eq!(left_larger_than_right(left, right), None);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Marijn Valk <marijncv@hotmail.com>

# Description
Adds a test for the `left_larger_than_right` function and rewrites the function match expression to match on both the `left` and `right` argument

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
