### PR TITLE
refactor: move checkpoint and errors into separate module

### DIFF
--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -1,6 +1,6 @@
 use arrow_schema::ArrowError;
 use deltalake::checkpoints::CheckpointError;
-use deltalake::{DeltaTableError, ObjectStoreError};
+use deltalake::{errors::DeltaTableError, ObjectStoreError};
 use pyo3::exceptions::{
     PyException, PyFileNotFoundError, PyIOError, PyNotImplementedError, PyValueError,
 };

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -1,5 +1,5 @@
 use arrow_schema::ArrowError;
-use deltalake::checkpoints::CheckpointError;
+use deltalake::action::ProtocolError;
 use deltalake::{errors::DeltaTableError, ObjectStoreError};
 use pyo3::exceptions::{
     PyException, PyFileNotFoundError, PyIOError, PyNotImplementedError, PyValueError,
@@ -59,16 +59,16 @@ fn arrow_to_py(err: ArrowError) -> PyErr {
     }
 }
 
-fn checkpoint_to_py(err: CheckpointError) -> PyErr {
+fn checkpoint_to_py(err: ProtocolError) -> PyErr {
     match err {
-        CheckpointError::Io { source } => PyIOError::new_err(source.to_string()),
-        CheckpointError::Arrow { source } => arrow_to_py(source),
-        CheckpointError::DeltaTable { source } => inner_to_py_err(source),
-        CheckpointError::ObjectStore { source } => object_store_to_py(source),
-        CheckpointError::MissingMetaData => DeltaProtocolError::new_err("Table metadata missing"),
-        CheckpointError::PartitionValueNotParseable(err) => PyValueError::new_err(err),
-        CheckpointError::JSONSerialization { source } => PyValueError::new_err(source.to_string()),
-        CheckpointError::Parquet { source } => PyIOError::new_err(source.to_string()),
+        ProtocolError::Arrow { source } => arrow_to_py(source),
+        ProtocolError::ObjectStore { source } => object_store_to_py(source),
+        ProtocolError::NoMetaData => DeltaProtocolError::new_err("Table metadata missing"),
+        ProtocolError::InvalidField(err) => PyValueError::new_err(err),
+        ProtocolError::InvalidRow(err) => PyValueError::new_err(err),
+        ProtocolError::SerializeOperation { source } => PyValueError::new_err(source.to_string()),
+        ProtocolError::ParquetParseError { source } => PyIOError::new_err(source.to_string()),
+        ProtocolError::Generic(msg) => DeltaError::new_err(msg),
     }
 }
 
@@ -81,7 +81,7 @@ pub enum PythonError {
     #[error("Error in arrow")]
     Arrow(#[from] ArrowError),
     #[error("Error in checkpoint")]
-    Checkpoint(#[from] CheckpointError),
+    Protocol(#[from] ProtocolError),
 }
 
 impl From<PythonError> for pyo3::PyErr {
@@ -90,7 +90,7 @@ impl From<PythonError> for pyo3::PyErr {
             PythonError::DeltaTable(err) => inner_to_py_err(err),
             PythonError::ObjectStore(err) => object_store_to_py(err),
             PythonError::Arrow(err) => arrow_to_py(err),
-            PythonError::Checkpoint(err) => checkpoint_to_py(err),
+            PythonError::Protocol(err) => checkpoint_to_py(err),
         }
     }
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -23,6 +23,7 @@ use deltalake::builder::DeltaTableBuilder;
 use deltalake::checkpoints::create_checkpoint;
 use deltalake::datafusion::prelude::SessionContext;
 use deltalake::delta_datafusion::DeltaDataChecker;
+use deltalake::errors::DeltaTableError;
 use deltalake::operations::optimize::OptimizeBuilder;
 use deltalake::operations::transaction::commit;
 use deltalake::operations::vacuum::VacuumBuilder;
@@ -174,7 +175,7 @@ impl RawDeltaTable {
         &self,
         partitions_filters: Vec<(&str, &str, PartitionFilterValue)>,
     ) -> PyResult<Vec<String>> {
-        let partition_filters: Result<Vec<PartitionFilter<&str>>, deltalake::DeltaTableError> =
+        let partition_filters: Result<Vec<PartitionFilter<&str>>, DeltaTableError> =
             partitions_filters
                 .into_iter()
                 .map(|filter| match filter {
@@ -520,7 +521,7 @@ impl RawDeltaTable {
 
 fn convert_partition_filters<'a>(
     partitions_filters: Vec<(&'a str, &'a str, PartitionFilterValue<'a>)>,
-) -> Result<Vec<PartitionFilter<&'a str>>, deltalake::DeltaTableError> {
+) -> Result<Vec<PartitionFilter<&'a str>>, DeltaTableError> {
     partitions_filters
         .into_iter()
         .map(|filter| match filter {

--- a/rust/examples/basic_operations.rs
+++ b/rust/examples/basic_operations.rs
@@ -37,7 +37,7 @@ fn get_table_batches() -> RecordBatch {
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), deltalake::DeltaTableError> {
+async fn main() -> Result<(), deltalake::errors::DeltaTableError> {
     // Create a delta operations client pointing at an un-initialized in-memory location.
     // In a production environment this would be created with "try_new" and point at
     // a real storage location.

--- a/rust/examples/read_delta_table.rs
+++ b/rust/examples/read_delta_table.rs
@@ -1,5 +1,5 @@
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), deltalake::DeltaTableError> {
+async fn main() -> Result<(), deltalake::errors::DeltaTableError> {
     let table_path = "./tests/data/delta-0.8.0";
     let table = deltalake::open_table(table_path).await?;
     println!("{table}");

--- a/rust/examples/recordbatch-writer.rs
+++ b/rust/examples/recordbatch-writer.rs
@@ -10,6 +10,7 @@
 use chrono::prelude::*;
 use deltalake::arrow::array::*;
 use deltalake::arrow::record_batch::RecordBatch;
+use deltalake::errors::DeltaTableError;
 use deltalake::writer::{DeltaWriter, RecordBatchWriter};
 use deltalake::*;
 use log::*;

--- a/rust/src/action/checkpoints.rs
+++ b/rust/src/action/checkpoints.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Datelike, Duration, Utc};
 use futures::StreamExt;
 use lazy_static::lazy_static;
 use log::*;
-use object_store::{path::Path, Error as ObjectStoreError, ObjectMeta, ObjectStore};
+use object_store::{path::Path, ObjectMeta, ObjectStore};
 use parquet::arrow::ArrowWriter;
 use parquet::errors::ParquetError;
 use regex::Regex;
@@ -17,31 +17,23 @@ use std::convert::TryFrom;
 use std::iter::Iterator;
 use std::ops::Add;
 
-use super::{Action, Add as AddAction, MetaData, Protocol, Txn};
+use super::{Action, Add as AddAction, MetaData, Protocol, ProtocolError, Txn};
 use crate::delta_arrow::delta_log_schema_for_table;
-use crate::errors::DeltaTableError;
 use crate::schema::*;
 use crate::storage::DeltaObjectStore;
 use crate::table_state::DeltaTableState;
 use crate::{open_table_with_version, time_utils, CheckPoint, DeltaTable};
 
+type SchemaPath = Vec<String>;
+
 /// Error returned when there is an error during creating a checkpoint.
 #[derive(thiserror::Error, Debug)]
-pub enum CheckpointError {
-    /// Error returned when the DeltaTableState does not contain a metadata action.
-    #[error("DeltaTableMetadata not present in DeltaTableState")]
-    MissingMetaData,
+enum CheckpointError {
     /// Error returned when a string formatted partition value cannot be parsed to its appropriate
     /// data type.
     #[error("Partition value {0} cannot be parsed from string.")]
     PartitionValueNotParseable(String),
-    /// Passthrough error returned when calling DeltaTable.
-    #[error("DeltaTableError: {source}")]
-    DeltaTable {
-        /// The source DeltaTableError.
-        #[from]
-        source: DeltaTableError,
-    },
+
     /// Error returned when the parquet writer fails while writing the checkpoint.
     #[error("Failed to write parquet: {}", .source)]
     Parquet {
@@ -49,6 +41,7 @@ pub enum CheckpointError {
         #[from]
         source: ParquetError,
     },
+
     /// Error returned when converting the schema to Arrow format failed.
     #[error("Failed to convert into Arrow schema: {}", .source)]
     Arrow {
@@ -56,48 +49,30 @@ pub enum CheckpointError {
         #[from]
         source: ArrowError,
     },
-    /// Passthrough error returned when calling ObjectStore.
-    #[error("ObjectStoreError: {source}")]
-    ObjectStore {
-        /// The source ObjectStoreError.
-        #[from]
-        source: ObjectStoreError,
-    },
-    /// Passthrough error returned by serde_json.
-    #[error("serde_json::Error: {source}")]
-    JSONSerialization {
-        /// The source serde_json::Error.
-        #[from]
-        source: serde_json::Error,
-    },
-    /// Passthrough error returned when doing std::io operations
-    #[error("std::io::Error: {source}")]
-    Io {
-        /// The source std::io::Error
-        #[from]
-        source: std::io::Error,
-    },
+}
+
+impl From<CheckpointError> for ProtocolError {
+    fn from(value: CheckpointError) -> Self {
+        match value {
+            CheckpointError::PartitionValueNotParseable(_) => Self::InvalidField(value.to_string()),
+            CheckpointError::Arrow { source } => Self::Arrow { source },
+            CheckpointError::Parquet { source } => Self::ParquetParseError { source },
+        }
+    }
 }
 
 /// The record batch size for checkpoint parquet file
 pub const CHECKPOINT_RECORD_BATCH_SIZE: usize = 5000;
 
-impl From<CheckpointError> for ArrowError {
-    fn from(error: CheckpointError) -> Self {
-        ArrowError::from_external_error(Box::new(error))
-    }
-}
-
 /// Creates checkpoint at current table version
-pub async fn create_checkpoint(table: &DeltaTable) -> Result<(), CheckpointError> {
+pub async fn create_checkpoint(table: &DeltaTable) -> Result<(), ProtocolError> {
     create_checkpoint_for(table.version(), table.get_state(), table.storage.as_ref()).await?;
-
     Ok(())
 }
 
 /// Delete expires log files before given version from table. The table log retention is based on
 /// the `logRetentionDuration` property of the Delta Table, 30 days by default.
-pub async fn cleanup_metadata(table: &DeltaTable) -> Result<i32, DeltaTableError> {
+pub async fn cleanup_metadata(table: &DeltaTable) -> Result<i32, ProtocolError> {
     let log_retention_timestamp =
         Utc::now().timestamp_millis() - table.get_state().log_retention_millis();
     cleanup_expired_logs_for(
@@ -115,8 +90,10 @@ pub async fn create_checkpoint_from_table_uri_and_cleanup(
     table_uri: &str,
     version: i64,
     cleanup: Option<bool>,
-) -> Result<(), CheckpointError> {
-    let table = open_table_with_version(table_uri, version).await?;
+) -> Result<(), ProtocolError> {
+    let table = open_table_with_version(table_uri, version)
+        .await
+        .map_err(|err| ProtocolError::Generic(err.to_string()))?;
     create_checkpoint_for(version, table.get_state(), table.storage.as_ref()).await?;
 
     let enable_expired_log_cleanup =
@@ -134,7 +111,7 @@ async fn create_checkpoint_for(
     version: i64,
     state: &DeltaTableState,
     storage: &DeltaObjectStore,
-) -> Result<(), CheckpointError> {
+) -> Result<(), ProtocolError> {
     // TODO: checkpoints _can_ be multi-part... haven't actually found a good reference for
     // an appropriate split point yet though so only writing a single part currently.
     // See https://github.com/delta-io/delta-rs/issues/288
@@ -167,7 +144,7 @@ async fn flush_delete_files<T: Fn(&(i64, ObjectMeta)) -> bool>(
     maybe_delete_files: &mut Vec<(i64, ObjectMeta)>,
     files_to_delete: &mut Vec<(i64, ObjectMeta)>,
     should_delete_file: T,
-) -> Result<i32, DeltaTableError> {
+) -> Result<i32, ProtocolError> {
     if !maybe_delete_files.is_empty() && should_delete_file(maybe_delete_files.last().unwrap()) {
         files_to_delete.append(maybe_delete_files);
     }
@@ -177,7 +154,7 @@ async fn flush_delete_files<T: Fn(&(i64, ObjectMeta)) -> bool>(
         .map(|file| async move {
             match storage.delete(&file.1.location).await {
                 Ok(_) => Ok(1),
-                Err(e) => Err(DeltaTableError::from(e)),
+                Err(e) => Err(ProtocolError::from(e)),
             }
         })
         .collect::<Vec<_>>();
@@ -200,7 +177,7 @@ pub async fn cleanup_expired_logs_for(
     until_version: i64,
     storage: &DeltaObjectStore,
     log_retention_timestamp: i64,
-) -> Result<i32, DeltaTableError> {
+) -> Result<i32, ProtocolError> {
     lazy_static! {
         static ref DELTA_LOG_REGEX: Regex =
             Regex::new(r#"_delta_log/(\d{20})\.(json|checkpoint).*$"#).unwrap();
@@ -304,10 +281,8 @@ pub async fn cleanup_expired_logs_for(
     }
 }
 
-fn parquet_bytes_from_state(state: &DeltaTableState) -> Result<bytes::Bytes, CheckpointError> {
-    let current_metadata = state
-        .current_metadata()
-        .ok_or(CheckpointError::MissingMetaData)?;
+fn parquet_bytes_from_state(state: &DeltaTableState) -> Result<bytes::Bytes, ProtocolError> {
+    let current_metadata = state.current_metadata().ok_or(ProtocolError::NoMetaData)?;
 
     let partition_col_data_types = current_metadata.get_partition_col_data_types();
 
@@ -370,7 +345,7 @@ fn parquet_bytes_from_state(state: &DeltaTableState) -> Result<bytes::Bytes, Che
 
         Action::remove(r)
     }))
-    .map(|a| serde_json::to_value(a).map_err(|err| ArrowError::JsonError(err.to_string())))
+    .map(|a| serde_json::to_value(a).map_err(ProtocolError::from))
     // adds
     .chain(state.files().iter().map(|f| {
         checkpoint_add_from_state(f, partition_col_data_types.as_slice(), &stats_conversions)
@@ -390,7 +365,7 @@ fn parquet_bytes_from_state(state: &DeltaTableState) -> Result<bytes::Bytes, Che
     let mut decoder = ReaderBuilder::new(arrow_schema)
         .with_batch_size(CHECKPOINT_RECORD_BATCH_SIZE)
         .build_decoder()?;
-    let jsons: Vec<serde_json::Value> = jsons.map(|r| r.unwrap()).collect();
+    let jsons = jsons.collect::<Result<Vec<serde_json::Value>, _>>()?;
     decoder.serialize(&jsons)?;
 
     while let Some(batch) = decoder.flush()? {
@@ -407,7 +382,7 @@ fn checkpoint_add_from_state(
     add: &AddAction,
     partition_col_data_types: &[(&str, &SchemaDataType)],
     stats_conversions: &[(SchemaPath, SchemaDataType)],
-) -> Result<Value, ArrowError> {
+) -> Result<Value, ProtocolError> {
     let mut v = serde_json::to_value(Action::add(add.clone()))
         .map_err(|err| ArrowError::JsonError(err.to_string()))?;
 
@@ -455,7 +430,7 @@ fn checkpoint_add_from_state(
 fn typed_partition_value_from_string(
     string_value: &str,
     data_type: &SchemaDataType,
-) -> Result<Value, CheckpointError> {
+) -> Result<Value, ProtocolError> {
     match data_type {
         SchemaDataType::primitive(primitive_type) => match primitive_type.as_str() {
             "string" | "binary" => Ok(string_value.to_owned().into()),
@@ -502,7 +477,7 @@ fn typed_partition_value_from_string(
 fn typed_partition_value_from_option_string(
     string_value: &Option<String>,
     data_type: &SchemaDataType,
-) -> Result<Value, CheckpointError> {
+) -> Result<Value, ProtocolError> {
     match string_value {
         Some(s) => {
             if s.is_empty() {
@@ -514,8 +489,6 @@ fn typed_partition_value_from_option_string(
         None => Ok(Value::Null),
     }
 }
-
-type SchemaPath = Vec<String>;
 
 fn collect_stats_conversions(
     paths: &mut Vec<(SchemaPath, SchemaDataType)>,

--- a/rust/src/action/parquet2_read/stats.rs
+++ b/rust/src/action/parquet2_read/stats.rs
@@ -1,9 +1,9 @@
-use crate::action::{ActionError, Add, Stats};
+use crate::action::{Add, ProtocolError, Stats};
 
 impl Add {
     /// Returns the composite HashMap representation of stats contained in the action if present.
     /// Since stats are defined as optional in the protocol, this may be None.
-    pub fn get_stats_parsed(&self) -> Result<Option<Stats>, ActionError> {
+    pub fn get_stats_parsed(&self) -> Result<Option<Stats>, ProtocolError> {
         Ok(None)
     }
 }

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -4,14 +4,15 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::delta::{DeltaResult, DeltaTable, DeltaTableError};
-use crate::storage::config::StorageOptions;
-use crate::storage::{DeltaObjectStore, ObjectStoreRef};
-
 use chrono::{DateTime, FixedOffset, Utc};
 use object_store::DynObjectStore;
 use serde::{Deserialize, Serialize};
 use url::Url;
+
+use crate::delta::DeltaTable;
+use crate::errors::{DeltaResult, DeltaTableError};
+use crate::storage::config::StorageOptions;
+use crate::storage::{DeltaObjectStore, ObjectStoreRef};
 
 #[allow(dead_code)]
 #[derive(Debug, thiserror::Error)]

--- a/rust/src/data_catalog/storage/mod.rs
+++ b/rust/src/data_catalog/storage/mod.rs
@@ -12,8 +12,9 @@ use datafusion_common::DataFusionError;
 use futures::TryStreamExt;
 use object_store::ObjectStore;
 
+use crate::errors::DeltaResult;
 use crate::storage::config::{configure_store, StorageOptions};
-use crate::{ensure_table_uri, open_table_with_storage_options, DeltaResult};
+use crate::{ensure_table_uri, open_table_with_storage_options};
 
 const DELTA_LOG_FOLDER: &str = "_delta_log";
 

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -10,17 +10,6 @@ use std::io::{BufRead, BufReader, Cursor};
 use std::sync::Arc;
 use std::{cmp::max, cmp::Ordering, collections::HashSet};
 
-use super::action;
-use super::action::{Action, DeltaOperation};
-use super::partitions::PartitionFilter;
-use super::schema::*;
-use super::table_state::DeltaTableState;
-use crate::action::{Add, Stats};
-use crate::delta_config::DeltaConfigError;
-use crate::operations::transaction::TransactionError;
-use crate::operations::vacuum::VacuumBuilder;
-use crate::storage::{commit_uri_from_version, ObjectStoreRef};
-
 use chrono::{DateTime, Duration, Utc};
 use futures::StreamExt;
 use lazy_static::lazy_static;
@@ -32,6 +21,16 @@ use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Map, Value};
 use uuid::Uuid;
+
+use super::action;
+use super::action::{Action, DeltaOperation};
+use super::partitions::PartitionFilter;
+use super::schema::*;
+use super::table_state::DeltaTableState;
+use crate::action::{Add, Stats};
+use crate::errors::{ApplyLogError, DeltaTableError, LoadCheckpointError};
+use crate::operations::vacuum::VacuumBuilder;
+use crate::storage::{commit_uri_from_version, ObjectStoreRef};
 
 // TODO re-exports only for transition
 pub use crate::builder::{DeltaTableBuilder, DeltaTableConfig, DeltaVersion};
@@ -63,213 +62,6 @@ impl PartialEq for CheckPoint {
 }
 
 impl Eq for CheckPoint {}
-
-/// A result returned by delta-rs
-pub type DeltaResult<T> = Result<T, DeltaTableError>;
-
-/// Delta Table specific error
-#[derive(thiserror::Error, Debug)]
-pub enum DeltaTableError {
-    /// Error returned when applying transaction log failed.
-    #[error("Failed to apply transaction log: {}", .source)]
-    ApplyLog {
-        /// Apply error details returned when applying transaction log failed.
-        #[from]
-        source: ApplyLogError,
-    },
-    /// Error returned when loading checkpoint failed.
-    #[error("Failed to load checkpoint: {}", .source)]
-    LoadCheckpoint {
-        /// Load checkpoint error details returned when loading checkpoint failed.
-        #[from]
-        source: LoadCheckpointError,
-    },
-    /// Error returned when reading the delta log object failed.
-    #[error("Failed to read delta log object: {}", .source)]
-    ObjectStore {
-        /// Storage error details when reading the delta log object failed.
-        #[from]
-        source: ObjectStoreError,
-    },
-
-    /// Error returned when parsing checkpoint parquet.
-    #[cfg(any(feature = "parquet", feature = "parquet2"))]
-    #[error("Failed to parse parquet: {}", .source)]
-    Parquet {
-        /// Parquet error details returned when reading the checkpoint failed.
-        #[cfg(feature = "parquet")]
-        #[from]
-        source: parquet::errors::ParquetError,
-        /// Parquet error details returned when reading the checkpoint failed.
-        #[cfg(feature = "parquet2")]
-        #[from]
-        source: parquet2::error::Error,
-    },
-
-    /// Error returned when converting the schema in Arrow format failed.
-    #[cfg(feature = "arrow")]
-    #[error("Failed to convert into Arrow schema: {}", .source)]
-    Arrow {
-        /// Arrow error details returned when converting the schema in Arrow format failed
-        #[from]
-        source: arrow::error::ArrowError,
-    },
-
-    /// Error returned when the log record has an invalid JSON.
-    #[error("Invalid JSON in log record, version={}, line=`{}`, err=`{}`", .version, .line, .json_err)]
-    InvalidJsonLog {
-        /// JSON error details returned when parsing the record JSON.
-        json_err: serde_json::error::Error,
-        /// invalid log entry content.
-        line: String,
-        /// corresponding table version for the log file.
-        version: i64,
-    },
-    /// Error returned when the log contains invalid stats JSON.
-    #[error("Invalid JSON in file stats: {}", .json_err)]
-    InvalidStatsJson {
-        /// JSON error details returned when parsing the stats JSON.
-        json_err: serde_json::error::Error,
-    },
-    /// Error returned when the log contains invalid stats JSON.
-    #[error("Invalid JSON in invariant expression, line=`{line}`, err=`{json_err}`")]
-    InvalidInvariantJson {
-        /// JSON error details returned when parsing the invariant expression JSON.
-        json_err: serde_json::error::Error,
-        /// Invariant expression.
-        line: String,
-    },
-    /// Error returned when the DeltaTable has an invalid version.
-    #[error("Invalid table version: {0}")]
-    InvalidVersion(i64),
-    /// Error returned when the DeltaTable has no data files.
-    #[error("Corrupted table, cannot read data file {}: {}", .path, .source)]
-    MissingDataFile {
-        /// Source error details returned when the DeltaTable has no data files.
-        source: std::io::Error,
-        /// The Path used of the DeltaTable
-        path: String,
-    },
-    /// Error returned when the datetime string is invalid for a conversion.
-    #[error("Invalid datetime string: {}", .source)]
-    InvalidDateTimeString {
-        /// Parse error details returned of the datetime string parse error.
-        #[from]
-        source: chrono::ParseError,
-    },
-    /// Error returned when the action record is invalid in log.
-    #[error("Invalid action record found in log: {}", .source)]
-    InvalidAction {
-        /// Action error details returned of the invalid action.
-        #[from]
-        source: action::ActionError,
-    },
-    /// Error returned when attempting to write bad data to the table
-    #[error("Attempted to write invalid data to the table: {:#?}", violations)]
-    InvalidData {
-        /// Action error details returned of the invalid action.
-        violations: Vec<String>,
-    },
-    /// Error returned when it is not a DeltaTable.
-    #[error("Not a Delta table: {0}")]
-    NotATable(String),
-
-    /// Error returned when no metadata was found in the DeltaTable.
-    #[error("No metadata found, please make sure table is loaded.")]
-    NoMetadata,
-    /// Error returned when no schema was found in the DeltaTable.
-    #[error("No schema found, please make sure table is loaded.")]
-    NoSchema,
-    /// Error returned when no partition was found in the DeltaTable.
-    #[error("No partitions found, please make sure table is partitioned.")]
-    LoadPartitions,
-
-    /// Error returned when writes are attempted with data that doesn't match the schema of the
-    /// table
-    #[error("Data does not match the schema or partitions of the table: {}", msg)]
-    SchemaMismatch {
-        /// Information about the mismatch
-        msg: String,
-    },
-
-    /// Error returned when a partition is not formatted as a Hive Partition.
-    #[error("This partition is not formatted with key=value: {}", .partition)]
-    PartitionError {
-        /// The malformed partition used.
-        partition: String,
-    },
-    /// Error returned when a invalid partition filter was found.
-    #[error("Invalid partition filter found: {}.", .partition_filter)]
-    InvalidPartitionFilter {
-        /// The invalid partition filter used.
-        partition_filter: String,
-    },
-    /// Error returned when a partition filter uses a nonpartitioned column.
-    #[error("Tried to filter partitions on non-partitioned columns: {:#?}", .nonpartitioned_columns)]
-    ColumnsNotPartitioned {
-        /// The columns used in the partition filter that is not partitioned
-        nonpartitioned_columns: Vec<String>,
-    },
-    /// Error returned when a line from log record is invalid.
-    #[error("Failed to read line from log record")]
-    Io {
-        /// Source error details returned while reading the log record.
-        #[from]
-        source: std::io::Error,
-    },
-    /// Error raised while commititng transaction
-    #[error("Transaction failed: {source}")]
-    Transaction {
-        /// The source error
-        source: TransactionError,
-    },
-    /// Error returned when transaction is failed to be committed because given version already exists.
-    #[error("Delta transaction failed, version {0} already exists.")]
-    VersionAlreadyExists(i64),
-    /// Error returned when user attempts to commit actions that don't belong to the next version.
-    #[error("Delta transaction failed, version {0} does not follow {1}")]
-    VersionMismatch(i64, i64),
-    /// A Feature is missing to perform operation
-    #[error("Delta-rs must be build with feature '{feature}' to support loading from: {url}.")]
-    MissingFeature {
-        /// Name of the missing feature
-        feature: &'static str,
-        /// Storage location url
-        url: String,
-    },
-    /// A Feature is missing to perform operation
-    #[error("Cannot infer storage location from: {0}")]
-    InvalidTableLocation(String),
-    /// Generic Delta Table error
-    #[error("Log JSON serialization error: {json_err}")]
-    SerializeLogJson {
-        /// JSON serialization error
-        json_err: serde_json::error::Error,
-    },
-    /// Generic Delta Table error
-    #[error("Schema JSON serialization error: {json_err}")]
-    SerializeSchemaJson {
-        /// JSON serialization error
-        json_err: serde_json::error::Error,
-    },
-    /// Generic Delta Table error
-    #[error("Generic DeltaTable error: {0}")]
-    Generic(String),
-    /// Generic Delta Table error
-    #[error("Generic error: {source}")]
-    GenericError {
-        /// Source error
-        source: Box<dyn std::error::Error + Send + Sync + 'static>,
-    },
-}
-
-impl From<object_store::path::Error> for DeltaTableError {
-    fn from(err: object_store::path::Error) -> Self {
-        Self::GenericError {
-            source: Box::new(err),
-        }
-    }
-}
 
 /// Delta table metadata
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -368,87 +160,6 @@ impl TryFrom<action::MetaData> for DeltaTableMetaData {
             created_time: action_metadata.created_time,
             configuration: action_metadata.configuration,
         })
-    }
-}
-
-/// Error related to Delta log application
-#[derive(thiserror::Error, Debug)]
-pub enum ApplyLogError {
-    /// Error returned when the end of transaction log is reached.
-    #[error("End of transaction log")]
-    EndOfLog,
-    /// Error returned when the JSON of the log record is invalid.
-    #[error("Invalid JSON found when applying log record")]
-    InvalidJson {
-        /// JSON error details returned when reading the JSON log record.
-        #[from]
-        source: serde_json::error::Error,
-    },
-    /// Error returned when the storage failed to read the log content.
-    #[error("Failed to read log content")]
-    Storage {
-        /// Storage error details returned while reading the log content.
-        source: ObjectStoreError,
-    },
-    /// Error returned when reading delta config failed.
-    #[error("Failed to read delta config: {}", .source)]
-    Config {
-        /// Delta config error returned when reading delta config failed.
-        #[from]
-        source: DeltaConfigError,
-    },
-    /// Error returned when a line from log record is invalid.
-    #[error("Failed to read line from log record")]
-    Io {
-        /// Source error details returned while reading the log record.
-        #[from]
-        source: std::io::Error,
-    },
-    /// Error returned when the action record is invalid in log.
-    #[error("Invalid action record found in log: {}", .source)]
-    InvalidAction {
-        /// Action error details returned of the invalid action.
-        #[from]
-        source: action::ActionError,
-    },
-}
-
-impl From<ObjectStoreError> for ApplyLogError {
-    fn from(error: ObjectStoreError) -> Self {
-        match error {
-            ObjectStoreError::NotFound { .. } => ApplyLogError::EndOfLog,
-            _ => ApplyLogError::Storage { source: error },
-        }
-    }
-}
-
-/// Error related to checkpoint loading
-#[derive(thiserror::Error, Debug)]
-pub enum LoadCheckpointError {
-    /// Error returned when the JSON checkpoint is not found.
-    #[error("Checkpoint file not found")]
-    NotFound,
-    /// Error returned when the JSON checkpoint is invalid.
-    #[error("Invalid JSON in checkpoint: {source}")]
-    InvalidJson {
-        /// Error details returned while reading the JSON.
-        #[from]
-        source: serde_json::error::Error,
-    },
-    /// Error returned when it failed to read the checkpoint content.
-    #[error("Failed to read checkpoint content: {source}")]
-    Storage {
-        /// Storage error details returned while reading the checkpoint content.
-        source: ObjectStoreError,
-    },
-}
-
-impl From<ObjectStoreError> for LoadCheckpointError {
-    fn from(error: ObjectStoreError) -> Self {
-        match error {
-            ObjectStoreError::NotFound { .. } => LoadCheckpointError::NotFound,
-            _ => LoadCheckpointError::Storage { source: error },
-        }
     }
 }
 

--- a/rust/src/delta_config.rs
+++ b/rust/src/delta_config.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, str::FromStr};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
-use crate::DeltaTableError;
+use crate::errors::DeltaTableError;
 
 /// Typed property keys that can be defined on a delta table
 /// <https://docs.delta.io/latest/table-properties.html#delta-table-properties-reference>

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -57,13 +57,12 @@ use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use object_store::ObjectMeta;
 use url::Url;
 
-use crate::action::Add;
+use crate::action::{self, Add};
 use crate::builder::ensure_table_uri;
+use crate::errors::{DeltaResult, DeltaTableError};
 use crate::storage::ObjectStoreRef;
 use crate::table_state::DeltaTableState;
-use crate::{action, open_table, open_table_with_storage_options, SchemaDataType};
-use crate::{DeltaResult, Invariant};
-use crate::{DeltaTable, DeltaTableError};
+use crate::{open_table, open_table_with_storage_options, DeltaTable, Invariant, SchemaDataType};
 
 impl From<DeltaTableError> for DataFusionError {
     fn from(err: DeltaTableError) -> Self {

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -1,0 +1,318 @@
+//! Exceptions for the deltalake crate
+use object_store::Error as ObjectStoreError;
+
+use crate::action::ActionError;
+use crate::delta_config::DeltaConfigError;
+use crate::operations::transaction::TransactionError;
+
+/// A result returned by delta-rs
+pub type DeltaResult<T> = Result<T, DeltaTableError>;
+
+/// Delta Table specific error
+#[derive(thiserror::Error, Debug)]
+pub enum DeltaTableError {
+    /// Error returned when applying transaction log failed.
+    #[error("Failed to apply transaction log: {}", .source)]
+    ApplyLog {
+        /// Apply error details returned when applying transaction log failed.
+        #[from]
+        source: ApplyLogError,
+    },
+
+    /// Error returned when loading checkpoint failed.
+    #[error("Failed to load checkpoint: {}", .source)]
+    LoadCheckpoint {
+        /// Load checkpoint error details returned when loading checkpoint failed.
+        #[from]
+        source: LoadCheckpointError,
+    },
+
+    /// Error returned when reading the delta log object failed.
+    #[error("Failed to read delta log object: {}", .source)]
+    ObjectStore {
+        /// Storage error details when reading the delta log object failed.
+        #[from]
+        source: ObjectStoreError,
+    },
+
+    /// Error returned when parsing checkpoint parquet.
+    #[cfg(any(feature = "parquet", feature = "parquet2"))]
+    #[error("Failed to parse parquet: {}", .source)]
+    Parquet {
+        /// Parquet error details returned when reading the checkpoint failed.
+        #[cfg(feature = "parquet")]
+        #[from]
+        source: parquet::errors::ParquetError,
+        /// Parquet error details returned when reading the checkpoint failed.
+        #[cfg(feature = "parquet2")]
+        #[from]
+        source: parquet2::error::Error,
+    },
+
+    /// Error returned when converting the schema in Arrow format failed.
+    #[cfg(feature = "arrow")]
+    #[error("Failed to convert into Arrow schema: {}", .source)]
+    Arrow {
+        /// Arrow error details returned when converting the schema in Arrow format failed
+        #[from]
+        source: arrow::error::ArrowError,
+    },
+
+    /// Error returned when the log record has an invalid JSON.
+    #[error("Invalid JSON in log record, version={}, line=`{}`, err=`{}`", .version, .line, .json_err)]
+    InvalidJsonLog {
+        /// JSON error details returned when parsing the record JSON.
+        json_err: serde_json::error::Error,
+        /// invalid log entry content.
+        line: String,
+        /// corresponding table version for the log file.
+        version: i64,
+    },
+
+    /// Error returned when the log contains invalid stats JSON.
+    #[error("Invalid JSON in file stats: {}", .json_err)]
+    InvalidStatsJson {
+        /// JSON error details returned when parsing the stats JSON.
+        json_err: serde_json::error::Error,
+    },
+
+    /// Error returned when the log contains invalid stats JSON.
+    #[error("Invalid JSON in invariant expression, line=`{line}`, err=`{json_err}`")]
+    InvalidInvariantJson {
+        /// JSON error details returned when parsing the invariant expression JSON.
+        json_err: serde_json::error::Error,
+        /// Invariant expression.
+        line: String,
+    },
+
+    /// Error returned when the DeltaTable has an invalid version.
+    #[error("Invalid table version: {0}")]
+    InvalidVersion(i64),
+
+    /// Error returned when the DeltaTable has no data files.
+    #[error("Corrupted table, cannot read data file {}: {}", .path, .source)]
+    MissingDataFile {
+        /// Source error details returned when the DeltaTable has no data files.
+        source: std::io::Error,
+        /// The Path used of the DeltaTable
+        path: String,
+    },
+
+    /// Error returned when the datetime string is invalid for a conversion.
+    #[error("Invalid datetime string: {}", .source)]
+    InvalidDateTimeString {
+        /// Parse error details returned of the datetime string parse error.
+        #[from]
+        source: chrono::ParseError,
+    },
+
+    /// Error returned when the action record is invalid in log.
+    #[error("Invalid action record found in log: {}", .source)]
+    InvalidAction {
+        /// Action error details returned of the invalid action.
+        #[from]
+        source: ActionError,
+    },
+
+    /// Error returned when attempting to write bad data to the table
+    #[error("Attempted to write invalid data to the table: {:#?}", violations)]
+    InvalidData {
+        /// Action error details returned of the invalid action.
+        violations: Vec<String>,
+    },
+
+    /// Error returned when it is not a DeltaTable.
+    #[error("Not a Delta table: {0}")]
+    NotATable(String),
+
+    /// Error returned when no metadata was found in the DeltaTable.
+    #[error("No metadata found, please make sure table is loaded.")]
+    NoMetadata,
+
+    /// Error returned when no schema was found in the DeltaTable.
+    #[error("No schema found, please make sure table is loaded.")]
+    NoSchema,
+
+    /// Error returned when no partition was found in the DeltaTable.
+    #[error("No partitions found, please make sure table is partitioned.")]
+    LoadPartitions,
+
+    /// Error returned when writes are attempted with data that doesn't match the schema of the
+    /// table
+    #[error("Data does not match the schema or partitions of the table: {}", msg)]
+    SchemaMismatch {
+        /// Information about the mismatch
+        msg: String,
+    },
+
+    /// Error returned when a partition is not formatted as a Hive Partition.
+    #[error("This partition is not formatted with key=value: {}", .partition)]
+    PartitionError {
+        /// The malformed partition used.
+        partition: String,
+    },
+
+    /// Error returned when a invalid partition filter was found.
+    #[error("Invalid partition filter found: {}.", .partition_filter)]
+    InvalidPartitionFilter {
+        /// The invalid partition filter used.
+        partition_filter: String,
+    },
+
+    /// Error returned when a partition filter uses a nonpartitioned column.
+    #[error("Tried to filter partitions on non-partitioned columns: {:#?}", .nonpartitioned_columns)]
+    ColumnsNotPartitioned {
+        /// The columns used in the partition filter that is not partitioned
+        nonpartitioned_columns: Vec<String>,
+    },
+
+    /// Error returned when a line from log record is invalid.
+    #[error("Failed to read line from log record")]
+    Io {
+        /// Source error details returned while reading the log record.
+        #[from]
+        source: std::io::Error,
+    },
+
+    /// Error raised while commititng transaction
+    #[error("Transaction failed: {source}")]
+    Transaction {
+        /// The source error
+        source: TransactionError,
+    },
+
+    /// Error returned when transaction is failed to be committed because given version already exists.
+    #[error("Delta transaction failed, version {0} already exists.")]
+    VersionAlreadyExists(i64),
+
+    /// Error returned when user attempts to commit actions that don't belong to the next version.
+    #[error("Delta transaction failed, version {0} does not follow {1}")]
+    VersionMismatch(i64, i64),
+
+    /// A Feature is missing to perform operation
+    #[error("Delta-rs must be build with feature '{feature}' to support loading from: {url}.")]
+    MissingFeature {
+        /// Name of the missing feature
+        feature: &'static str,
+        /// Storage location url
+        url: String,
+    },
+
+    /// A Feature is missing to perform operation
+    #[error("Cannot infer storage location from: {0}")]
+    InvalidTableLocation(String),
+
+    /// Generic Delta Table error
+    #[error("Log JSON serialization error: {json_err}")]
+    SerializeLogJson {
+        /// JSON serialization error
+        json_err: serde_json::error::Error,
+    },
+
+    /// Generic Delta Table error
+    #[error("Schema JSON serialization error: {json_err}")]
+    SerializeSchemaJson {
+        /// JSON serialization error
+        json_err: serde_json::error::Error,
+    },
+
+    /// Generic Delta Table error
+    #[error("Generic DeltaTable error: {0}")]
+    Generic(String),
+
+    /// Generic Delta Table error
+    #[error("Generic error: {source}")]
+    GenericError {
+        /// Source error
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+}
+
+impl From<object_store::path::Error> for DeltaTableError {
+    fn from(err: object_store::path::Error) -> Self {
+        Self::GenericError {
+            source: Box::new(err),
+        }
+    }
+}
+
+/// Error related to Delta log application
+#[derive(thiserror::Error, Debug)]
+pub enum ApplyLogError {
+    /// Error returned when the end of transaction log is reached.
+    #[error("End of transaction log")]
+    EndOfLog,
+    /// Error returned when the JSON of the log record is invalid.
+    #[error("Invalid JSON found when applying log record")]
+    InvalidJson {
+        /// JSON error details returned when reading the JSON log record.
+        #[from]
+        source: serde_json::error::Error,
+    },
+    /// Error returned when the storage failed to read the log content.
+    #[error("Failed to read log content")]
+    Storage {
+        /// Storage error details returned while reading the log content.
+        source: ObjectStoreError,
+    },
+    /// Error returned when reading delta config failed.
+    #[error("Failed to read delta config: {}", .source)]
+    Config {
+        /// Delta config error returned when reading delta config failed.
+        #[from]
+        source: DeltaConfigError,
+    },
+    /// Error returned when a line from log record is invalid.
+    #[error("Failed to read line from log record")]
+    Io {
+        /// Source error details returned while reading the log record.
+        #[from]
+        source: std::io::Error,
+    },
+    /// Error returned when the action record is invalid in log.
+    #[error("Invalid action record found in log: {}", .source)]
+    InvalidAction {
+        /// Action error details returned of the invalid action.
+        #[from]
+        source: ActionError,
+    },
+}
+
+impl From<ObjectStoreError> for ApplyLogError {
+    fn from(error: ObjectStoreError) -> Self {
+        match error {
+            ObjectStoreError::NotFound { .. } => ApplyLogError::EndOfLog,
+            _ => ApplyLogError::Storage { source: error },
+        }
+    }
+}
+
+/// Error related to checkpoint loading
+#[derive(thiserror::Error, Debug)]
+pub enum LoadCheckpointError {
+    /// Error returned when the JSON checkpoint is not found.
+    #[error("Checkpoint file not found")]
+    NotFound,
+    /// Error returned when the JSON checkpoint is invalid.
+    #[error("Invalid JSON in checkpoint: {source}")]
+    InvalidJson {
+        /// Error details returned while reading the JSON.
+        #[from]
+        source: serde_json::error::Error,
+    },
+    /// Error returned when it failed to read the checkpoint content.
+    #[error("Failed to read checkpoint content: {source}")]
+    Storage {
+        /// Storage error details returned while reading the checkpoint content.
+        source: ObjectStoreError,
+    },
+}
+
+impl From<ObjectStoreError> for LoadCheckpointError {
+    fn from(error: ObjectStoreError) -> Self {
+        match error {
+            ObjectStoreError::NotFound { .. } => LoadCheckpointError::NotFound,
+            _ => LoadCheckpointError::Storage { source: error },
+        }
+    }
+}

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -1,7 +1,7 @@
 //! Exceptions for the deltalake crate
 use object_store::Error as ObjectStoreError;
 
-use crate::action::ActionError;
+use crate::action::ProtocolError;
 use crate::delta_config::DeltaConfigError;
 use crate::operations::transaction::TransactionError;
 
@@ -111,7 +111,7 @@ pub enum DeltaTableError {
     InvalidAction {
         /// Action error details returned of the invalid action.
         #[from]
-        source: ActionError,
+        source: ProtocolError,
     },
 
     /// Error returned when attempting to write bad data to the table
@@ -242,6 +242,7 @@ pub enum ApplyLogError {
     /// Error returned when the end of transaction log is reached.
     #[error("End of transaction log")]
     EndOfLog,
+
     /// Error returned when the JSON of the log record is invalid.
     #[error("Invalid JSON found when applying log record")]
     InvalidJson {
@@ -249,12 +250,14 @@ pub enum ApplyLogError {
         #[from]
         source: serde_json::error::Error,
     },
+
     /// Error returned when the storage failed to read the log content.
     #[error("Failed to read log content")]
     Storage {
         /// Storage error details returned while reading the log content.
         source: ObjectStoreError,
     },
+
     /// Error returned when reading delta config failed.
     #[error("Failed to read delta config: {}", .source)]
     Config {
@@ -262,6 +265,7 @@ pub enum ApplyLogError {
         #[from]
         source: DeltaConfigError,
     },
+
     /// Error returned when a line from log record is invalid.
     #[error("Failed to read line from log record")]
     Io {
@@ -269,12 +273,13 @@ pub enum ApplyLogError {
         #[from]
         source: std::io::Error,
     },
+
     /// Error returned when the action record is invalid in log.
     #[error("Invalid action record found in log: {}", .source)]
     InvalidAction {
         /// Action error details returned of the invalid action.
         #[from]
-        source: ActionError,
+        source: ProtocolError,
     },
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -87,6 +87,7 @@ pub mod builder;
 pub mod data_catalog;
 pub mod delta;
 pub mod delta_config;
+pub mod errors;
 pub mod operations;
 pub mod partitions;
 pub mod schema;
@@ -97,8 +98,6 @@ pub mod time_utils;
 #[cfg(all(feature = "arrow"))]
 pub mod table_state_arrow;
 
-#[cfg(all(feature = "arrow", feature = "parquet"))]
-pub mod checkpoints;
 #[cfg(all(feature = "arrow", feature = "parquet"))]
 pub mod delta_arrow;
 #[cfg(feature = "datafusion")]
@@ -116,6 +115,8 @@ pub use object_store::{path::Path, Error as ObjectStoreError, ObjectMeta, Object
 pub use operations::DeltaOps;
 
 // convenience exports for consumers to avoid aligning crate versions
+#[cfg(all(feature = "arrow", feature = "parquet"))]
+pub use action::checkpoints;
 #[cfg(feature = "arrow")]
 pub use arrow;
 #[cfg(feature = "datafusion")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -111,6 +111,7 @@ pub use self::delta::*;
 pub use self::delta_config::*;
 pub use self::partitions::*;
 pub use self::schema::*;
+pub use errors::*;
 pub use object_store::{path::Path, Error as ObjectStoreError, ObjectMeta, ObjectStore};
 pub use operations::DeltaOps;
 

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -1,19 +1,21 @@
 //! Command for creating a new delta table
 // https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+use serde_json::{Map, Value};
+
 use super::transaction::commit;
 use super::{MAX_SUPPORTED_READER_VERSION, MAX_SUPPORTED_WRITER_VERSION};
 use crate::action::{Action, DeltaOperation, MetaData, Protocol, SaveMode};
 use crate::builder::ensure_table_uri;
 use crate::delta_config::DeltaConfigKey;
+use crate::errors::{DeltaResult, DeltaTableError};
 use crate::schema::{SchemaDataType, SchemaField, SchemaTypeStruct};
 use crate::storage::DeltaObjectStore;
-use crate::{DeltaResult, DeltaTable, DeltaTableError};
-use crate::{DeltaTableBuilder, DeltaTableMetaData};
-
-use futures::future::BoxFuture;
-use serde_json::{Map, Value};
-use std::collections::HashMap;
-use std::sync::Arc;
+use crate::{DeltaTable, DeltaTableBuilder, DeltaTableMetaData};
 
 #[derive(thiserror::Error, Debug)]
 enum CreateError {

--- a/rust/src/operations/delete.rs
+++ b/rust/src/operations/delete.rs
@@ -17,18 +17,10 @@
 //!     .await?;
 //! ````
 
-use crate::action::DeltaOperation;
-use crate::delta::DeltaResult;
-use crate::delta_datafusion::parquet_scan_from_actions;
-use crate::delta_datafusion::partitioned_file_from_action;
-use crate::delta_datafusion::register_store;
-use crate::operations::transaction::commit;
-use crate::operations::write::write_execution_plan;
-use crate::storage::DeltaObjectStore;
-use crate::storage::ObjectStoreRef;
-use crate::table_state::DeltaTableState;
-use crate::DeltaTable;
-use crate::DeltaTableError;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crate::action::{Action, Add, Remove};
 use arrow::array::StringArray;
@@ -59,10 +51,17 @@ use futures::stream::StreamExt;
 use parquet::file::properties::WriterProperties;
 use serde_json::Map;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use crate::action::DeltaOperation;
+use crate::delta_datafusion::{
+    parquet_scan_from_actions, partitioned_file_from_action, register_store,
+};
+use crate::errors::{DeltaResult, DeltaTableError};
+use crate::operations::transaction::commit;
+use crate::operations::write::write_execution_plan;
+use crate::storage::{DeltaObjectStore, ObjectStoreRef};
+use crate::table_state::DeltaTableState;
+use crate::DeltaTable;
 
 const PATH_COLUMN: &str = "__delta_rs_path";
 

--- a/rust/src/operations/filesystem_check.rs
+++ b/rust/src/operations/filesystem_check.rs
@@ -11,21 +11,25 @@
 //! let mut table = open_table("../path/to/table")?;
 //! let (table, metrics) = FileSystemCheckBuilder::new(table.object_store(), table.state).await?;
 //! ````
-use crate::action::{Action, Add, DeltaOperation, Remove};
-use crate::operations::transaction::commit;
-use crate::storage::DeltaObjectStore;
-use crate::table_state::DeltaTableState;
-use crate::{DeltaResult, DeltaTable, DeltaTableError};
-use futures::future::BoxFuture;
-use futures::StreamExt;
-pub use object_store::path::Path;
-use object_store::ObjectStore;
+
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
+
+use futures::future::BoxFuture;
+use futures::StreamExt;
+pub use object_store::path::Path;
+use object_store::ObjectStore;
 use url::{ParseError, Url};
+
+use crate::action::{Action, Add, DeltaOperation, Remove};
+use crate::errors::{DeltaResult, DeltaTableError};
+use crate::operations::transaction::commit;
+use crate::storage::DeltaObjectStore;
+use crate::table_state::DeltaTableState;
+use crate::DeltaTable;
 
 /// Audit the Delta Table's active files with the underlying file system.
 /// See this module's documentaiton for more information

--- a/rust/src/operations/load.rs
+++ b/rust/src/operations/load.rs
@@ -6,9 +6,10 @@ use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use futures::future::BoxFuture;
 
+use crate::errors::{DeltaResult, DeltaTableError};
 use crate::storage::DeltaObjectStore;
 use crate::table_state::DeltaTableState;
-use crate::{DeltaResult, DeltaTable, DeltaTableError};
+use crate::DeltaTable;
 
 #[derive(Debug, Clone)]
 pub struct LoadBuilder {

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -11,7 +11,8 @@ use self::create::CreateBuilder;
 use self::filesystem_check::FileSystemCheckBuilder;
 use self::vacuum::VacuumBuilder;
 use crate::builder::DeltaTableBuilder;
-use crate::{DeltaResult, DeltaTable, DeltaTableError};
+use crate::errors::{DeltaResult, DeltaTableError};
+use crate::DeltaTable;
 
 pub mod create;
 pub mod filesystem_check;

--- a/rust/src/operations/optimize.rs
+++ b/rust/src/operations/optimize.rs
@@ -20,14 +20,10 @@
 //! let (table, metrics) = OptimizeBuilder::new(table.object_store(), table.state).await?;
 //! ````
 
-use super::transaction::commit;
-use super::writer::{PartitionWriter, PartitionWriterConfig};
-use crate::action::{self, Action, DeltaOperation};
-use crate::crate_version;
-use crate::storage::ObjectStoreRef;
-use crate::table_state::DeltaTableState;
-use crate::writer::utils::arrow_schema_without_partitions;
-use crate::{DeltaResult, DeltaTable, DeltaTableError, ObjectMeta, PartitionFilter};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use arrow::datatypes::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
 use futures::future::BoxFuture;
 use futures::{StreamExt, TryStreamExt};
@@ -38,9 +34,15 @@ use parquet::basic::{Compression, ZstdLevel};
 use parquet::file::properties::WriterProperties;
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::transaction::commit;
+use super::writer::{PartitionWriter, PartitionWriterConfig};
+use crate::action::{self, Action, DeltaOperation};
+use crate::errors::{DeltaResult, DeltaTableError};
+use crate::storage::ObjectStoreRef;
+use crate::table_state::DeltaTableState;
+use crate::writer::utils::arrow_schema_without_partitions;
+use crate::{crate_version, DeltaTable, ObjectMeta, PartitionFilter};
 
 /// Metrics from Optimize
 #[derive(Default, Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/rust/src/operations/transaction/conflict_checker.rs
+++ b/rust/src/operations/transaction/conflict_checker.rs
@@ -7,8 +7,9 @@ use object_store::ObjectStore;
 use super::CommitInfo;
 use crate::action::{Action, Add, DeltaOperation, MetaData, Protocol, Remove};
 use crate::delta_config::IsolationLevel;
+use crate::errors::{DeltaResult, DeltaTableError};
 use crate::storage::commit_uri_from_version;
-use crate::{table_state::DeltaTableState, DeltaResult, DeltaTableError};
+use crate::table_state::DeltaTableState;
 
 #[cfg(feature = "datafusion")]
 use super::state::AddContainer;

--- a/rust/src/operations/transaction/mod.rs
+++ b/rust/src/operations/transaction/mod.rs
@@ -6,9 +6,10 @@ use object_store::{Error as ObjectStoreError, ObjectStore};
 use serde_json::{Map, Value};
 
 use crate::action::{Action, CommitInfo, DeltaOperation};
+use crate::crate_version;
+use crate::errors::{DeltaResult, DeltaTableError};
 use crate::storage::commit_uri_from_version;
 use crate::table_state::DeltaTableState;
-use crate::{crate_version, DeltaResult, DeltaTableError};
 
 mod conflict_checker;
 #[cfg(feature = "datafusion")]

--- a/rust/src/operations/transaction/state.rs
+++ b/rust/src/operations/transaction/state.rs
@@ -23,9 +23,8 @@ use crate::action::Add;
 use crate::delta_datafusion::{
     get_null_of_arrow_type, logical_expr_to_physical_expr, to_correct_scalar_value,
 };
+use crate::errors::{DeltaResult, DeltaTableError};
 use crate::table_state::DeltaTableState;
-use crate::DeltaResult;
-use crate::DeltaTableError;
 
 impl DeltaTableState {
     /// Get the table schema as an [`ArrowSchemaRef`]

--- a/rust/src/operations/vacuum.rs
+++ b/rust/src/operations/vacuum.rs
@@ -21,16 +21,19 @@
 //! let (table, metrics) = VacuumBuilder::new(table.object_store(). table.state).await?;
 //! ````
 
-use crate::storage::DeltaObjectStore;
-use crate::table_state::DeltaTableState;
-use crate::{DeltaResult, DeltaTable, DeltaTableError};
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::sync::Arc;
+
 use chrono::{Duration, Utc};
 use futures::future::BoxFuture;
 use futures::{StreamExt, TryStreamExt};
 use object_store::{path::Path, ObjectStore};
-use std::collections::HashSet;
-use std::fmt::Debug;
-use std::sync::Arc;
+
+use crate::errors::{DeltaResult, DeltaTableError};
+use crate::storage::DeltaObjectStore;
+use crate::table_state::DeltaTableState;
+use crate::DeltaTable;
 
 /// Errors that can occur during vacuum
 #[derive(thiserror::Error, Debug)]

--- a/rust/src/operations/write.rs
+++ b/rust/src/operations/write.rs
@@ -19,18 +19,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::writer::{DeltaWriter, WriterConfig};
-use super::MAX_SUPPORTED_WRITER_VERSION;
-use super::{transaction::commit, CreateBuilder};
-use crate::action::{Action, Add, DeltaOperation, Remove, SaveMode};
-use crate::delta::{DeltaResult, DeltaTable, DeltaTableError};
-use crate::delta_datafusion::DeltaDataChecker;
-use crate::schema::Schema;
-use crate::storage::{DeltaObjectStore, ObjectStoreRef};
-use crate::table_state::DeltaTableState;
-use crate::writer::record_batch::divide_by_partition_values;
-use crate::writer::utils::PartitionPath;
-
 use arrow_array::RecordBatch;
 use arrow_cast::{can_cast_types, cast};
 use arrow_schema::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
@@ -39,6 +27,19 @@ use datafusion::physical_plan::{memory::MemoryExec, ExecutionPlan};
 use futures::future::BoxFuture;
 use futures::StreamExt;
 use parquet::file::properties::WriterProperties;
+
+use super::writer::{DeltaWriter, WriterConfig};
+use super::MAX_SUPPORTED_WRITER_VERSION;
+use super::{transaction::commit, CreateBuilder};
+use crate::action::{Action, Add, DeltaOperation, Remove, SaveMode};
+use crate::delta::DeltaTable;
+use crate::delta_datafusion::DeltaDataChecker;
+use crate::errors::{DeltaResult, DeltaTableError};
+use crate::schema::Schema;
+use crate::storage::{DeltaObjectStore, ObjectStoreRef};
+use crate::table_state::DeltaTableState;
+use crate::writer::record_batch::divide_by_partition_values;
+use crate::writer::utils::PartitionPath;
 
 #[derive(thiserror::Error, Debug)]
 enum WriteError {

--- a/rust/src/operations/writer.rs
+++ b/rust/src/operations/writer.rs
@@ -2,16 +2,6 @@
 
 use std::collections::HashMap;
 
-use crate::action::Add;
-use crate::storage::ObjectStoreRef;
-use crate::writer::record_batch::{divide_by_partition_values, PartitionResult};
-use crate::writer::stats::create_add;
-use crate::writer::utils::{
-    arrow_schema_without_partitions, record_batch_without_partitions, PartitionPath,
-    ShareableBuffer,
-};
-use crate::{crate_version, DeltaResult, DeltaTableError};
-
 use arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
@@ -20,6 +10,17 @@ use object_store::{path::Path, ObjectStore};
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
+
+use crate::action::Add;
+use crate::crate_version;
+use crate::errors::{DeltaResult, DeltaTableError};
+use crate::storage::ObjectStoreRef;
+use crate::writer::record_batch::{divide_by_partition_values, PartitionResult};
+use crate::writer::stats::create_add;
+use crate::writer::utils::{
+    arrow_schema_without_partitions, record_batch_without_partitions, PartitionPath,
+    ShareableBuffer,
+};
 
 // TODO databricks often suggests a file size of 100mb, should we set this default?
 const DEFAULT_TARGET_FILE_SIZE: usize = 104_857_600;

--- a/rust/src/partitions.rs
+++ b/rust/src/partitions.rs
@@ -3,7 +3,7 @@
 use std::convert::TryFrom;
 
 use super::schema::SchemaDataType;
-use crate::DeltaTableError;
+use crate::errors::DeltaTableError;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use crate::DeltaTableError;
+use crate::errors::DeltaTableError;
 
 /// Type alias for a string expected to match a GUID/UUID format
 pub type Guid = String;

--- a/rust/src/storage/config.rs
+++ b/rust/src/storage/config.rs
@@ -1,15 +1,17 @@
 //! Configuration handling for defining Storage backends for DeltaTables.
-use super::file::FileStorageBackend;
-use super::utils::str_is_truthy;
-use crate::{DeltaResult, DeltaTableError};
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use object_store::memory::InMemory;
 use object_store::path::Path;
 use object_store::prefix::PrefixStore;
 use object_store::{DynObjectStore, ObjectStore};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::sync::Arc;
 use url::Url;
+
+use super::file::FileStorageBackend;
+use super::utils::str_is_truthy;
+use crate::errors::{DeltaResult, DeltaTableError};
 
 #[cfg(any(feature = "s3", feature = "s3-native-tls"))]
 use super::s3::{S3StorageBackend, S3StorageOptions};

--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -1,11 +1,9 @@
 //! Object storage backend abstraction layer for Delta Table transaction logs and data
 
-pub mod config;
-pub mod file;
-pub mod utils;
-
-use self::config::StorageOptions;
-use crate::DeltaResult;
+use std::collections::HashMap;
+use std::fmt;
+use std::ops::Range;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt};
@@ -13,12 +11,15 @@ use lazy_static::lazy_static;
 use serde::de::{Error, SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::HashMap;
-use std::fmt;
-use std::ops::Range;
-use std::sync::Arc;
 use tokio::io::AsyncWrite;
 use url::Url;
+
+use self::config::StorageOptions;
+use crate::errors::DeltaResult;
+
+pub mod config;
+pub mod file;
+pub mod utils;
 
 #[cfg(any(feature = "s3", feature = "s3-native-tls"))]
 pub mod s3;

--- a/rust/src/storage/utils.rs
+++ b/rust/src/storage/utils.rs
@@ -83,7 +83,7 @@ impl TryFrom<&Add> for ObjectMeta {
         let last_modified = DateTime::<Utc>::from_utc(
             NaiveDateTime::from_timestamp_millis(value.modification_time).ok_or(
                 DeltaTableError::InvalidAction {
-                    source: crate::action::ActionError::InvalidField(format!(
+                    source: crate::action::ProtocolError::InvalidField(format!(
                         "invalid modification_time: {:?}",
                         value.modification_time
                     )),

--- a/rust/src/storage/utils.rs
+++ b/rust/src/storage/utils.rs
@@ -1,15 +1,16 @@
 //! Utility functions for working across Delta tables
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
-use crate::action::Add;
-use crate::builder::DeltaTableBuilder;
-use crate::{DeltaResult, DeltaTableError};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::{DynObjectStore, ObjectMeta, Result as ObjectStoreResult};
-use std::sync::Arc;
+
+use crate::action::Add;
+use crate::builder::DeltaTableBuilder;
+use crate::errors::{DeltaResult, DeltaTableError};
 
 /// Copies the contents from the `from` location into the `to` location
 pub async fn copy_table(

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -1,20 +1,23 @@
 //! The module for delta table state.
 
-use crate::action::{self, Action, Add};
-use crate::delta_config::TableConfig;
-use crate::partitions::{DeltaTablePartition, PartitionFilter};
-use crate::schema::SchemaDataType;
-use crate::storage::commit_uri_from_version;
-use crate::Schema;
-use crate::{ApplyLogError, DeltaTable, DeltaTableError, DeltaTableMetaData};
-use chrono::Utc;
-use lazy_static::lazy_static;
-use object_store::{path::Path, ObjectStore};
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::io::{BufRead, BufReader, Cursor};
+
+use chrono::Utc;
+use lazy_static::lazy_static;
+use object_store::{path::Path, ObjectStore};
+use serde::{Deserialize, Serialize};
+
+use crate::action::{self, Action, Add};
+use crate::delta_config::TableConfig;
+use crate::errors::{ApplyLogError, DeltaTableError};
+use crate::partitions::{DeltaTablePartition, PartitionFilter};
+use crate::schema::SchemaDataType;
+use crate::storage::commit_uri_from_version;
+use crate::Schema;
+use crate::{DeltaTable, DeltaTableMetaData};
 
 #[cfg(any(feature = "parquet", feature = "parquet2"))]
 use super::{CheckPoint, DeltaTableConfig};

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -103,7 +103,7 @@ impl DeltaTableState {
             let preader = SerializedFileReader::new(data)?;
             let schema = preader.metadata().file_metadata().schema();
             if !schema.is_group() {
-                return Err(DeltaTableError::from(action::ActionError::Generic(
+                return Err(DeltaTableError::from(action::ProtocolError::Generic(
                     "Action record in checkpoint should be a struct".to_string(),
                 )));
             }
@@ -126,7 +126,7 @@ impl DeltaTableState {
 
             for row_group in metadata.row_groups {
                 for action in actions_from_row_group(row_group, &mut reader)
-                    .map_err(action::ActionError::from)?
+                    .map_err(action::ProtocolError::from)?
                 {
                     self.process_action(
                         action,

--- a/rust/src/table_state_arrow.rs
+++ b/rust/src/table_state_arrow.rs
@@ -2,22 +2,25 @@
 //!
 //! See [crate::table_state::DeltaTableState].
 
-use crate::action::{ColumnCountStat, ColumnValueStat, Stats};
-use crate::table_state::DeltaTableState;
-use crate::DeltaTableError;
-use crate::SchemaDataType;
-use crate::SchemaTypeStruct;
-use arrow::array::{
-    Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Float64Array, Int64Array, NullArray,
-    StringArray, StructArray, TimestampMicrosecondArray, TimestampMillisecondArray,
-};
-use arrow::compute::cast;
-use arrow::compute::kernels::cast_utils::Parser;
-use arrow::datatypes::{DataType, Date32Type, Field, Fields, TimeUnit, TimestampMicrosecondType};
-use itertools::Itertools;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
+
+use arrow::compute::cast;
+use arrow::compute::kernels::cast_utils::Parser;
+use arrow_array::types::{Date32Type, TimestampMicrosecondType};
+use arrow_array::{
+    Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Float64Array, Int64Array, NullArray,
+    StringArray, StructArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+};
+use arrow_schema::{DataType, Field, Fields, TimeUnit};
+use itertools::Itertools;
+
+use crate::action::{ColumnCountStat, ColumnValueStat, Stats};
+use crate::errors::DeltaTableError;
+use crate::table_state::DeltaTableState;
+use crate::SchemaDataType;
+use crate::SchemaTypeStruct;
 
 impl DeltaTableState {
     /// Get an [arrow::record_batch::RecordBatch] containing add action data.

--- a/rust/src/writer/json.rs
+++ b/rust/src/writer/json.rs
@@ -3,16 +3,6 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use super::stats::create_add;
-use super::utils::{
-    arrow_schema_without_partitions, next_data_path, record_batch_from_message,
-    record_batch_without_partitions, stringified_partition_value,
-};
-use super::{DeltaWriter, DeltaWriterError};
-use crate::builder::DeltaTableBuilder;
-use crate::{action::Add, DeltaTable, DeltaTableError, DeltaTableMetaData, Schema};
-use crate::{storage::DeltaObjectStore, writer::utils::ShareableBuffer};
-
 use arrow::datatypes::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
 use arrow::record_batch::*;
 use bytes::Bytes;
@@ -23,6 +13,17 @@ use parquet::{
     file::properties::WriterProperties,
 };
 use serde_json::Value;
+
+use super::stats::create_add;
+use super::utils::{
+    arrow_schema_without_partitions, next_data_path, record_batch_from_message,
+    record_batch_without_partitions, stringified_partition_value,
+};
+use super::{DeltaWriter, DeltaWriterError};
+use crate::builder::DeltaTableBuilder;
+use crate::errors::DeltaTableError;
+use crate::{action::Add, DeltaTable, DeltaTableMetaData, Schema};
+use crate::{storage::DeltaObjectStore, writer::utils::ShareableBuffer};
 
 type BadValue = (Value, ParquetError);
 

--- a/rust/src/writer/mod.rs
+++ b/rust/src/writer/mod.rs
@@ -1,14 +1,15 @@
 #![cfg(all(feature = "arrow", feature = "parquet"))]
 //! Abstractions and implementations for writing data to delta tables
 
-use crate::action::{Action, Add, ColumnCountStat};
-use crate::{DeltaTable, DeltaTableError};
-
 use arrow::{datatypes::SchemaRef, error::ArrowError};
 use async_trait::async_trait;
 use object_store::Error as ObjectStoreError;
 use parquet::errors::ParquetError;
 use serde_json::Value;
+
+use crate::action::{Action, Add, ColumnCountStat};
+use crate::errors::DeltaTableError;
+use crate::DeltaTable;
 
 pub use json::JsonWriter;
 pub use record_batch::RecordBatchWriter;

--- a/rust/src/writer/record_batch.rs
+++ b/rust/src/writer/record_batch.rs
@@ -28,18 +28,6 @@
 //! ```
 use std::{collections::HashMap, sync::Arc};
 
-use super::{
-    stats::create_add,
-    utils::{
-        arrow_schema_without_partitions, next_data_path, record_batch_without_partitions,
-        stringified_partition_value, PartitionPath,
-    },
-    DeltaWriter, DeltaWriterError,
-};
-use crate::builder::DeltaTableBuilder;
-use crate::writer::utils::ShareableBuffer;
-use crate::DeltaTableError;
-use crate::{action::Add, storage::DeltaObjectStore, DeltaTable, DeltaTableMetaData, Schema};
 use arrow::array::{Array, UInt32Array};
 use arrow::compute::{lexicographical_partition_ranges, take, SortColumn};
 use arrow::datatypes::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
@@ -51,6 +39,16 @@ use bytes::Bytes;
 use object_store::ObjectStore;
 use parquet::{arrow::ArrowWriter, errors::ParquetError};
 use parquet::{basic::Compression, file::properties::WriterProperties};
+
+use super::stats::create_add;
+use super::utils::{
+    arrow_schema_without_partitions, next_data_path, record_batch_without_partitions,
+    stringified_partition_value, PartitionPath, ShareableBuffer,
+};
+use super::{DeltaWriter, DeltaWriterError};
+use crate::builder::DeltaTableBuilder;
+use crate::errors::DeltaTableError;
+use crate::{action::Add, storage::DeltaObjectStore, DeltaTable, DeltaTableMetaData, Schema};
 
 /// Writes messages to a delta lake table.
 pub struct RecordBatchWriter {

--- a/rust/src/writer/stats.rs
+++ b/rust/src/writer/stats.rs
@@ -1,5 +1,7 @@
-use super::*;
-use crate::action::{Add, ColumnValueStat, Stats};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{collections::HashMap, ops::AddAssign};
+
 use parquet::format::FileMetaData;
 use parquet::schema::types::{ColumnDescriptor, SchemaDescriptor};
 use parquet::{basic::LogicalType, errors::ParquetError};
@@ -7,9 +9,9 @@ use parquet::{
     file::{metadata::RowGroupMetaData, statistics::Statistics},
     format::TimeUnit,
 };
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-use std::{collections::HashMap, ops::AddAssign};
+
+use super::*;
+use crate::action::{Add, ColumnValueStat, Stats};
 
 pub(crate) fn create_add(
     partition_values: &HashMap<String, Option<String>>,
@@ -455,7 +457,8 @@ mod tests {
     use crate::{
         action::{ColumnCountStat, ColumnValueStat},
         builder::DeltaTableBuilder,
-        DeltaTable, DeltaTableError,
+        errors::DeltaTableError,
+        DeltaTable,
     };
     use lazy_static::lazy_static;
     use parquet::data_type::{ByteArray, FixedLenByteArray};

--- a/rust/src/writer/utils.rs
+++ b/rust/src/writer/utils.rs
@@ -4,9 +4,6 @@ use std::fmt::Display;
 use std::io::Write;
 use std::sync::Arc;
 
-use crate::writer::DeltaWriterError;
-use crate::DeltaResult;
-
 use arrow::array::{
     as_boolean_array, as_generic_binary_array, as_primitive_array, as_string_array, Array,
 };
@@ -22,6 +19,9 @@ use object_store::path::Path;
 use parking_lot::RwLock;
 use serde_json::Value;
 use uuid::Uuid;
+
+use crate::errors::DeltaResult;
+use crate::writer::DeltaWriterError;
 
 const NULL_PARTITION_VALUE_DATA_PATH: &str = "__HIVE_DEFAULT_PARTITION__";
 const PARTITION_DATE_FORMAT: &str = "%Y-%m-%d";

--- a/rust/tests/command_filesystem_check.rs
+++ b/rust/tests/command_filesystem_check.rs
@@ -4,7 +4,7 @@ use deltalake::test_utils::{
     set_env_if_not_set, IntegrationContext, StorageIntegration, TestResult, TestTables,
 };
 use deltalake::Path;
-use deltalake::{DeltaOps, DeltaTableError};
+use deltalake::{errors::DeltaTableError, DeltaOps};
 use serial_test::serial;
 
 mod common;

--- a/rust/tests/command_optimize.rs
+++ b/rust/tests/command_optimize.rs
@@ -1,5 +1,9 @@
 #![cfg(all(feature = "arrow", feature = "parquet"))]
 
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+use std::{collections::HashMap, error::Error, sync::Arc};
+
 use arrow::datatypes::Schema as ArrowSchema;
 use arrow::{
     array::{Int32Array, StringArray},
@@ -7,16 +11,14 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use deltalake::action::{Action, Remove};
+use deltalake::errors::DeltaTableError;
 use deltalake::operations::optimize::{create_merge_plan, MetricDetails, Metrics};
 use deltalake::operations::DeltaOps;
 use deltalake::writer::{DeltaWriter, RecordBatchWriter};
-use deltalake::{DeltaTable, DeltaTableError, PartitionFilter, SchemaDataType, SchemaField};
+use deltalake::{DeltaTable, PartitionFilter, SchemaDataType, SchemaField};
 use parquet::file::properties::WriterProperties;
 use rand::prelude::*;
 use serde_json::json;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
-use std::{collections::HashMap, error::Error, sync::Arc};
 use tempdir::TempDir;
 
 struct Context {

--- a/rust/tests/integration_checkpoint.rs
+++ b/rust/tests/integration_checkpoint.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use deltalake::checkpoints::{cleanup_expired_logs_for, create_checkpoint};
 use deltalake::test_utils::{IntegrationContext, StorageIntegration, TestResult};
 use deltalake::writer::{DeltaWriter, JsonWriter};
-use deltalake::{DeltaOps, DeltaResult, DeltaTableBuilder, ObjectStore, SchemaDataType};
+use deltalake::{errors::DeltaResult, DeltaOps, DeltaTableBuilder, ObjectStore, SchemaDataType};
 use object_store::path::Path;
 use serde_json::json;
 use serial_test::serial;

--- a/rust/tests/integration_commit.rs
+++ b/rust/tests/integration_commit.rs
@@ -4,7 +4,7 @@
 mod fs_common;
 
 use deltalake::test_utils::{IntegrationContext, StorageIntegration, TestResult, TestTables};
-use deltalake::{action, DeltaTableBuilder, DeltaTableError};
+use deltalake::{action, errors::DeltaTableError, DeltaTableBuilder};
 use serial_test::serial;
 use std::collections::HashMap;
 

--- a/rust/tests/integration_commit.rs
+++ b/rust/tests/integration_commit.rs
@@ -151,7 +151,7 @@ mod simple_commit_fs {
         let result = table.try_commit_transaction(&commit, 1).await;
 
         match result {
-            Err(deltalake::DeltaTableError::VersionAlreadyExists(_)) => {
+            Err(DeltaTableError::VersionAlreadyExists(_)) => {
                 assert!(true, "Delta version already exists.");
             }
             _ => {

--- a/rust/tests/read_delta_partitions_test.rs
+++ b/rust/tests/read_delta_partitions_test.rs
@@ -1,8 +1,7 @@
-extern crate deltalake;
-
-use deltalake::schema::SchemaDataType;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+
+use deltalake::schema::SchemaDataType;
 
 #[allow(dead_code)]
 mod fs_common;
@@ -22,7 +21,7 @@ fn test_create_delta_table_partition() {
     let _wrong_path = "year=2021/month=";
     assert!(matches!(
         deltalake::DeltaTablePartition::try_from(_wrong_path).unwrap_err(),
-        deltalake::DeltaTableError::PartitionError {
+        deltalake::errors::DeltaTableError::PartitionError {
             partition: _wrong_path
         },
     ))

--- a/rust/tests/read_delta_test.rs
+++ b/rust/tests/read_delta_test.rs
@@ -563,7 +563,7 @@ async fn read_empty_folder() {
 
     assert!(matches!(
         result.unwrap_err(),
-        deltalake::DeltaTableError::NotATable(_),
+        deltalake::errors::DeltaTableError::NotATable(_),
     ));
 
     let dir = std::env::temp_dir();
@@ -575,7 +575,7 @@ async fn read_empty_folder() {
 
     assert!(matches!(
         result.unwrap_err(),
-        deltalake::DeltaTableError::NotATable(_),
+        deltalake::errors::DeltaTableError::NotATable(_),
     ));
 }
 


### PR DESCRIPTION
# Description

While doing #1409 it became evident, that our errors are somewhat organically grown and could do with some pruning. At the same time we are hoping to reorganize (#1136) delta-rs a bit, to make it easier to reason about.

This PR is a first attempt to introduce a more explicit approach to how we model our errors. Here I'd like to propose we work towards the approach taken in the object store crate - specifically have very specific errors in submodules, but do not surface those errors to the user. Rather collapse them into eventually a single error type.

Since delta-rs does much more things then object store, I believe we will eventually end up with some more top level errors, or have maybe a two level hierarch.

As a first step in this PR:
- move `checkpoints.rs` into actions module (as proposed in #1136)
- move top level errors into new `errors` module - at lest the ones defined in `delta.rs`
- try and consolidate `ActionError` and `CheckpointError` which are now part of the `action` module.

As I needed to touch a bunch of imports anyhow, I took the liberty to organize them according to what to the best of my knowledge is the [leading contender](https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#StdExternalCrate%5C%3A) for what rust-fmt might do.

@wjones127 @rtyler @Blajda - opening this as a draft to get some feedback, as this is a somewhat intrusive change to the overall crate, in case you want to go another way. 

# Related Issue(s)

part of: #1136

# Documentation

<!---
Share links to useful documentation
--->
