### PR TITLE
fix: use native-tls for python deltalake releases

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -8,6 +8,11 @@ defaults:
   run:
     working-directory: ./python
 
+env:
+  # For ease of development, we make rustls default. But for release we should
+  # use native TLS.
+  FEATURES_FLAG: --no-default-features --features native-tls
+
 jobs:
   validate-release-tag:
     name: Validate git tag
@@ -41,7 +46,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           command: publish
-          args: -m python/Cargo.toml --no-sdist
+          args: -m python/Cargo.toml --no-sdist $FEATURES_FLAG
 
   release-pypi-mac-universal2:
     needs: validate-release-tag
@@ -57,7 +62,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           command: publish
-          args: -m python/Cargo.toml --no-sdist --universal2
+          args: -m python/Cargo.toml --no-sdist --universal2 $FEATURES_FLAG
 
   release-pypi-windows:
     needs: validate-release-tag
@@ -73,7 +78,7 @@ jobs:
         with:
           target: x86_64-pc-windows-msvc
           command: publish
-          args: -m python/Cargo.toml --no-sdist
+          args: -m python/Cargo.toml --no-sdist $FEATURES_FLAG
 
   release-pypi-manylinux:
     needs: validate-release-tag
@@ -89,7 +94,7 @@ jobs:
         with:
           target: x86_64-unknown-linux-gnu
           command: publish
-          args: -m python/Cargo.toml
+          args: -m python/Cargo.toml $FEATURES_FLAG
 
       - name: Publish manylinux to pypi aarch64 (without sdist)
         uses: messense/maturin-action@v1
@@ -98,7 +103,7 @@ jobs:
         with:
           target: aarch64-unknown-linux-gnu
           command: publish
-          args: -m python/Cargo.toml --no-sdist
+          args: -m python/Cargo.toml --no-sdist $FEATURES_FLAG
 
   release-docs:
     needs:


### PR DESCRIPTION
# Description

We changed default to make our workspace harmonious, but didn't mean to change this for the Python release.

# Related Issue(s)

- closes #1224


# Documentation

<!---
Share links to useful documentation
--->
