### PR TITLE
docs: show data catalog options in Python API reference

### DIFF
--- a/python/deltalake/data_catalog.py
+++ b/python/deltalake/data_catalog.py
@@ -4,5 +4,14 @@ from enum import Enum
 class DataCatalog(Enum):
     """List of the Data Catalogs"""
 
-    AWS = "glue"  # AWS Glue Data Catalog
-    UNITY = "unity"  # Databricks Unity Catalog
+    AWS = "glue"
+    """
+    Refers to the
+    `AWS Glue Data Catalog <https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html>`_
+    """
+
+    UNITY = "unity"
+    """
+    Refers to the
+    `Databricks Unity Catalog <https://docs.databricks.com/data-governance/unity-catalog/index.html>`_
+    """


### PR DESCRIPTION
# Description

This PR shows the available options from the DataCatalog `Enum`, with links to their respective catalogs' documentation.

# Related Issue(s)
- Resolves: #1347.

# Documentation