### PR TITLE
fix: make sure we handle data checking correctly

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -31,6 +31,8 @@ write_new_deltalake: Callable[
     None,
 ]
 
+def batch_distinct(batch: pa.RecordBatch) -> pa.RecordBatch: ...
+
 # Can't implement inheritance (see note in src/schema.rs), so this is next
 # best thing.
 DataType = Union["PrimitiveType", "MapType", "StructType", "ArrayType"]

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -240,7 +240,7 @@ def write_deltalake(
                     for value in batch.column(column_index).unique():
                         partition = (
                             column_name,
-                            json.dumps(value.as_py(), cls=DeltaJSONEncoder),
+                            __encode_partition_value(value.as_py()),
                         )
                         if (
                             partition not in allowed_partitions
@@ -466,3 +466,21 @@ def get_file_stats_from_metadata(
                     maximum for maximum in maximums if maximum is not None
                 )
     return stats
+
+
+def __encode_partition_value(val: Any) -> str:
+    # Rules based on: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#partition-value-serialization
+    if isinstance(val, str):
+        return val
+    elif isinstance(val, (int, float)):
+        return str(val)
+    elif isinstance(val, bool):
+        return str(val).lower()
+    elif isinstance(val, date):
+        return val.isoformat()
+    elif isinstance(val, datetime):
+        return val.isoformat(sep=" ")
+    elif isinstance(val, bytes):
+        return val.decode("unicode_escape", "backslashreplace")
+    else:
+        raise ValueError(f"Could not encode partition value for type: {val}")

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -9,10 +9,12 @@ use chrono::{DateTime, Duration, FixedOffset, Utc};
 use deltalake::action::{
     self, Action, ColumnCountStat, ColumnValueStat, DeltaOperation, SaveMode, Stats,
 };
+use deltalake::arrow::compute::concat_batches;
 use deltalake::arrow::record_batch::RecordBatch;
 use deltalake::arrow::{self, datatypes::Schema as ArrowSchema};
 use deltalake::builder::DeltaTableBuilder;
 use deltalake::checkpoints::create_checkpoint;
+use deltalake::datafusion::prelude::SessionContext;
 use deltalake::delta_datafusion::DeltaDataChecker;
 use deltalake::operations::vacuum::VacuumBuilder;
 use deltalake::partitions::PartitionFilter;
@@ -24,6 +26,7 @@ use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::PyFrozenSet;
 use pyo3::types::PyType;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -39,6 +42,10 @@ create_exception!(deltalake, PyDeltaTableError, PyException);
 
 impl PyDeltaTableError {
     fn from_arrow(err: arrow::error::ArrowError) -> pyo3::PyErr {
+        PyDeltaTableError::new_err(err.to_string())
+    }
+
+    fn from_datafusion(err: deltalake::datafusion::error::DataFusionError) -> pyo3::PyErr {
         PyDeltaTableError::new_err(err.to_string())
     }
 
@@ -364,10 +371,11 @@ impl RawDeltaTable {
             .collect()
     }
 
-    fn get_active_partitions(
+    fn get_active_partitions<'py>(
         &self,
         partitions_filters: Option<Vec<(&str, &str, PartitionFilterValue)>>,
-    ) -> PyResult<HashSet<(String, Option<String>)>> {
+        py: Python<'py>,
+    ) -> PyResult<&'py PyFrozenSet> {
         let column_names: HashSet<&str> = self
             ._table
             .schema()
@@ -415,20 +423,26 @@ impl RawDeltaTable {
         let converted_filters = convert_partition_filters(partitions_filters.unwrap_or_default())
             .map_err(PyDeltaTableError::from_raw)?;
 
-        let add_actions = self
+        let partition_columns: Vec<&str> = partition_columns.into_iter().collect();
+
+        let active_partitions: HashSet<Vec<(&str, Option<&str>)>> = self
             ._table
             .get_state()
             .get_active_add_actions_by_partitions(&converted_filters)
-            .map_err(PyDeltaTableError::from_raw)?;
-        let active_partitions = add_actions
-            .flat_map(|add| {
-                add.partition_values
+            .map_err(PyDeltaTableError::from_raw)?
+            .map(|add| {
+                partition_columns
                     .iter()
-                    .map(|i| (i.0.to_owned(), i.1.to_owned()))
-                    .collect::<Vec<_>>()
+                    .map(|col| (*col, add.partition_values.get(*col).unwrap().as_deref()))
+                    .collect()
             })
-            .collect::<HashSet<_>>();
-        Ok(active_partitions)
+            .collect();
+
+        let active_partitions: Vec<&'py PyFrozenSet> = active_partitions
+            .into_iter()
+            .map(|part| PyFrozenSet::new(py, part.iter()))
+            .collect::<Result<_, PyErr>>()?;
+        PyFrozenSet::new(py, active_partitions.into_iter())
     }
 
     fn create_write_transaction(
@@ -668,6 +682,21 @@ fn rust_core_version() -> &'static str {
     deltalake::crate_version()
 }
 
+#[pyfunction]
+fn batch_distinct(batch: PyArrowType<RecordBatch>) -> PyResult<PyArrowType<RecordBatch>> {
+    let ctx = SessionContext::new();
+    let schema = batch.0.schema();
+    ctx.register_batch("batch", batch.0)
+        .map_err(PyDeltaTableError::from_datafusion)?;
+    let batches = rt()?
+        .block_on(async { ctx.table("batch").await?.distinct()?.collect().await })
+        .map_err(PyDeltaTableError::from_datafusion)?;
+
+    Ok(PyArrowType(
+        concat_batches(&schema, &batches).map_err(PyDeltaTableError::from_arrow)?,
+    ))
+}
+
 fn save_mode_from_str(value: &str) -> PyResult<SaveMode> {
     match value {
         "append" => Ok(SaveMode::Append),
@@ -796,6 +825,7 @@ fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
 
     m.add_function(pyo3::wrap_pyfunction!(rust_core_version, m)?)?;
     m.add_function(pyo3::wrap_pyfunction!(write_new_deltalake, m)?)?;
+    m.add_function(pyo3::wrap_pyfunction!(batch_distinct, m)?)?;
     m.add_class::<RawDeltaTable>()?;
     m.add_class::<RawDeltaTableMetaData>()?;
     m.add_class::<PyDeltaDataChecker>()?;

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -782,7 +782,7 @@ def test_partition_overwrite_with_wrong_partition(
     with pytest.raises(
         ValueError,
         match="Data should be aligned with partitioning. "
-        "Data contained values for partition {'p1': '1', 'p2': '2'}",
+        "Data contained values for partition p1=1 p2=2",
     ):
         write_deltalake(
             tmp_path,


### PR DESCRIPTION
# Description

This PR fixes a few issues with the overwrite partition functionality:

 1. We weren't handling serializing the partition values correctly when matching partitions, so we would get false positives when checking for incorrect data being written.
 2. We were considering partition values independently, rather than as a tuple of values. This could lead to subtle issues when there are multiple partition columns.
 3. The errors returned when our partition filters used incorrect column names were confusing.

Since this is an important new feature, I will cut a new bugfix release as soon as this is merged.

# Related Issue(s)

For example:

- closes #1220
- closes #1219

# Documentation

<!---
Share links to useful documentation
--->
