### PR TITLE
feat: move and update Optimize operation

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -18,7 +18,7 @@ doc = false
 name = "deltalake._internal"
 
 [dependencies]
-arrow-schema = { version = "31", features = ["serde"] }
+arrow-schema = { version = "32", features = ["serde"] }
 chrono = "0"
 env_logger = "0"
 futures = "0.3"
@@ -33,7 +33,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 reqwest = { version = "*", features = ["native-tls-vendored"] }
 
 [dependencies.pyo3]
-version = "0.17"
+version = "0.18"
 features = ["extension-module", "abi3", "abi3-py37"]
 
 [dependencies.deltalake]

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -366,7 +366,7 @@ given filters.
                 partition_expression=part_expression,
             )
             for file, part_expression in self._table.dataset_partitions(
-                partitions, self.schema().to_pyarrow()
+                self.schema().to_pyarrow(), partitions
             )
         ]
 

--- a/python/src/filesystem.rs
+++ b/python/src/filesystem.rs
@@ -30,7 +30,7 @@ pub struct DeltaFileSystemHandler {
 #[pymethods]
 impl DeltaFileSystemHandler {
     #[new]
-    #[args(options = "None")]
+    #[pyo3(signature = (table_uri, options = None))]
     fn new(table_uri: &str, options: Option<HashMap<String, String>>) -> PyResult<Self> {
         let storage = DeltaTableBuilder::from_uri(table_uri)
             .with_storage_options(options.clone().unwrap_or_default())
@@ -144,7 +144,7 @@ impl DeltaFileSystemHandler {
         Ok(infos)
     }
 
-    #[args(allow_not_found = "false", recursive = "false")]
+    #[pyo3(signature = (base_dir, allow_not_found = false, recursive = false))]
     fn get_file_info_selector<'py>(
         &self,
         base_dir: String,
@@ -237,7 +237,7 @@ impl DeltaFileSystemHandler {
         Ok(file)
     }
 
-    #[args(metadata = "None")]
+    #[pyo3(signature = (path, metadata = None))]
     fn open_output_stream(
         &self,
         path: String,
@@ -358,7 +358,7 @@ impl ObjectInputFile {
         Ok(self.content_length)
     }
 
-    #[args(whence = "0")]
+    #[pyo3(signature = (offset, whence = 0))]
     fn seek(&mut self, offset: i64, whence: i64) -> PyResult<i64> {
         self.check_closed()?;
         self.check_position(offset, "seek")?;
@@ -384,7 +384,7 @@ impl ObjectInputFile {
         Ok(self.pos)
     }
 
-    #[args(nbytes = "None")]
+    #[pyo3(signature = (nbytes = None))]
     fn read(&mut self, nbytes: Option<i64>) -> PyResult<Py<PyBytes>> {
         self.check_closed()?;
         let range = match nbytes {
@@ -516,14 +516,16 @@ impl ObjectOutputStream {
         Err(PyNotImplementedError::new_err("'size' not implemented"))
     }
 
-    #[args(whence = "0")]
-    fn seek(&mut self, _offset: i64, _whence: i64) -> PyResult<i64> {
+    #[allow(unused_variables)]
+    #[pyo3(signature = (offset, whence = 0))]
+    fn seek(&mut self, offset: i64, whence: i64) -> PyResult<i64> {
         self.check_closed()?;
         Err(PyNotImplementedError::new_err("'seek' not implemented"))
     }
 
-    #[args(nbytes = "None")]
-    fn read(&mut self, _nbytes: Option<i64>) -> PyResult<()> {
+    #[allow(unused_variables)]
+    #[pyo3(signature = (nbytes = None))]
+    fn read(&mut self, nbytes: Option<i64>) -> PyResult<()> {
         self.check_closed()?;
         Err(PyNotImplementedError::new_err("'read' not implemented"))
     }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -108,6 +108,7 @@ struct RawDeltaTableMetaData {
 #[pymethods]
 impl RawDeltaTable {
     #[new]
+    #[pyo3(signature = (table_uri, version = None, storage_options = None, without_files = false))]
     fn new(
         table_uri: &str,
         version: Option<deltalake::DeltaDataTypeLong>,
@@ -282,7 +283,9 @@ impl RawDeltaTable {
         schema_to_pyobject(schema, py)
     }
 
-    /// Run the Vacuum command on the Delta Table: list and delete files no longer referenced by the Delta table and are older than the retention threshold.
+    /// Run the Vacuum command on the Delta Table: list and delete files no longer referenced
+    /// by the Delta table and are older than the retention threshold.
+    #[pyo3(signature = (dry_run, retention_hours = None, enforce_retention_duration = true))]
     pub fn vacuum(
         &mut self,
         dry_run: bool,
@@ -334,8 +337,8 @@ impl RawDeltaTable {
     pub fn dataset_partitions<'py>(
         &mut self,
         py: Python<'py>,
-        partition_filters: Option<Vec<(&str, &str, PartitionFilterValue)>>,
         schema: PyArrowType<ArrowSchema>,
+        partition_filters: Option<Vec<(&str, &str, PartitionFilterValue)>>,
     ) -> PyResult<Vec<(String, Option<&'py PyAny>)>> {
         let path_set = match partition_filters {
             Some(filters) => Some(HashSet::<_>::from_iter(

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -279,7 +279,7 @@ impl TryFrom<SchemaDataType> for ArrayType {
 #[pymethods]
 impl ArrayType {
     #[new]
-    #[args(contains_null = true)]
+    #[pyo3(signature = (element_type, contains_null = true))]
     fn new(element_type: PyObject, contains_null: bool, py: Python) -> PyResult<Self> {
         let inner_type = SchemaTypeArray::new(
             Box::new(python_type_to_schema(element_type, py)?),
@@ -444,7 +444,7 @@ impl TryFrom<SchemaDataType> for MapType {
 #[pymethods]
 impl MapType {
     #[new]
-    #[args(value_contains_null = true)]
+    #[pyo3(signature = (key_type, value_type, value_contains_null = true))]
     fn new(
         key_type: PyObject,
         value_type: PyObject,
@@ -608,7 +608,7 @@ pub struct Field {
 #[pymethods]
 impl Field {
     #[new]
-    #[args(nullable = true)]
+    #[pyo3(signature = (name, ty, nullable = true, metadata = None))]
     fn new(
         name: String,
         ty: PyObject,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,10 @@ num-traits = "0.2.15"
 object_store = "0.5.3"
 once_cell = "1.16.0"
 parking_lot = "0.12"
-parquet = { version = "32", features = ["async"], optional = true }
+parquet = { version = "32", features = [
+    "async",
+    "object_store",
+], optional = true }
 parquet2 = { version = "0.17", optional = true }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-arrow = { version = "31", optional = true }
+arrow = { version = "32", optional = true }
 async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
@@ -29,7 +29,7 @@ num-traits = "0.2.15"
 object_store = "0.5.3"
 once_cell = "1.16.0"
 parking_lot = "0.12"
-parquet = { version = "31", features = ["async"], optional = true }
+parquet = { version = "32", features = ["async"], optional = true }
 parquet2 = { version = "0.17", optional = true }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
@@ -50,10 +50,10 @@ rusoto_dynamodb = { version = "0.47", default-features = false, optional = true 
 rusoto_glue = { version = "0.47", default-features = false, optional = true }
 
 # Datafusion
-datafusion = { version = "17", optional = true }
-datafusion-expr = { version = "17", optional = true }
-datafusion-common = { version = "17", optional = true }
-datafusion-proto = { version = "17", optional = true }
+datafusion = { version = "18", optional = true }
+datafusion-expr = { version = "18", optional = true }
+datafusion-common = { version = "18", optional = true }
+datafusion-proto = { version = "18", optional = true }
 
 # NOTE dependencies only for integration tests
 fs_extra = { version = "1.2.0", optional = true }
@@ -113,10 +113,7 @@ s3 = [
     "object_store/aws_profile",
 ]
 glue-native-tls = ["s3-native-tls", "rusoto_glue"]
-glue = [
-    "s3",
-    "rusoto_glue/rustls"
-]
+glue = ["s3", "rusoto_glue/rustls"]
 python = ["arrow/pyarrow"]
 
 # used only for integration testing

--- a/rust/examples/recordbatch-writer.rs
+++ b/rust/examples/recordbatch-writer.rs
@@ -125,7 +125,7 @@ fn fetch_readings() -> Vec<WeatherRecord> {
 
     for i in 1..=5 {
         let mut wx = WeatherRecord::default();
-        wx.temp = wx.temp - i;
+        wx.temp -= i;
         readings.push(wx);
     }
     readings

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -105,8 +105,6 @@ pub mod delta_arrow;
 #[cfg(feature = "datafusion")]
 pub mod delta_datafusion;
 #[cfg(all(feature = "arrow", feature = "parquet"))]
-pub mod optimize;
-#[cfg(all(feature = "arrow", feature = "parquet"))]
 pub mod writer;
 
 pub use self::builder::*;

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -127,6 +127,7 @@ impl DeltaOps {
     }
 
     /// Audit active files with files present on the filesystem
+    #[cfg(all(feature = "arrow", feature = "parquet"))]
     #[must_use]
     pub fn optimize<'a>(self) -> OptimizeBuilder<'a> {
         OptimizeBuilder::new(self.0.object_store(), self.0.state)

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -26,15 +26,15 @@ use self::{load::LoadBuilder, write::WriteBuilder};
 use arrow::record_batch::RecordBatch;
 #[cfg(feature = "datafusion")]
 pub use datafusion::physical_plan::common::collect as collect_sendable_stream;
+#[cfg(all(feature = "arrow", feature = "parquet"))]
+use optimize::OptimizeBuilder;
 
 #[cfg(feature = "datafusion")]
 mod load;
 #[cfg(feature = "datafusion")]
 pub mod write;
-// TODO the writer module does not actually depend on datafusion,
-// eventually we should consolidate with the record batch writer
-#[cfg(feature = "datafusion")]
-mod writer;
+#[cfg(all(feature = "arrow", feature = "parquet"))]
+pub mod writer;
 
 /// Maximum supported writer version
 pub const MAX_SUPPORTED_WRITER_VERSION: i32 = 1;
@@ -128,8 +128,8 @@ impl DeltaOps {
 
     /// Audit active files with files present on the filesystem
     #[must_use]
-    pub fn optimize(self) -> FileSystemCheckBuilder {
-        FileSystemCheckBuilder::new(self.0.object_store(), self.0.state)
+    pub fn optimize<'a>(self) -> OptimizeBuilder<'a> {
+        OptimizeBuilder::new(self.0.object_store(), self.0.state)
     }
 }
 

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -15,6 +15,8 @@ use crate::{DeltaResult, DeltaTable, DeltaTableError};
 
 pub mod create;
 pub mod filesystem_check;
+#[cfg(all(feature = "arrow", feature = "parquet"))]
+pub mod optimize;
 pub mod transaction;
 pub mod vacuum;
 
@@ -121,6 +123,12 @@ impl DeltaOps {
     /// Audit active files with files present on the filesystem
     #[must_use]
     pub fn filesystem_check(self) -> FileSystemCheckBuilder {
+        FileSystemCheckBuilder::new(self.0.object_store(), self.0.state)
+    }
+
+    /// Audit active files with files present on the filesystem
+    #[must_use]
+    pub fn optimize(self) -> FileSystemCheckBuilder {
         FileSystemCheckBuilder::new(self.0.object_store(), self.0.state)
     }
 }

--- a/rust/src/operations/optimize.rs
+++ b/rust/src/operations/optimize.rs
@@ -400,7 +400,7 @@ fn get_target_file_size(snapshot: &DeltaTableState) -> DeltaDataTypeLong {
     target_size
 }
 
-/// Build a Plan on which files to merge together. See [`Optimize`]
+/// Build a Plan on which files to merge together. See [`OptimizeBuilder`]
 pub fn create_merge_plan(
     snapshot: &DeltaTableState,
     filters: &[PartitionFilter<'_, &str>],

--- a/rust/src/operations/optimize.rs
+++ b/rust/src/operations/optimize.rs
@@ -16,7 +16,7 @@
 //! # Example
 //! ```rust ignore
 //! let table = open_table("../path/to/table")?;
-//! let metrics = Optimize::default().execute(table).await?;
+//! let (table, metrics) = OptimizeBuilder::new(table.object_store(). table.state).await?;
 //! ````
 
 use super::transaction::commit;

--- a/rust/src/operations/optimize.rs
+++ b/rust/src/operations/optimize.rs
@@ -475,7 +475,10 @@ pub fn create_merge_plan(
     let input_parameters = OptimizeInput { target_size };
     let file_schema = arrow_schema_without_partitions(
         &Arc::new(<ArrowSchema as TryFrom<&crate::schema::Schema>>::try_from(
-            &snapshot.current_metadata().unwrap().schema,
+            &snapshot
+                .current_metadata()
+                .ok_or(DeltaTableError::NoMetadata)?
+                .schema,
         )?),
         partitions_keys,
     );

--- a/rust/src/operations/optimize.rs
+++ b/rust/src/operations/optimize.rs
@@ -22,6 +22,7 @@
 
 use crate::action::DeltaOperation;
 use crate::action::{self, Action};
+use crate::table_properties;
 use crate::writer::utils::PartitionPath;
 use crate::writer::{DeltaWriter, RecordBatchWriter};
 use crate::{DeltaDataTypeLong, DeltaTable, DeltaTableError, PartitionFilter};
@@ -175,6 +176,7 @@ fn create_remove(
     partitions: &HashMap<String, Option<String>>,
     size: DeltaDataTypeLong,
 ) -> Result<Action, DeltaTableError> {
+    // NOTE unwrap is safe since UNIX_EPOCH will always be earlier then now.
     let deletion_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
     let deletion_time = deletion_time.as_millis() as i64;
 
@@ -301,7 +303,7 @@ fn get_target_file_size(table: &DeltaTable) -> DeltaDataTypeLong {
     let config = table.get_configurations();
     let mut target_size = 268_435_456;
     if let Ok(config) = config {
-        let config_str = config.get("delta.targetFileSize");
+        let config_str = config.get(table_properties::TARGET_FILE_SIZE);
         if let Some(s) = config_str {
             if let Some(s) = s {
                 let r = s.parse::<i64>();

--- a/rust/src/operations/optimize.rs
+++ b/rust/src/operations/optimize.rs
@@ -11,27 +11,31 @@
 //! optimized files. Optimize does not delete files from storage. To delete
 //! files that were removed, call `vacuum` on [`DeltaTable`].
 //!
-//! See [`Optimize`] for configuration.
+//! See [`OptimizeBuilder`] for configuration.
 //!
 //! # Example
 //! ```rust ignore
 //! let table = open_table("../path/to/table")?;
 //! let metrics = Optimize::default().execute(table).await?;
 //! ````
-#![allow(deprecated)]
 
-use crate::action::DeltaOperation;
-use crate::action::{self, Action};
-use crate::table_properties;
+use super::transaction::commit;
+use super::writer::{PartitionWriter, PartitionWriterConfig};
+use crate::action::{self, Action, DeltaOperation};
+use crate::storage::ObjectStoreRef;
+use crate::table_state::DeltaTableState;
+use crate::writer::utils::arrow_schema_without_partitions;
 use crate::writer::utils::PartitionPath;
-use crate::writer::{DeltaWriter, RecordBatchWriter};
-use crate::{DeltaDataTypeLong, DeltaTable, DeltaTableError, PartitionFilter};
-use log::debug;
-use log::error;
-use object_store::{path::Path, ObjectStore};
-use parquet::arrow::{ArrowReader, ParquetFileArrowReader};
-use parquet::file::reader::FileReader;
-use parquet::file::serialized_reader::SerializedFileReader;
+use crate::{table_properties, DeltaDataTypeVersion};
+use crate::{
+    DeltaDataTypeLong, DeltaResult, DeltaTable, DeltaTableError, ObjectMeta, PartitionFilter,
+};
+use arrow::datatypes::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
+use futures::future::BoxFuture;
+use futures::StreamExt;
+use log::{debug, error};
+use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
+use parquet::file::properties::WriterProperties;
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
 use std::collections::HashMap;
@@ -95,30 +99,85 @@ impl Default for MetricDetails {
 ///
 /// If a target file size is not provided then `delta.targetFileSize` from the
 /// table's configuration is read. Otherwise a default value is used.
-#[derive(Default)]
-pub struct Optimize<'a> {
+#[derive(Debug)]
+pub struct OptimizeBuilder<'a> {
+    /// A snapshot of the to-be-optimized table's state
+    snapshot: DeltaTableState,
+    /// Delta object store for handling data files
+    store: ObjectStoreRef,
+    /// Filters to select specific table partitions to be optimized
     filters: &'a [PartitionFilter<'a, &'a str>],
+    /// Desired file size after bin-packing files
     target_size: Option<i64>,
+    /// Properties passed to underlying parquet writer
+    writer_properties: Option<WriterProperties>,
+    /// Additional metadata to be added to commit
+    app_metadata: Option<HashMap<String, serde_json::Value>>,
 }
 
-impl<'a> Optimize<'a> {
+impl<'a> OptimizeBuilder<'a> {
+    /// Create a new [`OptimizeBuilder`]
+    pub fn new(store: ObjectStoreRef, snapshot: DeltaTableState) -> Self {
+        Self {
+            snapshot,
+            store,
+            filters: &[],
+            target_size: None,
+            writer_properties: None,
+            app_metadata: None,
+        }
+    }
+
     /// Only optimize files that return true for the specified partition filter
-    pub fn filter(mut self, filters: &'a [PartitionFilter<'a, &'a str>]) -> Self {
+    pub fn with_filters(mut self, filters: &'a [PartitionFilter<'a, &'a str>]) -> Self {
         self.filters = filters;
         self
     }
 
     /// Set the target file size
-    pub fn target_size(mut self, target: DeltaDataTypeLong) -> Self {
+    pub fn with_target_size(mut self, target: DeltaDataTypeLong) -> Self {
         self.target_size = Some(target);
         self
     }
 
-    /// Perform the optimization. On completion, a summary of how many files were added and removed is returned
-    pub async fn execute(&self, table: &mut DeltaTable) -> Result<Metrics, DeltaTableError> {
-        let plan = create_merge_plan(table, self.filters, self.target_size.to_owned())?;
-        let metrics = plan.execute(table).await?;
-        Ok(metrics)
+    /// Writer properties passed to parquet writer
+    pub fn with_writer_properties(mut self, writer_properties: WriterProperties) -> Self {
+        self.writer_properties = Some(writer_properties);
+        self
+    }
+
+    /// Additional metadata to be addedds to commit info
+    pub fn with_metadata(
+        mut self,
+        metadata: impl IntoIterator<Item = (String, serde_json::Value)>,
+    ) -> Self {
+        self.app_metadata = Some(HashMap::from_iter(metadata));
+        self
+    }
+}
+
+impl<'a> std::future::IntoFuture for OptimizeBuilder<'a> {
+    type Output = DeltaResult<(DeltaTable, Metrics)>;
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let this = self;
+
+        Box::pin(async move {
+            let writer_properties = this
+                .writer_properties
+                .unwrap_or_else(|| WriterProperties::builder().build());
+            let plan = create_merge_plan(
+                &this.snapshot,
+                this.filters,
+                this.target_size.to_owned(),
+                writer_properties,
+            )?;
+            let metrics = plan.execute(this.store.clone()).await?;
+            let mut table = DeltaTable::new_with_state(this.store, this.snapshot);
+            table.update().await?;
+            Ok((table, metrics))
+        })
     }
 }
 
@@ -139,7 +198,7 @@ impl From<OptimizeInput> for DeltaOperation {
 /// A collection of bins for a particular partition
 #[derive(Debug)]
 struct MergeBin {
-    files: Vec<Path>,
+    files: Vec<ObjectMeta>,
     size_bytes: DeltaDataTypeLong,
 }
 
@@ -165,9 +224,9 @@ impl MergeBin {
         self.files.len()
     }
 
-    fn add(&mut self, file_path: Path, size: i64) {
-        self.files.push(file_path);
-        self.size_bytes += size;
+    fn add(&mut self, meta: ObjectMeta) {
+        self.size_bytes += meta.size as i64;
+        self.files.push(meta);
     }
 }
 
@@ -195,17 +254,27 @@ fn create_remove(
 /// Encapsulates the operations required to optimize a Delta Table
 pub struct MergePlan {
     operations: HashMap<PartitionPath, PartitionMergePlan>,
+    /// metrics collected during operation
     metrics: Metrics,
+    /// parameters passed to optimize operation
     input_parameters: OptimizeInput,
+    /// Schema of written files
+    file_schema: ArrowSchemaRef,
+    /// Coulumn names the table si partitioned by
+    partition_columns: Vec<String>,
+    /// Properties passed to parquet writer
+    writer_properties: WriterProperties,
+    /// read table version
+    read_table_version: DeltaDataTypeVersion,
 }
 
 impl MergePlan {
     /// Peform the operations outlined in the plan.
-    pub async fn execute(self, table: &mut DeltaTable) -> Result<Metrics, DeltaTableError> {
-        // Read files into memory and write into memory. Once a file is complete write to underlying storage.
+    pub async fn execute(self, object_store: ObjectStoreRef) -> Result<Metrics, DeltaTableError> {
         let mut actions = vec![];
         let mut metrics = self.metrics;
 
+        // TODO since we are now async in read and write, should we parallelize this?
         for (_partition_path, merge_partition) in self.operations.iter() {
             let partition_values = &merge_partition.partition_values;
             let bins = &merge_partition.bins;
@@ -213,35 +282,44 @@ impl MergePlan {
             debug!("{:?}", _partition_path);
 
             for bin in bins {
-                let mut writer = RecordBatchWriter::for_table(table)?;
+                let config = PartitionWriterConfig::try_new(
+                    self.file_schema.clone(),
+                    partition_values.clone(),
+                    self.partition_columns.clone(),
+                    Some(self.writer_properties.clone()),
+                    Some(self.input_parameters.target_size as usize),
+                    None,
+                )?;
+                let mut writer = PartitionWriter::try_with_config(object_store.clone(), config)?;
 
-                for path in &bin.files {
-                    //Read the file into memory and append it to the writer.
-                    let data = table.storage.get(path).await?.bytes().await?;
-                    let size: DeltaDataTypeLong = data.len().try_into().unwrap();
-                    let reader = SerializedFileReader::new(data)?;
-                    let records = reader.metadata().file_metadata().num_rows();
+                for file_meta in &bin.files {
+                    let file_reader =
+                        ParquetObjectReader::new(object_store.clone(), file_meta.clone());
+                    let mut batch_stream = ParquetRecordBatchStreamBuilder::new(file_reader)
+                        .await?
+                        .build()?;
 
-                    let mut arrow_reader = ParquetFileArrowReader::new(Arc::new(reader));
-
-                    let batch_reader =
-                        arrow_reader.get_record_reader(records.try_into().unwrap())?;
-                    for batch in batch_reader {
+                    while let Some(batch) = batch_stream.next().await {
                         let batch = batch?;
-                        writer.write_partition(batch, partition_values).await?;
+                        writer.write(&batch).await?;
                     }
 
-                    actions.push(create_remove(path.as_ref(), partition_values, size)?);
+                    let size = file_meta.size as i64;
+                    actions.push(create_remove(
+                        file_meta.location.as_ref(),
+                        partition_values,
+                        size,
+                    )?);
 
                     metrics.num_files_removed += 1;
                     metrics.files_removed.total_files += 1;
-                    metrics.files_removed.total_size += size;
+                    metrics.files_removed.total_size += file_meta.size as i64;
                     metrics.files_removed.max = std::cmp::max(metrics.files_removed.max, size);
                     metrics.files_removed.min = std::cmp::min(metrics.files_removed.min, size);
                 }
 
                 // Save the file to storage and create corresponding add and remove actions. Do not commit yet.
-                let add_actions = writer.flush().await?;
+                let add_actions = writer.close().await?;
                 if add_actions.len() != 1 {
                     // Ensure we don't deviate from the merge plan which may result in idempotency being violated
                     return Err(DeltaTableError::Generic(
@@ -282,28 +360,30 @@ impl MergePlan {
         // optimized partition was updated then abort the commit. Requires (#593).
         if !actions.is_empty() {
             let mut metadata = Map::new();
-            metadata.insert("readVersion".to_owned(), table.version().into());
+            metadata.insert("readVersion".to_owned(), self.read_table_version.into());
             let maybe_map_metrics = serde_json::to_value(metrics.clone());
             if let Ok(map) = maybe_map_metrics {
                 metadata.insert("operationMetrics".to_owned(), map);
             }
 
-            let mut dtx = table.create_transaction(None);
-            dtx.add_actions(actions);
-            // TODO: Add predicate information when we can convert the filter to a string representation
-            dtx.commit(Some(self.input_parameters.into()), Some(metadata))
-                .await?;
+            commit(
+                object_store.as_ref(),
+                self.read_table_version + 1,
+                actions,
+                self.input_parameters.into(),
+                Some(metadata),
+            )
+            .await?;
         }
 
         Ok(metrics)
     }
 }
 
-fn get_target_file_size(table: &DeltaTable) -> DeltaDataTypeLong {
-    let config = table.get_configurations();
+fn get_target_file_size(snapshot: &DeltaTableState) -> DeltaDataTypeLong {
     let mut target_size = 268_435_456;
-    if let Ok(config) = config {
-        let config_str = config.get(table_properties::TARGET_FILE_SIZE);
+    if let Some(meta) = snapshot.current_metadata() {
+        let config_str = meta.configuration.get(table_properties::TARGET_FILE_SIZE);
         if let Some(s) = config_str {
             if let Some(s) = s {
                 let r = s.parse::<i64>();
@@ -317,24 +397,27 @@ fn get_target_file_size(table: &DeltaTable) -> DeltaDataTypeLong {
             }
         }
     }
-
     target_size
 }
 
 /// Build a Plan on which files to merge together. See [`Optimize`]
 pub fn create_merge_plan(
-    table: &mut DeltaTable,
+    snapshot: &DeltaTableState,
     filters: &[PartitionFilter<'_, &str>],
     target_size: Option<DeltaDataTypeLong>,
+    writer_properties: WriterProperties,
 ) -> Result<MergePlan, DeltaTableError> {
-    let target_size = target_size.unwrap_or_else(|| get_target_file_size(table));
+    let target_size = target_size.unwrap_or_else(|| get_target_file_size(snapshot));
     let mut candidates = HashMap::new();
     let mut operations: HashMap<PartitionPath, PartitionMergePlan> = HashMap::new();
     let mut metrics = Metrics::default();
-    let partitions_keys = &table.get_metadata()?.partition_columns;
+    let partitions_keys = &snapshot
+        .current_metadata()
+        .ok_or(DeltaTableError::NoMetadata)?
+        .partition_columns;
 
     //Place each add action into a bucket determined by the file's partition
-    for add in table.get_active_add_actions_by_partitions(filters)? {
+    for add in snapshot.get_active_add_actions_by_partitions(filters)? {
         let path = PartitionPath::from_hashmap(partitions_keys, &add.partition_values)?;
         let v = candidates
             .entry(path)
@@ -360,7 +443,7 @@ pub fn create_merge_plan(
             }
 
             if file.size + curr_bin.get_total_file_size() < target_size {
-                curr_bin.add(Path::from(file.path.as_str()), file.size);
+                curr_bin.add((*file).try_into()?);
             } else {
                 if curr_bin.get_num_files() > 1 {
                     bins.push(curr_bin);
@@ -368,7 +451,7 @@ pub fn create_merge_plan(
                     metrics.total_files_skipped += curr_bin.get_num_files();
                 }
                 curr_bin = MergeBin::new();
-                curr_bin.add(Path::from(file.path.as_str()), file.size);
+                curr_bin.add((*file).try_into()?);
             }
         }
 
@@ -390,10 +473,20 @@ pub fn create_merge_plan(
     }
 
     let input_parameters = OptimizeInput { target_size };
+    let file_schema = arrow_schema_without_partitions(
+        &Arc::new(<ArrowSchema as TryFrom<&crate::schema::Schema>>::try_from(
+            &snapshot.current_metadata().unwrap().schema,
+        )?),
+        partitions_keys,
+    );
 
     Ok(MergePlan {
         operations,
         metrics,
         input_parameters,
+        writer_properties,
+        file_schema,
+        partition_columns: partitions_keys.clone(),
+        read_table_version: snapshot.version(),
     })
 }

--- a/rust/src/operations/optimize.rs
+++ b/rust/src/operations/optimize.rs
@@ -16,7 +16,7 @@
 //! # Example
 //! ```rust ignore
 //! let table = open_table("../path/to/table")?;
-//! let (table, metrics) = OptimizeBuilder::new(table.object_store(). table.state).await?;
+//! let (table, metrics) = OptimizeBuilder::new(table.object_store(), table.state).await?;
 //! ````
 
 use super::transaction::commit;
@@ -146,7 +146,7 @@ impl<'a> OptimizeBuilder<'a> {
         self
     }
 
-    /// Additional metadata to be addedds to commit info
+    /// Additional metadata to be added to commit info
     pub fn with_metadata(
         mut self,
         metadata: impl IntoIterator<Item = (String, serde_json::Value)>,
@@ -254,17 +254,17 @@ fn create_remove(
 /// Encapsulates the operations required to optimize a Delta Table
 pub struct MergePlan {
     operations: HashMap<PartitionPath, PartitionMergePlan>,
-    /// metrics collected during operation
+    /// Metrics collected during operation
     metrics: Metrics,
-    /// parameters passed to optimize operation
+    /// Parameters passed to optimize operation
     input_parameters: OptimizeInput,
     /// Schema of written files
     file_schema: ArrowSchemaRef,
-    /// Coulumn names the table si partitioned by
+    /// Column names the table is partitioned by.
     partition_columns: Vec<String>,
     /// Properties passed to parquet writer
     writer_properties: WriterProperties,
-    /// read table version
+    /// Version of the table at beginning of optimization. Used for conflict resolution.
     read_table_version: DeltaDataTypeVersion,
 }
 
@@ -400,7 +400,7 @@ fn get_target_file_size(snapshot: &DeltaTableState) -> DeltaDataTypeLong {
     target_size
 }
 
-/// Build a Plan on which files to merge together. See [`OptimizeBuilder`]
+/// Build a Plan on which files to merge together. See [OptimizeBuilder]
 pub fn create_merge_plan(
     snapshot: &DeltaTableState,
     filters: &[PartitionFilter<'_, &str>],

--- a/rust/src/operations/writer.rs
+++ b/rust/src/operations/writer.rs
@@ -84,7 +84,7 @@ pub struct WriterConfig {
 }
 
 impl WriterConfig {
-    /// create a new instalce of [`WriterConfig`]
+    /// Create a new instance of [WriterConfig].
     pub fn new(
         table_schema: ArrowSchemaRef,
         partition_columns: Vec<String>,
@@ -199,7 +199,9 @@ impl DeltaWriter {
         Ok(())
     }
 
-    /// close the writer
+    /// Close the writer and get the new [Add] actions.
+    ///
+    /// This will flush all remaining data.
     pub async fn close(mut self) -> DeltaResult<Vec<Add>> {
         let writers = std::mem::take(&mut self.partition_writers);
         let mut actions = Vec::new();

--- a/rust/src/operations/writer.rs
+++ b/rust/src/operations/writer.rs
@@ -1,3 +1,5 @@
+//! Abstractions and implementations for writing data to delta tables
+
 use std::collections::HashMap;
 
 use crate::action::Add;
@@ -66,7 +68,8 @@ impl From<WriteError> for DeltaTableError {
     }
 }
 
-pub(crate) struct WriterConfig {
+/// Configuration to write data into Delta tables
+pub struct WriterConfig {
     /// Schema of the delta table
     table_schema: ArrowSchemaRef,
     /// Column names for columns the table is partitioned by
@@ -81,6 +84,7 @@ pub(crate) struct WriterConfig {
 }
 
 impl WriterConfig {
+    /// create a new instalce of [`WriterConfig`]
     pub fn new(
         table_schema: ArrowSchemaRef,
         partition_columns: Vec<String>,
@@ -105,13 +109,14 @@ impl WriterConfig {
         }
     }
 
+    /// Schema of files written to disk
     pub fn file_schema(&self) -> ArrowSchemaRef {
         arrow_schema_without_partitions(&self.table_schema, &self.partition_columns)
     }
 }
 
 /// A parquet writer implementation tailored to the needs of writing data to a delta table.
-pub(crate) struct DeltaWriter {
+pub struct DeltaWriter {
     /// An object store pointing at Delta table root
     object_store: ObjectStoreRef,
     /// configuration for the writers
@@ -121,6 +126,7 @@ pub(crate) struct DeltaWriter {
 }
 
 impl DeltaWriter {
+    /// Create a new instance of [`DeltaWriter`]
     pub fn new(object_store: ObjectStoreRef, config: WriterConfig) -> Self {
         Self {
             object_store,
@@ -193,6 +199,7 @@ impl DeltaWriter {
         Ok(())
     }
 
+    /// close the writer
     pub async fn close(mut self) -> DeltaResult<Vec<Add>> {
         let writers = std::mem::take(&mut self.partition_writers);
         let mut actions = Vec::new();

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -31,6 +31,7 @@ pub use object_store::{
     DynObjectStore, Error as ObjectStoreError, GetResult, ListResult, MultipartId, ObjectMeta,
     ObjectStore, Result as ObjectStoreResult,
 };
+pub use utils::*;
 
 lazy_static! {
     static ref DELTA_LOG_PATH: Path = Path::from("_delta_log");

--- a/rust/src/storage/utils.rs
+++ b/rust/src/storage/utils.rs
@@ -2,11 +2,13 @@
 
 use std::collections::HashMap;
 
+use crate::action::Add;
 use crate::builder::DeltaTableBuilder;
-use crate::DeltaTableError;
+use crate::{DeltaResult, DeltaTableError};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
-use object_store::{DynObjectStore, Result as ObjectStoreResult};
+use object_store::{DynObjectStore, ObjectMeta, Result as ObjectStoreResult};
 use std::sync::Arc;
 
 /// Copies the contents from the `from` location into the `to` location
@@ -63,4 +65,36 @@ pub(crate) fn str_is_truthy(val: &str) -> bool {
         | val.eq_ignore_ascii_case("on")
         | val.eq_ignore_ascii_case("yes")
         | val.eq_ignore_ascii_case("y")
+}
+
+impl TryFrom<Add> for ObjectMeta {
+    type Error = DeltaTableError;
+
+    fn try_from(value: Add) -> DeltaResult<Self> {
+        (&value).try_into()
+    }
+}
+
+impl TryFrom<&Add> for ObjectMeta {
+    type Error = DeltaTableError;
+
+    fn try_from(value: &Add) -> DeltaResult<Self> {
+        let last_modified = DateTime::<Utc>::from_utc(
+            NaiveDateTime::from_timestamp_millis(value.modification_time).ok_or(
+                DeltaTableError::InvalidAction {
+                    source: crate::action::ActionError::InvalidField(format!(
+                        "invalid modification_time: {:?}",
+                        value.modification_time
+                    )),
+                },
+            )?,
+            Utc,
+        );
+        Ok(Self {
+            // TODO this won't work for absoute paths, since Paths are always relative to store.
+            location: Path::from(value.path.as_str()),
+            last_modified,
+            size: value.size as usize,
+        })
+    }
 }

--- a/rust/tests/command_optimize.rs
+++ b/rust/tests/command_optimize.rs
@@ -6,17 +6,17 @@ use arrow::{
     datatypes::{DataType, Field},
     record_batch::RecordBatch,
 };
-use deltalake::optimize::{MetricDetails, Metrics};
-use deltalake::DeltaTableError;
+use deltalake::operations::optimize::{create_merge_plan, MetricDetails, Metrics, Optimize};
 use deltalake::{
     action,
     action::Remove,
     builder::DeltaTableBuilder,
-    optimize::{create_merge_plan, Optimize},
     writer::{DeltaWriter, RecordBatchWriter},
-    DeltaTableMetaData, PartitionFilter,
 };
-use deltalake::{DeltaTable, Schema, SchemaDataType, SchemaField};
+use deltalake::{
+    DeltaTable, DeltaTableError, DeltaTableMetaData, PartitionFilter, Schema, SchemaDataType,
+    SchemaField,
+};
 use rand::prelude::*;
 use serde_json::{json, Map, Value};
 use std::time::SystemTime;


### PR DESCRIPTION
# Description

This PR moves the optimize operation into the operations module. As part of this we do a few updates to the operation as well

- adopt `IntoFuture` pattern
- use writer from operations module
- replace `SerializedFileReader` with `ParquetRecordBatchStream`

As part of this we also update datafusion and arrow, which in turn requires updating pyo3. This requires updating some deprecated features. i.e. how function signatures are annotated. It also leads to a breaking change in the python funcitons - specifically the order of arguments in `dataset_partitions`. 

There is one more thing is was considering while doing these updates. Essentially we may be getting some undesired behaviour, as the writer in the operations module already considers file size, so not all data in a bin might actually end up in the same file. there may also be a naïve yet much simpler way to do this now, by just passing all data in a partition through the partition writer. This should yield files of the desired size within the accuracy of the configured row-group size. It may of course lead to a rather small remainder file.

cc @Blajda

# Related Issue(s)

part of #1136

# Documentation

<!---
Share links to useful documentation
--->
