### PR TITLE
feat: add z-order optimize

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2021"
 [dependencies]
 arrow = { version = "39", optional = true }
 arrow-array = { version = "39", optional = true }
+arrow-buffer = { version = "39", optional = true }
 arrow-cast = { version = "39", optional = true }
 arrow-ord = { version = "39", optional = true }
 arrow-row = { version = "39", optional = true }
@@ -104,7 +105,7 @@ utime = "0.3"
 
 [features]
 azure = ["object_store/azure"]
-arrow = ["dep:arrow", "arrow-array", "arrow-cast", "arrow-ord", "arrow-row", "arrow-schema", "arrow-select"]
+arrow = ["dep:arrow", "arrow-array", "arrow-cast", "arrow-ord", "arrow-row", "arrow-schema", "arrow-select", "arrow-buffer"]
 default = ["arrow", "parquet"]
 datafusion = [
     "dep:datafusion",

--- a/rust/tests/command_optimize.rs
+++ b/rust/tests/command_optimize.rs
@@ -7,7 +7,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use deltalake::action::{Action, Remove};
-use deltalake::operations::optimize::{create_merge_plan, MetricDetails, Metrics};
+use deltalake::operations::optimize::{create_merge_plan, MetricDetails, Metrics, OptimizeType};
 use deltalake::operations::DeltaOps;
 use deltalake::writer::{DeltaWriter, RecordBatchWriter};
 use deltalake::{DeltaTable, DeltaTableError, PartitionFilter, SchemaDataType, SchemaField};
@@ -263,6 +263,7 @@ async fn test_conflict_for_remove_actions() -> Result<(), Box<dyn Error>> {
     //create the merge plan, remove a file, and execute the plan.
     let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
     let plan = create_merge_plan(
+        OptimizeType::Compact,
         &dt.state,
         &filter,
         None,
@@ -325,6 +326,7 @@ async fn test_no_conflict_for_append_actions() -> Result<(), Box<dyn Error>> {
     //create the merge plan, remove a file, and execute the plan.
     let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
     let plan = create_merge_plan(
+        OptimizeType::Compact,
         &dt.state,
         &filter,
         None,

--- a/rust/tests/command_optimize.rs
+++ b/rust/tests/command_optimize.rs
@@ -6,11 +6,17 @@ use arrow::{
     datatypes::{DataType, Field},
     record_batch::RecordBatch,
 };
+use arrow_select::concat::concat_batches;
 use deltalake::action::{Action, Remove};
 use deltalake::operations::optimize::{create_merge_plan, MetricDetails, Metrics, OptimizeType};
 use deltalake::operations::DeltaOps;
+use deltalake::storage::ObjectStoreRef;
 use deltalake::writer::{DeltaWriter, RecordBatchWriter};
-use deltalake::{DeltaTable, DeltaTableError, PartitionFilter, SchemaDataType, SchemaField};
+use deltalake::{DeltaTable, DeltaTableError, PartitionFilter, Path, SchemaDataType, SchemaField};
+use futures::TryStreamExt;
+use object_store::ObjectStore;
+use parquet::arrow::async_reader::ParquetObjectReader;
+use parquet::arrow::ParquetRecordBatchStreamBuilder;
 use parquet::file::properties::WriterProperties;
 use rand::prelude::*;
 use serde_json::json;
@@ -496,4 +502,198 @@ async fn test_commit_info() -> Result<(), Box<dyn Error>> {
     // assert_eq!(parameters["predicate"], None);
 
     Ok(())
+}
+
+#[tokio::test]
+async fn test_zorder_rejects_zero_columns() -> Result<(), Box<dyn Error>> {
+    let context = setup_test(true).await?;
+    let dt = context.table;
+
+    // Rejects zero columns
+    let result = DeltaOps(dt)
+        .optimize()
+        .with_type(OptimizeType::ZOrder(vec![]))
+        .await;
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Z-order requires at least one column"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_zorder_rejects_nonexistent_columns() -> Result<(), Box<dyn Error>> {
+    let context = setup_test(true).await?;
+    let dt = context.table;
+
+    // Rejects non-existent columns
+    let result = DeltaOps(dt)
+        .optimize()
+        .with_type(OptimizeType::ZOrder(vec!["non-existent".to_string()]))
+        .await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains(
+        "Z-order columns must be present in the table schema. Unknown columns: [\"non-existent\"]"
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_zorder_rejects_partition_column() -> Result<(), Box<dyn Error>> {
+    let context = setup_test(true).await?;
+    let mut dt = context.table;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
+
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(1, 2), (1, 3), (1, 4)], "2022-05-22")?,
+    )
+    .await?;
+    // Rejects partition columns
+    let result = DeltaOps(dt)
+        .optimize()
+        .with_type(OptimizeType::ZOrder(vec!["date".to_string()]))
+        .await;
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Z-order columns cannot be partition columns. Found: [\"date\"]"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_zorder_unpartitioned() -> Result<(), Box<dyn Error>> {
+    let context = setup_test(false).await?;
+    let mut dt = context.table;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
+
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(1, 1), (1, 2), (1, 2)], "1970-01-01")?,
+    )
+    .await?;
+
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(2, 1), (2, 2), (1, 2)], "1970-01-04")?,
+    )
+    .await?;
+
+    let optimize = DeltaOps(dt).optimize().with_type(OptimizeType::ZOrder(vec![
+        "date".to_string(),
+        "x".to_string(),
+        "y".to_string(),
+    ]));
+    let (dt, metrics) = optimize.await?;
+
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 2);
+    assert_eq!(metrics.total_files_skipped, 0);
+    assert_eq!(metrics.total_considered_files, 2);
+
+    // Check data
+    let files = dt.get_files();
+    assert_eq!(files.len(), 1);
+
+    let actual = read_parquet_file(&files[0], dt.object_store()).await?;
+    let expected = RecordBatch::try_new(
+        actual.schema(),
+        // Note that the order is not hierarchically sorted.
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 1, 1, 1, 2])),
+            Arc::new(Int32Array::from(vec![1, 1, 2, 2, 2, 2])),
+            Arc::new(StringArray::from(vec![
+                "1970-01-01",
+                "1970-01-04",
+                "1970-01-01",
+                "1970-01-01",
+                "1970-01-04",
+                "1970-01-04",
+            ])),
+        ],
+    )?;
+
+    assert_eq!(actual, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_zorder_partitioned() -> Result<(), Box<dyn Error>> {
+    let context = setup_test(true).await?;
+    let mut dt = context.table;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
+
+    // Write data in sorted order. Each value is a power of 2, so will affect
+    // a new bit in the z-ordering.
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(1, 1), (1, 2), (1, 4)], "2022-05-22")?,
+    )
+    .await?;
+
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(2, 1), (2, 2), (2, 4)], "2022-05-22")?,
+    )
+    .await?;
+
+    // This batch doesn't matter; we just use it to test partition filtering
+    write(
+        &mut writer,
+        &mut dt,
+        tuples_to_batch(vec![(1, 1), (1, 1), (1, 1)], "2022-05-23")?,
+    )
+    .await?;
+
+    let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
+
+    let optimize = DeltaOps(dt)
+        .optimize()
+        .with_type(OptimizeType::ZOrder(vec!["x".to_string(), "y".to_string()]))
+        .with_filters(&filter);
+    let (dt, metrics) = optimize.await?;
+
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 2);
+
+    // Check data
+    let files = dt.get_files_by_partitions(&filter)?;
+    assert_eq!(files.len(), 1);
+
+    let actual = read_parquet_file(&files[0], dt.object_store()).await?;
+    let expected = RecordBatch::try_new(
+        actual.schema(),
+        // Note that the order is not hierarchically sorted.
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 1, 2, 1, 2])),
+            Arc::new(Int32Array::from(vec![1, 1, 2, 2, 4, 4])),
+        ],
+    )?;
+
+    assert_eq!(actual, expected);
+
+    Ok(())
+}
+
+async fn read_parquet_file(
+    path: &Path,
+    object_store: ObjectStoreRef,
+) -> Result<RecordBatch, Box<dyn Error>> {
+    let file = object_store.head(path).await?;
+    let file_reader = ParquetObjectReader::new(object_store, file);
+    let batches = ParquetRecordBatchStreamBuilder::new(file_reader)
+        .await?
+        .build()?
+        .try_collect::<Vec<_>>()
+        .await?;
+    Ok(concat_batches(&batches[0].schema(), &batches)?)
 }


### PR DESCRIPTION
# Description

Implements Z-order in Rust. This is a very basic version that requires loading the whole partition into memory for sorting. In the future, we can implement a DataFusion-based code path that allows sorting with spilling to disk for even larger optimize jobs.

The Z-order function here is based on Arrow's row format. We truncate to take the first 16 bytes of data (padding with zeros at end as necessary). So for variable-width columns like strings, this means that we are only using the first 15 bytes of the string (the first byte is used to differentiate null and empty strings, [see row format docs](https://docs.rs/arrow-row/40.0.0/arrow_row/struct.RowConverter.html#variable-length-bytes-including-strings-encoding)). If a user has a string column where they all share the same prefix, this z-order function won't work well for them. But in many common cases it will work.

We'll also expose this in Python as a follow up.

# Related Issue(s)

- closes #1127


# Documentation

<!---
Share links to useful documentation
--->
