### PR TITLE
ci: enforce conventional commit PR titles

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -7,6 +7,7 @@ on:
       - opened
       - edited
       - synchronize
+      - reopened
 
 jobs:
   process:
@@ -28,3 +29,56 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/workflows/dev_pr/labeler.yml
           sync-labels: true
+
+  commitlint:
+    name: PR title / description conforms to semantic-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - run: npm install @commitlint/config-conventional
+      - run: >
+          echo 'module.exports = {
+            // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
+            "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)]
+          }' > .commitlintrc.js
+      - run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
+        env:
+          COMMIT_MSG: >
+            ${{ github.event.pull_request.title }}
+
+            ${{ github.event.pull_request.body }}
+      - if: failure()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const message = `**ACTION NEEDED**
+              
+              delta-rs follows the [Conventional Commits
+              specification](https://www.conventionalcommits.org/en/v1.0.0/) for
+              release automation.
+
+              The PR title and description are used as the merge commit message.\
+              Please update your PR title and description to match the specification.
+              `
+            // Get list of current comments
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            // Check if this job already commented
+            for (const comment of comments) {
+              if (comment.body === message) {
+                return // Already commented
+              }
+            }
+            // Post the comment about Conventional Commits
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: message
+            })
+            core.setFailed(message)


### PR DESCRIPTION
# Description

This PR adds enforcement for [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) PR titles. This will allow us to totally automate the release process for the main Rust crate, so we can do more frequent releases.

The script is based on the substrait-io/substrait repo ([script](https://github.com/substrait-io/substrait/blob/main/.github/workflows/pr_title.yml)), which does weekly automated release ([release script](https://github.com/substrait-io/substrait/blob/main/.github/workflows/release.yml)).

Once we have the next release after this one, all commit messages will be compliant and we will be able to implement the release script.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
