### PR TITLE
chore: add deprecation notices for commit logic on `DeltaTable`

### DIFF
--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -144,7 +144,7 @@ def test_roundtrip_metadata(tmp_path: pathlib.Path, sample_data: pa.Table):
         sample_data,
         name="test_name",
         description="test_desc",
-        configuration={"configTest": "foobar"},
+        configuration={"delta.appendOnly": "false"},
     )
 
     delta_table = DeltaTable(tmp_path)
@@ -153,7 +153,7 @@ def test_roundtrip_metadata(tmp_path: pathlib.Path, sample_data: pa.Table):
 
     assert metadata.name == "test_name"
     assert metadata.description == "test_desc"
-    assert metadata.configuration == {"configTest": "foobar"}
+    assert metadata.configuration == {"delta.appendOnly": "false"}
 
 
 @pytest.mark.parametrize(

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -1112,6 +1112,10 @@ impl DeltaTable {
     }
 
     /// Vacuum the delta table. See [`VacuumBuilder`] for more information.
+    #[deprecated(
+        since = "0.10.0",
+        note = "use DelaOps from operations module to create a Vacuum operation."
+    )]
     pub async fn vacuum(
         &mut self,
         retention_hours: Option<u64>,
@@ -1133,6 +1137,11 @@ impl DeltaTable {
     /// Creates a new DeltaTransaction for the DeltaTable.
     /// The transaction holds a mutable reference to the DeltaTable, preventing other references
     /// until the transaction is dropped.
+    #[deprecated(
+        since = "0.10.0",
+        note = "use 'commit' function from operations module to commit to Delta table."
+    )]
+    #[allow(deprecated)]
     pub fn create_transaction(
         &mut self,
         options: Option<DeltaTransactionOptions>,
@@ -1145,6 +1154,11 @@ impl DeltaTable {
     /// This is low-level transaction API. If user does not want to maintain the commit loop then
     /// the `DeltaTransaction.commit` is desired to be used as it handles `try_commit_transaction`
     /// with retry logic.
+    #[deprecated(
+        since = "0.10.0",
+        note = "use 'commit' function from operations module to commite to Delta table."
+    )]
+    #[allow(deprecated)]
     pub async fn try_commit_transaction(
         &mut self,
         commit: &PreparedCommit,
@@ -1168,6 +1182,11 @@ impl DeltaTable {
     }
 
     /// Create a DeltaTable with version 0 given the provided MetaData, Protocol, and CommitInfo
+    #[deprecated(
+        since = "0.10.0",
+        note = "use DelaOps from operations module to create a Create operation."
+    )]
+    #[allow(deprecated)]
     pub async fn create(
         &mut self,
         metadata: DeltaTableMetaData,
@@ -1322,12 +1341,17 @@ impl Default for DeltaTransactionOptions {
 /// Please not that in case of non-retryable error the temporary commit file such as
 /// `_delta_log/_commit_<uuid>.json` will orphaned in storage.
 #[derive(Debug)]
+#[deprecated(
+    since = "0.10.0",
+    note = "use 'commit' function from operations module to commit to Delta table."
+)]
 pub struct DeltaTransaction<'a> {
     delta_table: &'a mut DeltaTable,
     actions: Vec<Action>,
     options: DeltaTransactionOptions,
 }
 
+#[allow(deprecated)]
 impl<'a> DeltaTransaction<'a> {
     /// Creates a new delta transaction.
     /// Holds a mutable reference to the delta table to prevent outside mutation while a transaction commit is in progress.
@@ -1377,7 +1401,6 @@ impl<'a> DeltaTransaction<'a> {
         // } else {
         //     IsolationLevel::Serializable
         // };
-
         let prepared_commit = self.prepare_commit(operation, app_metadata).await?;
 
         // try to commit in a loop in case other writers write the next version first
@@ -1430,6 +1453,7 @@ impl<'a> DeltaTransaction<'a> {
         Ok(PreparedCommit { uri: path })
     }
 
+    #[allow(deprecated)]
     async fn try_commit_loop(
         &mut self,
         commit: &PreparedCommit,
@@ -1473,6 +1497,10 @@ impl<'a> DeltaTransaction<'a> {
 /// Holds the uri to prepared commit temporary file created with `DeltaTransaction.prepare_commit`.
 /// Once created, the actual commit could be executed with `DeltaTransaction.try_commit`.
 #[derive(Debug)]
+#[deprecated(
+    since = "0.10.0",
+    note = "use 'commit' function from operations module to commit to Delta table."
+)]
 pub struct PreparedCommit {
     uri: Path,
 }
@@ -1624,6 +1652,7 @@ mod tests {
             serde_json::Value::String("test user".to_string()),
         );
         // Action
+        #[allow(deprecated)]
         dt.create(delta_md.clone(), protocol.clone(), Some(commit_info), None)
             .await
             .unwrap();

--- a/rust/src/delta_config.rs
+++ b/rust/src/delta_config.rs
@@ -10,6 +10,7 @@ use crate::DeltaTableError;
 /// Typed property keys that can be defined on a delta table
 /// <https://docs.delta.io/latest/table-properties.html#delta-table-properties-reference>
 /// <https://learn.microsoft.com/en-us/azure/databricks/delta/table-properties>
+#[derive(PartialEq, Eq, Hash)]
 pub enum DeltaConfigKey {
     /// true for this Delta table to be append-only. If append-only,
     /// existing records cannot be deleted, and existing values cannot be updated.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -109,6 +109,7 @@ pub mod writer;
 pub use self::builder::*;
 pub use self::data_catalog::{get_data_catalog, DataCatalog, DataCatalogError};
 pub use self::delta::*;
+pub use self::delta_config::*;
 pub use self::partitions::*;
 pub use self::schema::*;
 pub use object_store::{path::Path, Error as ObjectStoreError, ObjectMeta, ObjectStore};

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -125,8 +125,11 @@ impl CreateBuilder {
     }
 
     /// Specify columns to append to schema
-    pub fn with_columns(mut self, columns: impl IntoIterator<Item = SchemaField>) -> Self {
-        self.columns.extend(columns);
+    pub fn with_columns(
+        mut self,
+        columns: impl IntoIterator<Item = impl Into<SchemaField>>,
+    ) -> Self {
+        self.columns.extend(columns.into_iter().map(|c| c.into()));
         self
     }
 

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -272,7 +272,7 @@ impl CreateBuilder {
         actions.extend(
             self.actions
                 .into_iter()
-                .filter(|a| matches!(a, Action::protocol(_))),
+                .filter(|a| !matches!(a, Action::protocol(_))),
         );
 
         Ok((table, actions, operation))

--- a/rust/src/writer/mod.rs
+++ b/rust/src/writer/mod.rs
@@ -128,6 +128,7 @@ pub trait DeltaWriter<T> {
         table: &mut DeltaTable,
     ) -> Result<DeltaDataTypeVersion, DeltaTableError> {
         let mut adds = self.flush().await?;
+        #[allow(deprecated)]
         let mut tx = table.create_transaction(None);
         tx.add_actions(adds.drain(..).map(Action::add).collect());
         let version = tx.commit(None, None).await?;

--- a/rust/src/writer/test_utils.rs
+++ b/rust/src/writer/test_utils.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Utilities for writing unit tests
 use super::*;
 use crate::{

--- a/rust/tests/commit_info_format.rs
+++ b/rust/tests/commit_info_format.rs
@@ -1,4 +1,4 @@
-#[allow(dead_code)]
+#![allow(dead_code, deprecated)]
 mod fs_common;
 
 use deltalake::action::{Action, DeltaOperation, SaveMode};

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -1,5 +1,4 @@
-#![allow(dead_code)]
-#![allow(unused_variables)]
+#![allow(dead_code, unused_variables, deprecated)]
 
 use bytes::Bytes;
 use deltalake::action::{self, Add, Remove};

--- a/rust/tests/fs_common/mod.rs
+++ b/rust/tests/fs_common/mod.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use chrono::Utc;
 use deltalake::action::{Action, Add, Protocol, Remove};
 use deltalake::{


### PR DESCRIPTION
# Description

Now that we have a decent test coverage to the low-level commit logic in the transactions module, we should deprecate the commit logic exposed directly on `DeltaTable`.

In some places I also updated internal call sites, however did not go through all of them.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
