### PR TITLE
feat(python): add filters argument to DeltaTable.to_pandas() for filter pushdown

### DIFF
--- a/python/stubs/pyarrow/dataset.pyi
+++ b/python/stubs/pyarrow/dataset.pyi
@@ -2,6 +2,8 @@ from typing import Any
 
 Dataset: Any
 dataset: Any
+Expression: Any
+field: Any
 partitioning: Any
 FileSystemDataset: Any
 ParquetFileFormat: Any

--- a/python/stubs/pyarrow/parquet/core.pyi
+++ b/python/stubs/pyarrow/parquet/core.pyi
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def filters_to_expression(filters: Any) -> Any:
+    ...

--- a/python/stubs/pyarrow/parquet/core.pyi
+++ b/python/stubs/pyarrow/parquet/core.pyi
@@ -1,5 +1,3 @@
 from typing import Any
 
-
-def filters_to_expression(filters: Any) -> Any:
-    ...
+def filters_to_expression(filters: Any) -> Any: ...

--- a/python/stubs/pyarrow/parquet/core.pyi
+++ b/python/stubs/pyarrow/parquet/core.pyi
@@ -1,3 +1,0 @@
-from typing import Any
-
-def filters_to_expression(filters: Any) -> Any: ...

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -404,6 +404,49 @@ def test_delta_table_with_filesystem():
     assert dt.to_pandas(filesystem=filesystem).equals(pd.DataFrame({"id": [5, 7, 9]}))
 
 
+@pytest.mark.pandas
+def test_delta_table_with_filters():
+    table_path = "../rust/tests/data/COVID-19_NYT"
+    dt = DeltaTable(table_path)
+    dataset = dt.to_pyarrow_dataset()
+
+    filter_expr = ds.field("date") > "2021-02-20"
+    data = dataset.to_table(filter=filter_expr)
+    assert len(dt.to_pandas(filters=[("date", ">", "2021-02-20")])) == data.num_rows
+
+    filter_expr = (ds.field("date") > "2021-02-20") | (
+        ds.field("state").isin(["Alabama", "Wyoming"])
+    )
+    data = dataset.to_table(filter=filter_expr)
+    assert (
+        len(
+            dt.to_pandas(
+                filters=[
+                    [("date", ">", "2021-02-20")],
+                    [("state", "in", ["Alabama", "Wyoming"])],
+                ]
+            )
+        )
+        == data.num_rows
+    )
+
+    filter_expr = (ds.field("date") > "2021-02-20") & (
+        ds.field("state").isin(["Alabama", "Wyoming"])
+    )
+    data = dataset.to_table(filter=filter_expr)
+    assert (
+        len(
+            dt.to_pandas(
+                filters=[
+                    ("date", ">", "2021-02-20"),
+                    ("state", "in", ["Alabama", "Wyoming"]),
+                ]
+            )
+        )
+        == data.num_rows
+    )
+
+
 def test_writer_fails_on_protocol():
     table_path = "../rust/tests/data/simple_table"
     dt = DeltaTable(table_path)


### PR DESCRIPTION
# Description

This pull request adds support for filtering to the `to_pandas` method of `DeltaTable`. The new filters argument allows
users to specify filtering criteria in a format that is compatible with `pyarrow.compute.Expression`.

- Adding the `filters` argument to `DeltaTable.to_pandas`.
- Adding the `_filters_to_expression` function to `table` module, which is based on [this implementation](https://github.com/apache/arrow/blob/b9cc5df8a4f7c7fe09f40ba92a74981dee5e536a/python/pyarrow/parquet/core.py#LL155C5-L155C26), but with improved type consistency.
- ~~Based on [the existing conventional unit tests](https://github.com/delta-io/delta-rs/blob/b5230835bc1d1b01d59da3649033f1180232ddb7/python/tests/test_table_read.py#L392), I did not add any additional test cases for this feature. Instead, I tested the feature on my local development environment.~~
- Adding a unit test for the feature.

# Related Issue(s)

- closes #1316

# Documentation

[The DNF filter format](https://github.com/apache/arrow/blob/b9cc5df8a4f7c7fe09f40ba92a74981dee5e536a/python/pyarrow/parquet/core.py#LL155C5-L155C26).
