### PR TITLE
feat: write command improvements

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,12 +13,18 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-arrow = { version = "37.0.0", optional = true }
+arrow = { version = "37", optional = true }
+arrow-array = { version = "37", optional = true }
+arrow-cast = { version = "37", optional = true }
+arrow-schema = { version = "37", optional = true }
 async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
 cfg-if = "1"
-datafusion-objectstore-hdfs = { version = "0.1.3", default-features = false, features = ["hdfs3", "try_spawn_blocking"], optional = true }
+datafusion-objectstore-hdfs = { version = "0.1.3", default-features = false, features = [
+    "hdfs3",
+    "try_spawn_blocking",
+], optional = true }
 errno = "0.3"
 futures = "0.3"
 itertools = "0.10"
@@ -91,6 +97,7 @@ glibc_version = { path = "../glibc_version", version = "0.1" }
 
 [features]
 azure = ["object_store/azure"]
+arrow = ["dep:arrow", "arrow-array", "arrow-cast", "arrow-schema"]
 default = ["arrow", "parquet"]
 datafusion = [
     "dep:datafusion",

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -28,9 +28,7 @@ use std::sync::Arc;
 
 use arrow::array::ArrayRef;
 use arrow::compute::{cast_with_options, CastOptions};
-use arrow::datatypes::{
-    DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef, TimeUnit,
-};
+use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, SchemaRef, TimeUnit};
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
@@ -376,21 +374,6 @@ impl TableProvider for DeltaTable {
             .state
             .physical_arrow_schema(self.object_store())
             .await?;
-
-        let schema = Arc::new(ArrowSchema::new(
-            schema
-                .fields()
-                .iter()
-                .map(|field| match field.data_type() {
-                    ArrowDataType::Timestamp(TimeUnit::Microsecond, tz) => ArrowField::new(
-                        field.name().clone(),
-                        ArrowDataType::Timestamp(TimeUnit::Nanosecond, tz.clone()),
-                        field.is_nullable(),
-                    ),
-                    _ => field.clone(),
-                })
-                .collect(),
-        ));
 
         register_store(self, session.runtime_env().clone());
 

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -28,7 +28,9 @@ use std::sync::Arc;
 
 use arrow::array::ArrayRef;
 use arrow::compute::{cast_with_options, CastOptions};
-use arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, SchemaRef, TimeUnit};
+use arrow::datatypes::{
+    DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef, TimeUnit,
+};
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
@@ -374,6 +376,21 @@ impl TableProvider for DeltaTable {
             .state
             .physical_arrow_schema(self.object_store())
             .await?;
+
+        let schema = Arc::new(ArrowSchema::new(
+            schema
+                .fields()
+                .iter()
+                .map(|field| match field.data_type() {
+                    ArrowDataType::Timestamp(TimeUnit::Microsecond, tz) => ArrowField::new(
+                        field.name().clone(),
+                        ArrowDataType::Timestamp(TimeUnit::Nanosecond, tz.clone()),
+                        field.is_nullable(),
+                    ),
+                    _ => field.clone(),
+                })
+                .collect(),
+        ));
 
         register_store(self, session.runtime_env().clone());
 

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -109,9 +109,7 @@ impl DeltaOps {
     #[cfg(feature = "datafusion")]
     #[must_use]
     pub fn write(self, batches: impl IntoIterator<Item = RecordBatch>) -> WriteBuilder {
-        WriteBuilder::default()
-            .with_input_batches(batches)
-            .with_object_store(self.0.object_store())
+        WriteBuilder::new(self.0.object_store(), self.0.state).with_input_batches(batches)
     }
 
     /// Vacuum stale files from delta table

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -188,13 +188,14 @@ async fn test_datafusion_write_from_serialized_delta_scan() -> Result<()> {
 
     // Trying to execute the write from the input plan without providing Datafusion with a session
     // state containing the referenced object store in the registry results in an error.
-    assert!(WriteBuilder::new()
-        .with_input_execution_plan(source_scan.clone())
-        .with_object_store(target_table.object_store())
-        .await
-        .unwrap_err()
-        .to_string()
-        .contains("No suitable object store found for delta-rs://"));
+    assert!(
+        WriteBuilder::new(target_table.object_store(), target_table.state.clone())
+            .with_input_execution_plan(source_scan.clone())
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("No suitable object store found for delta-rs://")
+    );
 
     // Register the missing source table object store
     let source_uri = source_scan
@@ -212,10 +213,9 @@ async fn test_datafusion_write_from_serialized_delta_scan() -> Result<()> {
         .register_object_store(source_store_url, Arc::from(source_store));
 
     // Execute write to the target table with the proper state
-    let target_table = WriteBuilder::new()
+    let target_table = WriteBuilder::new(target_table.object_store(), target_table.state.clone())
         .with_input_execution_plan(source_scan)
         .with_input_session_state(state)
-        .with_object_store(target_table.object_store())
         .await?;
     ctx.register_table("target", Arc::new(target_table))?;
 


### PR DESCRIPTION
# Description

This PR updates the write operation, specifically:

* makes handling state consistent with other operations
* avoids some IO when creating updated table state

One potentially more controversial change is that we now try to case all batches written to either the physical schema (derived from latest parquet file) or the schema derived from the table. I feel this logic may eventually need some updating or at least we need to make sure this is consistently handled across all write paths. In any case, using the file schema we dis already see some schema mis-matches in current tests, so that I included some casting for record batches here.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
