### PR TITLE
Add description of decimal primitive to SchemaDataType

### DIFF
--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -300,6 +300,7 @@ pub enum SchemaDataType {
     ///  * binary: a sequence of binary data
     ///  * date: A calendar date, represented as a year-month-day triple without a timezone
     ///  * timestamp: Microsecond precision timestamp without a timezone
+    ///  * decimal: Signed decimal number with fixed precision (maximum number of digits) and scale (number of digits on right side of dot), where the precision and scale can be up to 38
     primitive(String),
     /// Variant representing a struct.
     r#struct(SchemaTypeStruct),


### PR DESCRIPTION
# Description
Add description of `decimal` primitive into the documentation comment of `schema::SchemaDataType`

# Related Issue(s)
- closes #1280 

# Documentation
[schema::SchemaDataType](https://docs.rs/deltalake/latest/deltalake/schema/enum.SchemaDataType.html)
