### PR TITLE
ci: install newer rust for macos python release

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -39,6 +39,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # We use extra recent Cargo.toml syntax, so we need at least Rust 1.71.0
+      - name: Install newer rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          override: true
+
       - name: Publish to pypi (without sdist)
         uses: messense/maturin-action@v1
         env:


### PR DESCRIPTION
The bleeding edge features we are using caused the macos Python release to fail, because the GH runners are still on 1.70. https://github.com/delta-io/delta-rs/actions/runs/5676317320/job/15382866806

The Windows runner already has 1.71 and the Linux are fresh installing in a manylinux container already, so it's just MacOS that's the problem.