### PR TITLE
Set AddAction timestamps to milliseconds. Fixes #1124

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -223,7 +223,7 @@ def write_deltalake(
                 path,
                 size,
                 partition_values,
-                int(datetime.now().timestamp()),
+                int(datetime.now().timestamp() * 1000),
                 True,
                 json.dumps(stats, cls=DeltaJSONEncoder),
             )

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -62,7 +62,7 @@ def test_roundtrip_basic(tmp_path: pathlib.Path, sample_data: pa.Table):
         path = os.path.join(tmp_path, action["path"])
         actual_size = os.path.getsize(path)
         assert actual_size == action["size"]
-        
+
         modification_time = action["modificationTime"] / 1000  # convert back to seconds
         assert start_time < modification_time
         assert modification_time < end_time

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -42,8 +42,9 @@ def test_handle_existing(tmp_path: pathlib.Path, sample_data: pa.Table):
 def test_roundtrip_basic(tmp_path: pathlib.Path, sample_data: pa.Table):
     # Check we can create the subdirectory
     tmp_path = tmp_path / "path" / "to" / "table"
-
+    start_time = datetime.now().timestamp()
     write_deltalake(str(tmp_path), sample_data)
+    end_time = datetime.now().timestamp()
 
     assert ("0" * 20 + ".json") in os.listdir(tmp_path / "_delta_log")
 
@@ -61,6 +62,10 @@ def test_roundtrip_basic(tmp_path: pathlib.Path, sample_data: pa.Table):
         path = os.path.join(tmp_path, action["path"])
         actual_size = os.path.getsize(path)
         assert actual_size == action["size"]
+        
+        modification_time = action["modificationTime"] / 1000  # convert back to seconds
+        assert start_time < modification_time
+        assert modification_time < end_time
 
 
 def test_roundtrip_nulls(tmp_path: pathlib.Path):


### PR DESCRIPTION
# Description
Updates timestamp for AddActions to use milliseconds.

# Related Issue(s)
- closes #1124 

# Documentation

\