### PR TITLE
perf: avoid holding GIL in DeltaFileSystemHandler

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Build and install deltalake
         run: |
+          # Needed for openssl build
+          yum install -y perl-IPC-Cmd
           pip install virtualenv
           virtualenv venv
           source venv/bin/activate

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -26,6 +26,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # "stdlib"
+bytes = { workspace = true }
 chrono = { workspace = true }
 env_logger = "0"
 lazy_static = "1"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -26,7 +26,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # "stdlib"
-bytes = { workspace = true }
 chrono = { workspace = true }
 env_logger = "0"
 lazy_static = "1"

--- a/python/src/filesystem.rs
+++ b/python/src/filesystem.rs
@@ -386,7 +386,7 @@ impl ObjectInputFile {
     }
 
     #[pyo3(signature = (nbytes = None))]
-    fn read<'py>(&mut self, nbytes: Option<i64>, py: Python<'py>) -> PyResult<Py<PyBytes>> {
+    fn read(&mut self, nbytes: Option<i64>, py: Python<'_>) -> PyResult<Py<PyBytes>> {
         self.check_closed()?;
         let range = match nbytes {
             Some(len) => {
@@ -483,7 +483,7 @@ impl ObjectOutputStream {
 
 #[pymethods]
 impl ObjectOutputStream {
-    fn close<'py>(&mut self, py: Python<'py>) -> PyResult<()> {
+    fn close(&mut self, py: Python<'_>) -> PyResult<()> {
         self.closed = true;
         py.allow_threads(|| match self.rt.block_on(self.writer.shutdown()) {
             Ok(_) => Ok(()),
@@ -552,7 +552,7 @@ impl ObjectOutputStream {
         })
     }
 
-    fn flush<'py>(&mut self, py: Python<'py>) -> PyResult<()> {
+    fn flush(&mut self, py: Python<'_>) -> PyResult<()> {
         py.allow_threads(|| match self.rt.block_on(self.writer.flush()) {
             Ok(_) => Ok(()),
             Err(err) => {

--- a/python/tests/test_benchmark.py
+++ b/python/tests/test_benchmark.py
@@ -13,7 +13,7 @@ from deltalake import DeltaTable, write_deltalake
 
 @pytest.fixture()
 def sample_table() -> pa.Table:
-    max_size_bytes = 128 * 1024 * 1024
+    max_size_bytes = 10 * 128 * 1024 * 1024
     ncols = 20
     nrows = max_size_bytes // 20 // 8
     tab = pa.table({f"x{i}": standard_normal(nrows) for i in range(ncols)})
@@ -45,7 +45,13 @@ def test_benchmark_write(benchmark, sample_table, tmp_path):
 
 @pytest.mark.benchmark(group="read")
 def test_benchmark_read(benchmark, sample_table, tmp_path):
-    write_deltalake(str(tmp_path), sample_table)
+    write_deltalake(
+        str(tmp_path),
+        sample_table,
+        max_rows_per_file=100_000,
+        max_rows_per_group=10_000,
+        min_rows_per_group=10_000,
+    )
     dt = DeltaTable(str(tmp_path))
 
     result = benchmark(dt.to_pyarrow_table)
@@ -54,7 +60,13 @@ def test_benchmark_read(benchmark, sample_table, tmp_path):
 
 @pytest.mark.benchmark(group="read")
 def test_benchmark_read_pyarrow(benchmark, sample_table, tmp_path):
-    write_deltalake(str(tmp_path), sample_table)
+    write_deltalake(
+        str(tmp_path),
+        sample_table,
+        max_rows_per_file=100_000,
+        max_rows_per_group=10_000,
+        min_rows_per_group=10_000,
+    )
     dt = DeltaTable(str(tmp_path))
 
     fs = pa_fs.SubTreeFileSystem(str(tmp_path), pa_fs.LocalFileSystem())


### PR DESCRIPTION
# Description

I'm not sure yet this is the root cause of the performance issues we are seeing in #1569, but this seems like an obvious change that might help.

Any method that takes `&mut self` implicitly holds the GIL, so we'll need to allow threads explicitly in those methods.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
