### PR TITLE
ci: permissions for the pr title checker

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -33,6 +33,8 @@ jobs:
   commitlint:
     name: PR title / description conforms to semantic-release
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
# Description

Messages aren't showing up because the GitHub action doesn't have the necessary permissions.

