### PR TITLE
docs: update message since we fixed the commit logic

### DIFF
--- a/rust/src/operations/optimize.rs
+++ b/rust/src/operations/optimize.rs
@@ -4,8 +4,9 @@
 //! file. Bin-packing reduces the number of API calls required for read
 //! operations.
 //!
-//! *WARNING:* Currently Optimize only supports append-only workflows. Use with
-//! other workflows may corrupt your table state.
+//! Optimize will fail if a concurrent write operation removes files from the
+//! table (such as in an overwrite). It will always succeed if concurrent writers
+//! are only appending.
 //!
 //! Optimize increments the table's version and creates remove actions for
 //! optimized files. Optimize does not delete files from storage. To delete


### PR DESCRIPTION
# Description

We addressed the issues with our commit logic in https://github.com/delta-io/delta-rs/pull/632, so I think we can remove this disclaimer now from the optimize command.

# Related Issue(s)

For example:

- closes #1125


# Documentation

<!---
Share links to useful documentation
--->
