### PR TITLE
fix: include stats for all columns (#1223)

### DIFF
--- a/rust/tests/add_actions_test.rs
+++ b/rust/tests/add_actions_test.rs
@@ -204,10 +204,14 @@ async fn test_only_struct_stats() {
             "null_count.null",
             Arc::new(array::Int64Array::from(vec![1])),
         ),
+        ("min.null", Arc::new(array::NullArray::new(1))),
+        ("max.null", Arc::new(array::NullArray::new(1))),
         (
             "null_count.boolean",
             Arc::new(array::Int64Array::from(vec![0])),
         ),
+        ("min.boolean", Arc::new(array::NullArray::new(1))),
+        ("max.boolean", Arc::new(array::NullArray::new(1))),
         (
             "null_count.double",
             Arc::new(array::Int64Array::from(vec![0])),
@@ -256,6 +260,8 @@ async fn test_only_struct_stats() {
             "null_count.binary",
             Arc::new(array::Int64Array::from(vec![0])),
         ),
+        ("min.binary", Arc::new(array::NullArray::new(1))),
+        ("max.binary", Arc::new(array::NullArray::new(1))),
         (
             "null_count.date",
             Arc::new(array::Int64Array::from(vec![0])),


### PR DESCRIPTION
# Description
This is a proposal for how #1223 could be fixed.

# Related Issue(s)
- fixes #1223

# Documentation
The current implementation excludes all columns that lack statistical information. The proposed fix will generate information for all columns, with missing statistical values being replaced by 'null' values. However, it is unclear if this is the correct behavior since the `stats_as_batch` function lacks documentation.