### PR TITLE
feat: update writers to include compression method in file name

### DIFF
--- a/rust/src/operations/writer.rs
+++ b/rust/src/operations/writer.rs
@@ -2,6 +2,16 @@
 
 use std::collections::HashMap;
 
+use crate::action::Add;
+use crate::storage::ObjectStoreRef;
+use crate::writer::record_batch::{divide_by_partition_values, PartitionResult};
+use crate::writer::stats::create_add;
+use crate::writer::utils::{
+    self, arrow_schema_without_partitions, record_batch_without_partitions, PartitionPath,
+    ShareableBuffer,
+};
+use crate::{crate_version, DeltaResult, DeltaTableError};
+
 use arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
@@ -10,17 +20,6 @@ use object_store::{path::Path, ObjectStore};
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
-
-use crate::action::Add;
-use crate::crate_version;
-use crate::errors::{DeltaResult, DeltaTableError};
-use crate::storage::ObjectStoreRef;
-use crate::writer::record_batch::{divide_by_partition_values, PartitionResult};
-use crate::writer::stats::create_add;
-use crate::writer::utils::{
-    arrow_schema_without_partitions, record_batch_without_partitions, PartitionPath,
-    ShareableBuffer,
-};
 
 // TODO databricks often suggests a file size of 100mb, should we set this default?
 const DEFAULT_TARGET_FILE_SIZE: usize = 104_857_600;
@@ -297,12 +296,14 @@ impl PartitionWriter {
     }
 
     fn next_data_path(&mut self) -> Path {
-        let part = format!("{:0>5}", self.part_counter);
         self.part_counter += 1;
-        // TODO: what does c000 mean?
-        // TODO handle file name for different compressions
-        let file_name = format!("part-{}-{}-c000.snappy.parquet", part, self.writer_id);
-        self.config.prefix.child(file_name)
+
+        utils::next_data_path(
+            &self.config.prefix,
+            self.part_counter,
+            &self.writer_id,
+            &self.config.writer_properties,
+        )
     }
 
     fn reset_writer(&mut self) -> DeltaResult<(ArrowWriter<ShareableBuffer>, ShareableBuffer)> {

--- a/rust/src/writer/json.rs
+++ b/rust/src/writer/json.rs
@@ -3,27 +3,28 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
+use super::stats::create_add;
+use super::utils::{
+    arrow_schema_without_partitions, next_data_path, record_batch_from_message,
+    record_batch_without_partitions, stringified_partition_value, PartitionPath,
+};
+use super::{DeltaWriter, DeltaWriterError};
+use crate::builder::DeltaTableBuilder;
+use crate::{action::Add, DeltaTable, DeltaTableError, DeltaTableMetaData, Schema};
+use crate::{storage::DeltaObjectStore, writer::utils::ShareableBuffer};
+
 use arrow::datatypes::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
 use arrow::record_batch::*;
 use bytes::Bytes;
 use log::{info, warn};
+use object_store::path::Path;
 use object_store::ObjectStore;
 use parquet::{
     arrow::ArrowWriter, basic::Compression, errors::ParquetError,
     file::properties::WriterProperties,
 };
 use serde_json::Value;
-
-use super::stats::create_add;
-use super::utils::{
-    arrow_schema_without_partitions, next_data_path, record_batch_from_message,
-    record_batch_without_partitions, stringified_partition_value,
-};
-use super::{DeltaWriter, DeltaWriterError};
-use crate::builder::DeltaTableBuilder;
-use crate::errors::DeltaTableError;
-use crate::{action::Add, DeltaTable, DeltaTableMetaData, Schema};
-use crate::{storage::DeltaObjectStore, writer::utils::ShareableBuffer};
+use uuid::Uuid;
 
 type BadValue = (Value, ParquetError);
 
@@ -362,7 +363,12 @@ impl DeltaWriter<Vec<Value>> for JsonWriter {
 
         for (_, writer) in writers {
             let metadata = writer.arrow_writer.close()?;
-            let path = next_data_path(&self.partition_columns, &writer.partition_values, None)?;
+            let prefix =
+                PartitionPath::from_hashmap(&self.partition_columns, &writer.partition_values)?;
+            let prefix = Path::parse(prefix)?;
+            let uuid = Uuid::new_v4();
+
+            let path = next_data_path(&prefix, 0, &uuid, &writer.writer_properties);
             let obj_bytes = Bytes::from(writer.buffer.to_vec());
             let file_size = obj_bytes.len() as i64;
             self.storage.put(&path, obj_bytes).await?;

--- a/rust/src/writer/utils.rs
+++ b/rust/src/writer/utils.rs
@@ -90,14 +90,16 @@ pub(crate) fn next_data_path(
 ) -> Path {
     fn compression_to_str(compression: &Compression) -> &str {
         match compression {
+            // This is to match HADOOP's convention
+            // https://github.com/apache/parquet-mr/blob/c4977579ab3b149ea045a177b039f055b5408e8f/parquet-common/src/main/java/org/apache/parquet/hadoop/metadata/CompressionCodecName.java#L27-L34
             Compression::UNCOMPRESSED => "",
             Compression::SNAPPY => ".snappy",
             Compression::GZIP(_) => ".gz",
             Compression::LZO => ".lzo",
-            Compression::BROTLI(_) => ".brotli",
+            Compression::BROTLI(_) => ".br",
             Compression::LZ4 => ".lz4",
             Compression::ZSTD(_) => ".zstd",
-            Compression::LZ4_RAW => ".lz4_raw",
+            Compression::LZ4_RAW => ".lz4raw",
         }
     }
 

--- a/rust/src/writer/utils.rs
+++ b/rust/src/writer/utils.rs
@@ -371,7 +371,6 @@ mod tests {
         let uuid = Uuid::parse_str("02f09a3f-1624-3b1d-8409-44eff7708208").unwrap();
 
         // Validated against Spark
-
         let props = WriterProperties::builder()
             .set_compression(Compression::UNCOMPRESSED)
             .build();
@@ -413,13 +412,12 @@ mod tests {
             "x=0/y=0/part-00001-02f09a3f-1624-3b1d-8409-44eff7708208-c000.zstd.parquet"
         );
 
-        // Unable to validate against spark
         let props = WriterProperties::builder()
             .set_compression(Compression::LZ4_RAW)
             .build();
         assert_eq!(
             next_data_path(&prefix, 1, &uuid, &props).as_ref(),
-            "x=0/y=0/part-00001-02f09a3f-1624-3b1d-8409-44eff7708208-c000.lz4_raw.parquet"
+            "x=0/y=0/part-00001-02f09a3f-1624-3b1d-8409-44eff7708208-c000.lz4raw.parquet"
         );
 
         let props = WriterProperties::builder()
@@ -427,7 +425,7 @@ mod tests {
             .build();
         assert_eq!(
             next_data_path(&prefix, 1, &uuid, &props).as_ref(),
-            "x=0/y=0/part-00001-02f09a3f-1624-3b1d-8409-44eff7708208-c000.brotli.parquet"
+            "x=0/y=0/part-00001-02f09a3f-1624-3b1d-8409-44eff7708208-c000.br.parquet"
         );
     }
 }

--- a/rust/src/writer/utils.rs
+++ b/rust/src/writer/utils.rs
@@ -88,7 +88,6 @@ pub(crate) fn next_data_path(
     writer_id: &Uuid,
     writer_properties: &WriterProperties,
 ) -> Path {
-
     fn compression_to_str(compression: &Compression) -> &str {
         match compression {
             Compression::UNCOMPRESSED => "",
@@ -110,7 +109,12 @@ pub(crate) fn next_data_path(
     let part = format!("{:0>5}", part_count);
 
     // TODO: what does c000 mean?
-    let file_name = format!("part-{}-{}-c000{}.parquet", part, writer_id, compression_to_str(&compression));
+    let file_name = format!(
+        "part-{}-{}-c000{}.parquet",
+        part,
+        writer_id,
+        compression_to_str(&compression)
+    );
     prefix.child(file_name)
 }
 


### PR DESCRIPTION
# Description
The compression name was hard-coded to include snappy however users can now  specify their own methods which will cause a disconnect in the the name and the method used.

The naming convention is used as a hint by spark and hive to create the correct reader without reading having read the header of the file.
