### PR TITLE
feat: add package version

### DIFF
--- a/python/deltalake/__init__.py
+++ b/python/deltalake/__init__.py
@@ -1,4 +1,4 @@
-from ._internal import PyDeltaTableError, RawDeltaTable, rust_core_version
+from ._internal import PyDeltaTableError, RawDeltaTable, __version__, rust_core_version
 from .data_catalog import DataCatalog
 from .schema import DataType, Field, Schema
 from .table import DeltaTable, Metadata

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -11,6 +11,8 @@ import pyarrow.fs as fs
 
 from deltalake.writer import AddAction
 
+__version__: str
+
 RawDeltaTable: Any
 rust_core_version: Callable[[], str]
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -822,7 +822,7 @@ impl PyDeltaDataChecker {
 // module name need to match project name
 fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
-
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_function(pyo3::wrap_pyfunction!(rust_core_version, m)?)?;
     m.add_function(pyo3::wrap_pyfunction!(write_new_deltalake, m)?)?;
     m.add_function(pyo3::wrap_pyfunction!(batch_distinct, m)?)?;


### PR DESCRIPTION
# Description

Low maintenance way to expose package version. It will come from the `cargo.toml`.

Note that we have a separate function already called `rust_core_version` that provides the version of the `deltalake` Rust crate. That currently matches the Python library, but I don't think we provide any guarantee it will continue to.

# Related Issue(s)

For example:

- closes #1227 


# Documentation

<!---
Share links to useful documentation
--->
