### PR TITLE
chore: df / arrow changes after update

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-arrow = { version = "37.0.0", optional = true }
+arrow = { version = "36.0.0", optional = true }
 async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
@@ -29,7 +29,7 @@ num-traits = "0.2.15"
 object_store = "0.5.6"
 once_cell = "1.16.0"
 parking_lot = "0.12"
-parquet = { version = "37", features = [
+parquet = { version = "36", features = [
     "async",
     "object_store",
 ], optional = true }
@@ -58,8 +58,9 @@ datafusion-expr = { version = "22", optional = true }
 datafusion-common = { version = "22", optional = true }
 datafusion-proto = { version = "22", optional = true }
 datafusion-sql = { version = "22", optional = true }
+datafusion-physical-expr = { version = "22", optional = true }
 
-sqlparser = { version = "0.30", optional = true }
+sqlparser = { version = "0.32", optional = true }
 
 # NOTE dependencies only for integration tests
 fs_extra = { version = "1.2.0", optional = true }
@@ -94,6 +95,7 @@ datafusion = [
     "datafusion-expr",
     "datafusion-common",
     "datafusion-proto",
+    "datafusion-physical-expr",
     "datafusion-sql",
     "sqlparser",
     "arrow",

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -42,14 +42,16 @@ use datafusion::execution::FunctionRegistry;
 use datafusion::optimizer::utils::conjunction;
 use datafusion::physical_expr::PhysicalSortExpr;
 use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
-use datafusion::physical_plan::file_format::{partition_type_wrap, FileScanConfig};
+use datafusion::physical_plan::file_format::{wrap_partition_type_in_dict, FileScanConfig};
 use datafusion::physical_plan::{
     ColumnStatistics, ExecutionPlan, Partitioning, SendableRecordBatchStream, Statistics,
 };
 use datafusion_common::scalar::ScalarValue;
-use datafusion_common::{Column, DataFusionError, Result as DataFusionResult};
+use datafusion_common::{Column, DataFusionError, Result as DataFusionResult, ToDFSchema};
 use datafusion_expr::logical_plan::CreateExternalTable;
 use datafusion_expr::{Expr, Extension, LogicalPlan, TableProviderFilterPushDown};
+use datafusion_physical_expr::execution_props::ExecutionProps;
+use datafusion_physical_expr::{create_physical_expr, PhysicalExpr};
 use datafusion_proto::logical_plan::LogicalExtensionCodec;
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use object_store::{path::Path, ObjectMeta};
@@ -337,7 +339,7 @@ impl PruningStatistics for DeltaTable {
 fn register_store(table: &DeltaTable, env: Arc<RuntimeEnv>) {
     let object_store_url = table.storage.object_store_url();
     let url: &Url = object_store_url.as_ref();
-    env.register_object_store(&url, table.object_store());
+    env.register_object_store(url, table.object_store());
 }
 
 #[async_trait]
@@ -378,14 +380,15 @@ impl TableProvider for DeltaTable {
 
         register_store(self, session.runtime_env().clone());
 
+        let filter_expr = conjunction(filters.iter().cloned())
+            .map(|expr| logical_expr_to_physical_expr(&expr, &schema));
+
         // TODO we group files together by their partition values. If the table is partitioned
         // and partitions are somewhat evenly distributed, probably not the worst choice ...
         // However we may want to do some additional balancing in case we are far off from the above.
         let mut file_groups: HashMap<Vec<ScalarValue>, Vec<PartitionedFile>> = HashMap::new();
-        if let Some(Some(predicate)) =
-            (!filters.is_empty()).then_some(conjunction(filters.iter().cloned()))
-        {
-            let pruning_predicate = PruningPredicate::try_new(predicate, schema.clone())?;
+        if let Some(predicate) = &filter_expr {
+            let pruning_predicate = PruningPredicate::try_new(predicate.clone(), schema.clone())?;
             let files_to_prune = pruning_predicate.prune(&self.state)?;
             self.get_state()
                 .files()
@@ -435,14 +438,16 @@ impl TableProvider for DeltaTable {
                         .map(|c| {
                             Ok((
                                 c.to_owned(),
-                                partition_type_wrap(schema.field_with_name(c)?.data_type().clone()),
+                                wrap_partition_type_in_dict(
+                                    schema.field_with_name(c)?.data_type().clone(),
+                                ),
                             ))
                         })
                         .collect::<Result<Vec<_>, ArrowError>>()?,
                     output_ordering: None,
                     infinite_source: false,
                 },
-                filters,
+                filter_expr.as_ref(),
             )
             .await?;
 
@@ -767,6 +772,15 @@ fn left_larger_than_right(left: ScalarValue, right: ScalarValue) -> Option<bool>
             None
         }
     }
+}
+
+pub(crate) fn logical_expr_to_physical_expr(
+    expr: &Expr,
+    schema: &ArrowSchema,
+) -> Arc<dyn PhysicalExpr> {
+    let df_schema = schema.clone().to_dfschema().unwrap();
+    let execution_props = ExecutionProps::new();
+    create_physical_expr(expr, &df_schema, schema, &execution_props).unwrap()
 }
 
 /// Responsible for checking batches of data conform to table's invariants.

--- a/rust/tests/datafusion_test.rs
+++ b/rust/tests/datafusion_test.rs
@@ -207,11 +207,9 @@ async fn test_datafusion_write_from_serialized_delta_scan() -> Result<()> {
     let source_store = DeltaObjectStore::try_new(source_location, HashMap::new()).unwrap();
     let object_store_url = source_store.object_store_url();
     let source_store_url: &Url = object_store_url.as_ref();
-    state.runtime_env().register_object_store(
-        source_store_url.scheme(),
-        source_store_url.host_str().unwrap_or_default(),
-        Arc::from(source_store),
-    );
+    state
+        .runtime_env()
+        .register_object_store(source_store_url, Arc::from(source_store));
 
     // Execute write to the target table with the proper state
     let target_table = WriteBuilder::new()


### PR DESCRIPTION
# Description

@rtyler - this updates some more arrow / datafusion stuff that broke after the update. Had to downgrade to arrow 36 again, since its used with datafusion 22.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
