### PR TITLE
feat: typed commit info

### DIFF
--- a/rust/src/action/mod.rs
+++ b/rust/src/action/mod.rs
@@ -768,7 +768,6 @@ mod tests {
         let info = serde_json::from_str::<CommitInfo>(raw);
         assert!(info.is_ok());
 
-
         // assert that commit info has no required filelds
         let raw = "{}";
         let info = serde_json::from_str::<CommitInfo>(raw);

--- a/rust/src/action/mod.rs
+++ b/rust/src/action/mod.rs
@@ -449,9 +449,6 @@ pub struct Protocol {
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CommitInfo {
-    /// Version number the commit corresponds to
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<DeltaDataTypeVersion>,
     /// Timestamp in millis when the commit was created
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<DeltaDataTypeTimestamp>,

--- a/rust/src/action/mod.rs
+++ b/rust/src/action/mod.rs
@@ -589,7 +589,7 @@ impl DeltaOperation {
         }
     }
 
-    /// Paraemters configured for operation.
+    /// Parameters configured for operation.
     pub fn operation_parameters(&self) -> DeltaResult<impl Iterator<Item = (String, Value)>> {
         // TODO remove unwrap
         let serialized = serde_json::to_value(self)
@@ -611,7 +611,7 @@ impl DeltaOperation {
                 }))
         } else {
             Err(ActionError::Generic(
-                "operation parameetrs serialized into unexpected shape".into(),
+                "Operation parameters serialized into unexpected shape".into(),
             )
             .into())
         }
@@ -619,7 +619,13 @@ impl DeltaOperation {
 
     /// Denotes if the operation changes the data contained in the table
     pub fn changes_data(&self) -> bool {
-        !matches!(self, Self::Optimize { .. })
+        match self {
+            Self::Optimize { .. } => false,
+            Self::Create { .. }
+            | Self::FileSystemCheck {}
+            | Self::StreamingUpdate { .. }
+            | Self::Write { .. } => true,
+        }
     }
 
     /// Retrieve basic commit information to be added to Delta commits
@@ -632,7 +638,7 @@ impl DeltaOperation {
         }
     }
 
-    /// Get predicate expression applien when the operation reads data from the table.
+    /// Get predicate expression applied when the operation reads data from the table.
     pub fn read_predicate(&self) -> Option<String> {
         match self {
             // TODO add more operations
@@ -762,7 +768,6 @@ mod tests {
         let info = serde_json::from_str::<CommitInfo>(raw);
         assert!(info.is_ok());
 
-        println!("{:?}", info);
 
         // assert that commit info has no required filelds
         let raw = "{}";

--- a/rust/src/action/mod.rs
+++ b/rust/src/action/mod.rs
@@ -8,7 +8,8 @@ mod parquet_read;
 #[cfg(feature = "parquet2")]
 pub mod parquet2_read;
 
-use crate::{schema::*, DeltaTableError, DeltaTableMetaData};
+use crate::delta_config::IsolationLevel;
+use crate::{schema::*, DeltaResult, DeltaTableError, DeltaTableMetaData};
 use percent_encoding::percent_decode;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -43,6 +44,13 @@ pub enum ActionError {
         /// Parquet error details returned when parsing the checkpoint parquet
         #[from]
         source: parquet::errors::ParquetError,
+    },
+    /// Faild to serialize operation
+    #[error("Failed to serialize operation: {source}")]
+    SerializeOperation {
+        #[from]
+        /// The source error
+        source: serde_json::Error,
     },
 }
 
@@ -435,7 +443,46 @@ pub struct Protocol {
     pub min_writer_version: DeltaDataTypeInt,
 }
 
-type CommitInfo = Map<String, Value>;
+/// The commitInfo is a fairly flexible action within the delta specification, where arbitrary data can be stored.
+/// However the reference implementation as well as delta-rs store useful information that may for instance
+/// allow us to be more permissive in commit conflict resolution.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitInfo {
+    /// Version number the commit corresponds to
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<DeltaDataTypeVersion>,
+    /// Timestamp in millis when the commit was created
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<DeltaDataTypeTimestamp>,
+    /// Id of the user invoking the commit
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    /// Name of the user invoking the commit
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_name: Option<String>,
+    /// The operation performed during the
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation: Option<String>,
+    /// Parameters used for table operation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation_parameters: Option<HashMap<String, serde_json::Value>>,
+    /// Version of the table when the operation was started
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_version: Option<i64>,
+    /// The isolation level of the commit
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub isolation_level: Option<IsolationLevel>,
+    /// TODO
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_blind_append: Option<bool>,
+    /// Delta engine which created the commit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub engine_info: Option<String>,
+    /// Additional provenance information for the commit
+    #[serde(flatten, default)]
+    pub info: Map<String, serde_json::Value>,
+}
 
 /// Represents an action in the Delta log. The Delta log is an aggregate of all actions performed
 /// on the table, so the full list of actions is required to properly read a table.
@@ -457,6 +504,16 @@ pub enum Action {
     protocol(Protocol),
     /// Describes commit provenance information for the table.
     commitInfo(CommitInfo),
+}
+
+impl Action {
+    /// Create a commit info from a map
+    pub fn commit_info(info: Map<String, serde_json::Value>) -> Self {
+        Self::commitInfo(CommitInfo {
+            info,
+            ..Default::default()
+        })
+    }
 }
 
 /// Operation performed when creating a new log entry with one or more actions.
@@ -517,45 +574,71 @@ pub enum DeltaOperation {
 }
 
 impl DeltaOperation {
-    /// Retrieve basic commit information to be added to Delta commits
-    pub fn get_commit_info(&self) -> Map<String, Value> {
-        let mut commit_info = Map::<String, Value>::new();
-        let operation = match &self {
-            DeltaOperation::Create { .. } => "delta-rs.Create",
-            DeltaOperation::Write { .. } => "delta-rs.Write",
-            DeltaOperation::StreamingUpdate { .. } => "delta-rs.StreamingUpdate",
-            DeltaOperation::Optimize { .. } => "delta-rs.Optimize",
-            DeltaOperation::FileSystemCheck { .. } => "delta-rs.FileSystemCheck",
-        };
-        commit_info.insert(
-            "operation".to_string(),
-            serde_json::Value::String(operation.into()),
-        );
+    /// A human readable name for the operation
+    pub fn name(&self) -> &str {
+        // operation names taken from https://learn.microsoft.com/en-us/azure/databricks/delta/history#--operation-metrics-keys
+        match &self {
+            DeltaOperation::Create { mode, .. } if matches!(mode, SaveMode::Overwrite) => {
+                "CREATE OR REPLACE TABLE"
+            }
+            DeltaOperation::Create { .. } => "CREATE TABLE",
+            DeltaOperation::Write { .. } => "WRITE",
+            DeltaOperation::StreamingUpdate { .. } => "STREAMING UPDATE",
+            DeltaOperation::Optimize { .. } => "OPTIMIZE",
+            DeltaOperation::FileSystemCheck { .. } => "FSCK",
+        }
+    }
 
-        if let Ok(serde_json::Value::Object(map)) = serde_json::to_value(self) {
-            let all_operation_fields = map.values().next().unwrap().as_object().unwrap();
-            let converted_operation_fields: Map<String, Value> = all_operation_fields
-                .iter()
+    /// Paraemters configured for operation.
+    pub fn operation_parameters(&self) -> DeltaResult<impl Iterator<Item = (String, Value)>> {
+        // TODO remove unwrap
+        let serialized = serde_json::to_value(self)
+            .map_err(|err| ActionError::SerializeOperation { source: err })?;
+        if let serde_json::Value::Object(map) = serialized {
+            let all_operation_fields = map.values().next().unwrap().as_object().unwrap().clone();
+            Ok(all_operation_fields
+                .into_iter()
                 .filter(|item| !item.1.is_null())
                 .map(|(k, v)| {
                     (
-                        k.clone(),
+                        k,
                         serde_json::Value::String(if v.is_string() {
                             String::from(v.as_str().unwrap())
                         } else {
                             v.to_string()
                         }),
                     )
-                })
-                .collect();
+                }))
+        } else {
+            Err(ActionError::Generic(
+                "operation parameetrs serialized into unexpected shape".into(),
+            )
+            .into())
+        }
+    }
 
-            commit_info.insert(
-                "operationParameters".to_string(),
-                serde_json::Value::Object(converted_operation_fields),
-            );
-        };
+    /// Denotes if the operation changes the data contained in the table
+    pub fn changes_data(&self) -> bool {
+        !matches!(self, Self::Optimize { .. })
+    }
 
-        commit_info
+    /// Retrieve basic commit information to be added to Delta commits
+    pub fn get_commit_info(&self) -> CommitInfo {
+        // TODO infer additional info from operation parameters ...
+        CommitInfo {
+            operation: Some(self.name().into()),
+            operation_parameters: self.operation_parameters().ok().map(|iter| iter.collect()),
+            ..Default::default()
+        }
+    }
+
+    /// Get predicate expression applien when the operation reads data from the table.
+    pub fn read_predicate(&self) -> Option<String> {
+        match self {
+            // TODO add more operations
+            Self::Write { predicate, .. } => predicate.clone(),
+            _ => None,
+        }
     }
 }
 
@@ -653,5 +736,66 @@ mod tests {
                 .unwrap(),
             1
         );
+    }
+
+    #[test]
+    fn test_read_commit_info() {
+        let raw = r#"
+        {
+            "timestamp": 1670892998177,
+            "operation": "WRITE",
+            "operationParameters": {
+                "mode": "Append",
+                "partitionBy": "[\"c1\",\"c2\"]"
+            },
+            "isolationLevel": "Serializable",
+            "isBlindAppend": true,
+            "operationMetrics": {
+                "numFiles": "3",
+                "numOutputRows": "3",
+                "numOutputBytes": "1356"
+            },
+            "engineInfo": "Apache-Spark/3.3.1 Delta-Lake/2.2.0",
+            "txnId": "046a258f-45e3-4657-b0bf-abfb0f76681c"
+        }"#;
+
+        let info = serde_json::from_str::<CommitInfo>(raw);
+        assert!(info.is_ok());
+
+        println!("{:?}", info);
+
+        // assert that commit info has no required filelds
+        let raw = "{}";
+        let info = serde_json::from_str::<CommitInfo>(raw);
+        assert!(info.is_ok());
+
+        // arbitrary field data may be added to commit
+        let raw = r#"
+        {
+            "timestamp": 1670892998177,
+            "operation": "WRITE",
+            "operationParameters": {
+                "mode": "Append",
+                "partitionBy": "[\"c1\",\"c2\"]"
+            },
+            "isolationLevel": "Serializable",
+            "isBlindAppend": true,
+            "operationMetrics": {
+                "numFiles": "3",
+                "numOutputRows": "3",
+                "numOutputBytes": "1356"
+            },
+            "engineInfo": "Apache-Spark/3.3.1 Delta-Lake/2.2.0",
+            "txnId": "046a258f-45e3-4657-b0bf-abfb0f76681c",
+            "additionalField": "more data",
+            "additionalStruct": {
+                "key": "value",
+                "otherKey": 123
+            }
+        }"#;
+
+        let info = serde_json::from_str::<CommitInfo>(raw).expect("should parse");
+        assert!(info.info.contains_key("additionalField"));
+        assert!(info.info.contains_key("additionalStruct"));
     }
 }

--- a/rust/src/action/parquet2_read/mod.rs
+++ b/rust/src/action/parquet2_read/mod.rs
@@ -223,7 +223,7 @@ impl ActionVariant for CommitInfo {
     type Variant = CommitInfo;
 
     fn default_action() -> Action {
-        Action::commitInfo(CommitInfo::new())
+        Action::commitInfo(CommitInfo::default())
     }
 
     fn try_mut_from_action(a: &mut Action) -> Result<&mut Self, ParseError> {

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -303,7 +303,7 @@ impl std::future::IntoFuture for CreateBuilder {
             let version = commit(
                 table.object_store().as_ref(),
                 0,
-                actions,
+                &actions,
                 operation,
                 metadata,
             )

--- a/rust/src/operations/filesystem_check.rs
+++ b/rust/src/operations/filesystem_check.rs
@@ -156,7 +156,7 @@ impl FileSystemCheckPlan {
         commit(
             store,
             version + 1,
-            actions,
+            &actions,
             DeltaOperation::FileSystemCheck {},
             None,
         )

--- a/rust/src/operations/optimize.rs
+++ b/rust/src/operations/optimize.rs
@@ -369,7 +369,7 @@ impl MergePlan {
             commit(
                 object_store.as_ref(),
                 self.read_table_version + 1,
-                actions,
+                &actions,
                 self.input_parameters.into(),
                 Some(metadata),
             )

--- a/rust/src/operations/transaction.rs
+++ b/rust/src/operations/transaction.rs
@@ -52,7 +52,9 @@ fn commit_uri_from_version(version: DeltaDataTypeVersion) -> Path {
 }
 
 // Convert actions to their json representation
-fn log_entry_from_actions(actions: &[Action]) -> Result<String, TransactionError> {
+fn log_entry_from_actions<'a>(
+    actions: impl IntoIterator<Item = &'a Action>,
+) -> Result<String, TransactionError> {
     let mut jsons = Vec::<String>::new();
     for action in actions {
         let json = serde_json::to_string(action)
@@ -64,7 +66,7 @@ fn log_entry_from_actions(actions: &[Action]) -> Result<String, TransactionError
 
 pub(crate) fn get_commit_bytes(
     operation: &DeltaOperation,
-    actions: &mut Vec<Action>,
+    actions: &Vec<Action>,
     app_metadata: Option<Map<String, Value>>,
 ) -> Result<bytes::Bytes, TransactionError> {
     if !actions.iter().any(|a| matches!(a, Action::commitInfo(..))) {
@@ -79,20 +81,23 @@ pub(crate) fn get_commit_bytes(
             extra_info.append(&mut meta)
         }
         commit_info.info = extra_info;
-        actions.push(Action::commitInfo(commit_info));
+        Ok(bytes::Bytes::from(log_entry_from_actions(
+            actions
+                .iter()
+                .chain(std::iter::once(&Action::commitInfo(commit_info))),
+        )?))
+    } else {
+        Ok(bytes::Bytes::from(log_entry_from_actions(actions)?))
     }
-
-    // Serialize all actions that are part of this log entry.
-    Ok(bytes::Bytes::from(log_entry_from_actions(actions)?))
 }
 
 /// Low-level transaction API. Creates a temporary commit file. Once created,
 /// the transaction object could be dropped and the actual commit could be executed
 /// with `DeltaTable.try_commit_transaction`.
-pub(crate) async fn prepare_commit(
+pub(crate) async fn prepare_commit<'a>(
     storage: &dyn ObjectStore,
     operation: &DeltaOperation,
-    actions: &mut Vec<Action>,
+    actions: &Vec<Action>,
     app_metadata: Option<Map<String, Value>>,
 ) -> Result<Path, TransactionError> {
     // Serialize all actions that are part of this log entry.
@@ -135,11 +140,11 @@ async fn try_commit_transaction(
 pub(crate) async fn commit(
     storage: &DeltaObjectStore,
     version: DeltaDataTypeVersion,
-    mut actions: Vec<Action>,
+    actions: &Vec<Action>,
     operation: DeltaOperation,
     app_metadata: Option<Map<String, Value>>,
 ) -> DeltaResult<DeltaDataTypeVersion> {
-    let tmp_commit = prepare_commit(storage, &operation, &mut actions, app_metadata).await?;
+    let tmp_commit = prepare_commit(storage, &operation, actions, app_metadata).await?;
     match try_commit_transaction(storage, &tmp_commit, version).await {
         Ok(version) => Ok(version),
         Err(TransactionError::VersionAlreadyExists(version)) => {
@@ -185,7 +190,7 @@ mod tests {
             .unwrap();
 
         // successfully write in clean location
-        commit(storage.as_ref(), 0, vec![], operation.clone(), None)
+        commit(storage.as_ref(), 0, &vec![], operation.clone(), None)
             .await
             .unwrap();
         let head = storage.head(&commit_path).await;
@@ -193,7 +198,7 @@ mod tests {
         assert_eq!(head.as_ref().unwrap().location, commit_path);
 
         // fail on overwriting
-        let failed_commit = commit(storage.as_ref(), 0, vec![], operation, None).await;
+        let failed_commit = commit(storage.as_ref(), 0, &vec![], operation, None).await;
         assert!(failed_commit.is_err());
         assert!(matches!(
             failed_commit.unwrap_err(),

--- a/rust/src/operations/write.rs
+++ b/rust/src/operations/write.rs
@@ -448,7 +448,7 @@ impl std::future::IntoFuture for WriteBuilder {
             let _version = commit(
                 &table.storage,
                 table.version() + 1,
-                actions,
+                &actions,
                 operation,
                 None,
             )

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -5,7 +5,7 @@ pub mod file;
 pub mod utils;
 
 use self::config::{ObjectStoreKind, StorageOptions};
-use crate::DeltaResult;
+use crate::{DeltaDataTypeVersion, DeltaResult};
 
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt};
@@ -35,6 +35,12 @@ pub use utils::*;
 
 lazy_static! {
     static ref DELTA_LOG_PATH: Path = Path::from("_delta_log");
+}
+
+/// Return the uri of commit version.
+pub(crate) fn commit_uri_from_version(version: DeltaDataTypeVersion) -> Path {
+    let version = format!("{version:020}.json");
+    DELTA_LOG_PATH.child(version.as_str())
 }
 
 /// Sharable reference to [`DeltaObjectStore`]

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -4,6 +4,7 @@ use crate::action::{self, Action, Add};
 use crate::delta_config::TableConfig;
 use crate::partitions::{DeltaTablePartition, PartitionFilter};
 use crate::schema::SchemaDataType;
+use crate::storage::commit_uri_from_version;
 use crate::Schema;
 use crate::{
     ApplyLogError, DeltaDataTypeLong, DeltaDataTypeVersion, DeltaTable, DeltaTableError,
@@ -13,7 +14,6 @@ use chrono::Utc;
 use lazy_static::lazy_static;
 use object_store::{path::Path, ObjectStore};
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryFrom;
@@ -34,7 +34,7 @@ pub struct DeltaTableState {
     // active files for table state
     files: Vec<action::Add>,
     // Information added to individual commits
-    commit_infos: Vec<Map<String, Value>>,
+    commit_infos: Vec<action::CommitInfo>,
     app_transaction_version: HashMap<String, DeltaDataTypeVersion>,
     min_reader_version: i32,
     min_writer_version: i32,
@@ -66,7 +66,7 @@ impl DeltaTableState {
         table: &DeltaTable,
         version: DeltaDataTypeVersion,
     ) -> Result<Self, ApplyLogError> {
-        let commit_uri = table.commit_uri_from_version(version);
+        let commit_uri = commit_uri_from_version(version);
         let commit_log_bytes = table.storage.get(&commit_uri).await?.bytes().await?;
         let reader = BufReader::new(Cursor::new(commit_log_bytes));
 
@@ -164,7 +164,7 @@ impl DeltaTableState {
     }
 
     /// List of commit info maps.
-    pub fn commit_infos(&self) -> &Vec<Map<String, Value>> {
+    pub fn commit_infos(&self) -> &Vec<action::CommitInfo> {
         &self.commit_infos
     }
 

--- a/rust/tests/command_optimize.rs
+++ b/rust/tests/command_optimize.rs
@@ -507,16 +507,14 @@ async fn test_commit_info() -> Result<(), Box<dyn Error>> {
     let last_commit = &commit_info[commit_info.len() - 1];
 
     let commit_metrics =
-        serde_json::from_value::<Metrics>(last_commit["operationMetrics"].clone())?;
+        serde_json::from_value::<Metrics>(last_commit.info["operationMetrics"].clone())?;
 
     assert_eq!(commit_metrics, metrics);
-    assert_eq!(last_commit["readVersion"], json!(version));
-    assert_eq!(
-        last_commit["operationParameters"]["targetSize"],
-        json!("2000000")
-    );
+    assert_eq!(last_commit.read_version, Some(version));
+    let parameters = last_commit.operation_parameters.clone().unwrap();
+    assert_eq!(parameters["targetSize"], json!("2000000"));
     // TODO: Requires a string representation for PartitionFilter
-    assert_eq!(last_commit["operationParameters"]["predicate"], Value::Null);
+    // assert_eq!(parameters["predicate"], None);
 
     Ok(())
 }

--- a/rust/tests/commit_info_format.rs
+++ b/rust/tests/commit_info_format.rs
@@ -2,8 +2,7 @@
 mod fs_common;
 
 use deltalake::action::{Action, DeltaOperation, SaveMode};
-
-use serde_json::{json, Value};
+use serde_json::json;
 use std::error::Error;
 use tempdir::TempDir;
 
@@ -27,15 +26,10 @@ async fn test_operational_parameters() -> Result<(), Box<dyn Error>> {
 
     let commit_info = table.history(None).await?;
     let last_commit = &commit_info[commit_info.len() - 1];
-
-    assert_eq!(last_commit["operationParameters"]["mode"], json!("Append"));
-
-    assert_eq!(
-        last_commit["operationParameters"]["partitionBy"],
-        json!("[\"some_partition\"]")
-    );
-
-    assert_eq!(last_commit["operationParameters"]["predicate"], Value::Null);
+    let parameters = last_commit.operation_parameters.clone().unwrap();
+    assert_eq!(parameters["mode"], json!("Append"));
+    assert_eq!(parameters["partitionBy"], json!("[\"some_partition\"]"));
+    // assert_eq!(parameters["predicate"], None);
 
     Ok(())
 }


### PR DESCRIPTION
# Description

Another PR on the road to #632 - ~~keeping it a draft, as it is based on #1206~~

While the `commitInfo` action is defined as completely optional, spark and delta-rs write at the very least interesting, but often also quite helpful information into the commit info. To make it easier to work with and centralize some conventions, we introduce a `CommitInfo` struct, that exposes some of the fields at the top level. Additionally we harmonize a bit between spark and delta-rs conventions.

# Related Issue(s)

part of #632 

# Documentation

<!---
Share links to useful documentation
--->
