### PR TITLE
Add Max Partitions Arg to Write

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -77,6 +77,7 @@ def write_deltalake(
     filesystem: Optional[pa_fs.FileSystem] = None,
     mode: Literal["error", "append", "overwrite", "ignore"] = "error",
     file_options: Optional[ds.ParquetFileWriteOptions] = None,
+    max_partitions: Optional[int] = None,
     max_open_files: int = 1024,
     max_rows_per_file: int = 10 * 1024 * 1024,
     min_rows_per_group: int = 64 * 1024,
@@ -87,7 +88,6 @@ def write_deltalake(
     overwrite_schema: bool = False,
     storage_options: Optional[Dict[str, str]] = None,
     partition_filters: Optional[List[Tuple[str, str, Any]]] = None,
-    max_partitions: Optional[int] = None,
 ) -> None:
     """Write to a Delta Lake table
 
@@ -115,6 +115,7 @@ def write_deltalake(
         Can be provided with defaults using ParquetFileWriteOptions().make_write_options().
         Please refer to https://github.com/apache/arrow/blob/master/python/pyarrow/_dataset_parquet.pyx#L492-L533
         for the list of available options
+    :param max_partitions: the maximum number of partitions that will be used.
     :param max_open_files: Limits the maximum number of
         files that can be left open while writing. If an attempt is made to open
         too many files then the least recently used file will be closed.
@@ -136,7 +137,6 @@ def write_deltalake(
     :param overwrite_schema: If True, allows updating the schema of the table.
     :param storage_options: options passed to the native delta filesystem. Unused if 'filesystem' is defined.
     :param partition_filters: the partition filters that will be used for partition overwrite.
-    :param max_partitions: the maximum number of partitions that will be used
     """
     if _has_pandas and isinstance(data, pd.DataFrame):
         if schema is not None:

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -87,6 +87,7 @@ def write_deltalake(
     overwrite_schema: bool = False,
     storage_options: Optional[Dict[str, str]] = None,
     partition_filters: Optional[List[Tuple[str, str, Any]]] = None,
+    max_partitions: Optional[int] = None,
 ) -> None:
     """Write to a Delta Lake table
 
@@ -135,6 +136,7 @@ def write_deltalake(
     :param overwrite_schema: If True, allows updating the schema of the table.
     :param storage_options: options passed to the native delta filesystem. Unused if 'filesystem' is defined.
     :param partition_filters: the partition filters that will be used for partition overwrite.
+    :param max_partitions: the maximum number of partitions that will be used
     """
     if _has_pandas and isinstance(data, pd.DataFrame):
         if schema is not None:
@@ -306,6 +308,7 @@ def write_deltalake(
         min_rows_per_group=min_rows_per_group,
         max_rows_per_group=max_rows_per_group,
         filesystem=filesystem,
+        max_partitions=max_partitions,
     )
 
     if table is None:

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -801,10 +801,14 @@ def test_handles_binary_data(tmp_path: pathlib.Path):
     out = dt.to_pyarrow_table()
     assert table == out
 
+
 def test_max_partitions_exceeding_fragment_should_fail(
     tmp_path: pathlib.Path, sample_data_for_partitioning: pa.Table
 ):
-    with pytest.raises(ValueError, match=r"Fragment would be written into \d+ partitions\. This exceeds the maximum of \d+"):
+    with pytest.raises(
+        ValueError,
+        match=r"Fragment would be written into \d+ partitions\. This exceeds the maximum of \d+",
+    ):
         write_deltalake(
             tmp_path,
             sample_data_for_partitioning,

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -800,3 +800,15 @@ def test_handles_binary_data(tmp_path: pathlib.Path):
     dt = DeltaTable(tmp_path)
     out = dt.to_pyarrow_table()
     assert table == out
+
+def test_max_partitions_exceeding_fragment_should_fail(
+    tmp_path: pathlib.Path, sample_data_for_partitioning: pa.Table
+):
+    with pytest.raises(ValueError, match=r"Fragment would be written into \d+ partitions\. This exceeds the maximum of \d+"):
+        write_deltalake(
+            tmp_path,
+            sample_data_for_partitioning,
+            mode="overwrite",
+            max_partitions=1,
+            partition_by=["p1", "p2"],
+        )


### PR DESCRIPTION
# Description

Add optional max partitions arg to be passed to pyArrow dataset.write_dataset.

# Related Issue(s)
This resolves an issue where users are unable to write more than 1024 partitions and have no way of overriding the parameter

```
  File "/lib/python3.8/site-packages/deltalake/writer.py", line 293, in write_deltalake
    ds.write_dataset(
  File "/lib/python3.8/site-packages/pyarrow/dataset.py", line 900, in write_dataset
    _filesystemdataset_write(
  File "pyarrow/_dataset.pyx", line 2479, in pyarrow._dataset._filesystemdataset_write
  File "pyarrow/error.pxi", line 99, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: Fragment would be written into 1246 partitions. This exceeds the maximum of 1024
```

# Documentation

https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html
