### PR TITLE
improve err msg on use of non-partitioned column

### DIFF
--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -385,8 +385,7 @@ def test_get_files_partitioned_table():
         dt.files(partition_filters)
     assert (
         str(exception.value)
-        == 'Tried to filter partitions on column "unknown", but that column'
-        " is not partitioned."
+        == 'Tried to filter partitions on non-partitioned columns: [\n    "unknown",\n]'
     )
 
 

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -385,8 +385,8 @@ def test_get_files_partitioned_table():
         dt.files(partition_filters)
     assert (
         str(exception.value)
-        == 'Invalid partition filter found: [PartitionFilter { key: "unknown", value:'
-        ' Equal("3") }].'
+        == 'Tried to filter partitions on column "unknown", but that column'
+        ' is not partitioned.'
     )
 
 

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -386,7 +386,7 @@ def test_get_files_partitioned_table():
     assert (
         str(exception.value)
         == 'Tried to filter partitions on column "unknown", but that column'
-        ' is not partitioned.'
+        " is not partitioned."
     )
 
 

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -203,6 +203,13 @@ pub enum DeltaTableError {
         /// The invalid partition filter used.
         partition_filter: String,
     },
+    /// Error returned when a partition filter uses a non-partitioned column
+    /// column.
+    #[error("Tried to filter partitions on column '{}', but that isn't one of the partition columns.", .column)]
+    ColumnNotPartitioned {
+        /// The column used in the partition filter that is not partitioned
+        column: String,
+    },
     /// Error returned when a line from log record is invalid.
     #[error("Failed to read line from log record")]
     Io {

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -205,7 +205,7 @@ pub enum DeltaTableError {
     },
     /// Error returned when a partition filter uses a non-partitioned column
     /// column.
-    #[error("Tried to filter partitions on column '{}', but that isn't one of the partition columns.", .column)]
+    #[error("Tried to filter partitions on column {}, but that column is not partitioned.", .column)]
     ColumnNotPartitioned {
         /// The column used in the partition filter that is not partitioned
         column: String,

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -205,10 +205,10 @@ pub enum DeltaTableError {
     },
     /// Error returned when a partition filter uses a non-partitioned column
     /// column.
-    #[error("Tried to filter partitions on column {}, but that column is not partitioned.", .column)]
-    ColumnNotPartitioned {
-        /// The column used in the partition filter that is not partitioned
-        column: String,
+    #[error("Tried to filter partitions on non-partitioned columns: {:#?}", .nonpartitioned_columns)]
+    ColumnsNotPartitioned {
+        /// The columns used in the partition filter that is not partitioned
+        nonpartitioned_columns: Vec<String>,
     },
     /// Error returned when a line from log record is invalid.
     #[error("Failed to read line from log record")]

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -203,8 +203,7 @@ pub enum DeltaTableError {
         /// The invalid partition filter used.
         partition_filter: String,
     },
-    /// Error returned when a partition filter uses a non-partitioned column
-    /// column.
+    /// Error returned when a partition filter uses a nonpartitioned column.
     #[error("Tried to filter partitions on non-partitioned columns: {:#?}", .nonpartitioned_columns)]
     ColumnsNotPartitioned {
         /// The columns used in the partition filter that is not partitioned

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -368,14 +368,14 @@ impl DeltaTableState {
         filters: &'a [PartitionFilter<'a, &'a str>],
     ) -> Result<impl Iterator<Item = &'a Add> + '_, DeltaTableError> {
         let current_metadata = self.current_metadata().ok_or(DeltaTableError::NoMetadata)?;
-        if !filters
-            .iter()
-            .all(|f| current_metadata.partition_columns.contains(&f.key.into()))
-        {
-            return Err(DeltaTableError::InvalidPartitionFilter {
-                partition_filter: format!("{filters:?}"),
-            });
-        }
+
+        for f in filters {
+            if !current_metadata.partition_columns.contains(&f.key.into()) {
+                return Err(DeltaTableError::ColumnNotPartitioned {
+                    column: f.key.to_string()
+                })
+            }
+        };
 
         let partition_col_data_types: HashMap<&str, &SchemaDataType> = current_metadata
             .get_partition_col_data_types()

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -371,8 +371,9 @@ impl DeltaTableState {
 
         for f in filters {
             if !current_metadata.partition_columns.contains(&f.key.into()) {
+                let column = f.key.to_string();
                 return Err(DeltaTableError::ColumnNotPartitioned {
-                    column: f.key.to_string(),
+                    column: format!("{column:?}"),
                 });
             }
         }

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -372,10 +372,10 @@ impl DeltaTableState {
         for f in filters {
             if !current_metadata.partition_columns.contains(&f.key.into()) {
                 return Err(DeltaTableError::ColumnNotPartitioned {
-                    column: f.key.to_string()
-                })
+                    column: f.key.to_string(),
+                });
             }
-        };
+        }
 
         let partition_col_data_types: HashMap<&str, &SchemaDataType> = current_metadata
             .get_partition_col_data_types()


### PR DESCRIPTION
# Description
Updates the error message when trying to use a partition filter with a column that is not partitioned. 

Code to trigger the error (adapted from #1219):
```python
from datetime import date

import numpy as np
import numpy.random
import pandas as pd
from deltalake import DeltaTable, write_deltalake

nrows = 9
data = pd.DataFrame(
    {
        "year": np.repeat(2023, nrows),
        "month": np.repeat([1, 2, 3], nrows / 3),
        "values": numpy.random.normal(size=nrows),
    }
)
table_path = "tables/monthly"
write_deltalake(
    table_path,
    data,
    partition_by=["year", "month"],
    mode="overwrite",
)

nrows = 4
new_data = pd.DataFrame(
    {
        "year": np.repeat(2023, nrows),
        "month": np.repeat([4], nrows),
        "values": numpy.random.normal(size=nrows) + 10,
    }
)

write_deltalake(
    table_path,
    new_data,
    mode="overwrite",
    partition_filters=[("values", "=", "1")],
)
DeltaTable(table_path).to_pandas()
```

# Related Issue(s)
closes #1218 

# Documentation

<!---
Share links to useful documentation
--->
