### PR TITLE
fix: quick correction on documentation

### DIFF
--- a/rust/src/writer/record_batch.rs
+++ b/rust/src/writer/record_batch.rs
@@ -11,7 +11,7 @@
 //! ```rust ignore
 //! let table = DeltaTable::try_from_uri("../path/to/table")
 //! let batch: RecordBatch = ...
-//! let mut writer = RecordBatchWriter::for_table(table, /*storage_options=*/ HashMap::new())
+//! let mut writer = RecordBatchWriter::for_table(table)
 //! writer.write(batch)?;
 //! let actions: Vec<action::Action> = writer.flush()?.iter()
 //!     .map(|add| Action::add(add.into()))


### PR DESCRIPTION
# Description
Just a simple documentation fix. `for_table` only has a single argument, no longer accepts storage options as far as I'm aware. Found this while going through documentation and just thought I'd pass in for a little clean up.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
