### PR TITLE
feat!: bulk delete for vacuum

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -414,7 +414,6 @@ given filters.
         retention_hours: Optional[int] = None,
         dry_run: bool = True,
         enforce_retention_duration: bool = True,
-        max_concurrent_requests: int = 10,
     ) -> List[str]:
         """
         Run the Vacuum command on the Delta Table: list and delete files no longer referenced by the Delta table and are older than the retention threshold.
@@ -422,9 +421,6 @@ given filters.
         :param retention_hours: the retention threshold in hours, if none then the value from `configuration.deletedFileRetentionDuration` is used or default of 1 week otherwise.
         :param dry_run: when activated, list only the files, delete otherwise
         :param enforce_retention_duration: when disabled, accepts retention hours smaller than the value from `configuration.deletedFileRetentionDuration`.
-        :param max_concurrent_requests: the maximum number of concurrent requests to send to the backend.
-          Increasing this number may improve performance of vacuuming large tables, however it might also
-          increase the risk of hitting rate limits.
         :return: the list of files no longer referenced by the Delta Table and are older than the retention threshold.
         """
         if retention_hours:
@@ -435,7 +431,6 @@ given filters.
             dry_run,
             retention_hours,
             enforce_retention_duration,
-            max_concurrent_requests,
         )
 
     @property

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -244,18 +244,16 @@ impl RawDeltaTable {
 
     /// Run the Vacuum command on the Delta Table: list and delete files no longer referenced
     /// by the Delta table and are older than the retention threshold.
-    #[pyo3(signature = (dry_run, retention_hours = None, enforce_retention_duration = true, max_concurrent_requests = 10))]
+    #[pyo3(signature = (dry_run, retention_hours = None, enforce_retention_duration = true))]
     pub fn vacuum(
         &mut self,
         dry_run: bool,
         retention_hours: Option<u64>,
         enforce_retention_duration: bool,
-        max_concurrent_requests: usize,
     ) -> PyResult<Vec<String>> {
         let mut cmd = VacuumBuilder::new(self._table.object_store(), self._table.state.clone())
             .with_enforce_retention_duration(enforce_retention_duration)
-            .with_dry_run(dry_run)
-            .with_max_concurrent_requests(max_concurrent_requests);
+            .with_dry_run(dry_run);
         if let Some(retention_period) = retention_hours {
             cmd = cmd.with_retention_period(Duration::hours(retention_period as i64));
         }


### PR DESCRIPTION
# Description
Bulk delete was added to the object store https://github.com/apache/arrow-rs/issues/2615 which deletes multiple files within a single API call if the underlying store supports it. If it is not supported then concurrent requests are performed underneath.

This PR updates vacuum with the object store changes. Currently on S3 will see any benefits since the default bulk delete is not overridden for other backends.

# Related Issue(s)
- progresses #393 