### PR TITLE
improve debuggability of json ser/de errors

### DIFF
--- a/rust/src/table_state_arrow.rs
+++ b/rust/src/table_state_arrow.rs
@@ -283,7 +283,7 @@ impl DeltaTableState {
             .iter()
             .map(|f| {
                 f.get_stats()
-                    .map_err(|err| DeltaTableError::InvalidJson { source: err })
+                    .map_err(|err| DeltaTableError::InvalidStatsJson { json_err: err })
             })
             .collect::<Result<_, DeltaTableError>>()?;
 


### PR DESCRIPTION
# Description

JSON serde errors are very hard to debug because they are usually displayed with the following vague error messages:

```
Error: Invalid JSON in log record: EOF while parsing a value at line 1 column 1                                                                                                              
                                                                                                                                                                                             
Caused by:                                                                                                                                                                                   
    EOF while parsing a value at line 1 column 1  
```

This PR separates JSON ser/de errors by different scenarios as well as adding more context to each error whenever applicable.