### PR TITLE
ci(python): make release idempotent

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           command: publish
-          args: -m python/Cargo.toml --no-sdist --universal2 ${{ env.FEATURES_FLAG }}
+          args: --skip-existing -m python/Cargo.toml --no-sdist --universal2 ${{ env.FEATURES_FLAG }}
 
   release-pypi-windows:
     needs: validate-release-tag
@@ -78,7 +78,7 @@ jobs:
         with:
           target: x86_64-pc-windows-msvc
           command: publish
-          args: -m python/Cargo.toml --no-sdist ${{ env.FEATURES_FLAG }}
+          args: --skip-existing -m python/Cargo.toml --no-sdist ${{ env.FEATURES_FLAG }}
 
   release-pypi-manylinux:
     needs: validate-release-tag
@@ -94,7 +94,7 @@ jobs:
         with:
           target: x86_64-unknown-linux-gnu
           command: publish
-          args: -m python/Cargo.toml ${{ env.FEATURES_FLAG }}
+          args: --skip-existing -m python/Cargo.toml ${{ env.FEATURES_FLAG }}
 
       - name: Publish manylinux to pypi aarch64 (without sdist)
         uses: messense/maturin-action@v1
@@ -103,7 +103,7 @@ jobs:
         with:
           target: aarch64-unknown-linux-gnu
           command: publish
-          args: -m python/Cargo.toml --no-sdist ${{ env.FEATURES_FLAG }}
+          args: --skip-existing -m python/Cargo.toml --no-sdist ${{ env.FEATURES_FLAG }}
 
   release-docs:
     needs:


### PR DESCRIPTION
# Description

The docs release is stuck because the Linux wheel publication is failing. The publication is failing because they already exist. We should just continue if it already exists instead.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
