### PR TITLE
Fix double encoding of spaces in storage prefix

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -232,7 +232,7 @@ pub enum DeltaTableError {
     /// A Feature is missing to perform operation
     #[error("Delta-rs must be build with feature '{feature}' to support loading from: {url}.")]
     MissingFeature {
-        /// Name of the missiing feature
+        /// Name of the missing feature
         feature: &'static str,
         /// Storage location url
         url: String,
@@ -261,6 +261,14 @@ pub enum DeltaTableError {
         /// Source error
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
+}
+
+impl From<object_store::path::Error> for DeltaTableError {
+    fn from(err: object_store::path::Error) -> Self {
+        Self::GenericError {
+            source: Box::new(err),
+        }
+    }
 }
 
 /// Delta table metadata

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -4,7 +4,7 @@ pub mod config;
 pub mod file;
 pub mod utils;
 
-use self::config::{ObjectStoreKind, StorageOptions};
+use self::config::StorageOptions;
 use crate::{DeltaDataTypeVersion, DeltaResult};
 
 use bytes::Bytes;
@@ -89,12 +89,12 @@ impl DeltaObjectStore {
     /// * `location` - A url pointing to the root of the delta table.
     /// * `options` - Options passed to underlying builders. See [`with_storage_options`](crate::builder::DeltaTableBuilder::with_storage_options)
     pub fn try_new(location: Url, options: impl Into<StorageOptions> + Clone) -> DeltaResult<Self> {
-        let storage =
-            ObjectStoreKind::parse_url(&location)?.into_impl(&location, options.clone())?;
+        let options = options.into();
+        let storage = config::configure_store(&location, &options)?;
         Ok(Self {
             storage,
             location,
-            options: options.into(),
+            options,
         })
     }
 


### PR DESCRIPTION
When storage was built from URL "file:///data/dir with spaces" all files were created in a directory named "/data/dir%2520with%2520spaces". Name of directory was not only incorrect, but also was causing errors on some filesystems.

# Description
Path in URL is already url encoded when passed to prefix store where it is encoded one more time.

# Related
Fail to read delta table on mounted disk #1189 
