### PR TITLE
ci(python): fix release script to use environment variable

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           command: publish
-          args: -m python/Cargo.toml --no-sdist $FEATURES_FLAG
+          args: -m python/Cargo.toml --no-sdist ${{ env.FEATURES_FLAG }}
 
   release-pypi-mac-universal2:
     needs: validate-release-tag
@@ -62,7 +62,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           command: publish
-          args: -m python/Cargo.toml --no-sdist --universal2 $FEATURES_FLAG
+          args: -m python/Cargo.toml --no-sdist --universal2 ${{ env.FEATURES_FLAG }}
 
   release-pypi-windows:
     needs: validate-release-tag
@@ -78,7 +78,7 @@ jobs:
         with:
           target: x86_64-pc-windows-msvc
           command: publish
-          args: -m python/Cargo.toml --no-sdist $FEATURES_FLAG
+          args: -m python/Cargo.toml --no-sdist ${{ env.FEATURES_FLAG }}
 
   release-pypi-manylinux:
     needs: validate-release-tag
@@ -94,7 +94,7 @@ jobs:
         with:
           target: x86_64-unknown-linux-gnu
           command: publish
-          args: -m python/Cargo.toml $FEATURES_FLAG
+          args: -m python/Cargo.toml ${{ env.FEATURES_FLAG }}
 
       - name: Publish manylinux to pypi aarch64 (without sdist)
         uses: messense/maturin-action@v1
@@ -103,7 +103,7 @@ jobs:
         with:
           target: aarch64-unknown-linux-gnu
           command: publish
-          args: -m python/Cargo.toml --no-sdist $FEATURES_FLAG
+          args: -m python/Cargo.toml --no-sdist ${{ env.FEATURES_FLAG }}
 
   release-docs:
     needs:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -46,7 +46,7 @@ pyspark = [
 
 [project.urls]
 documentation = "https://delta-io.github.io/delta-rs/python/"
-repository = "https://github.com/delta-io/delta-rs"
+repository = "https://github.com/delta-io/delta-rs/tree/main/python/"
 
 [tool.mypy]
 files = "deltalake/*.py"


### PR DESCRIPTION
# Description
mac os and windows jobs failed due to this environment variable not being referenced properly https://github.com/delta-io/delta-rs/actions/runs/4902626950/jobs/8754581863

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
