### PR TITLE
Unique delta object store url

### DIFF
--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -93,7 +93,7 @@ impl DeltaObjectStore {
         let root_store =
             ObjectStoreKind::parse_url(&location)?.into_impl(location.as_ref(), options.clone())?;
         let storage = if prefix != Path::from("/") {
-            root_store.into_prefix(prefix.clone())
+            root_store.into_prefix(prefix)
         } else {
             root_store.into_store()
         };

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -347,14 +347,14 @@ mod tests {
         let location_1 = Url::from_file_path(tmp_dir_1.path()).unwrap();
         let store_1 = DeltaObjectStore::new(
             Arc::from(LocalFileSystem::new_with_prefix(tmp_dir_1.path()).unwrap()),
-            location_1.clone(),
+            location_1,
         );
 
         let tmp_dir_2 = TempDir::new("table_2").unwrap();
         let location_2 = Url::from_file_path(tmp_dir_2.path()).unwrap();
         let store_2 = DeltaObjectStore::new(
             Arc::from(LocalFileSystem::new_with_prefix(tmp_dir_2.path()).unwrap()),
-            location_2.clone(),
+            location_2,
         );
 
         assert_ne!(

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -59,8 +59,6 @@ pub struct DeltaObjectStore {
     storage: Arc<dyn ObjectStore>,
     location: Url,
     options: StorageOptions,
-    #[allow(unused)]
-    prefix: Path,
 }
 
 impl std::fmt::Display for DeltaObjectStore {
@@ -77,11 +75,9 @@ impl DeltaObjectStore {
     /// * `storage` - A shared reference to an [`ObjectStore`](object_store::ObjectStore) with "/" pointing at delta table root (i.e. where `_delta_log` is located).
     /// * `location` - A url corresponding to the storage location of `storage`.
     pub fn new(storage: Arc<DynObjectStore>, location: Url) -> Self {
-        let prefix = Path::from(location.path());
         Self {
             storage,
             location,
-            prefix,
             options: HashMap::new().into(),
         }
     }
@@ -104,7 +100,6 @@ impl DeltaObjectStore {
         Ok(Self {
             storage,
             location,
-            prefix,
             options: options.into(),
         })
     }
@@ -133,7 +128,7 @@ impl DeltaObjectStore {
             "delta-rs://{}",
             // NOTE We need to also replace colons, but its fine, since it just needs
             // to be a unique-ish identifier for the object store in datafusion
-            self.prefix
+            Path::from(self.location.path())
                 .as_ref()
                 .replace(DELIMITER, "-")
                 .replace(':', "-")

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -125,7 +125,7 @@ impl DeltaObjectStore {
     /// registering/fetching. In our case the scheme is hard-coded to "delta-rs", so to get a unique
     /// host we convert the location from this `DeltaObjectStore` to a valid name, combining the
     /// original scheme, host and path with invalid characters replaced.
-    pub(crate) fn object_store_url(&self) -> ObjectStoreUrl {
+    pub fn object_store_url(&self) -> ObjectStoreUrl {
         // we are certain, that the URL can be parsed, since
         // we make sure when we are parsing the table uri
         ObjectStoreUrl::parse(format!(

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -355,7 +355,7 @@ mod tests {
             // Different scheme/host, same path
             ("s3://my_bucket/path/to/table_1", "file:///path/to/table_1"),
             // Same scheme, different host, same path
-            ("s3://bucket_1/table_1", "s3://bucket_2/table_2"),
+            ("s3://bucket_1/table_1", "s3://bucket_2/table_1"),
         ] {
             let url_1 = Url::parse(location_1).unwrap();
             let url_2 = Url::parse(location_2).unwrap();


### PR DESCRIPTION
# Description
Make the object store url be unique for stores created via `DeltaObjectStore::new`, by generating it from the location instead of the prefix (which was previously hard-coded to `/`), in the same manner as for `try_new`.

Also, in the (unlikely) case that I'm not mistaken about `DeltaScan::execute` logic being redundant (see #1188 for more details), I've removed it and added a couple of tests.

# Related Issue(s)
Closes #1188 

# Documentation

