### PR TITLE
add test for get_boolean_from_metadata

### DIFF
--- a/rust/src/delta_config.rs
+++ b/rust/src/delta_config.rs
@@ -214,6 +214,31 @@ mod tests {
     }
 
     #[test]
+    fn get_boolean_from_metadata_test() {
+        let mut md = dummy_metadata();
+
+        // default value is true
+        assert_eq!(
+            ENABLE_EXPIRED_LOG_CLEANUP
+                .get_boolean_from_metadata(&md)
+                .unwrap(),
+            true,
+        );
+
+        // change to false
+        md.configuration.insert(
+            ENABLE_EXPIRED_LOG_CLEANUP.key.to_string(),
+            Some("false".to_string()),
+        );
+        assert_eq!(
+            ENABLE_EXPIRED_LOG_CLEANUP
+                .get_boolean_from_metadata(&md)
+                .unwrap(),
+            false,
+        );
+    }
+
+    #[test]
     fn parse_interval_test() {
         assert_eq!(
             parse_interval("interval 123 nanosecond").unwrap(),


### PR DESCRIPTION
Signed-off-by: Marijn Valk <marijncv@hotmail.com>

# Description
Adds a test for `get_boolean_from_metadata` from the `DeltaConfig`

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
