### PR TITLE
fix: don't re-encode paths

### DIFF
--- a/python/tests/data_acceptance/test_reader.py
+++ b/python/tests/data_acceptance/test_reader.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 from typing import Any, Dict, NamedTuple, Optional
 
@@ -44,7 +45,7 @@ for path in reader_case_path.iterdir():
 
 failing_cases = {
     "multi_partitioned_2": "Waiting for PyArrow 11.0.0 for decimal cast support (#1078)",
-    "multi_partitioned": "Escaped characters in data file paths aren't yet handled (#1079)",
+    "multi_partitioned": "Test case handles binary poorly",
 }
 
 
@@ -63,6 +64,10 @@ def test_dat(case: ReadCase):
 
     # Load table
     dt = DeltaTable(str(delta_root), version=version)
+
+    # Verify table paths can be found
+    for path in dt.file_uris():
+        assert os.path.exists(path)
 
     # Compare protocol versions
     assert dt.protocol().min_reader_version == version_metadata["min_reader_version"]

--- a/python/tests/data_acceptance/test_reader.py
+++ b/python/tests/data_acceptance/test_reader.py
@@ -44,9 +44,7 @@ for path in reader_case_path.iterdir():
 
 failing_cases = {
     "multi_partitioned_2": "Waiting for PyArrow 11.0.0 for decimal cast support (#1078)",
-    "nested_types": "Waiting for PyArrow 11.0.0 so we can ignore internal field names in equality",
     "multi_partitioned": "Escaped characters in data file paths aren't yet handled (#1079)",
-    "no_stats": "We don't yet support files without stats (#582)",
 }
 
 
@@ -85,7 +83,11 @@ def test_dat(case: ReadCase):
 
 def assert_tables_equal(first: pa.Table, second: pa.Table) -> None:
     assert first.schema == second.schema
-    sort_keys = [(col, "ascending") for col in first.column_names]
+    sort_keys = [
+        (col, "ascending")
+        for i, col in enumerate(first.column_names)
+        if not pa.types.is_nested(first.schema.field(i).type)
+    ]
     first_sorted = first.sort_by(sort_keys)
     second_sorted = second.sort_by(sort_keys)
     assert first_sorted == second_sorted

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -208,6 +208,28 @@ def test_read_table_with_stats():
         assert data.num_rows == 0
 
 
+def test_read_special_partition():
+    table_path = "../rust/tests/data/delta-0.8.0-special-partition"
+    dt = DeltaTable(table_path)
+
+    file1 = (
+        r"x=A%2FA/part-00007-b350e235-2832-45df-9918-6cab4f7578f7.c000.snappy.parquet"
+    )
+    file2 = (
+        r"x=B%20B/part-00015-e9abbc6f-85e9-457b-be8e-e9f5b8a22890.c000.snappy.parquet"
+    )
+
+    assert set(dt.files()) == {file1, file2}
+
+    assert dt.files([("x", "=", "A/A")]) == [file1]
+    assert dt.files([("x", "=", "B B")]) == [file2]
+    assert dt.files([("x", "=", "c")]) == []
+
+    table = dt.to_pyarrow_table()
+
+    assert set(table["x"].to_pylist()) == {"A/A", "B B"}
+
+
 def test_read_partitioned_table_metadata():
     table_path = "../rust/tests/data/delta-0.8.0-partitioned"
     dt = DeltaTable(table_path)

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -675,7 +675,13 @@ impl DeltaTable {
     ) -> Result<Vec<Path>, DeltaTableError> {
         Ok(self
             .get_active_add_actions_by_partitions(filters)?
-            .map(|add| Path::from(add.path.as_ref()))
+            .map(|add| {
+                // Try to preserve percent encoding if possible
+                match Path::parse(&add.path) {
+                    Ok(path) => path,
+                    Err(_) => Path::from(add.path.as_ref()),
+                }
+            })
             .collect())
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -414,12 +414,14 @@ mod tests {
         assert_eq!(
             table.get_files(),
             vec![
-                Path::from(
+                Path::parse(
                     "x=A%2FA/part-00007-b350e235-2832-45df-9918-6cab4f7578f7.c000.snappy.parquet"
-                ),
-                Path::from(
+                )
+                .unwrap(),
+                Path::parse(
                     "x=B%20B/part-00015-e9abbc6f-85e9-457b-be8e-e9f5b8a22890.c000.snappy.parquet"
                 )
+                .unwrap()
             ]
         );
 
@@ -429,9 +431,10 @@ mod tests {
         }];
         assert_eq!(
             table.get_files_by_partitions(&filters).unwrap(),
-            vec![Path::from(
+            vec![Path::parse(
                 "x=A%2FA/part-00007-b350e235-2832-45df-9918-6cab4f7578f7.c000.snappy.parquet"
-            )]
+            )
+            .unwrap()]
         );
     }
 

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -204,7 +204,10 @@ impl DeltaTableState {
     /// Returns an iterator of file names present in the loaded state
     #[inline]
     pub fn file_paths_iter(&self) -> impl Iterator<Item = Path> + '_ {
-        self.files.iter().map(|add| Path::from(add.path.as_ref()))
+        self.files.iter().map(|add| match Path::parse(&add.path) {
+            Ok(path) => path,
+            Err(_) => Path::from(add.path.as_ref()),
+        })
     }
 
     /// HashMap containing the last txn version stored for every app id writing txn


### PR DESCRIPTION
# Description

In the delta log, paths are percent encoded. We decode them here:

https://github.com/delta-io/delta-rs/blob/787c13a63efa9ada96d303c10c093424215aaa80/rust/src/action/mod.rs#L435-L437

Which is good. But then we've been re-encoding them with `Path::from`. This PR changes to use `Path::parse` when possible instead. Instead of propagating errors, we just fallback to `Path::from` for now. Read more here: https://docs.rs/object_store/0.7.0/object_store/path/struct.Path.html#encode

# Related Issue(s)

* closes #1533
* closes #1446 
* closes #1079
* closes #1393
* closes #1228


# Documentation

<!---
Share links to useful documentation
--->
