### PR TITLE
fix: stop using deprecated from_utc method

### DIFF
--- a/rust/src/delta_datafusion.rs
+++ b/rust/src/delta_datafusion.rs
@@ -35,7 +35,7 @@ use arrow::record_batch::RecordBatch;
 use arrow_array::StringArray;
 use arrow_schema::Field;
 use async_trait::async_trait;
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{NaiveDateTime, TimeZone, Utc};
 use datafusion::datasource::file_format::{parquet::ParquetFormat, FileFormat};
 use datafusion::datasource::physical_plan::FileScanConfig;
 use datafusion::datasource::provider::TableProviderFactory;
@@ -651,10 +651,8 @@ pub(crate) fn partitioned_file_from_action(
 
     let ts_secs = action.modification_time / 1000;
     let ts_ns = (action.modification_time % 1000) * 1_000_000;
-    let last_modified = DateTime::<Utc>::from_utc(
-        NaiveDateTime::from_timestamp_opt(ts_secs, ts_ns as u32).unwrap(),
-        Utc,
-    );
+    let last_modified =
+        Utc.from_utc_datetime(&NaiveDateTime::from_timestamp_opt(ts_secs, ts_ns as u32).unwrap());
     PartitionedFile {
         object_meta: ObjectMeta {
             last_modified,

--- a/rust/src/storage/utils.rs
+++ b/rust/src/storage/utils.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{NaiveDateTime, TimeZone, Utc};
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::{DynObjectStore, ObjectMeta, Result as ObjectStoreResult};
@@ -80,14 +80,13 @@ impl TryFrom<&Add> for ObjectMeta {
     type Error = DeltaTableError;
 
     fn try_from(value: &Add) -> DeltaResult<Self> {
-        let last_modified = DateTime::<Utc>::from_utc(
-            NaiveDateTime::from_timestamp_millis(value.modification_time).ok_or(
+        let last_modified = Utc.from_utc_datetime(
+            &NaiveDateTime::from_timestamp_millis(value.modification_time).ok_or(
                 DeltaTableError::from(crate::action::ProtocolError::InvalidField(format!(
                     "invalid modification_time: {:?}",
                     value.modification_time
                 ))),
             )?,
-            Utc,
         );
         Ok(Self {
             // TODO this won't work for absolute paths, since Paths are always relative to store.

--- a/rust/tests/command_restore.rs
+++ b/rust/tests/command_restore.rs
@@ -3,7 +3,7 @@
 use arrow::datatypes::Schema as ArrowSchema;
 use arrow_array::{Int32Array, RecordBatch};
 use arrow_schema::{DataType, Field};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use deltalake::action::SaveMode;
 use deltalake::{DeltaOps, DeltaTable, SchemaDataType, SchemaField};
 use rand::Rng;
@@ -119,7 +119,7 @@ async fn test_restore_by_datetime() -> Result<(), Box<dyn Error>> {
     let history = table.history(Some(10)).await?;
     let timestamp = history.get(1).unwrap().timestamp.unwrap();
     let naive = NaiveDateTime::from_timestamp_millis(timestamp).unwrap();
-    let datetime: DateTime<Utc> = DateTime::from_utc(naive, Utc);
+    let datetime: DateTime<Utc> = Utc.from_utc_datetime(&naive);
 
     let result = DeltaOps(table)
         .restore()


### PR DESCRIPTION
# Description
HEAD is currently failing `cargo check` because a new deprecation was just pushed to chrono, deprecating from_utc: https://github.com/chronotope/chrono/pull/1175. Since we fail on warnings, this breaks the build.

Might be worth relaxing some of these checks, as typically marking something as deprecated is done specifically to _not_ break downstream projects.
