### PR TITLE
refactor: remove `LoadCheckpointError` and `ApplyLogError`

### DIFF
--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -64,6 +64,7 @@ fn checkpoint_to_py(err: ProtocolError) -> PyErr {
         ProtocolError::Arrow { source } => arrow_to_py(source),
         ProtocolError::ObjectStore { source } => object_store_to_py(source),
         ProtocolError::NoMetaData => DeltaProtocolError::new_err("Table metadata missing"),
+        ProtocolError::CheckpointNotFound => DeltaProtocolError::new_err(err.to_string()),
         ProtocolError::InvalidField(err) => PyValueError::new_err(err),
         ProtocolError::InvalidRow(err) => PyValueError::new_err(err),
         ProtocolError::SerializeOperation { source } => PyValueError::new_err(source.to_string()),

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -63,7 +63,7 @@ fn checkpoint_to_py(err: ProtocolError) -> PyErr {
     match err {
         ProtocolError::Arrow { source } => arrow_to_py(source),
         ProtocolError::ObjectStore { source } => object_store_to_py(source),
-        ProtocolError::EndOfLog => DeltaProtocolError::new_err("Enf of log"),
+        ProtocolError::EndOfLog => DeltaProtocolError::new_err("End of log"),
         ProtocolError::NoMetaData => DeltaProtocolError::new_err("Table metadata missing"),
         ProtocolError::CheckpointNotFound => DeltaProtocolError::new_err(err.to_string()),
         ProtocolError::InvalidField(err) => PyValueError::new_err(err),

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -63,12 +63,14 @@ fn checkpoint_to_py(err: ProtocolError) -> PyErr {
     match err {
         ProtocolError::Arrow { source } => arrow_to_py(source),
         ProtocolError::ObjectStore { source } => object_store_to_py(source),
+        ProtocolError::EndOfLog => DeltaProtocolError::new_err("Enf of log"),
         ProtocolError::NoMetaData => DeltaProtocolError::new_err("Table metadata missing"),
         ProtocolError::CheckpointNotFound => DeltaProtocolError::new_err(err.to_string()),
         ProtocolError::InvalidField(err) => PyValueError::new_err(err),
         ProtocolError::InvalidRow(err) => PyValueError::new_err(err),
         ProtocolError::SerializeOperation { source } => PyValueError::new_err(source.to_string()),
         ProtocolError::ParquetParseError { source } => PyIOError::new_err(source.to_string()),
+        ProtocolError::IO { source } => PyIOError::new_err(source.to_string()),
         ProtocolError::Generic(msg) => DeltaError::new_err(msg),
     }
 }

--- a/rust/src/action/mod.rs
+++ b/rust/src/action/mod.rs
@@ -11,8 +11,12 @@ mod parquet_read;
 
 #[cfg(all(feature = "arrow"))]
 use arrow_schema::ArrowError;
-use object_store::Error as ObjectStoreError;
+use futures::StreamExt;
+use lazy_static::lazy_static;
+use log::*;
+use object_store::{path::Path, Error as ObjectStoreError, ObjectStore};
 use percent_encoding::percent_decode;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::borrow::Borrow;
@@ -21,7 +25,8 @@ use std::hash::{Hash, Hasher};
 
 use crate::delta_config::IsolationLevel;
 use crate::errors::DeltaResult;
-use crate::{schema::*, DeltaTableMetaData};
+use crate::storage::ObjectStoreRef;
+use crate::{delta::CheckPoint, schema::*, DeltaTableMetaData};
 
 /// Error returned when an invalid Delta log action is encountered.
 #[allow(missing_docs)]
@@ -29,6 +34,9 @@ use crate::{schema::*, DeltaTableMetaData};
 pub enum ProtocolError {
     #[error("Table state does not contain metadata")]
     NoMetaData,
+
+    #[error("Checkpoint file not found")]
+    CheckpointNotFound,
 
     /// The action contains an invalid field.
     #[error("Invalid action field: {0}")]
@@ -42,20 +50,15 @@ pub enum ProtocolError {
     #[error("Generic action error: {0}")]
     Generic(String),
 
-    #[cfg(feature = "parquet2")]
-    #[error("Failed to parse parquet checkpoint: {}", .source)]
-    /// Error returned when parsing checkpoint parquet using the parquet2 crate.
+    /// Error returned when parsing checkpoint parquet using the parquet crate.
+    #[error("Failed to parse parquet checkpoint: {source}")]
     ParquetParseError {
         /// Parquet error details returned when parsing the checkpoint parquet
+        #[cfg(feature = "parquet2")]
         #[from]
         source: parquet2::error::Error,
-    },
-
-    #[cfg(feature = "parquet")]
-    #[error("Failed to parse parquet checkpoint: {}", .source)]
-    /// Error returned when parsing checkpoint parquet using the parquet crate.
-    ParquetParseError {
         /// Parquet error details returned when parsing the checkpoint parquet
+        #[cfg(feature = "parquet")]
         #[from]
         source: parquet::errors::ParquetError,
     },
@@ -720,6 +723,87 @@ pub enum OutputMode {
     Complete,
     /// Only rows with updates will be written when new or changed data is available.
     Update,
+}
+
+pub(crate) async fn get_last_checkpoint(
+    object_store: &ObjectStoreRef,
+) -> Result<CheckPoint, ProtocolError> {
+    let last_checkpoint_path = Path::from_iter(["_delta_log", "_last_checkpoint"]);
+    debug!("loading checkpoint from {last_checkpoint_path}");
+    match object_store.get(&last_checkpoint_path).await {
+        Ok(data) => Ok(serde_json::from_slice(&data.bytes().await?)?),
+        Err(ObjectStoreError::NotFound { .. }) => {
+            match find_latest_check_point_for_version(object_store, i64::MAX).await {
+                Ok(Some(cp)) => Ok(cp),
+                _ => Err(ProtocolError::CheckpointNotFound),
+            }
+        }
+        Err(err) => Err(ProtocolError::ObjectStore { source: err }),
+    }
+}
+
+pub(crate) async fn find_latest_check_point_for_version(
+    object_store: &ObjectStoreRef,
+    version: i64,
+) -> Result<Option<CheckPoint>, ProtocolError> {
+    lazy_static! {
+        static ref CHECKPOINT_REGEX: Regex =
+            Regex::new(r#"^_delta_log/(\d{20})\.checkpoint\.parquet$"#).unwrap();
+        static ref CHECKPOINT_PARTS_REGEX: Regex =
+            Regex::new(r#"^_delta_log/(\d{20})\.checkpoint\.\d{10}\.(\d{10})\.parquet$"#).unwrap();
+    }
+
+    let mut cp: Option<CheckPoint> = None;
+    let mut stream = object_store.list(Some(object_store.log_path())).await?;
+
+    while let Some(obj_meta) = stream.next().await {
+        // Exit early if any objects can't be listed.
+        // We exclude the special case of a not found error on some of the list entities.
+        // This error mainly occurs for local stores when a temporary file has been deleted by
+        // concurrent writers or if the table is vacuumed by another client.
+        let obj_meta = match obj_meta {
+            Ok(meta) => Ok(meta),
+            Err(ObjectStoreError::NotFound { .. }) => continue,
+            Err(err) => Err(err),
+        }?;
+        if let Some(captures) = CHECKPOINT_REGEX.captures(obj_meta.location.as_ref()) {
+            let curr_ver_str = captures.get(1).unwrap().as_str();
+            let curr_ver: i64 = curr_ver_str.parse().unwrap();
+            if curr_ver > version {
+                // skip checkpoints newer than max version
+                continue;
+            }
+            if cp.is_none() || curr_ver > cp.unwrap().version {
+                cp = Some(CheckPoint {
+                    version: curr_ver,
+                    size: 0,
+                    parts: None,
+                });
+            }
+            continue;
+        }
+
+        if let Some(captures) = CHECKPOINT_PARTS_REGEX.captures(obj_meta.location.as_ref()) {
+            let curr_ver_str = captures.get(1).unwrap().as_str();
+            let curr_ver: i64 = curr_ver_str.parse().unwrap();
+            if curr_ver > version {
+                // skip checkpoints newer than max version
+                continue;
+            }
+            if cp.is_none() || curr_ver > cp.unwrap().version {
+                let parts_str = captures.get(2).unwrap().as_str();
+                let parts = parts_str.parse().unwrap();
+                cp = Some(CheckPoint {
+                    version: curr_ver,
+                    size: 0,
+                    parts: Some(parts),
+                });
+            }
+            continue;
+        }
+    }
+
+    Ok(cp)
 }
 
 #[cfg(test)]

--- a/rust/src/action/mod.rs
+++ b/rust/src/action/mod.rs
@@ -38,6 +38,9 @@ pub enum ProtocolError {
     #[error("Checkpoint file not found")]
     CheckpointNotFound,
 
+    #[error("End of transaction log")]
+    EndOfLog,
+
     /// The action contains an invalid field.
     #[error("Invalid action field: {0}")]
     InvalidField(String),
@@ -86,6 +89,12 @@ pub enum ProtocolError {
         /// The source ObjectStoreError.
         #[from]
         source: ObjectStoreError,
+    },
+
+    #[error("Io: {source}")]
+    IO {
+        #[from]
+        source: std::io::Error,
     },
 }
 

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -23,12 +23,14 @@ use serde_json::{Map, Value};
 use uuid::Uuid;
 
 use super::action;
-use super::action::{Action, DeltaOperation};
+use super::action::{
+    find_latest_check_point_for_version, get_last_checkpoint, Action, DeltaOperation,
+};
 use super::partitions::PartitionFilter;
 use super::schema::*;
 use super::table_state::DeltaTableState;
-use crate::action::{Add, Stats};
-use crate::errors::{ApplyLogError, DeltaTableError, LoadCheckpointError};
+use crate::action::{Add, ProtocolError, Stats};
+use crate::errors::{ApplyLogError, DeltaTableError};
 use crate::operations::vacuum::VacuumBuilder;
 use crate::storage::{commit_uri_from_version, ObjectStoreRef};
 
@@ -40,8 +42,8 @@ pub use crate::builder::{DeltaTableBuilder, DeltaTableConfig, DeltaVersion};
 pub struct CheckPoint {
     /// Delta table version
     pub(crate) version: i64, // 20 digits decimals
-    size: i64,
-    parts: Option<u32>, // 10 digits decimals
+    pub(crate) size: i64,
+    pub(crate) parts: Option<u32>, // 10 digits decimals
 }
 
 impl CheckPoint {
@@ -345,86 +347,6 @@ impl DeltaTable {
         Ok(current_delta_log_ver)
     }
 
-    async fn get_last_checkpoint(&self) -> Result<CheckPoint, LoadCheckpointError> {
-        let last_checkpoint_path = Path::from_iter(["_delta_log", "_last_checkpoint"]);
-        debug!("loading checkpoint from {last_checkpoint_path}");
-        match self.storage.get(&last_checkpoint_path).await {
-            Ok(data) => Ok(serde_json::from_slice(&data.bytes().await?)?),
-            Err(ObjectStoreError::NotFound { .. }) => {
-                match self.find_latest_check_point_for_version(i64::MAX).await {
-                    Ok(Some(cp)) => Ok(cp),
-                    _ => Err(LoadCheckpointError::NotFound),
-                }
-            }
-            Err(err) => Err(LoadCheckpointError::Storage { source: err }),
-        }
-    }
-
-    async fn find_latest_check_point_for_version(
-        &self,
-        version: i64,
-    ) -> Result<Option<CheckPoint>, DeltaTableError> {
-        lazy_static! {
-            static ref CHECKPOINT_REGEX: Regex =
-                Regex::new(r#"^_delta_log/(\d{20})\.checkpoint\.parquet$"#).unwrap();
-            static ref CHECKPOINT_PARTS_REGEX: Regex =
-                Regex::new(r#"^_delta_log/(\d{20})\.checkpoint\.\d{10}\.(\d{10})\.parquet$"#)
-                    .unwrap();
-        }
-
-        let mut cp: Option<CheckPoint> = None;
-        let mut stream = self.storage.list(Some(self.storage.log_path())).await?;
-
-        while let Some(obj_meta) = stream.next().await {
-            // Exit early if any objects can't be listed.
-            // We exclude the special case of a not found error on some of the list entities.
-            // This error mainly occurs for local stores when a temporary file has been deleted by
-            // concurrent writers or if the table is vacuumed by another client.
-            let obj_meta = match obj_meta {
-                Ok(meta) => Ok(meta),
-                Err(ObjectStoreError::NotFound { .. }) => continue,
-                Err(err) => Err(err),
-            }?;
-            if let Some(captures) = CHECKPOINT_REGEX.captures(obj_meta.location.as_ref()) {
-                let curr_ver_str = captures.get(1).unwrap().as_str();
-                let curr_ver: i64 = curr_ver_str.parse().unwrap();
-                if curr_ver > version {
-                    // skip checkpoints newer than max version
-                    continue;
-                }
-                if cp.is_none() || curr_ver > cp.unwrap().version {
-                    cp = Some(CheckPoint {
-                        version: curr_ver,
-                        size: 0,
-                        parts: None,
-                    });
-                }
-                continue;
-            }
-
-            if let Some(captures) = CHECKPOINT_PARTS_REGEX.captures(obj_meta.location.as_ref()) {
-                let curr_ver_str = captures.get(1).unwrap().as_str();
-                let curr_ver: i64 = curr_ver_str.parse().unwrap();
-                if curr_ver > version {
-                    // skip checkpoints newer than max version
-                    continue;
-                }
-                if cp.is_none() || curr_ver > cp.unwrap().version {
-                    let parts_str = captures.get(2).unwrap().as_str();
-                    let parts = parts_str.parse().unwrap();
-                    cp = Some(CheckPoint {
-                        version: curr_ver,
-                        size: 0,
-                        parts: Some(parts),
-                    });
-                }
-                continue;
-            }
-        }
-
-        Ok(cp)
-    }
-
     #[cfg(any(feature = "parquet", feature = "parquet2"))]
     async fn restore_checkpoint(&mut self, check_point: CheckPoint) -> Result<(), DeltaTableError> {
         self.state = DeltaTableState::from_checkpoint(self, &check_point).await?;
@@ -433,14 +355,14 @@ impl DeltaTable {
     }
 
     async fn get_latest_version(&mut self) -> Result<i64, DeltaTableError> {
-        let mut version = match self.get_last_checkpoint().await {
+        let mut version = match get_last_checkpoint(&self.storage).await {
             Ok(last_check_point) => last_check_point.version + 1,
-            Err(LoadCheckpointError::NotFound) => {
+            Err(ProtocolError::CheckpointNotFound) => {
                 // no checkpoint, start with version 0
                 0
             }
             Err(e) => {
-                return Err(DeltaTableError::LoadCheckpoint { source: e });
+                return Err(DeltaTableError::from(e));
             }
         };
 
@@ -525,7 +447,7 @@ impl DeltaTable {
     /// loading the last checkpoint and incrementally applying each version since.
     #[cfg(any(feature = "parquet", feature = "parquet2"))]
     pub async fn update(&mut self) -> Result<(), DeltaTableError> {
-        match self.get_last_checkpoint().await {
+        match get_last_checkpoint(&self.storage).await {
             Ok(last_check_point) => {
                 debug!("update with latest checkpoint {last_check_point:?}");
                 if Some(last_check_point) == self.last_check_point {
@@ -536,11 +458,11 @@ impl DeltaTable {
                     self.update_incremental(None).await
                 }
             }
-            Err(LoadCheckpointError::NotFound) => {
+            Err(ProtocolError::CheckpointNotFound) => {
                 debug!("update without checkpoint");
                 self.update_incremental(None).await
             }
-            Err(source) => Err(DeltaTableError::LoadCheckpoint { source }),
+            Err(err) => Err(DeltaTableError::from(err)),
         }
     }
 
@@ -600,7 +522,7 @@ impl DeltaTable {
 
         // 1. find latest checkpoint below version
         #[cfg(any(feature = "parquet", feature = "parquet2"))]
-        match self.find_latest_check_point_for_version(version).await? {
+        match find_latest_check_point_for_version(&self.storage, version).await? {
             Some(check_point) => {
                 self.restore_checkpoint(check_point).await?;
             }

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -2,7 +2,6 @@
 use object_store::Error as ObjectStoreError;
 
 use crate::action::ProtocolError;
-use crate::delta_config::DeltaConfigError;
 use crate::operations::transaction::TransactionError;
 
 /// A result returned by delta-rs
@@ -14,14 +13,6 @@ pub type DeltaResult<T> = Result<T, DeltaTableError>;
 pub enum DeltaTableError {
     #[error("Delta protocol violation: {source}")]
     Protocol { source: ProtocolError },
-
-    /// Error returned when applying transaction log failed.
-    #[error("Failed to apply transaction log: {}", .source)]
-    ApplyLog {
-        /// Apply error details returned when applying transaction log failed.
-        #[from]
-        source: ApplyLogError,
-    },
 
     /// Error returned when reading the delta log object failed.
     #[error("Failed to read delta log object: {}", .source)]
@@ -229,6 +220,7 @@ impl From<ProtocolError> for DeltaTableError {
         match value {
             #[cfg(feature = "arrow")]
             ProtocolError::Arrow { source } => DeltaTableError::Arrow { source },
+            ProtocolError::IO { source } => DeltaTableError::Io { source },
             ProtocolError::ObjectStore { source } => DeltaTableError::ObjectStore { source },
             ProtocolError::ParquetParseError { source } => DeltaTableError::Parquet { source },
             _ => DeltaTableError::Protocol { source: value },
@@ -236,58 +228,13 @@ impl From<ProtocolError> for DeltaTableError {
     }
 }
 
-/// Error related to Delta log application
-#[derive(thiserror::Error, Debug)]
-pub enum ApplyLogError {
-    /// Error returned when the end of transaction log is reached.
-    #[error("End of transaction log")]
-    EndOfLog,
-
-    /// Error returned when the JSON of the log record is invalid.
-    #[error("Invalid JSON found when applying log record")]
-    InvalidJson {
-        /// JSON error details returned when reading the JSON log record.
-        #[from]
-        source: serde_json::error::Error,
-    },
-
-    /// Error returned when the storage failed to read the log content.
-    #[error("Failed to read log content")]
-    Storage {
-        /// Storage error details returned while reading the log content.
-        source: ObjectStoreError,
-    },
-
-    /// Error returned when reading delta config failed.
-    #[error("Failed to read delta config: {}", .source)]
-    Config {
-        /// Delta config error returned when reading delta config failed.
-        #[from]
-        source: DeltaConfigError,
-    },
-
-    /// Error returned when a line from log record is invalid.
-    #[error("Failed to read line from log record")]
-    Io {
-        /// Source error details returned while reading the log record.
-        #[from]
-        source: std::io::Error,
-    },
-
-    /// Error returned when the action record is invalid in log.
-    #[error("Invalid action record found in log: {}", .source)]
-    InvalidAction {
-        /// Action error details returned of the invalid action.
-        #[from]
-        source: ProtocolError,
-    },
-}
-
-impl From<ObjectStoreError> for ApplyLogError {
-    fn from(error: ObjectStoreError) -> Self {
-        match error {
-            ObjectStoreError::NotFound { .. } => ApplyLogError::EndOfLog,
-            _ => ApplyLogError::Storage { source: error },
-        }
+impl DeltaTableError {
+    /// Crate a NotATable Error with message for given path.
+    pub fn not_a_table(path: impl AsRef<str>) -> Self {
+        let msg = format!(
+            "No snapshot or version 0 found, perhaps {} is an empty dir?",
+            path.as_ref()
+        );
+        Self::NotATable(msg)
     }
 }

--- a/rust/src/storage/utils.rs
+++ b/rust/src/storage/utils.rs
@@ -82,12 +82,10 @@ impl TryFrom<&Add> for ObjectMeta {
     fn try_from(value: &Add) -> DeltaResult<Self> {
         let last_modified = DateTime::<Utc>::from_utc(
             NaiveDateTime::from_timestamp_millis(value.modification_time).ok_or(
-                DeltaTableError::InvalidAction {
-                    source: crate::action::ProtocolError::InvalidField(format!(
-                        "invalid modification_time: {:?}",
-                        value.modification_time
-                    )),
-                },
+                DeltaTableError::from(crate::action::ProtocolError::InvalidField(format!(
+                    "invalid modification_time: {:?}",
+                    value.modification_time
+                ))),
             )?,
             Utc,
         );


### PR DESCRIPTION
# Description

This PR removes `LoadCheckpointError` and  `ApplyLogError` as well as moves some more checkpoint related functions into the checkpoint module.

Aside from cleaning up errors, this moves us a little bit closer to isolating log handling related logic in preparation for some upcoming work.

# Related Issue(s)

part of: #1136