### PR TITLE
feat: update incremental after operations

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -334,6 +334,7 @@ given filters.
         :return: the metrics from optimize
         """
         metrics = self._table.optimize(partition_filters, target_size)
+        self.update_incremental()
         return json.loads(metrics)
 
     def pyarrow_schema(self) -> pyarrow.Schema:

--- a/python/tests/test_optimize.py
+++ b/python/tests/test_optimize.py
@@ -22,6 +22,8 @@ def test_optimize_run_table(
     write_deltalake(table_path, sample_data, mode="append")
 
     dt = DeltaTable(table_path)
+    old_version = dt.version()
     dt.optimize()
     last_action = dt.history(1)[0]
     assert last_action["operation"] == "OPTIMIZE"
+    assert dt.version() == old_version + 1

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -118,8 +118,6 @@ def test_update_schema(existing_table: DeltaTable):
 
     write_deltalake(existing_table, new_data, mode="overwrite", overwrite_schema=True)
 
-    existing_table.update_incremental()
-
     read_data = existing_table.to_pyarrow_table()
     assert new_data == read_data
     assert existing_table.schema().to_pyarrow() == new_data.schema
@@ -174,7 +172,7 @@ def test_roundtrip_metadata(tmp_path: pathlib.Path, sample_data: pa.Table):
 def test_roundtrip_partitioned(
     tmp_path: pathlib.Path, sample_data: pa.Table, column: str
 ):
-    write_deltalake(tmp_path, sample_data, partition_by=[column])
+    write_deltalake(tmp_path, sample_data, partition_by=column)
 
     delta_table = DeltaTable(tmp_path)
     assert delta_table.schema().to_pyarrow() == sample_data.schema
@@ -259,14 +257,13 @@ def test_append_only_should_append_only_with_the_overwrite_mode(
             write_deltalake(data_store_type, sample_data, mode=mode)
 
     expected = pa.concat_tables([sample_data, sample_data])
-    table.update_incremental()
+
     assert table.to_pyarrow_table() == expected
     assert table.version() == 1
 
 
 def test_writer_with_table(existing_table: DeltaTable, sample_data: pa.Table):
     write_deltalake(existing_table, sample_data, mode="overwrite")
-    existing_table.update_incremental()
     assert existing_table.to_pyarrow_table() == sample_data
 
 


### PR DESCRIPTION
# Description

It can be really confusing when writing to a Delta Table that afterwards the `DeltaTable` still needs to have `update_incremental` to reflect the changes. I felt this myself in #1336.

So this adds `update_incremental` at the end of write and optimize.

I also add it to the beginning of write, since I discovered you could get commit errors if you are passing in an old table state.

Also, made it so the `partition_by` argument can handle just a single string. (I think PyArrow does the same, which must be why I have muscle memory for it.)

# Related Issue(s)
No issue.

# Documentation

<!---
Share links to useful documentation
--->
