### PR TITLE
chore: let dependabot ignore arrow and datafusion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # arrow and datafusion are bumped manually
+      - dependency-name: "arrow*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "datafusion*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
# Description
The description of the main changes of your pull request
Let dependabot ignore Arrow and DataFusion updates since we usually update them manually.
# Related Issue(s)
<!---
For example:

- closes #106
--->
Closes #1193.
# Documentation

<!---
Share links to useful documentation
--->
