### PR TITLE
add function & test for parsing table_or_uri

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1,6 +1,7 @@
 import json
 import warnings
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import pyarrow
@@ -100,7 +101,7 @@ class DeltaTable:
 
     def __init__(
         self,
-        table_uri: str,
+        table_uri: Union[str, Path],
         version: Optional[int] = None,
         storage_options: Optional[Dict[str, str]] = None,
         without_files: bool = False,
@@ -119,7 +120,7 @@ class DeltaTable:
         """
         self._storage_options = storage_options
         self._table = RawDeltaTable(
-            table_uri,
+            str(table_uri),
             version=version,
             storage_options=storage_options,
             without_files=without_files,

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -317,23 +317,33 @@ def try_get_table_and_table_uri(
     table_or_uri: Union[str, Path, DeltaTable],
     storage_options: Optional[Dict[str, str]] = None,
 ) -> Tuple[Optional[DeltaTable], str]:
-    """Parses `table_or_uri` and returns `table` & `table_uri`.
+    """Parses the `table_or_uri`.
 
-    Raises a ValueError if `table_or_uri` is not of type `str`, `Path` or `DeltaTable`
+    Parameters
+    ----------
+    table_or_uri : str, Path or DeltaTable
+        URI of a table or a DeltaTable object.
+    storage_options : dict(str, str), optional
+        Options passed to the native delta filesystem.
+
+    Returns
+    -------
+    table: DeltaTable
+        DeltaTable object
+    table_uri: str
+        URI of the table
+
+    Raises
+    ------
+    ValueError
+        If `table_or_uri` is not of type str, Path or DeltaTable
     """
     if not isinstance(table_or_uri, (str, Path, DeltaTable)):
         raise ValueError("table_or_uri must be a str, Path or DeltaTable")
 
-    if isinstance(table_or_uri, str):
-        if "://" in table_or_uri:
-            table_uri = table_or_uri
-        else:
-            # Non-existant local paths are only accepted as fully-qualified URIs
-            table_uri = "file://" + str(Path(table_or_uri).absolute())
+    if isinstance(table_or_uri, (str, Path)):
         table = try_get_deltatable(table_or_uri, storage_options)
-    elif isinstance(table_or_uri, Path):
-        table_uri = "file://" + str(table_or_uri.absolute())
-        table = try_get_deltatable(table_uri, storage_options)
+        table_uri = str(table_or_uri)
     else:
         table = table_or_uri
         table_uri = table._table.table_uri()
@@ -342,7 +352,7 @@ def try_get_table_and_table_uri(
 
 
 def try_get_deltatable(
-    table_uri: str, storage_options: Optional[Dict[str, str]]
+    table_uri: Union[str, Path], storage_options: Optional[Dict[str, str]]
 ) -> Optional[DeltaTable]:
     try:
         return DeltaTable(table_uri, storage_options=storage_options)

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -319,24 +319,11 @@ def try_get_table_and_table_uri(
 ) -> Tuple[Optional[DeltaTable], str]:
     """Parses the `table_or_uri`.
 
-    Parameters
-    ----------
-    table_or_uri : str, Path or DeltaTable
-        URI of a table or a DeltaTable object.
-    storage_options : dict(str, str), optional
-        Options passed to the native delta filesystem.
-
-    Returns
-    -------
-    table: DeltaTable
-        DeltaTable object
-    table_uri: str
-        URI of the table
-
-    Raises
-    ------
-    ValueError
-        If `table_or_uri` is not of type str, Path or DeltaTable
+    :param table_or_uri: URI of a table or a DeltaTable object.
+    :param storage_options: Options passed to the native delta filesystem.
+    :raises ValueError: If `table_or_uri` is not of type str, Path or DeltaTable.
+    :returns table: DeltaTable object
+    :return table_uri: URI of the table
     """
     if not isinstance(table_or_uri, (str, Path, DeltaTable)):
         raise ValueError("table_or_uri must be a str, Path or DeltaTable")

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -65,6 +65,7 @@ nitpick_ignore = [
     ("py:class", "RawDeltaTable"),
     ("py:class", "pandas.DataFrame"),
     ("py:class", "pyarrow._dataset_parquet.ParquetFileWriteOptions"),
+    ("py:class", "pathlib.Path"),
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -505,7 +505,7 @@ def test_writer_with_options(tmp_path: pathlib.Path):
 
 def test_try_get_table_and_table_uri(tmp_path: pathlib.Path):
     data = pa.table({"vals": pa.array(["1", "2", "3"])})
-    table_or_uri = str(tmp_path / "delta_table")
+    table_or_uri = tmp_path / "delta_table"
     write_deltalake(table_or_uri, data)
     delta_table = DeltaTable(table_or_uri)
 
@@ -518,21 +518,21 @@ def test_try_get_table_and_table_uri(tmp_path: pathlib.Path):
     # table_or_uri as str
     assert try_get_table_and_table_uri(str(tmp_path / "delta_table"), None) == (
         delta_table,
-        "file://" + str(tmp_path / "delta_table"),
+        str(tmp_path / "delta_table"),
     )
     assert try_get_table_and_table_uri(str(tmp_path / "str"), None) == (
         None,
-        "file://" + str(tmp_path / "str"),
+        str(tmp_path / "str"),
     )
 
     # table_or_uri as Path
     assert try_get_table_and_table_uri(tmp_path / "delta_table", None) == (
         delta_table,
-        "file://" + str(tmp_path / "delta_table"),
+        str(tmp_path / "delta_table"),
     )
     assert try_get_table_and_table_uri(tmp_path / "Path", None) == (
         None,
-        "file://" + str(tmp_path / "Path"),
+        str(tmp_path / "Path"),
     )
 
     # table_or_uri with invalid parameter type

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -505,8 +505,6 @@ def test_writer_with_options(tmp_path: pathlib.Path):
 
 def test_try_get_table_and_table_uri(tmp_path: pathlib.Path):
     data = pa.table({"vals": pa.array(["1", "2", "3"])})
-    write_deltalake(str(tmp_path), data)
-
     table_or_uri = str(tmp_path / "delta_table")
     write_deltalake(table_or_uri, data)
     delta_table = DeltaTable(table_or_uri)

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from typing import Dict, Iterable, List
 from unittest.mock import Mock
 
-import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
@@ -505,9 +504,11 @@ def test_writer_with_options(tmp_path: pathlib.Path):
 
 
 def test_try_get_table_and_table_uri(tmp_path: pathlib.Path):
-    example_df = pd.DataFrame({"part": ["a", "a", "b", "b"], "value": [1, 2, 3, 4]})
+    data = pa.table({"vals": pa.array(["1", "2", "3"])})
+    write_deltalake(str(tmp_path), data)
+
     table_or_uri = str(tmp_path / "delta_table")
-    write_deltalake(table_or_uri, example_df)
+    write_deltalake(table_or_uri, data)
     delta_table = DeltaTable(table_or_uri)
 
     # table_or_uri as DeltaTable


### PR DESCRIPTION
# Description
Adds a more specific ValueError if a wrong `table_or_uri` is provided in the `write_delta_lake` function. It also adds support for a pathlib `Path` object.

# Related Issue(s)
- closes #1123 

# Documentation

<!---
Share links to useful documentation
--->
