### PR TITLE
fix: correct whitespace in delta protocol reader minimum version error message

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -471,7 +471,7 @@ given filters.
         """
         if self.protocol().min_reader_version > MAX_SUPPORTED_READER_VERSION:
             raise DeltaProtocolError(
-                f"The table's minimum reader version is {self.protocol().min_reader_version}"
+                f"The table's minimum reader version is {self.protocol().min_reader_version} "
                 f"but deltalake only supports up to version {MAX_SUPPORTED_READER_VERSION}."
             )
 


### PR DESCRIPTION
Currently the `DeltaProtocolError` given by an unsupported minimum reader version reads:

`DeltaProtocolError: The table's minimum reader version is 2but deltalake only supports up to version 1.`

This just adds a space between the min reader version number and the following word ("but") so that it reads

`DeltaProtocolError: The table's minimum reader version is 2 but deltalake only supports up to version 1.`