### PR TITLE
feat: make find_files public

### DIFF
--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -1289,7 +1289,7 @@ pub(crate) async fn scan_memory_table(
     join_batches_with_add_actions(batches, map)
 }
 
-pub(crate) async fn find_files<'a>(
+pub async fn find_files<'a>(
     snapshot: &DeltaTableState,
     object_store: ObjectStoreRef,
     schema: Arc<ArrowSchema>,

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -1085,7 +1085,7 @@ impl TreeNodeVisitor for FindFilesExprProperties {
     }
 }
 
-/// Representing the result of the `find_files` function.
+/// Representing the result of the [find_files] function.
 pub struct FindFiles {
     /// A list of `Add` objects that match the given predicate
     pub candidates: Vec<Add>,

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -1085,7 +1085,9 @@ impl TreeNodeVisitor for FindFilesExprProperties {
     }
 }
 
+/// Representing the result of the `find_files` function.
 pub struct FindFiles {
+    /// A list of `Add` objects that match the given predicate
     pub candidates: Vec<Add>,
     /// Was a physical read to the datastore required to determine the candidates
     pub partition_scan: bool,
@@ -1289,6 +1291,7 @@ pub(crate) async fn scan_memory_table(
     join_batches_with_add_actions(batches, map)
 }
 
+/// Finds files in a snapshot that match the provided predicate.
 pub async fn find_files<'a>(
     snapshot: &DeltaTableState,
     object_store: ObjectStoreRef,

--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -1085,7 +1085,7 @@ impl TreeNodeVisitor for FindFilesExprProperties {
     }
 }
 
-pub(crate) struct FindFiles {
+pub struct FindFiles {
     pub candidates: Vec<Add>,
     /// Was a physical read to the datastore required to determine the candidates
     pub partition_scan: bool,


### PR DESCRIPTION
# Description
Make the find_files API public, same as public API for connectors' [`markFilesAsRead`](https://delta-io.github.io/connectors/latest/delta-standalone/api/java/io/delta/standalone/OptimisticTransaction.html#markFilesAsRead-io.delta.standalone.expressions.Expression-): 


# Related Issue(s)
<!---
For example:

- 
--->

closes #1559

# Documentation

<!---
Share links to useful documentation
--->
