### PR TITLE
first setup of ruff for python linting

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: 3.7
       - name: Check Python
         run: |
-          pip install black isort mypy types-dataclasses typing-extensions
+          pip install ruff black mypy types-dataclasses typing-extensions
           make check-python
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rs/toolchain@v1

--- a/python/Makefile
+++ b/python/Makefile
@@ -54,7 +54,7 @@ format: ## Format the code
 	cargo fmt
 	$(info --- Python format ---)
 	black .
-	isort .
+	ruff . --fix
 
 .PHONY: check-rust
 check-rust: ## Run check on Rust
@@ -65,10 +65,10 @@ check-rust: ## Run check on Rust
 
 .PHONY: check-python
 check-python: ## Run check on Python
-	$(info Check Python isort)
-	isort --diff --check-only .
 	$(info Check Python black)
 	black --check .
+	$(info Check Python ruff)
+	ruff check .
 	$(info Check Python mypy)
 	mypy
 

--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -5,7 +5,14 @@ import pyarrow as pa
 if TYPE_CHECKING:
     import pandas as pd
 
-from ._internal import ArrayType, Field, MapType, PrimitiveType, Schema, StructType
+from ._internal import (  # noqa: F401
+    ArrayType,
+    Field,
+    MapType,
+    PrimitiveType,
+    Schema,
+    StructType,
+)
 
 # Can't implement inheritance (see note in src/schema.rs), so this is next
 # best thing.

--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -5,14 +5,12 @@ import pyarrow as pa
 if TYPE_CHECKING:
     import pandas as pd
 
-from ._internal import (  # noqa: F401
-    ArrayType,
-    Field,
-    MapType,
-    PrimitiveType,
-    Schema,
-    StructType,
-)
+from ._internal import ArrayType as ArrayType
+from ._internal import Field as Field
+from ._internal import MapType as MapType
+from ._internal import PrimitiveType as PrimitiveType
+from ._internal import Schema as Schema
+from ._internal import StructType as StructType
 
 # Can't implement inheritance (see note in src/schema.rs), so this is next
 # best thing.

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -1,5 +1,4 @@
 import json
-import os.path
 import uuid
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -43,7 +42,7 @@ from ._internal import write_new_deltalake as _write_new_deltalake
 from .table import MAX_SUPPORTED_WRITER_VERSION, DeltaTable, DeltaTableProtocolError
 
 try:
-    import pandas as pd
+    import pandas as pd  # noqa: F811
 except ModuleNotFoundError:
     _has_pandas = False
 else:
@@ -134,7 +133,6 @@ def write_deltalake(
     :param overwrite_schema: If True, allows updating the schema of the table.
     :param storage_options: options passed to the native delta filesystem. Unused if 'filesystem' is defined.
     """
-
     if _has_pandas and isinstance(data, pd.DataFrame):
         if schema is not None:
             data = pa.Table.from_pandas(data, schema=schema)
@@ -295,7 +293,8 @@ def __enforce_append_only(
     )
     if config_delta_append_only and mode != "append":
         raise ValueError(
-            f"If configuration has delta.appendOnly = 'true', mode must be 'append'. Mode is currently {mode}"
+            "If configuration has delta.appendOnly = 'true', mode must be 'append'."
+            f" Mode is currently {mode}"
         )
 
 

--- a/python/docs/source/_ext/edit_on_github.py
+++ b/python/docs/source/_ext/edit_on_github.py
@@ -1,5 +1,4 @@
-"""
-Sphinx extension to add ReadTheDocs-style "Edit on GitHub" links to the
+"""Sphinx extension to add ReadTheDocs-style "Edit on GitHub" links to the
 sidebar.
 
 Loosely based on https://github.com/astropy/astropy/pull/347

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -20,8 +20,7 @@ sys.path.insert(0, os.path.abspath("./_ext"))
 
 
 def get_release_version() -> str:
-    """
-    Get the release version from the Cargo.toml file
+    """Get the release version from the Cargo.toml file.
 
     :return:
     """

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,7 +26,7 @@ pandas = [
 devel = [
     "mypy",
     "black",
-    "isort",
+    "ruff",
     "packaging>=20",
     "pytest",
     "pytest-mock",
@@ -66,13 +66,28 @@ warn_return_any = false
 implicit_reexport = true
 strict_equality = true
 
-[tool.isort]
-profile = "black"
-src_paths = ["deltalake", "tests"]
 
 [tool.black]
 include = '\.pyi?$'
 exclude = "venv"
+
+[tool.ruff]
+select = [
+    # pycodestyle error
+    "E",
+    # pyflakes
+    "F",
+    # isort
+    "I"
+]
+unfixable = ["F401"]
+ignore = ["E501"]
+
+[tool.ruff.per-file-ignores]
+"deltalake/__init__.py" = ["F401"]
+
+[tool.ruff.isort]
+known-first-party = ["deltalake"]
 
 [tool.pytest.ini_options]
 addopts = "--cov=deltalake -v -m 'not integration'"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -13,11 +13,10 @@ from deltalake import DeltaTable, write_deltalake
 
 def wait_till_host_is_available(host: str, timeout_sec: int = 30):
     spacing = 2
-    attempts = timeout_sec / spacing
     while True:
         try:
             subprocess.run(["curl", host], timeout=500, check=True)
-        except:
+        except BaseException:
             pass
         else:
             break
@@ -121,7 +120,7 @@ def azurite_creds():
     env = os.environ.copy()
     env.update(config)
     env["AZURE_STORAGE_CONNECTION_STRING"] = (
-        f"DefaultEndpointsProtocol=http;"
+        "DefaultEndpointsProtocol=http;"
         f"AccountName={config['AZURE_STORAGE_ACCOUNT_NAME']};"
         f"AccountKey={config['AZURE_STORAGE_ACCOUNT_KEY']};"
         f"BlobEndpoint={endpoint_url};"
@@ -171,7 +170,7 @@ def azurite_sas_creds(azurite_creds):
     env = os.environ.copy()
     env.update(azurite_creds)
     env["AZURE_STORAGE_CONNECTION_STRING"] = (
-        f"DefaultEndpointsProtocol=http;"
+        "DefaultEndpointsProtocol=http;"
         f"AccountName={azurite_creds['AZURE_STORAGE_ACCOUNT_NAME']};"
         f"AccountKey={azurite_creds['AZURE_STORAGE_ACCOUNT_KEY']};"
         f"BlobEndpoint={endpoint_url};"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -16,7 +16,7 @@ def wait_till_host_is_available(host: str, timeout_sec: int = 30):
     while True:
         try:
             subprocess.run(["curl", host], timeout=500, check=True)
-        except BaseException:
+        except Exception:
             pass
         else:
             break

--- a/python/tests/pyspark_integration/test_write_to_pyspark.py
+++ b/python/tests/pyspark_integration/test_write_to_pyspark.py
@@ -1,4 +1,4 @@
-"""Tests that deltalake(delta-rs) can write to tables written by PySpark"""
+"""Tests that deltalake(delta-rs) can write to tables written by PySpark."""
 import pathlib
 
 import pyarrow as pa

--- a/python/tests/pyspark_integration/test_writer_readable.py
+++ b/python/tests/pyspark_integration/test_writer_readable.py
@@ -1,6 +1,5 @@
-"""Test that pyspark can read tables written by deltalake(delta-rs)"""
+"""Test that pyspark can read tables written by deltalake(delta-rs)."""
 import pathlib
-from typing import List
 
 import pyarrow as pa
 import pytest
@@ -13,7 +12,6 @@ try:
     import delta
     import delta.pip_utils
     import delta.tables
-    import pyspark
 
     spark = get_spark()
 except ModuleNotFoundError:

--- a/python/tests/test_fs.py
+++ b/python/tests/test_fs.py
@@ -4,7 +4,6 @@ import urllib
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from pyarrow.fs import S3FileSystem
 
 from deltalake import DeltaTable, PyDeltaTableError
 from deltalake.fs import DeltaStorageHandler

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -1,17 +1,8 @@
-from array import array
-
 import pyarrow
 import pytest
 
 from deltalake import DeltaTable, Field
-from deltalake.schema import (
-    ArrayType,
-    DataType,
-    MapType,
-    PrimitiveType,
-    Schema,
-    StructType,
-)
+from deltalake.schema import ArrayType, MapType, PrimitiveType, Schema, StructType
 
 
 def test_table_schema():

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -350,17 +350,17 @@ def test_get_files_partitioned_table():
 
     partition_filters = [("day", "not in", ["3", "20"])]
     paths = [
-        f"year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet",
-        f"year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet",
-        f"year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet",
-        f"year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet",
+        "year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet",
+        "year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet",
+        "year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet",
+        "year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet",
     ]
     assert_correct_files(dt, partition_filters, paths)
 
     partition_filters = [("day", "not in", ["3", "20"]), ("year", "=", "2021")]
     paths = [
-        f"year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet",
-        f"year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet",
+        "year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet",
+        "year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet",
     ]
     assert_correct_files(dt, partition_filters, paths)
 
@@ -385,7 +385,8 @@ def test_get_files_partitioned_table():
         dt.files(partition_filters)
     assert (
         str(exception.value)
-        == 'Invalid partition filter found: [PartitionFilter { key: "unknown", value: Equal("3") }].'
+        == 'Invalid partition filter found: [PartitionFilter { key: "unknown", value:'
+        ' Equal("3") }].'
     )
 
 
@@ -468,8 +469,7 @@ class ExcPassThroughThread(Thread):
 @pytest.mark.integration
 @pytest.mark.timeout(timeout=5, method="thread")
 def test_read_multiple_tables_from_s3(s3_localstack):
-    """
-    Should be able to create multiple cloud storage based DeltaTable instances
+    """Should be able to create multiple cloud storage based DeltaTable instances
     without blocking on async rust function calls.
     """
     for path in ["s3://deltars/simple", "s3://deltars/simple"]:

--- a/python/tests/test_vacuum.py
+++ b/python/tests/test_vacuum.py
@@ -30,7 +30,8 @@ def test_vacuum_dry_run_simple_table():
         dt.vacuum(retention_periods)
     assert (
         str(exception.value)
-        == "Generic error: Invalid retention period, minimum retention for vacuum is configured to be greater than 168 hours, got 167 hours"
+        == "Generic error: Invalid retention period, minimum retention for vacuum is"
+        " configured to be greater than 168 hours, got 167 hours"
     )
 
 

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -250,7 +250,10 @@ def test_append_only_should_append_only_with_the_overwrite_mode(
     for data_store_type, mode in itertools.product(data_store_types, fail_modes):
         with pytest.raises(
             ValueError,
-            match=f"If configuration has delta.appendOnly = 'true', mode must be 'append'. Mode is currently {mode}",
+            match=(
+                "If configuration has delta.appendOnly = 'true', mode must be"
+                f" 'append'. Mode is currently {mode}"
+            ),
         ):
             write_deltalake(data_store_type, sample_data, mode=mode)
 
@@ -321,9 +324,7 @@ def test_writer_partitioning(tmp_path: pathlib.Path):
 
 
 def get_log_path(table: DeltaTable) -> str:
-    """
-    Returns _delta_log path for this delta table.
-    """
+    """Returns _delta_log path for this delta table."""
     return table._table.table_uri() + "/_delta_log/" + ("0" * 20 + ".json")
 
 


### PR DESCRIPTION
# Description
This PR sets up ruff for python linting. It also enables isort from within ruff and removes the standalone isort. 

# Related Issue(s)
closes #1149 
