### PR TITLE
Implement pruning on partition columns

### DIFF
--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -37,20 +37,15 @@ impl From<BuilderError> for DeltaTableError {
 }
 
 /// possible version specifications for loading a delta table
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum DeltaVersion {
     /// load the newest version
+    #[default]
     Newest,
     /// specify the version to load
     Version(DeltaDataTypeVersion),
     /// specify the timestamp in UTC
     Timestamp(DateTime<Utc>),
-}
-
-impl Default for DeltaVersion {
-    fn default() -> Self {
-        DeltaVersion::Newest
-    }
 }
 
 /// Configuration options for delta table

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -575,11 +575,9 @@ fn get_null_of_arrow_type(t: &ArrowDataType) -> ScalarValue {
         | ArrowDataType::Time64(_)
         | ArrowDataType::Duration(_)
         | ArrowDataType::Interval(_)
+        | ArrowDataType::RunEndEncoded(_, _)
         | ArrowDataType::Map(_, _) => {
-            panic!(
-                "{}",
-                format!("Implement data type for Delta Lake {}", t.to_string())
-            );
+            panic!("{}", format!("Implement data type for Delta Lake {}", t));
         }
     }
 }

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -541,7 +541,6 @@ fn get_null_of_arrow_type(t: &ArrowDataType) -> ScalarValue {
         ArrowDataType::UInt16 => ScalarValue::UInt16(None),
         ArrowDataType::UInt32 => ScalarValue::UInt32(None),
         ArrowDataType::UInt64 => ScalarValue::UInt64(None),
-        ArrowDataType::Float16 => panic!("Unsupported type"),
         ArrowDataType::Float32 => ScalarValue::Float32(None),
         ArrowDataType::Float64 => ScalarValue::Float64(None),
         ArrowDataType::Date32 => ScalarValue::Date32(None),
@@ -553,9 +552,19 @@ fn get_null_of_arrow_type(t: &ArrowDataType) -> ScalarValue {
         ArrowDataType::LargeUtf8 => ScalarValue::LargeUtf8(None),
         ArrowDataType::Decimal128(precision, scale) => {
             ScalarValue::Decimal128(None, precision.to_owned(), scale.to_owned())
-        }
+        },
+        ArrowDataType::Timestamp(unit, tz) => {
+            let tz = tz.to_owned();
+            match unit {
+                TimeUnit::Second => ScalarValue::TimestampSecond(None, tz),
+                TimeUnit::Millisecond => ScalarValue::TimestampMillisecond(None, tz),
+                TimeUnit::Microsecond => ScalarValue::TimestampMicrosecond(None, tz),
+                TimeUnit::Nanosecond => ScalarValue::TimestampNanosecond(None, tz),
+            }
+        },
         //Unsupported types...
-        ArrowDataType::Decimal256(_, _)
+        ArrowDataType::Float16 
+        | ArrowDataType::Decimal256(_, _)
         | ArrowDataType::Union(_, _, _)
         | ArrowDataType::Dictionary(_, _)
         | ArrowDataType::LargeList(_)
@@ -565,10 +574,9 @@ fn get_null_of_arrow_type(t: &ArrowDataType) -> ScalarValue {
         | ArrowDataType::Time32(_)
         | ArrowDataType::Time64(_)
         | ArrowDataType::Duration(_)
-        | ArrowDataType::Timestamp(_, _)
         | ArrowDataType::Interval(_)
         | ArrowDataType::Map(_, _) => {
-            todo!("Implement remaining mappings");
+            panic!("{}", format!("Implement data type for Delta Lake {}", t.to_string()));
         }
     }
 }

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -552,7 +552,7 @@ fn get_null_of_arrow_type(t: &ArrowDataType) -> ScalarValue {
         ArrowDataType::LargeUtf8 => ScalarValue::LargeUtf8(None),
         ArrowDataType::Decimal128(precision, scale) => {
             ScalarValue::Decimal128(None, precision.to_owned(), scale.to_owned())
-        },
+        }
         ArrowDataType::Timestamp(unit, tz) => {
             let tz = tz.to_owned();
             match unit {
@@ -561,9 +561,9 @@ fn get_null_of_arrow_type(t: &ArrowDataType) -> ScalarValue {
                 TimeUnit::Microsecond => ScalarValue::TimestampMicrosecond(None, tz),
                 TimeUnit::Nanosecond => ScalarValue::TimestampNanosecond(None, tz),
             }
-        },
+        }
         //Unsupported types...
-        ArrowDataType::Float16 
+        ArrowDataType::Float16
         | ArrowDataType::Decimal256(_, _)
         | ArrowDataType::Union(_, _, _)
         | ArrowDataType::Dictionary(_, _)
@@ -576,7 +576,10 @@ fn get_null_of_arrow_type(t: &ArrowDataType) -> ScalarValue {
         | ArrowDataType::Duration(_)
         | ArrowDataType::Interval(_)
         | ArrowDataType::Map(_, _) => {
-            panic!("{}", format!("Implement data type for Delta Lake {}", t.to_string()));
+            panic!(
+                "{}",
+                format!("Implement data type for Delta Lake {}", t.to_string())
+            );
         }
     }
 }

--- a/rust/src/writer/record_batch.rs
+++ b/rust/src/writer/record_batch.rs
@@ -382,7 +382,6 @@ pub(crate) fn divide_by_partition_values(
         // get row indices for current partition
         let idx: UInt32Array = (range.start..range.end)
             .map(|i| Some(indices.value(i)))
-            .into_iter()
             .collect();
 
         let partition_key_iter = sorted_partition_columns.iter().map(|c| {

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -5,7 +5,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use arrow::array::*;
-use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+use arrow::datatypes::{
+    DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema, TimeUnit,
+};
 use arrow::record_batch::RecordBatch;
 use common::datafusion::context_with_delta_table_factory;
 use datafusion::assert_batches_sorted_eq;
@@ -15,6 +17,7 @@ use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::{common::collect, file_format::ParquetExec, metrics::Label};
 use datafusion::physical_plan::{visit_execution_plan, ExecutionPlan, ExecutionPlanVisitor};
 use datafusion_common::scalar::ScalarValue;
+use datafusion_common::ScalarValue::*;
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::Expr;
 
@@ -61,7 +64,8 @@ impl ExecutionPlanVisitor for ExecutionMetricsCollector {
 async fn prepare_table(
     batches: Vec<RecordBatch>,
     save_mode: SaveMode,
-) -> (tempfile::TempDir, Arc<DeltaTable>) {
+    partitions: Vec<String>,
+) -> (tempfile::TempDir, DeltaTable) {
     let table_dir = tempfile::tempdir().unwrap();
     let table_path = table_dir.path();
     let table_uri = table_path.to_str().unwrap().to_string();
@@ -73,6 +77,7 @@ async fn prepare_table(
         .create()
         .with_save_mode(SaveMode::Ignore)
         .with_columns(table_schema.get_fields().clone())
+        .with_partition_columns(partitions)
         .await
         .unwrap();
 
@@ -84,7 +89,7 @@ async fn prepare_table(
             .unwrap();
     }
 
-    (table_dir, Arc::new(table))
+    (table_dir, table)
 }
 
 #[tokio::test]
@@ -301,6 +306,99 @@ async fn get_scan_metrics(
     return Ok(metrics);
 }
 
+fn create_all_types_batch(not_null_rows: usize, null_rows: usize, offset: usize) -> RecordBatch {
+    let mut decimal_builder = Decimal128Builder::with_capacity(not_null_rows + null_rows);
+    for x in 0..not_null_rows {
+        decimal_builder.append_value(((x + offset) * 100) as i128);
+    }
+    decimal_builder.append_nulls(null_rows);
+    let decimal = decimal_builder
+        .finish()
+        .with_precision_and_scale(10, 2)
+        .unwrap();
+
+    let data: Vec<ArrayRef> = vec![
+        Arc::new(StringArray::from_iter(
+            (0..not_null_rows)
+                .map(|x| Some((x + offset).to_string()))
+                .chain((0..null_rows).map(|_| None)),
+        )),
+        Arc::new(Int64Array::from_iter(
+            (0..not_null_rows)
+                .map(|x| Some((x + offset) as i64))
+                .chain((0..null_rows).map(|_| None)),
+        )),
+        Arc::new(Int32Array::from_iter(
+            (0..not_null_rows)
+                .map(|x| Some((x + offset) as i32))
+                .chain((0..null_rows).map(|_| None)),
+        )),
+        Arc::new(Int16Array::from_iter(
+            (0..not_null_rows)
+                .map(|x| Some((x + offset) as i16))
+                .chain((0..null_rows).map(|_| None)),
+        )),
+        Arc::new(Int8Array::from_iter(
+            (0..not_null_rows)
+                .map(|x| Some((x + offset) as i8))
+                .chain((0..null_rows).map(|_| None)),
+        )),
+        Arc::new(Float64Array::from_iter(
+            (0..not_null_rows)
+                .map(|x| Some((x + offset) as f64))
+                .chain((0..null_rows).map(|_| None)),
+        )),
+        Arc::new(Float32Array::from_iter(
+            (0..not_null_rows)
+                .map(|x| Some((x + offset) as f32))
+                .chain((0..null_rows).map(|_| None)),
+        )),
+        Arc::new(BooleanArray::from_iter(
+            (0..not_null_rows)
+                .map(|x| Some((x + offset) % 2 == 0))
+                .chain((0..null_rows).map(|_| None)),
+        )),
+        Arc::new(BinaryArray::from_iter(
+            (0..not_null_rows)
+                .map(|x| Some((x + offset).to_string().as_bytes().to_owned()))
+                .chain((0..null_rows).map(|_| None)),
+        )),
+        Arc::new(decimal),
+        //Convert to seconds
+        Arc::new(TimestampMicrosecondArray::from_iter(
+            (0..not_null_rows)
+                .map(|x| Some(((x + offset) * 1_000_000) as i64))
+                .chain((0..null_rows).map(|_| None)),
+        )),
+        Arc::new(Date32Array::from_iter(
+            (0..not_null_rows)
+                .map(|x| Some((x + offset) as i32))
+                .chain((0..null_rows).map(|_| None)),
+        )),
+    ];
+
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("utf8", ArrowDataType::Utf8, true),
+        ArrowField::new("int64", ArrowDataType::Int64, true),
+        ArrowField::new("int32", ArrowDataType::Int32, true),
+        ArrowField::new("int16", ArrowDataType::Int16, true),
+        ArrowField::new("int8", ArrowDataType::Int8, true),
+        ArrowField::new("float64", ArrowDataType::Float64, true),
+        ArrowField::new("float32", ArrowDataType::Float32, true),
+        ArrowField::new("boolean", ArrowDataType::Boolean, true),
+        ArrowField::new("binary", ArrowDataType::Binary, true),
+        ArrowField::new("decimal", ArrowDataType::Decimal128(10, 2), true),
+        ArrowField::new(
+            "timestamp",
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            true,
+        ),
+        ArrowField::new("date", ArrowDataType::Date32, true),
+    ]));
+
+    RecordBatch::try_new(schema, data).unwrap()
+}
+
 #[tokio::test]
 async fn test_files_scanned() -> Result<()> {
     // Validate that datafusion prunes files based on file statistics
@@ -309,37 +407,238 @@ async fn test_files_scanned() -> Result<()> {
     let ctx = SessionContext::new();
     let state = ctx.state();
 
-    let arrow_schema = Arc::new(ArrowSchema::new(vec![
-        ArrowField::new("id", ArrowDataType::Int32, true),
-        ArrowField::new("string", ArrowDataType::Utf8, true),
-    ]));
-    let columns_1: Vec<ArrayRef> = vec![
-        Arc::new(Int32Array::from(vec![Some(1), Some(2)])),
-        Arc::new(StringArray::from(vec![Some("hello"), Some("world")])),
-    ];
-    let columns_2: Vec<ArrayRef> = vec![
-        Arc::new(Int32Array::from(vec![Some(10), Some(20)])),
-        Arc::new(StringArray::from(vec![Some("hello"), Some("world")])),
-    ];
-    let batches = vec![
-        RecordBatch::try_new(arrow_schema.clone(), columns_1)?,
-        RecordBatch::try_new(arrow_schema.clone(), columns_2)?,
-    ];
-    let (_temp_dir, table) = prepare_table(batches, SaveMode::Append).await;
-    assert_eq!(table.version(), 2);
+    async fn append_to_table(table: DeltaTable, batch: RecordBatch) -> DeltaTable {
+        DeltaOps(table)
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .await
+            .unwrap()
+    }
+
+    fn to_binary(s: &str) -> Vec<u8> {
+        s.as_bytes().to_owned()
+    }
+
+    let batch = create_all_types_batch(3, 0, 0);
+    let (_tmp, table) = prepare_table(vec![batch], SaveMode::Overwrite, vec![]).await;
+
+    let batch = create_all_types_batch(3, 0, 4);
+    let table = append_to_table(table, batch).await;
+
+    let batch = create_all_types_batch(3, 0, 7);
+    let table = append_to_table(table, batch).await;
 
     let metrics = get_scan_metrics(&table, &state, &[]).await?;
-    assert!(metrics.num_scanned_files() == 2);
+    assert!(metrics.num_scanned_files() == 3);
 
-    let e = col("id").gt(lit(5));
+    // (Column name, value from file 1, value from file 2, value from file 3, non existant value)
+    let tests = [
+        ("utf8", lit("1"), lit("5"), lit("8"), lit("3")),
+        (
+            "int64",
+            lit(1 as i64),
+            lit(5 as i64),
+            lit(8 as i64),
+            lit(3 as i64),
+        ),
+        (
+            "int32",
+            lit(1 as i32),
+            lit(5 as i32),
+            lit(8 as i32),
+            lit(3 as i32),
+        ),
+        (
+            "int16",
+            lit(1 as i16),
+            lit(5 as i16),
+            lit(8 as i16),
+            lit(3 as i16),
+        ),
+        (
+            "int8",
+            lit(1 as i8),
+            lit(5 as i8),
+            lit(8 as i8),
+            lit(3 as i8),
+        ),
+        (
+            "float64",
+            lit(1 as f64),
+            lit(5 as f64),
+            lit(8 as f64),
+            lit(3 as f64),
+        ),
+        (
+            "float32",
+            lit(1 as f32),
+            lit(5 as f32),
+            lit(8 as f32),
+            lit(3 as f32),
+        ),
+        // TODO: I think decimal statistics are being written to the log incorrectly. The underlying i128 is written
+        // not the proper string representation as specified by the percision and scale
+        (
+            "decimal",
+            lit(Decimal128(Some(100), 10, 2)),
+            lit(Decimal128(Some(500), 10, 2)),
+            lit(Decimal128(Some(800), 10, 2)),
+            lit(Decimal128(Some(300), 10, 2)),
+        ),
+        (
+            "timestamp",
+            lit(ScalarValue::TimestampMicrosecond(Some(1 * 1_000_000), None)),
+            lit(ScalarValue::TimestampMicrosecond(Some(5 * 1_000_000), None)),
+            lit(ScalarValue::TimestampMicrosecond(Some(8 * 1_000_000), None)),
+            lit(ScalarValue::TimestampMicrosecond(Some(3 * 1_000_000), None)),
+        ),
+        // TODO: The writer does not write complete statistiics for date columns
+        (
+            "date",
+            lit(ScalarValue::Date32(Some(1))),
+            lit(ScalarValue::Date32(Some(5))),
+            lit(ScalarValue::Date32(Some(8))),
+            lit(ScalarValue::Date32(Some(3))),
+        ),
+        // TODO: The writer does not write complete statistics for binary columns
+        (
+            "binary",
+            lit(to_binary("1")),
+            lit(to_binary("5")),
+            lit(to_binary("8")),
+            lit(to_binary("3")),
+        ),
+    ];
+
+    for test in &tests {
+        let test = test.to_owned();
+        //TODO: The following types either have proper stats written.
+        if test.0 == "decimal" || test.0 == "date" || test.0 == "binary" {
+            continue;
+        }
+        println!("Test Column: {}", test.0);
+
+        // Equality
+        let e = col(test.0).eq(test.1.clone());
+        let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+        assert_eq!(metrics.num_scanned_files(), 1);
+
+        // Value does not exist
+        let e = col(test.0).eq(test.4);
+        let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+        assert_eq!(metrics.num_scanned_files(), 0);
+
+        // Conjuction
+        let e = col(test.0).gt(test.1.clone()).and(col(test.0).lt(test.2));
+        let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+        assert_eq!(metrics.num_scanned_files(), 2);
+
+        // Disjunction
+        let e = col(test.0).lt(test.1).or(col(test.0).gt(test.3));
+        let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+        assert_eq!(metrics.num_scanned_files(), 2);
+    }
+
+    // Validate Boolean type
+    let batch = create_all_types_batch(1, 0, 0);
+    let (_tmp, table) = prepare_table(vec![batch], SaveMode::Overwrite, vec![]).await;
+    let batch = create_all_types_batch(1, 0, 1);
+    let table = append_to_table(table, batch).await;
+
+    let e = col("boolean").eq(lit(true));
     let metrics = get_scan_metrics(&table, &state, &[e]).await?;
-    assert!(metrics.num_scanned_files() == 1);
+    assert_eq!(metrics.num_scanned_files(), 1);
+
+    let e = col("boolean").eq(lit(false));
+    let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+    assert_eq!(metrics.num_scanned_files(), 1);
+
+    // Ensure that tables with stats and partition columns can be pruned
+    for test in tests {
+        //TODO: Float, timestamp, decimal, date, binary partitions are not supported by the writer
+        if test.0 == "float32"
+            || test.0 == "float64"
+            || test.0 == "timestamp"
+            || test.0 == "decimal"
+            || test.0 == "date"
+            || test.0 == "binary"
+        {
+            continue;
+        }
+
+        println!("test {}", test.0);
+
+        let partitions = vec![test.0.to_owned()];
+        let batch = create_all_types_batch(3, 0, 0);
+        let (_tmp, table) = prepare_table(vec![batch], SaveMode::Overwrite, partitions).await;
+
+        let batch = create_all_types_batch(3, 0, 4);
+        let table = append_to_table(table, batch).await;
+
+        let batch = create_all_types_batch(3, 0, 7);
+        let table = append_to_table(table, batch).await;
+
+        // Equality
+        let e = col(test.0).eq(test.1.clone());
+        let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+        assert_eq!(metrics.num_scanned_files(), 1);
+
+        // Value does not exist
+        let e = col(test.0).eq(test.4);
+        let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+        assert_eq!(metrics.num_scanned_files(), 0);
+
+        // Conjuction
+        let e = col(test.0).gt(test.1.clone()).and(col(test.0).lt(test.2));
+        let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+        assert_eq!(metrics.num_scanned_files(), 2);
+
+        // Disjunction
+        let e = col(test.0).lt(test.1).or(col(test.0).gt(test.3));
+        let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+        assert_eq!(metrics.num_scanned_files(), 2);
+
+        // Validate null pruning
+        let batch = create_all_types_batch(5, 2, 0);
+        let partitions = vec![test.0.to_owned()];
+        let (_tmp, table) = prepare_table(vec![batch], SaveMode::Overwrite, partitions).await;
+
+        let e = col(test.0).is_null();
+        let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+        assert_eq!(metrics.num_scanned_files(), 1);
+
+        /*  logically we should be able to prune the null partition but Datafusion's current implementation prevents this */
+        /*
+        let e = col(value.0).is_not_null();
+        let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+        if value.0 == "boolean" {
+            assert_eq!(metrics.num_scanned_files(), 2);
+        } else {
+            assert_eq!(metrics.num_scanned_files(), 5);
+        }
+        */
+    }
+
+    // Validate Boolean partition
+    let batch = create_all_types_batch(1, 0, 0);
+    let (_tmp, table) =
+        prepare_table(vec![batch], SaveMode::Overwrite, vec!["boolean".to_owned()]).await;
+    let batch = create_all_types_batch(1, 0, 1);
+    let table = append_to_table(table, batch).await;
+
+    let e = col("boolean").eq(lit(true));
+    let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+    assert_eq!(metrics.num_scanned_files(), 1);
+
+    let e = col("boolean").eq(lit(false));
+    let metrics = get_scan_metrics(&table, &state, &[e]).await?;
+    assert_eq!(metrics.num_scanned_files(), 1);
 
     // Ensure that tables without stats and partition columns can be pruned for just partitions
     let table = deltalake::open_table("./tests/data/delta-0.8.0-null-partition").await?;
 
     /*
-    // Logically this should prune... Might require an update on datafusion
+    // Logically this should prune. See above
     let e = col("k").eq(lit("A")).and(col("k").is_not_null());
     let metrics = get_scan_metrics(&table, &state, &[e]).await.unwrap();
     println!("{:?}", metrics);
@@ -359,25 +658,6 @@ async fn test_files_scanned() -> Result<()> {
     let e = col("k").is_not_null();
     let metrics = get_scan_metrics(&table, &state, &[e]).await?;
     assert!(metrics.num_scanned_files() == 2);
-
-    // Ensure that tables with stats and partition columns can be pruned
-    let table = deltalake::open_table("./tests/data/delta-2.2.0-partitioned-types").await?;
-
-    let e = col("c1").eq(lit(1));
-    let metrics = get_scan_metrics(&table, &state, &[e]).await?;
-    assert!(metrics.num_scanned_files() == 0);
-
-    let e = col("c1").eq(lit(4));
-    let metrics = get_scan_metrics(&table, &state, &[e]).await?;
-    assert!(metrics.num_scanned_files() == 1);
-
-    let e = col("c3").eq(lit(4));
-    let metrics = get_scan_metrics(&table, &state, &[e]).await?;
-    assert!(metrics.num_scanned_files() == 1);
-
-    let e = col("c3").eq(lit(0));
-    let metrics = get_scan_metrics(&table, &state, &[e]).await?;
-    assert!(metrics.num_scanned_files() == 0);
 
     Ok(())
 }

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -336,10 +336,7 @@ async fn test_files_scanned() -> Result<()> {
     assert!(metrics.num_scanned_files() == 1);
 
     // Ensure that tables without stats and partition columns can be pruned for just partitions
-    let table = deltalake::open_table(
-        "./tests/data/delta-0.8.0-null-partition",
-    )
-    .await?;
+    let table = deltalake::open_table("./tests/data/delta-0.8.0-null-partition").await?;
 
     /*
     // Logically this should prune... Might require an update on datafusion
@@ -364,10 +361,7 @@ async fn test_files_scanned() -> Result<()> {
     assert!(metrics.num_scanned_files() == 2);
 
     // Ensure that tables with stats and partition columns can be pruned
-    let table = deltalake::open_table(
-        "./tests/data/delta-2.2.0-partitioned-types",
-    )
-    .await?;
+    let table = deltalake::open_table("./tests/data/delta-2.2.0-partitioned-types").await?;
 
     let e = col("c1").eq(lit(1));
     let metrics = get_scan_metrics(&table, &state, &[e]).await?;

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -546,7 +546,13 @@ async fn test_files_scanned() -> Result<()> {
         // binary fails since arrow does not implement a natural order
         // The current Datafusion pruning implementation does not work for binary columns since they do not have a natural order. See #1214
         // Timestamp and date are disabled since the hive path contains illegal Windows values. see #1215
-        if column == "float32" || column == "float64" || column == "decimal" || column == "binary" || column == "timestamp" || column == "date" {
+        if column == "float32"
+            || column == "float64"
+            || column == "decimal"
+            || column == "binary"
+            || column == "timestamp"
+            || column == "date"
+        {
             continue;
         }
         println!("test {}", column);

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -545,7 +545,8 @@ async fn test_files_scanned() -> Result<()> {
         // TODO: Float and decimal partitions are not supported by the writer
         // binary fails since arrow does not implement a natural order
         // The current Datafusion pruning implementation does not work for binary columns since they do not have a natural order. See #1214
-        if column == "float32" || column == "float64" || column == "decimal" || column == "binary" {
+        // Timestamp and date are disabled since the hive path contains illegal Windows values. see #1215
+        if column == "float32" || column == "float64" || column == "decimal" || column == "binary" || column == "timestamp" || column == "date" {
             continue;
         }
         println!("test {}", column);

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -337,7 +337,7 @@ async fn test_files_scanned() -> Result<()> {
 
     // Ensure that tables without stats and partition columns can be pruned for just partitions
     let table = deltalake::open_table(
-        "file:///home/david/programming/delta-rs/rust/tests/data/delta-0.8.0-null-partition",
+        "./tests/data/delta-0.8.0-null-partition",
     )
     .await?;
 
@@ -365,7 +365,7 @@ async fn test_files_scanned() -> Result<()> {
 
     // Ensure that tables with stats and partition columns can be pruned
     let table = deltalake::open_table(
-        "file:///home/david/programming/delta-rs/rust/tests/data/delta-2.2.0-partitioned-types",
+        "./tests/data/delta-2.2.0-partitioned-types",
     )
     .await?;
 

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -485,7 +485,10 @@ async fn test_files_scanned() -> Result<()> {
             non_existent_value,
         } = test.to_owned();
         let column = column.to_owned();
-        //TODO: The following types don't have proper stats written.
+        // TODO: The following types don't have proper stats written.
+        // See issue #1208 for decimal type
+        // See issue #1209 for dates
+        // Min and Max is not calculated for binary columns. This matches the Spark writer
         if column == "decimal" || column == "date" || column == "binary" {
             continue;
         }
@@ -539,14 +542,10 @@ async fn test_files_scanned() -> Result<()> {
             file3_value,
             non_existent_value,
         } = test;
-        //TODO: Float, timestamp, decimal, date, binary partitions are not supported by the writer
-        if column == "float32"
-            || column == "float64"
-            || column == "timestamp"
-            || column == "decimal"
-            || column == "date"
-            || column == "binary"
-        {
+        // TODO: Float and decimal partitions are not supported by the writer
+        // binary fails since arrow does not implement a natural order
+        // The current Datafusion pruning implementation does not work for binary columns since they do not have a natural order. See #1214
+        if column == "float32" || column == "float64" || column == "decimal" || column == "binary" {
             continue;
         }
         println!("test {}", column);


### PR DESCRIPTION
# Description
Exposes partition columns in Datafusion's `PruningStatistics` which will reduce the number of files scanned when the table is queried.

This also resolves another partition issues where involving `null` partitions. Previously  `ScalarValue::Null` was used which would cause an error when the actual datatype was obtained from the physical parquet files.

# Related Issue(s)
- closes #1175


