### PR TITLE
Make DeltaTable clonable

### DIFF
--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -54,7 +54,7 @@ impl Default for DeltaVersion {
 }
 
 /// Configuration options for delta table
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeltaTableConfig {
     /// Indicates whether our use case requires tracking tombstones.

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -443,6 +443,7 @@ pub enum PeekCommit {
 }
 
 /// In memory representation of a Delta Table
+#[derive(Clone)]
 pub struct DeltaTable {
     /// The state of the table as of the most recent loaded Delta log entry.
     pub state: DeltaTableState,


### PR DESCRIPTION
# Description
Simply add `Clone` attribute to `DeltaTable` as well as the contained `DeltaTableConfig` (see #1172 for motivation).

# Related Issue(s)
Closes #1172

# Documentation

