### PR TITLE
feat(python): expose z-order in Python

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -625,7 +625,7 @@ class TableOptimizer:
 
     def __call__(
         self,
-        partition_filters: Optional[List[Tuple[str, str, Any]]] = None,
+        partition_filters: Optional[FilterType] = None,
         target_size: Optional[int] = None,
         max_concurrent_tasks: Optional[int] = None,
     ) -> Dict[str, Any]:
@@ -644,7 +644,7 @@ class TableOptimizer:
 
     def compact(
         self,
-        partition_filters: Optional[List[Tuple[str, str, Any]]] = None,
+        partition_filters: Optional[FilterType] = None,
         target_size: Optional[int] = None,
         max_concurrent_tasks: Optional[int] = None,
     ) -> Dict[str, Any]:
@@ -675,7 +675,7 @@ class TableOptimizer:
     def z_order(
         self,
         columns: Iterable[str],
-        partition_filters: Optional[List[Tuple[str, str, Any]]] = None,
+        partition_filters: Optional[FilterType] = None,
         target_size: Optional[int] = None,
         max_concurrent_tasks: Optional[int] = None,
     ) -> Dict[str, Any]:

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -635,7 +635,7 @@ class TableOptimizer:
         """
 
         warnings.warn(
-            "Call to deprecated method files_by_partitions. Please use file_uris instead.",
+            "Call to deprecated method DeltaTable.optimize. Use DeltaTable.optimize.compact() instead.",
             category=DeprecationWarning,
             stacklevel=2,
         )

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -441,9 +441,6 @@ given filters.
     @property
     def optimize(
         self,
-        partition_filters: Optional[List[Tuple[str, str, Any]]] = None,
-        target_size: Optional[int] = None,
-        max_concurrent_tasks: Optional[int] = None,
     ) -> "TableOptimizer":
         return TableOptimizer(self)
 
@@ -686,6 +683,16 @@ class TableOptimizer:
         Reorders the data using a Z-order curve to improve data skipping.
 
         This also performs compaction, so the same parameters as compact() apply.
+
+        :param columns: the columns to use for Z-ordering. There must be at least one column.
+        :param partition_filters: the partition filters that will be used for getting the matched files
+        :param target_size: desired file size after bin-packing files, in bytes. If not
+          provided, will attempt to read the table configuration value ``delta.targetFileSize``.
+          If that value isn't set, will use default value of 256MB.
+        :param max_concurrent_tasks: the maximum number of concurrent tasks to use for
+            file compaction. Defaults to number of CPUs. More concurrent tasks can make compaction
+            faster, but will also use more memory.
+        :return: the metrics from optimize
         """
         metrics = self.table._table.z_order_optimize(
             list(columns), partition_filters, target_size, max_concurrent_tasks

--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -417,7 +417,7 @@ into a large file. Bin-packing reduces the number of API calls required for read
 Optimizing will increments the table's version and creates remove actions for optimized files.
 Optimize does not delete files from storage. To delete files that were removed, call :meth:`DeltaTable.vacuum`.
 
-:attr:`DeltaTable.optimize` returns a :class:`TableOptimizer` object which provides
+``DeltaTable.optimize`` returns a :class:`TableOptimizer` object which provides
 methods for optimizing the table. Note that these method will fail if a concurrent
 writer performs an operation that removes any files (such as an overwrite).
 

--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -417,17 +417,34 @@ into a large file. Bin-packing reduces the number of API calls required for read
 Optimizing will increments the table's version and creates remove actions for optimized files.
 Optimize does not delete files from storage. To delete files that were removed, call :meth:`DeltaTable.vacuum`.
 
-Use :meth:`DeltaTable.optimize` to perform the optimize operation. Note that this method will fail if a
-concurrent writer performs an operation that removes any files (such as an overwrite).
+:attr:`DeltaTable.optimize` returns a :class:`TableOptimizer` object which provides
+methods for optimizing the table. Note that these method will fail if a concurrent
+writer performs an operation that removes any files (such as an overwrite).
+
+For just file compaction, use the :meth:`TableOptimizer.compact` method:
 
 .. code-block:: python
 
     >>> dt = DeltaTable("../rust/tests/data/simple_table")
-    >>> dt.optimize()
+    >>> dt.optimize.compact()
     {'numFilesAdded': 1, 'numFilesRemoved': 5,
      'filesAdded': {'min': 555, 'max': 555, 'avg': 555.0, 'totalFiles': 1, 'totalSize': 555},
      'filesRemoved': {'min': 262, 'max': 429, 'avg': 362.2, 'totalFiles': 5, 'totalSize': 1811},
      'partitionsOptimized': 1, 'numBatches': 1, 'totalConsideredFiles': 5,
+     'totalFilesSkipped': 0, 'preserveInsertionOrder': True}
+
+For improved data skipping, use the :meth:`TableOptimizer.z_order` method. This
+is slower than just file compaction, but can improve performance for queries that
+filter on multiple columns at once.
+
+.. code-block:: python
+
+    >>> dt = DeltaTable("../rust/tests/data/COVID-19_NYT")
+    >>> dt.optimize.z_order(["date", "county"])
+    {'numFilesAdded': 1, 'numFilesRemoved': 8,
+     'filesAdded': {'min': 2473439, 'max': 2473439, 'avg': 2473439.0, 'totalFiles': 1, 'totalSize': 2473439},
+     'filesRemoved': {'min': 325440, 'max': 895702, 'avg': 773810.625, 'totalFiles': 8, 'totalSize': 6190485},
+     'partitionsOptimized': 0, 'numBatches': 1, 'totalConsideredFiles': 8,
      'totalFilesSkipped': 0, 'preserveInsertionOrder': True}
 
 Writing Delta Tables

--- a/python/tests/test_optimize.py
+++ b/python/tests/test_optimize.py
@@ -23,7 +23,26 @@ def test_optimize_run_table(
 
     dt = DeltaTable(table_path)
     old_version = dt.version()
-    dt.optimize()
+    with pytest.warns(DeprecationWarning):
+        dt.optimize()
+    last_action = dt.history(1)[0]
+    assert last_action["operation"] == "OPTIMIZE"
+    assert dt.version() == old_version + 1
+
+
+def test_z_order_optimize(
+    tmp_path: pathlib.Path,
+    sample_data: pa.Table,
+):
+    write_deltalake(tmp_path, sample_data, mode="append")
+    write_deltalake(tmp_path, sample_data, mode="append")
+    write_deltalake(tmp_path, sample_data, mode="append")
+
+    dt = DeltaTable(tmp_path)
+    old_version = dt.version()
+
+    dt.optimize.z_order(["date32", "timestamp"])
+
     last_action = dt.history(1)[0]
     assert last_action["operation"] == "OPTIMIZE"
     assert dt.version() == old_version + 1


### PR DESCRIPTION
# Description

Updated the API to:

```python
DeltaTable.optimize.compact()
DeltaTable.optimize.z_order()
```

The old API of `DeltaTable.optimize()` still works, but now issues a deprecation warning.

# Related Issue(s)

- closes #1442


# Documentation

<!---
Share links to useful documentation
--->
