### PR TITLE
fix: avoid writing statistics for binary columns to fix JSON error

### DIFF
--- a/rust/src/action/checkpoints.rs
+++ b/rust/src/action/checkpoints.rs
@@ -287,7 +287,7 @@ fn filter_binary(schema: &Schema) -> Schema {
     Schema::new(
         schema
             .get_fields()
-            .into_iter()
+            .iter()
             .flat_map(|f| match f.get_type() {
                 SchemaDataType::primitive(p) => {
                     if p != "binary" {

--- a/rust/src/action/checkpoints.rs
+++ b/rust/src/action/checkpoints.rs
@@ -281,8 +281,8 @@ pub async fn cleanup_expired_logs_for(
     }
 }
 
-// Filter binary from the schema so that it isn't serialized into JSON,
-// as arrow currently does not support this.
+/// Filter binary from the schema so that it isn't serialized into JSON,
+/// as arrow currently does not support this.
 fn filter_binary(schema: &Schema) -> Schema {
     Schema::new(
         schema

--- a/rust/src/action/parquet_read/mod.rs
+++ b/rust/src/action/parquet_read/mod.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use chrono::{SecondsFormat, TimeZone, Utc};
 use num_bigint::BigInt;
-use num_traits::cast::ToPrimitive;
 use parquet::record::{Field, ListAccessor, MapAccessor, RowAccessor};
 use serde_json::json;
 
@@ -255,12 +254,7 @@ fn primitive_parquet_field_to_json_value(field: &Field) -> Result<serde_json::Va
         Field::Float(value) => Ok(json!(value)),
         Field::Double(value) => Ok(json!(value)),
         Field::Str(value) => Ok(json!(value)),
-        Field::Decimal(decimal) => match BigInt::from_signed_bytes_be(decimal.data()).to_f64() {
-            Some(int) => Ok(json!(
-                int / (10_i64.pow((decimal.scale()).try_into().unwrap()) as f64)
-            )),
-            _ => Err("Invalid type for min/max values."),
-        },
+        Field::Decimal(decimal) => Ok(serde_json::Value::String(BigInt::from_signed_bytes_be(decimal.data()).to_string())),
         Field::TimestampMicros(timestamp) => Ok(serde_json::Value::String(
             convert_timestamp_micros_to_string(*timestamp)?,
         )),

--- a/rust/src/action/parquet_read/mod.rs
+++ b/rust/src/action/parquet_read/mod.rs
@@ -254,7 +254,9 @@ fn primitive_parquet_field_to_json_value(field: &Field) -> Result<serde_json::Va
         Field::Float(value) => Ok(json!(value)),
         Field::Double(value) => Ok(json!(value)),
         Field::Str(value) => Ok(json!(value)),
-        Field::Decimal(decimal) => Ok(serde_json::Value::String(BigInt::from_signed_bytes_be(decimal.data()).to_string())),
+        Field::Decimal(decimal) => Ok(serde_json::Value::String(
+            BigInt::from_signed_bytes_be(decimal.data()).to_string(),
+        )),
         Field::TimestampMicros(timestamp) => Ok(serde_json::Value::String(
             convert_timestamp_micros_to_string(*timestamp)?,
         )),

--- a/rust/src/writer/stats.rs
+++ b/rust/src/writer/stats.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashMap, ops::AddAssign};
 
-use num_bigint::BigInt;
 use parquet::format::FileMetaData;
 use parquet::schema::types::{ColumnDescriptor, SchemaDescriptor};
 use parquet::{basic::LogicalType, errors::ParquetError};
@@ -220,16 +219,17 @@ impl StatsScalar {
 
                 let val = if val.len() <= 4 {
                     let mut bytes = [0; 4];
-                    bytes[..val.len()].copy_from_slice(val);
-                    BigInt::from(i32::from_be_bytes(bytes))
+                    bytes[(4 - val.len())..4].copy_from_slice(val);
+                    i32::from_be_bytes(bytes).to_string()
                 } else if val.len() <= 8 {
                     let mut bytes = [0; 8];
-                    bytes[..val.len()].copy_from_slice(val);
-                    BigInt::from(i64::from_be_bytes(bytes))
+                    bytes[(8 - val.len())..8].copy_from_slice(val);
+                    i64::from_be_bytes(bytes).to_string()
                 } else if val.len() <= 16 {
                     let mut bytes = [0; 16];
-                    bytes[..val.len()].copy_from_slice(val);
-                    BigInt::from(i128::from_be_bytes(bytes))
+                    bytes[(16 - val.len())..16].copy_from_slice(val);
+                    let thing = i128::from_be_bytes(bytes);
+                    thing.to_string()
                 } else {
                     return Err(DeltaWriterError::StatsParsingFailed {
                         debug_value: format!("{val:?}"),
@@ -240,14 +240,16 @@ impl StatsScalar {
                     });
                 };
 
-
-                let str_val = val.to_string();
-                let decimal_string = if str_val.len() > *scale as usize {
+                let decimal_string = if val.len() > *scale as usize {
                     let (integer_part, fractional_part) =
-                        str_val.split_at(str_val.len() - *scale as usize);
-                    format!("{}.{}", integer_part, fractional_part)
+                        val.split_at(val.len() - *scale as usize);
+                    if fractional_part.len() == 0 {
+                      integer_part.to_string()
+                    } else {
+                      format!("{}.{}", integer_part, fractional_part)
+                    }
                 } else {
-                    format!("0.{}", str_val)
+                    format!("0.{}", val)
                 };
                 Ok(Self::Decimal(decimal_string))
             }

--- a/rust/src/writer/stats.rs
+++ b/rust/src/writer/stats.rs
@@ -242,13 +242,13 @@ impl StatsScalar {
 
                 let decimal_string = if val.len() > *scale as usize {
                     let (integer_part, fractional_part) = val.split_at(val.len() - *scale as usize);
-                    if fractional_part.len() == 0 {
+                    if fractional_part.is_empty() {
                         integer_part.to_string()
                     } else {
                         format!("{}.{}", integer_part, fractional_part)
                     }
                 } else if *scale < 0 {
-                    let abs_scale = scale.abs() as usize;
+                    let abs_scale = scale.unsigned_abs() as usize;
                     let decimal_zeros = "0".repeat(abs_scale);
                     format!("{}{}", val, decimal_zeros)
                 } else {
@@ -519,7 +519,7 @@ mod tests {
                     scale: 3,
                     precision: 4,
                 }),
-                Value::from(1.234),
+                Value::from("1.234"),
             ),
             (
                 simple_parquet_stat!(Statistics::Int32, 1234),
@@ -527,7 +527,7 @@ mod tests {
                     scale: -1,
                     precision: 4,
                 }),
-                Value::from(12340.0),
+                Value::from("12340"),
             ),
             (
                 simple_parquet_stat!(Statistics::Int32, 737821),
@@ -564,7 +564,7 @@ mod tests {
                     scale: 3,
                     precision: 4,
                 }),
-                Value::from(1.234),
+                Value::from("1.234"),
             ),
             (
                 simple_parquet_stat!(Statistics::Int64, 1234),
@@ -572,7 +572,7 @@ mod tests {
                     scale: -1,
                     precision: 4,
                 }),
-                Value::from(12340.0),
+                Value::from("12340"),
             ),
             (
                 simple_parquet_stat!(Statistics::Int64, 1234),
@@ -598,7 +598,7 @@ mod tests {
                     scale: 3,
                     precision: 16,
                 }),
-                Value::from(1243124142314.423),
+                Value::from("1243124142314.423"),
             ),
         ];
 

--- a/rust/src/writer/stats.rs
+++ b/rust/src/writer/stats.rs
@@ -228,8 +228,7 @@ impl StatsScalar {
                 } else if val.len() <= 16 {
                     let mut bytes = [0; 16];
                     bytes[(16 - val.len())..16].copy_from_slice(val);
-                    let thing = i128::from_be_bytes(bytes);
-                    thing.to_string()
+                    i128::from_be_bytes(bytes).to_string()
                 } else {
                     return Err(DeltaWriterError::StatsParsingFailed {
                         debug_value: format!("{val:?}"),

--- a/rust/src/writer/stats.rs
+++ b/rust/src/writer/stats.rs
@@ -241,13 +241,16 @@ impl StatsScalar {
                 };
 
                 let decimal_string = if val.len() > *scale as usize {
-                    let (integer_part, fractional_part) =
-                        val.split_at(val.len() - *scale as usize);
+                    let (integer_part, fractional_part) = val.split_at(val.len() - *scale as usize);
                     if fractional_part.len() == 0 {
-                      integer_part.to_string()
+                        integer_part.to_string()
                     } else {
-                      format!("{}.{}", integer_part, fractional_part)
+                        format!("{}.{}", integer_part, fractional_part)
                     }
+                } else if *scale < 0 {
+                    let abs_scale = scale.abs() as usize;
+                    let decimal_zeros = "0".repeat(abs_scale);
+                    format!("{}{}", val, decimal_zeros)
                 } else {
                     format!("0.{}", val)
                 };

--- a/rust/tests/checkpoint_writer.rs
+++ b/rust/tests/checkpoint_writer.rs
@@ -34,7 +34,7 @@ mod simple_checkpoint {
             ),
             SchemaField::new(
                 "dec".to_owned(),
-                SchemaDataType::primitive("decimal(38,10)".to_owned()),
+                SchemaDataType::primitive("decimal(23,0)".to_owned()),
                 false,
                 HashMap::new(),
             ),
@@ -53,12 +53,12 @@ mod simple_checkpoint {
 
     fn get_batch(items: Vec<&[u8]>, decimals: Vec<i128>) -> Result<RecordBatch, Box<dyn Error>> {
         let x_array = BinaryArray::from(items);
-        let dec_array = Decimal128Array::from(decimals);
+        let dec_array = Decimal128Array::from(decimals).with_precision_and_scale(23, 0)?;
 
         Ok(RecordBatch::try_new(
             Arc::new(ArrowSchema::new(vec![
                 Field::new("bin", DataType::Binary, false),
-                Field::new("dec", DataType::Decimal128(38, 10), false),
+                Field::new("dec", DataType::Decimal128(23, 0), false),
             ])),
             vec![Arc::new(x_array), Arc::new(dec_array)],
         )?)
@@ -80,7 +80,7 @@ mod simple_checkpoint {
         let mut dt = context.table;
         let mut writer = RecordBatchWriter::for_table(&dt)?;
 
-        write(&mut writer, &mut dt, get_batch(vec![&[1, 2]], vec![12390211983908098091820909809])?).await?;
+        write(&mut writer, &mut dt, get_batch(vec![&[1, 2]], vec![18446744073709551614])?).await?;
 
         // Just checking that this doesn't fail. https://github.com/delta-io/delta-rs/issues/1493
         checkpoints::create_checkpoint(&dt).await?;

--- a/rust/tests/checkpoint_writer.rs
+++ b/rust/tests/checkpoint_writer.rs
@@ -9,7 +9,7 @@ mod fs_common;
 #[cfg(all(feature = "arrow", feature = "parquet"))]
 mod simple_checkpoint {
     use arrow::datatypes::Schema as ArrowSchema;
-    use arrow_array::{BinaryArray, RecordBatch, Decimal128Array};
+    use arrow_array::{BinaryArray, Decimal128Array, RecordBatch};
     use arrow_schema::{DataType, Field};
     use deltalake::writer::{DeltaWriter, RecordBatchWriter};
     use deltalake::*;
@@ -80,7 +80,12 @@ mod simple_checkpoint {
         let mut dt = context.table;
         let mut writer = RecordBatchWriter::for_table(&dt)?;
 
-        write(&mut writer, &mut dt, get_batch(vec![&[1, 2]], vec![18446744073709551614])?).await?;
+        write(
+            &mut writer,
+            &mut dt,
+            get_batch(vec![&[1, 2]], vec![18446744073709551614])?,
+        )
+        .await?;
 
         // Just checking that this doesn't fail. https://github.com/delta-io/delta-rs/issues/1493
         checkpoints::create_checkpoint(&dt).await?;


### PR DESCRIPTION
# Description
Avoid writing statistics for binary columns to fix JSON error thrown by Arrow

# Related Issue(s)
 - closes #1493

