### PR TITLE
refactor: use pa.table.cast in delta_arrow_schema_from_pandas

### DIFF
--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -43,5 +43,5 @@ def delta_arrow_schema_from_pandas(
         else:
             schema_out.append(field)
     schema = pa.schema(schema_out, metadata=schema.metadata)
-    data = pa.Table.from_pandas(data, schema=schema)
-    return data, schema
+    table = table.cast(target_schema=schema)
+    return table, schema


### PR DESCRIPTION
# Description
I noticed that `pa.Table.from_pandas` was called twice even after the schema was constructed. Seems more efficient to just cast the existing that data has been read into memory with the newly created schema.


