### PR TITLE
feat: add hdfs support in python

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -50,6 +50,11 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+      
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
 
       - uses: Swatinem/rust-cache@v2
 
@@ -57,14 +62,16 @@ jobs:
         run: |
           echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
 
+      # hdfs support requires clang 3.5+, which requires an scl package on this image
       - name: Build and install deltalake
         run: |
+          yum install -y llvm-toolset-7
           pip install virtualenv
           virtualenv venv
           source venv/bin/activate
           make setup
           # Install minimum PyArrow version
-          pip install -e .[pandas,devel] pyarrow==7.0.0
+          scl enable llvm-toolset-7 'pip install -e .[pandas,devel] pyarrow==7.0.0'
 
       - name: Run tests
         run: |
@@ -88,6 +95,10 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - uses: beyondstorage/setup-hdfs@master
+        with:
+          hdfs-version: '3.3.2'
+
       - uses: Swatinem/rust-cache@v2
 
       - uses: actions/setup-python@v3
@@ -110,7 +121,7 @@ jobs:
       - name: Run tests
         run: |
           source venv/bin/activate
-          python -m pytest -m '((s3 or azure) and integration) or not integration'
+          python -m pytest -m '((s3 or azure or hdfs) and integration) or not integration'
 
       - name: Test without pandas
         run: |

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -50,12 +50,6 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-      
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
       - uses: Swatinem/rust-cache@v2
 
       - name: Enable manylinux Python targets
@@ -65,13 +59,12 @@ jobs:
       # hdfs support requires clang 3.5+, which requires an scl package on this image
       - name: Build and install deltalake
         run: |
-          yum install -y llvm-toolset-7
           pip install virtualenv
           virtualenv venv
           source venv/bin/activate
           make setup
           # Install minimum PyArrow version
-          scl enable llvm-toolset-7 'pip install -e .[pandas,devel] pyarrow==7.0.0'
+          pip install -e .[pandas,devel] pyarrow==7.0.0
 
       - name: Run tests
         run: |
@@ -113,7 +106,7 @@ jobs:
           pip install virtualenv
           virtualenv venv
           source venv/bin/activate
-          make develop      
+          MATURIN_EXTRA_ARGS="--features hdfs" make develop      
               
       - name: Download Data Acceptance Tests (DAT) files
         run: make setup-dat

--- a/dev/hdfs/core-site.xml
+++ b/dev/hdfs/core-site.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://localhost:9000</value>
+    </property>
+    <property>
+        <name>fs.permissions.umask-mode</name>
+        <value>000</value>
+    </property>
+</configuration>

--- a/dev/hdfs/hdfs-site.xml
+++ b/dev/hdfs/hdfs-site.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+    <property>
+        <name>dfs.namenode.rpc-bind-host</name>
+        <value>0.0.0.0</value>
+    </property>
+</configuration>

--- a/dev/hdfs/start-hdfs.sh
+++ b/dev/hdfs/start-hdfs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+[ ! -d "/tmp/hadoop-hadoop/dfs/name" ] && hdfs namenode -format
+
+hdfs --daemon start namenode
+hdfs --daemon start datanode
+
+hdfs dfs -chmod 777 /
+
+exec tail -n 1000 -f /var/log/hadoop/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,17 @@ services:
     image: mcr.microsoft.com/azure-storage/azurite
     ports:
       - 10000:10000
+
+  hdfs:
+    image: apache/hadoop:3
+    ports:
+      - 9000:9000
+      - 9866:9866
+    volumes:
+      - ./dev/hdfs/core-site.xml:/opt/hadoop/etc/hadoop/core-site.xml
+      - ./dev/hdfs/hdfs-site.xml:/opt/hadoop/etc/hadoop/hdfs-site.xml
+      - ./dev/hdfs/start-hdfs.sh:/start-hdfs.sh
+    entrypoint: /start-hdfs.sh
+    # Only run on a profile so we can use the github action for HDFS support during CI
+    profiles:
+      - hdfs

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -48,6 +48,9 @@ Unit test:
 make unit-test
 ```
 
+### Working with HDFS
+HDFS support is disabled by default for local development, due to the Java dependency to build. To enable HDFS support locally, set `MATURIN_EXTRA_ARGS="-F hdfs"` with the above commands.
+
 ## Release process
 
 1. Make a new PR to update the version in pyproject.toml.

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -39,7 +39,7 @@ features = ["extension-module", "abi3", "abi3-py37"]
 [dependencies.deltalake]
 path = "../rust"
 version = "0"
-features = ["azure", "gcs", "python", "datafusion", "unity-experimental"]
+features = ["azure", "gcs", "python", "datafusion", "unity-experimental", "hdfs"]
 
 [features]
 default = ["rustls"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -39,9 +39,10 @@ features = ["extension-module", "abi3", "abi3-py37"]
 [dependencies.deltalake]
 path = "../rust"
 version = "0"
-features = ["azure", "gcs", "python", "datafusion", "unity-experimental", "hdfs"]
+features = ["azure", "gcs", "python", "datafusion", "unity-experimental"]
 
 [features]
 default = ["rustls"]
+hdfs = ["deltalake/hdfs"]
 native-tls = ["deltalake/s3-native-tls", "deltalake/glue-native-tls"]
 rustls = ["deltalake/s3", "deltalake/glue"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -98,6 +98,7 @@ markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
     "s3: marks tests as integration tests with S3 (deselect with '-m \"not s3\"')",
     "azure: marks tests as integration tests with Azure Blob Store",
+    "hdfs: marks tests as integrations tests with HDFS",
     "pandas: marks tests that require pandas",
     "pyspark: marks tests that require pyspark",
 ]

--- a/python/tests/test_fs.py
+++ b/python/tests/test_fs.py
@@ -254,3 +254,20 @@ def test_pickle_roundtrip(tmp_path):
 
     infos = store_pkl.get_file_info(["asd.pkl"])
     assert infos[0].size > 0
+
+
+@pytest.mark.hdfs
+@pytest.mark.integration
+@pytest.mark.timeout(timeout=30, method="thread")
+def test_read_hdfs(hdfs_url):
+    table_path = f"{hdfs_url}/deltars/simple"
+    handler = DeltaStorageHandler(table_path)
+    dt = DeltaTable(table_path)
+    files = dt.file_uris()
+    assert len(files) > 0
+    for file in files:
+        rel_path = file[len(table_path) :]
+        with handler.open_input_file(rel_path) as f_:
+            table = pq.read_table(f_)
+            assert isinstance(table, pa.Table)
+            assert table.shape > (0, 0)


### PR DESCRIPTION
# Description
The description of the main changes of your pull request

Adds support for HDFS in the Python package by enabling the `hdfs` feature from the Rust library. Additionally adds a simple integration test, and docker-compose support to run the integration test locally.

Had to update some of the workflows to accommodate. The trickiest one was the Python 3.7 stage that uses an old OS, which doesn't have a new enough clang library to compile the HDFS object store I guess?

This might require Java to build and develop on any Python related thing now? Not totally sure what side effects this might induce, first time playing around with this library (avid Spark user).

# Related Issue(s)
<!---
For example:

- closes #106
--->
Closes https://github.com/delta-io/delta-rs/issues/1358

# Documentation

<!---
Share links to useful documentation
--->
