### PR TITLE
fix: Parse paths before encoding them via a utility.

### DIFF
--- a/rust/examples/recordbatch-writer.rs
+++ b/rust/examples/recordbatch-writer.rs
@@ -36,6 +36,7 @@ async fn main() -> Result<(), DeltaTableError> {
     })?;
     info!("Using the location of: {:?}", table_uri);
 
+    // Using Path::from can double encode the uri
     let table_path = Path::from(table_uri.as_ref());
 
     let maybe_table = deltalake::open_table(&table_path).await;

--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -28,7 +28,7 @@ use super::schema::*;
 use super::table_state::DeltaTableState;
 use crate::action::{Add, ProtocolError, Stats};
 use crate::errors::DeltaTableError;
-use crate::storage::{commit_uri_from_version, ObjectStoreRef};
+use crate::storage::{commit_uri_from_version, get_path, ObjectStoreRef};
 
 // TODO re-exports only for transition
 pub use crate::builder::{DeltaTableBuilder, DeltaTableConfig, DeltaVersion};
@@ -675,7 +675,7 @@ impl DeltaTable {
     ) -> Result<Vec<Path>, DeltaTableError> {
         Ok(self
             .get_active_add_actions_by_partitions(filters)?
-            .map(|add| Path::from(add.path.as_ref()))
+            .map(|add| get_path(&add.path))
             .collect())
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -134,6 +134,8 @@ pub mod test_utils;
 
 #[cfg(test)]
 mod tests {
+    use crate::storage::get_path;
+
     use super::*;
     use std::collections::HashMap;
 
@@ -414,10 +416,10 @@ mod tests {
         assert_eq!(
             table.get_files(),
             vec![
-                Path::from(
+                get_path(
                     "x=A%2FA/part-00007-b350e235-2832-45df-9918-6cab4f7578f7.c000.snappy.parquet"
                 ),
-                Path::from(
+                get_path(
                     "x=B%20B/part-00015-e9abbc6f-85e9-457b-be8e-e9f5b8a22890.c000.snappy.parquet"
                 )
             ]
@@ -429,7 +431,7 @@ mod tests {
         }];
         assert_eq!(
             table.get_files_by_partitions(&filters).unwrap(),
-            vec![Path::from(
+            vec![get_path(
                 "x=A%2FA/part-00007-b350e235-2832-45df-9918-6cab4f7578f7.c000.snappy.parquet"
             )]
         );

--- a/rust/src/operations/restore.rs
+++ b/rust/src/operations/restore.rs
@@ -26,13 +26,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{DateTime, Utc};
 use futures::future::BoxFuture;
-use object_store::path::Path;
 use object_store::ObjectStore;
 use serde::Serialize;
 
 use crate::action::{Action, Add, DeltaOperation, Remove};
 use crate::operations::transaction::{prepare_commit, try_commit_transaction, TransactionError};
-use crate::storage::ObjectStoreRef;
+use crate::storage::{ObjectStoreRef, get_path};
 use crate::table_state::DeltaTableState;
 use crate::{action, DeltaResult, DeltaTable, DeltaTableConfig, DeltaTableError, ObjectStoreError};
 
@@ -252,7 +251,7 @@ async fn check_files_available(
     files: &Vec<action::Add>,
 ) -> DeltaResult<()> {
     for file in files {
-        let file_path = Path::from(file.path.clone());
+        let file_path = get_path(file.path.clone());
         match object_store.head(&file_path).await {
             Ok(_) => {}
             Err(ObjectStoreError::NotFound { .. }) => {

--- a/rust/src/operations/writer.rs
+++ b/rust/src/operations/writer.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use crate::action::Add;
-use crate::storage::ObjectStoreRef;
+use crate::storage::{ObjectStoreRef, get_path};
 use crate::writer::record_batch::{divide_by_partition_values, PartitionResult};
 use crate::writer::stats::create_add;
 use crate::writer::utils::{
@@ -247,7 +247,7 @@ impl PartitionWriterConfig {
             .map_err(|err| WriteError::FileName {
                 source: Box::new(err),
             })?;
-        let prefix = Path::from(part_path.as_ref());
+        let prefix = get_path(part_path);
         let writer_properties = writer_properties.unwrap_or_else(|| {
             WriterProperties::builder()
                 .set_created_by(format!("delta-rs version {}", crate_version()))
@@ -420,7 +420,7 @@ mod tests {
         assert_eq!(files.len(), 1);
         assert_eq!(files.len(), adds.len());
         let head = object_store
-            .head(&Path::from(adds[0].path.clone()))
+            .head(&get_path(adds[0].path.clone()))
             .await
             .unwrap();
         assert_eq!(head.size, adds[0].size as usize)

--- a/rust/src/storage/s3.rs
+++ b/rust/src/storage/s3.rs
@@ -1,5 +1,6 @@
 //! AWS S3 storage backend.
 
+use super::get_path;
 use super::utils::str_is_truthy;
 use crate::builder::{s3_storage_options, str_option};
 use bytes::Bytes;
@@ -145,7 +146,7 @@ impl S3LockClient {
             }
 
             let mut rename_result = s3
-                .rename_no_replace(&Path::from(data.source), &Path::from(data.destination))
+                .rename_no_replace(&get_path(data.source), &get_path(data.destination))
                 .await;
 
             if lock.acquired_expired_lock {

--- a/rust/src/table_state.rs
+++ b/rust/src/table_state.rs
@@ -16,6 +16,7 @@ use crate::errors::DeltaTableError;
 use crate::partitions::{DeltaTablePartition, PartitionFilter};
 use crate::schema::SchemaDataType;
 use crate::storage::commit_uri_from_version;
+use crate::storage::get_path;
 use crate::Schema;
 use crate::{DeltaTable, DeltaTableMetaData};
 
@@ -204,7 +205,7 @@ impl DeltaTableState {
     /// Returns an iterator of file names present in the loaded state
     #[inline]
     pub fn file_paths_iter(&self) -> impl Iterator<Item = Path> + '_ {
-        self.files.iter().map(|add| Path::from(add.path.as_ref()))
+        self.files.iter().map(|add| get_path(&add.path))
     }
 
     /// HashMap containing the last txn version stored for every app id writing txn


### PR DESCRIPTION
# Description
The use of `Path::from` double encodes strings in some cases. This is seen when reading tables with a timestamp as the partition for instance. When written to the table the `:` is encoded as %3A. Calling Path::from on such a table double encodes the aready % encoded fields.

This PR merely adds a utility that first calls `parse` on the string, which validates that it has indeed been encoded correctly. In the case of failure, the string is then handed to Path::from to be handled.

# Related Issue(s)
- fixes #1228

# Documentation

[object_store::path::Path](https://docs.rs/object_store/latest/object_store/path/struct.Path.html)
