### PR TITLE
feat: add list_with_offset to DeltaObjectStore

### DIFF
--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -236,6 +236,18 @@ impl ObjectStore for DeltaObjectStore {
         self.storage.list(prefix).await
     }
 
+    /// List all the objects with the given prefix and a location greater than `offset`
+    ///
+    /// Some stores, such as S3 and GCS, may be able to push `offset` down to reduce
+    /// the number of network requests required
+    async fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> ObjectStoreResult<BoxStream<'_, ObjectStoreResult<ObjectMeta>>> {
+        self.storage.list_with_offset(prefix, offset).await
+    }
+
     /// List objects with the given prefix and an implementation specific
     /// delimiter. Returns common prefixes (directories) in addition to object
     /// metadata.


### PR DESCRIPTION
# Description
Adds the `list_with_offset` delegation method to `DeltaObjectStore`.

# Related Issue(s)
- closes #1252 

# Documentation

https://github.com/apache/arrow-rs/issues/3970
