### PR TITLE
feat(rust): expose WriterProperties method on RecordBatchWriter and DeltaWriter

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -20,7 +20,7 @@ setup-dat: ## Download DAT test files
 	mkdir -p dat-data
 	rm -rf dat-data/v$(DAT_VERSION)
 	curl -L --silent --output dat-data/deltalake-dat-v$(DAT_VERSION).tar.gz \
-		https://github.com/delta-incubator/dat/releases/download/v$(DAT_VERSION)/deltalake-dat-v$(DAT_VERSION).tar.gz
+		https://github.com/delta-incubator/dat/releases/download/v$(DAT_VERSION)/deltalake-dat-v$(DAT_VERSION).tar.gz 
 	tar --no-same-permissions -xzf dat-data/deltalake-dat-v$(DAT_VERSION).tar.gz
 	mv out dat-data/v$(DAT_VERSION)
 	rm dat-data/deltalake-dat-v$(DAT_VERSION).tar.gz
@@ -70,7 +70,7 @@ check-python: ## Run check on Python
 	$(info Check Python ruff)
 	ruff check .
 	$(info Check Python mypy)
-	mypy --no-warn-unused-ignores
+	mypy
 
 .PHONY: unit-test
 unit-test: ## Run unit test

--- a/python/Makefile
+++ b/python/Makefile
@@ -20,7 +20,7 @@ setup-dat: ## Download DAT test files
 	mkdir -p dat-data
 	rm -rf dat-data/v$(DAT_VERSION)
 	curl -L --silent --output dat-data/deltalake-dat-v$(DAT_VERSION).tar.gz \
-		https://github.com/delta-incubator/dat/releases/download/v$(DAT_VERSION)/deltalake-dat-v$(DAT_VERSION).tar.gz 
+		https://github.com/delta-incubator/dat/releases/download/v$(DAT_VERSION)/deltalake-dat-v$(DAT_VERSION).tar.gz
 	tar --no-same-permissions -xzf dat-data/deltalake-dat-v$(DAT_VERSION).tar.gz
 	mv out dat-data/v$(DAT_VERSION)
 	rm dat-data/deltalake-dat-v$(DAT_VERSION).tar.gz
@@ -70,7 +70,7 @@ check-python: ## Run check on Python
 	$(info Check Python ruff)
 	ruff check .
 	$(info Check Python mypy)
-	mypy
+	mypy --no-warn-unused-ignores
 
 .PHONY: unit-test
 unit-test: ## Run unit test

--- a/rust/examples/basic_operations.rs
+++ b/rust/examples/basic_operations.rs
@@ -5,6 +5,11 @@ use arrow::{
 };
 use deltalake::operations::collect_sendable_stream;
 use deltalake::{action::SaveMode, DeltaOps, SchemaDataType, SchemaField};
+use parquet::{
+    basic::{Compression, ZstdLevel},
+    file::properties::WriterProperties,
+};
+
 use std::sync::Arc;
 
 fn get_table_columns() -> Vec<SchemaField> {
@@ -55,15 +60,27 @@ async fn main() -> Result<(), deltalake::errors::DeltaTableError> {
 
     assert_eq!(table.version(), 0);
 
+    let writer_properties = WriterProperties::builder()
+        .set_compression(Compression::ZSTD(ZstdLevel::try_new(3).unwrap()))
+        .build();
+
     let batch = get_table_batches();
-    let table = DeltaOps(table).write(vec![batch.clone()]).await?;
+    let table = DeltaOps(table)
+        .write(vec![batch.clone()])
+        .with_writer_properties(writer_properties)
+        .await?;
 
     assert_eq!(table.version(), 1);
+
+    let writer_properties = WriterProperties::builder()
+        .set_compression(Compression::ZSTD(ZstdLevel::try_new(3).unwrap()))
+        .build();
 
     // To overwrite instead of append (which is the default), use `.with_save_mode`:
     let table = DeltaOps(table)
         .write(vec![batch.clone()])
         .with_save_mode(SaveMode::Overwrite)
+        .with_writer_properties(writer_properties)
         .await?;
 
     assert_eq!(table.version(), 2);

--- a/rust/src/operations/write.rs
+++ b/rust/src/operations/write.rs
@@ -99,6 +99,8 @@ pub struct WriteBuilder {
     batches: Option<Vec<RecordBatch>>,
     /// how to handle cast failures, either return NULL (safe=true) or return ERR (safe=false)
     safe_cast: bool,
+    /// Parquet writer properties
+    writer_properties: Option<WriterProperties>,
 }
 
 impl WriteBuilder {
@@ -116,6 +118,7 @@ impl WriteBuilder {
             write_batch_size: None,
             batches: None,
             safe_cast: false,
+            writer_properties: None,
         }
     }
 
@@ -175,6 +178,12 @@ impl WriteBuilder {
     /// how to handle cast failures, either return NULL (safe=true) or return ERR (safe=false)
     pub fn with_cast_safety(mut self, safe: bool) -> Self {
         self.safe_cast = safe;
+        self
+    }
+
+    /// Specify the writer properties to use when writing a parquet file
+    pub fn with_writer_properties(mut self, writer_properties: WriterProperties) -> Self {
+        self.writer_properties = Some(writer_properties);
         self
     }
 
@@ -390,7 +399,7 @@ impl std::future::IntoFuture for WriteBuilder {
                 this.store.clone(),
                 this.target_file_size,
                 this.write_batch_size,
-                None,
+                this.writer_properties,
                 this.safe_cast,
             )
             .await?;

--- a/rust/src/operations/writer.rs
+++ b/rust/src/operations/writer.rs
@@ -134,6 +134,12 @@ impl DeltaWriter {
         }
     }
 
+    /// Apply custom writer_properties to the underlying parquet writer
+    pub fn with_writer_properties(&mut self, writer_properties: WriterProperties) -> &mut Self {
+        self.config.writer_properties = writer_properties;
+        self
+    }
+
     fn divide_by_partition_values(
         &mut self,
         values: &RecordBatch,

--- a/rust/src/operations/writer.rs
+++ b/rust/src/operations/writer.rs
@@ -135,7 +135,7 @@ impl DeltaWriter {
     }
 
     /// Apply custom writer_properties to the underlying parquet writer
-    pub fn with_writer_properties(&mut self, writer_properties: WriterProperties) -> &mut Self {
+    pub fn with_writer_properties(mut self, writer_properties: WriterProperties) -> Self {
         self.config.writer_properties = writer_properties;
         self
     }

--- a/rust/src/writer/record_batch.rs
+++ b/rust/src/writer/record_batch.rs
@@ -200,6 +200,12 @@ impl RecordBatchWriter {
         Ok(())
     }
 
+    /// Sets the writer properties for the underlying arrow writer.
+    pub fn with_writer_properties(mut self, writer_properties: WriterProperties) -> Self {
+        self.writer_properties = writer_properties;
+        self
+    }
+
     fn divide_by_partition_values(
         &mut self,
         values: &RecordBatch,
@@ -209,15 +215,6 @@ impl RecordBatchWriter {
             self.partition_columns.clone(),
             values,
         )
-    }
-
-    /// Sets the writer properties for the underlying arrow writer.
-    pub fn with_writer_properties(
-        &mut self,
-        writer_properties: WriterProperties,
-    ) -> Result<(), DeltaTableError> {
-        self.writer_properties = writer_properties;
-        Ok(())
     }
 }
 

--- a/rust/src/writer/record_batch.rs
+++ b/rust/src/writer/record_batch.rs
@@ -73,16 +73,20 @@ impl RecordBatchWriter {
         schema: ArrowSchemaRef,
         partition_columns: Option<Vec<String>>,
         storage_options: Option<HashMap<String, String>>,
+        writer_properties: Option<WriterProperties>,
     ) -> Result<Self, DeltaTableError> {
         let storage = DeltaTableBuilder::from_uri(table_uri)
             .with_storage_options(storage_options.unwrap_or_default())
             .build_storage()?;
 
         // Initialize writer properties for the underlying arrow writer
-        let writer_properties = WriterProperties::builder()
-            // NOTE: Consider extracting config for writer properties and setting more than just compression
-            .set_compression(Compression::SNAPPY)
-            .build();
+        let writer_properties = match writer_properties {
+            Some(properties) => properties,
+            None => WriterProperties::builder()
+                // NOTE: Consider extracting config for writer properties and setting more than just compression
+                .set_compression(Compression::SNAPPY)
+                .build(),
+        };
 
         Ok(Self {
             storage,
@@ -205,6 +209,15 @@ impl RecordBatchWriter {
             self.partition_columns.clone(),
             values,
         )
+    }
+
+    /// Sets the writer properties for the underlying arrow writer.
+    pub fn with_writer_properties(
+        &mut self,
+        writer_properties: WriterProperties,
+    ) -> Result<(), DeltaTableError> {
+        self.writer_properties = writer_properties;
+        Ok(())
     }
 }
 

--- a/rust/src/writer/record_batch.rs
+++ b/rust/src/writer/record_batch.rs
@@ -73,20 +73,16 @@ impl RecordBatchWriter {
         schema: ArrowSchemaRef,
         partition_columns: Option<Vec<String>>,
         storage_options: Option<HashMap<String, String>>,
-        writer_properties: Option<WriterProperties>,
     ) -> Result<Self, DeltaTableError> {
         let storage = DeltaTableBuilder::from_uri(table_uri)
             .with_storage_options(storage_options.unwrap_or_default())
             .build_storage()?;
 
         // Initialize writer properties for the underlying arrow writer
-        let writer_properties = match writer_properties {
-            Some(properties) => properties,
-            None => WriterProperties::builder()
-                // NOTE: Consider extracting config for writer properties and setting more than just compression
-                .set_compression(Compression::SNAPPY)
-                .build(),
-        };
+        let writer_properties = WriterProperties::builder()
+            // NOTE: Consider extracting config for writer properties and setting more than just compression
+            .set_compression(Compression::SNAPPY)
+            .build();
 
         Ok(Self {
             storage,


### PR DESCRIPTION
# Description
Adds the capability to pass a configured WriterProperties to the `RecordBatchWriter` and `DeltaWriter` similar to how the `OptimizeBuilder` can be updated.

# Related Issue(s)
- closes #1469 
- closes #1235 

# Documentation
