### PR TITLE
feat: more efficient parquet writer and more statistics

### DIFF
--- a/rust/src/writer/json.rs
+++ b/rust/src/writer/json.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use super::stats::{apply_null_counts, create_add, NullCounts};
+use super::stats::create_add;
 use super::utils::{
     arrow_schema_without_partitions, next_data_path, record_batch_from_message,
     record_batch_without_partitions, stringified_partition_value,
@@ -42,7 +42,6 @@ pub(crate) struct DataArrowWriter {
     buffer: ShareableBuffer,
     arrow_writer: ArrowWriter<ShareableBuffer>,
     partition_values: HashMap<String, Option<String>>,
-    null_counts: NullCounts,
     buffered_record_batch_count: usize,
 }
 
@@ -120,7 +119,6 @@ impl DataArrowWriter {
         match result {
             Ok(_) => {
                 self.buffered_record_batch_count += 1;
-                apply_null_counts(&record_batch.into(), &mut self.null_counts, 0);
                 Ok(())
             }
             // If a write fails we need to reset the state of the DeltaArrowWriter
@@ -152,7 +150,6 @@ impl DataArrowWriter {
         )?;
 
         let partition_values = HashMap::new();
-        let null_counts = NullCounts::new();
         let buffered_record_batch_count = 0;
 
         Ok(Self {
@@ -161,7 +158,6 @@ impl DataArrowWriter {
             buffer,
             arrow_writer,
             partition_values,
-            null_counts,
             buffered_record_batch_count,
         })
     }

--- a/rust/src/writer/mod.rs
+++ b/rust/src/writer/mod.rs
@@ -4,7 +4,7 @@
 use crate::action::{Action, Add, ColumnCountStat};
 use crate::{DeltaTable, DeltaTableError};
 
-use arrow::{datatypes::SchemaRef, datatypes::*, error::ArrowError};
+use arrow::{datatypes::SchemaRef, error::ArrowError};
 use async_trait::async_trait;
 use object_store::Error as ObjectStoreError;
 use parquet::errors::ParquetError;

--- a/rust/src/writer/mod.rs
+++ b/rust/src/writer/mod.rs
@@ -7,7 +7,7 @@ use crate::{DeltaTable, DeltaTableError};
 use arrow::{datatypes::SchemaRef, datatypes::*, error::ArrowError};
 use async_trait::async_trait;
 use object_store::Error as ObjectStoreError;
-use parquet::{basic::LogicalType, errors::ParquetError};
+use parquet::errors::ParquetError;
 use serde_json::Value;
 
 pub use json::JsonWriter;
@@ -55,9 +55,15 @@ pub(crate) enum DeltaWriterError {
     },
 
     /// Serialization of delta log statistics failed.
-    #[error("Serialization of delta log statistics failed: {source}")]
-    StatsSerializationFailed {
-        /// error raised during stats serialization.
+    #[error("Failed to write statistics value {debug_value} with logical type {logical_type:?}")]
+    StatsParsingFailed {
+        debug_value: String,
+        logical_type: Option<parquet::basic::LogicalType>,
+    },
+
+    /// JSON serialization failed
+    #[error("Failed to serialize data to JSON: {source}")]
+    JSONSerializationFailed {
         #[from]
         source: serde_json::Error,
     },

--- a/rust/src/writer/record_batch.rs
+++ b/rust/src/writer/record_batch.rs
@@ -26,30 +26,31 @@
 //!     }))
 //! }
 //! ```
+use std::{collections::HashMap, sync::Arc};
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::sync::Arc;
-
-use arrow_array::{ArrayRef, RecordBatch, UInt32Array};
-use arrow_ord::{partition::lexicographical_partition_ranges, sort::SortColumn};
+use super::{
+    stats::create_add,
+    utils::{
+        arrow_schema_without_partitions, next_data_path, record_batch_without_partitions,
+        stringified_partition_value, PartitionPath,
+    },
+    DeltaWriter, DeltaWriterError,
+};
+use crate::builder::DeltaTableBuilder;
+use crate::writer::utils::ShareableBuffer;
+use crate::DeltaTableError;
+use crate::{action::Add, storage::DeltaObjectStore, DeltaTable, DeltaTableMetaData, Schema};
+use arrow::array::{Array, UInt32Array};
+use arrow::compute::{lexicographical_partition_ranges, take, SortColumn};
+use arrow::datatypes::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
+use arrow::error::ArrowError;
+use arrow::record_batch::RecordBatch;
+use arrow_array::ArrayRef;
 use arrow_row::{RowConverter, SortField};
-use arrow_schema::{ArrowError, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
-use arrow_select::take::take;
 use bytes::Bytes;
 use object_store::ObjectStore;
 use parquet::{arrow::ArrowWriter, errors::ParquetError};
 use parquet::{basic::Compression, file::properties::WriterProperties};
-
-use super::stats::{create_add, NullCounts};
-use super::utils::{
-    arrow_schema_without_partitions, next_data_path, record_batch_without_partitions,
-    stringified_partition_value, PartitionPath,
-};
-use super::{DeltaTableError, DeltaWriter, DeltaWriterError};
-use crate::builder::DeltaTableBuilder;
-use crate::writer::{stats::apply_null_counts, utils::ShareableBuffer};
-use crate::{action::Add, storage::DeltaObjectStore, DeltaTable, DeltaTableMetaData, Schema};
 
 /// Writes messages to a delta lake table.
 pub struct RecordBatchWriter {
@@ -258,7 +259,6 @@ struct PartitionWriter {
     pub(super) buffer: ShareableBuffer,
     pub(super) arrow_writer: ArrowWriter<ShareableBuffer>,
     pub(super) partition_values: HashMap<String, Option<String>>,
-    pub(super) null_counts: NullCounts,
     pub(super) buffered_record_batch_count: usize,
 }
 
@@ -275,7 +275,6 @@ impl PartitionWriter {
             Some(writer_properties.clone()),
         )?;
 
-        let null_counts = NullCounts::new();
         let buffered_record_batch_count = 0;
 
         Ok(Self {
@@ -284,7 +283,6 @@ impl PartitionWriter {
             buffer,
             arrow_writer,
             partition_values,
-            null_counts,
             buffered_record_batch_count,
         })
     }
@@ -306,7 +304,6 @@ impl PartitionWriter {
         match self.arrow_writer.write(record_batch) {
             Ok(_) => {
                 self.buffered_record_batch_count += 1;
-                apply_null_counts(&record_batch.clone().into(), &mut self.null_counts, 0);
                 Ok(())
             }
             // If a write fails we need to reset the state of the PartitionWriter

--- a/rust/src/writer/record_batch.rs
+++ b/rust/src/writer/record_batch.rs
@@ -225,19 +225,15 @@ impl DeltaWriter<RecordBatch> for RecordBatchWriter {
         let writers = std::mem::take(&mut self.arrow_writers);
         let mut actions = Vec::new();
 
-        for (_, mut writer) in writers {
+        for (_, writer) in writers {
             let metadata = writer.arrow_writer.close()?;
             let path = next_data_path(&self.partition_columns, &writer.partition_values, None)?;
             let obj_bytes = Bytes::from(writer.buffer.to_vec());
             let file_size = obj_bytes.len() as i64;
             self.storage.put(&path, obj_bytes).await?;
 
-            // Replace self null_counts with an empty map. Use the other for stats.
-            let null_counts = std::mem::take(&mut writer.null_counts);
-
             actions.push(create_add(
                 &writer.partition_values,
-                null_counts,
                 path.to_string(),
                 file_size,
                 &metadata,

--- a/rust/src/writer/stats.rs
+++ b/rust/src/writer/stats.rs
@@ -615,8 +615,6 @@ mod tests {
         let mut null_count_keys = vec!["some_list", "some_nested_list"];
         null_count_keys.extend_from_slice(min_max_keys.as_slice());
 
-        dbg!(&stats);
-
         assert_eq!(min_max_keys.len(), stats.min_values.len());
         assert_eq!(min_max_keys.len(), stats.max_values.len());
         assert_eq!(null_count_keys.len(), stats.null_count.len());

--- a/rust/src/writer/test_utils.rs
+++ b/rust/src/writer/test_utils.rs
@@ -1,10 +1,10 @@
 #![allow(deprecated)]
 //! Utilities for writing unit tests
-use super::*;
 use crate::{
     action::Protocol, schema::Schema, DeltaTable, DeltaTableBuilder, DeltaTableMetaData,
     SchemaDataType, SchemaField,
 };
+use arrow::datatypes::{DataType, Field};
 use arrow::record_batch::RecordBatch;
 use arrow::{
     array::{Int32Array, StringArray, UInt32Array},


### PR DESCRIPTION
# Description

* Removed the data copies in a tight loop, which were extremely bad for performance when writing files > 100MB.
* Rewrote statistics handling to collect null values from metadata, just like min and max.
* Added support for more types in statistics.

# Related Issue(s)

- closes #1394
- closes #1209 
- closes #1208


# Documentation

<!---
Share links to useful documentation
--->
