### PR TITLE
docs: updated schema.rs to use the right signature for decimal data type in documentation

### DIFF
--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -110,7 +110,7 @@ fn python_type_to_schema(ob: PyObject, py: Python) -> PyResult<SchemaDataType> {
 ///  * "binary",
 ///  * "date",
 ///  * "timestamp",
-///  * "decimal(<scale>, <precision>)"
+///  * "decimal(<precision>, <scale>)"
 ///
 /// :param data_type: string representation of the data type
 #[pyclass(module = "deltalake.schema", text_signature = "(data_type)")]


### PR DESCRIPTION
# Description
docs: Minor change in the docs. The documentation says Decimal(\<scale\>, \<precision\>) but it should be Decimal(\<precision\>, \<scale\>)

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
