### PR TITLE
refactor: unify with_predicate for delete ops

### DIFF
--- a/rust/src/operations/delete.rs
+++ b/rust/src/operations/delete.rs
@@ -42,7 +42,7 @@ use crate::storage::{DeltaObjectStore, ObjectStoreRef};
 use crate::table_state::DeltaTableState;
 use crate::DeltaTable;
 
-use super::datafusion::Expression;
+use super::datafusion_utils::Expression;
 
 /// Delete Records from the Delta Table.
 /// See this module's documentaiton for more information

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -170,7 +170,7 @@ impl AsRef<DeltaTable> for DeltaOps {
 }
 
 #[cfg(feature = "datafusion")]
-mod datafusion {
+mod datafusion_utils {
     use datafusion_expr::Expr;
 
     /// Used to represent user input of either a Datafusion expression or string expression

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -24,9 +24,9 @@ pub mod vacuum;
 #[cfg(feature = "datafusion")]
 use self::{delete::DeleteBuilder, load::LoadBuilder, update::UpdateBuilder, write::WriteBuilder};
 #[cfg(feature = "datafusion")]
-use arrow::record_batch::RecordBatch;
+pub use ::datafusion::physical_plan::common::collect as collect_sendable_stream;
 #[cfg(feature = "datafusion")]
-pub use datafusion::physical_plan::common::collect as collect_sendable_stream;
+use arrow::record_batch::RecordBatch;
 #[cfg(all(feature = "arrow", feature = "parquet"))]
 use optimize::OptimizeBuilder;
 
@@ -166,5 +166,35 @@ impl From<DeltaOps> for DeltaTable {
 impl AsRef<DeltaTable> for DeltaOps {
     fn as_ref(&self) -> &DeltaTable {
         &self.0
+    }
+}
+
+#[cfg(feature = "datafusion")]
+mod datafusion {
+    use datafusion_expr::Expr;
+
+    /// Used to represent user input of either a Datafusion expression or string expression
+    pub enum Expression {
+        /// Datafusion Expression
+        DataFusion(Expr),
+        /// String Expression
+        String(String),
+    }
+
+    impl From<Expr> for Expression {
+        fn from(val: Expr) -> Self {
+            Expression::DataFusion(val)
+        }
+    }
+
+    impl From<&str> for Expression {
+        fn from(val: &str) -> Self {
+            Expression::String(val.to_string())
+        }
+    }
+    impl From<String> for Expression {
+        fn from(val: String) -> Self {
+            Expression::String(val)
+        }
     }
 }

--- a/rust/src/operations/update.rs
+++ b/rust/src/operations/update.rs
@@ -56,32 +56,7 @@ use crate::{
     DeltaResult, DeltaTable, DeltaTableError,
 };
 
-use super::{transaction::commit, write::write_execution_plan};
-
-/// Used to represent user input of either a Datafusion expression or string expression
-pub enum Expression {
-    /// Datafusion Expression
-    DataFusion(Expr),
-    /// String Expression
-    String(String),
-}
-
-impl From<Expr> for Expression {
-    fn from(val: Expr) -> Self {
-        Expression::DataFusion(val)
-    }
-}
-
-impl From<&str> for Expression {
-    fn from(val: &str) -> Self {
-        Expression::String(val.to_string())
-    }
-}
-impl From<String> for Expression {
-    fn from(val: String) -> Self {
-        Expression::String(val)
-    }
-}
+use super::{datafusion::Expression, transaction::commit, write::write_execution_plan};
 
 /// Updates records in the Delta Table.
 /// See this module's documentation for more information

--- a/rust/src/operations/update.rs
+++ b/rust/src/operations/update.rs
@@ -56,7 +56,7 @@ use crate::{
     DeltaResult, DeltaTable, DeltaTableError,
 };
 
-use super::{datafusion::Expression, transaction::commit, write::write_execution_plan};
+use super::{datafusion_utils::Expression, transaction::commit, write::write_execution_plan};
 
 /// Updates records in the Delta Table.
 /// See this module's documentation for more information


### PR DESCRIPTION
# Description
A small refactor on the delete op to have the same interface as the update op

Allows a single method to be used for predicates represented as an Datafusion `Expr` or as a string.