### PR TITLE
chore: move deps to `[workspace.dependencies]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,5 @@
 [workspace]
-members = [
-    "rust",
-    "python",
-]
+members = ["rust", "python"]
 exclude = ["proofs", "delta-inspect"]
 
 [profile.release-with-debug]
@@ -14,3 +11,41 @@ debug = true
 # <https://github.com/delta-io/delta-rs/issues/1550?
 [profile.test]
 debug = "line-tables-only"
+
+[workspace.dependencies]
+# arrow
+arrow = { version = "43" }
+arrow-array = { version = "43" }
+arrow-buffer = { version = "43" }
+arrow-cast = { version = "43" }
+arrow-ord = { version = "43" }
+arrow-row = { version = "43" }
+arrow-schema = { version = "43" }
+arrow-select = { version = "43" }
+parquet = { version = "43" }
+
+# datafusion
+datafusion = { version = "28" }
+datafusion-expr = { version = "28" }
+datafusion-common = { version = "28" }
+datafusion-proto = { version = "28" }
+datafusion-sql = { version = "28" }
+datafusion-physical-expr = { version = "28" }
+
+# serde
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# "stdlib"
+bytes = { version = "1" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+regex = { version = "1" }
+thiserror = { version = "1" }
+url = { version = "2" }
+uuid = { version = "1" }
+
+# runtime / async
+async-trait = { version = "0.1" }
+futures = { version = "0.3" }
+tokio = { version = "1" }
+num_cpus = { version = "1" }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -18,17 +18,24 @@ doc = false
 name = "deltalake._internal"
 
 [dependencies]
-arrow-schema = { version = "43", features = ["serde"] }
-chrono = "0"
+# arrow
+arrow-schema = { workspace = true, features = ["serde"] }
+
+# serde
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# "stdlib"
+chrono = { workspace = true }
 env_logger = "0"
-futures = "0.3"
 lazy_static = "1"
-regex = "1"
-serde = "1"
-serde_json = "1"
-thiserror = "1"
-tokio = { version = "1", features = ["rt-multi-thread"] }
-num_cpus = "1"
+regex = { workspace = true }
+thiserror = { workspace = true }
+
+# runtime
+futures = { workspace = true }
+num_cpus = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 # reqwest is pulled in by azure sdk, but not used by python binding itself
 # for binary wheel best practice, statically link openssl

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,47 +13,71 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-arrow = { version = "43", optional = true }
-arrow-array = { version = "43", optional = true }
-arrow-buffer = { version = "43", optional = true }
-arrow-cast = { version = "43", optional = true }
-arrow-ord = { version = "43", optional = true }
-arrow-row = { version = "43", optional = true }
-arrow-schema = { version = "43", optional = true }
-arrow-select = { version = "43", optional = true }
-async-trait = "0.1"
-bytes = "1"
-chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
+# arrow
+arrow = { workspace = true, optional = true }
+arrow-array = { workspace = true, optional = true }
+arrow-buffer = { workspace = true, optional = true }
+arrow-cast = { workspace = true, optional = true }
+arrow-ord = { workspace = true, optional = true }
+arrow-row = { workspace = true, optional = true }
+arrow-schema = { workspace = true, optional = true }
+arrow-select = { workspace = true, optional = true }
+parquet = { workspace = true, features = [
+    "async",
+    "object_store",
+], optional = true }
+
+# datafusion
+datafusion = { workspace = true, optional = true }
+datafusion-expr = { workspace = true, optional = true }
+datafusion-common = { workspace = true, optional = true }
+datafusion-proto = { workspace = true, optional = true }
+datafusion-sql = { workspace = true, optional = true }
+datafusion-physical-expr = { workspace = true, optional = true }
+
+# serde
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+
+# "stdlib"
+bytes = { workspace = true }
+chrono = { workspace = true, default-features = false, features = ["clock"] }
+regex = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v4"] }
+url = { workspace = true }
+
+# runtime
+async-trait = { workspace = true }
+futures = { workspace = true }
+num_cpus = { workspace = true }
+tokio = { workspace = true, features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "fs",
+    "parking_lot",
+] }
+
+# other deps (these should be organized and pulled into workspace.dependencies as necessary)
 cfg-if = "1"
 datafusion-objectstore-hdfs = { version = "0.1.3", default-features = false, features = [
     "hdfs3",
     "try_spawn_blocking",
 ], optional = true }
 errno = "0.3"
-futures = "0.3"
 itertools = "0.11"
 lazy_static = "1"
 log = "0"
 libc = ">=0.2.90, <1"
 num-bigint = "0.4"
-num_cpus = "1"
 num-traits = "0.2.15"
 object_store = "0.6.1"
 once_cell = "1.16.0"
 parking_lot = "0.12"
-parquet = { version = "43", features = [
-    "async",
-    "object_store",
-], optional = true }
 parquet2 = { version = "0.17", optional = true }
 percent-encoding = "2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "1"
-tokio = { version = "1.28", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
-regex = "1"
-uuid = { version = "1", features = ["serde", "v4"] }
-url = "2.3"
 
 # S3 lock client
 rusoto_core = { version = "0.47", default-features = false, optional = true }
@@ -74,13 +98,6 @@ reqwest-retry = { version = "0.2.2", optional = true }
 
 # Datafusion
 dashmap = { version = "5", optional = true }
-datafusion = { version = "28", optional = true }
-datafusion-expr = { version = "28", optional = true }
-datafusion-common = { version = "28", optional = true }
-datafusion-proto = { version = "28", optional = true }
-datafusion-sql = { version = "28", optional = true }
-datafusion-physical-expr = { version = "28", optional = true }
-
 
 sqlparser = { version = "0.35", optional = true }
 
@@ -103,7 +120,16 @@ utime = "0.3"
 
 [features]
 azure = ["object_store/azure"]
-arrow = ["dep:arrow", "arrow-array", "arrow-cast", "arrow-ord", "arrow-row", "arrow-schema", "arrow-select", "arrow-buffer"]
+arrow = [
+    "dep:arrow",
+    "arrow-array",
+    "arrow-cast",
+    "arrow-ord",
+    "arrow-row",
+    "arrow-schema",
+    "arrow-select",
+    "arrow-buffer",
+]
 default = ["arrow", "parquet"]
 datafusion = [
     "dep:datafusion",


### PR DESCRIPTION
# Description

This commit moves a common set of dependencies from `rust/` and `python/` Cargo.toml files in favor of using the `workspace = true` variation.

The goal of this commit if merely organization. Pruning features, bumping versions are not goals of this commit.

# Related Issue(s)

- Closes #1572
# Documentation

<!---
Share links to useful documentation
--->
