### PR TITLE
perf: improve record batch partitioning

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,10 @@ edition = "2021"
 arrow = { version = "39", optional = true }
 arrow-array = { version = "39", optional = true }
 arrow-cast = { version = "39", optional = true }
+arrow-ord = { version = "39", optional = true }
+arrow-row = { version = "39", optional = true }
 arrow-schema = { version = "39", optional = true }
+arrow-select = { version = "39", optional = true }
 async-trait = "0.1"
 bytes = "1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
@@ -102,7 +105,7 @@ glibc_version = { path = "../glibc_version", version = "0.1" }
 
 [features]
 azure = ["object_store/azure"]
-arrow = ["dep:arrow", "arrow-array", "arrow-cast", "arrow-schema"]
+arrow = ["dep:arrow", "arrow-array", "arrow-cast", "arrow-ord", "arrow-row", "arrow-schema", "arrow-select"]
 default = ["arrow", "parquet"]
 datafusion = [
     "dep:datafusion",


### PR DESCRIPTION
# Description

Some time ago, the arrow-row crate was published, specifically with use cases like multi-column ordering / sorting in mind. We need to do this whenever we write data to a table to partition batches according to their partition values. In this PR we adopt this. As a drive-by I also updated the imports in the module to import from the respective sub-crates.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
