### PR TITLE
fix: remove alpha classifier

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,6 @@ license = {file = "LICENSE.txt"}
 requires-python = ">=3.7"
 keywords = ["deltalake", "delta", "datalake", "pandas", "arrow"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only"
 ]


### PR DESCRIPTION
# Description
Should the project remove the alpha classifier? or is it still considerer an alpha project?
I am asking that because the alpha classifier currently associated with the project might be creating some hesitation among prospective users or partners. The alpha classifier suggests that the project is not ready for a wider use.

If the maintainers still think that the project should be classified as a alpha please feel free to close this PR