### PR TITLE
feat: add `wasbs` to known schemes

### DIFF
--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -349,8 +349,8 @@ pub(crate) fn str_option(map: &HashMap<String, String>, key: &str) -> Option<Str
 lazy_static::lazy_static! {
     static ref KNOWN_SCHEMES: Vec<&'static str> =
         Vec::from([
-            "file", "memory", "az", "abfs", "abfss", "azure", "wasb", "adl", "s3", "s3a", "gs", "hdfs",
-            "https", "http",
+            "file", "memory", "az", "abfs", "abfss", "azure", "wasb", "wasbs", "adl", "s3", "s3a",
+            "gs", "hdfs", "https", "http",
         ]);
 }
 

--- a/rust/src/storage/config.rs
+++ b/rust/src/storage/config.rs
@@ -110,7 +110,9 @@ pub(crate) fn configure_store(
                 .ok_or_else(|| DeltaTableError::InvalidTableLocation(url.to_string()))?,
         ),
         "memory" => try_configure_memory(url),
-        "az" | "abfs" | "abfss" | "azure" | "wasb" | "adl" => try_configure_azure(url, options),
+        "az" | "abfs" | "abfss" | "azure" | "wasb" | "wasbs" | "adl" => {
+            try_configure_azure(url, options)
+        }
         "s3" | "s3a" => try_configure_s3(url, options),
         "gs" => try_configure_gcs(url, options),
         "hdfs" => try_configure_hdfs(url, options),


### PR DESCRIPTION
# Description
The description of the main changes of your pull request

According to [this page](https://learn.microsoft.com/en-us/azure/hdinsight/hdinsight-hadoop-use-blob-storage#access-files-from-within-cluster) `wasbs` is a legit and in fact recommended scheme for Azure Blob Storage. However we currently do not include it in `KNOWN_SCHEMES` which should lead to automatic detection of storage backend  to fail if we use `wasbs`.

This PR solves the problem.
# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
