### PR TITLE
fix: change map nullable value to false

### DIFF
--- a/rust/src/delta_arrow.rs
+++ b/rust/src/delta_arrow.rs
@@ -64,7 +64,7 @@ impl TryFrom<&schema::SchemaTypeMap> for ArrowField {
 
     fn try_from(a: &schema::SchemaTypeMap) -> Result<Self, ArrowError> {
         Ok(ArrowField::new_map(
-            "entires",
+            "map",
             "entries",
             ArrowField::new("key", ArrowDataType::try_from(a.get_key_type())?, false),
             ArrowField::new(


### PR DESCRIPTION
# Description

This value was true but where arrow defines it as always false https://github.com/apache/arrow-rs/blob/master/arrow-schema/src/field.rs#L230.

This is also described in apache/arrow-rs#1697.

This also replaces `key_value` as the struct name with `entries` to remain consistent with https://github.com/apache/arrow-rs/blob/878217b9e330b4f1ed13e798a214ea11fbeb2bbb/arrow-schema/src/datatype.rs#L247-L250

The description of the main changes of your pull request

# Related Issue(s)

- closes #1619 

# Documentation

<!---
Share links to useful documentation
--->
