### PR TITLE
feat: pass known file sizes to filesystem in Python

### DIFF
--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -254,7 +254,7 @@ class DeltaFileSystemHandler:
         """
     def normalize_path(self, path: str) -> str:
         """Normalize filesystem path."""
-    def open_input_file(self, path: str) -> ObjectInputFile:
+    def open_input_file(self, path: str, size: int | None = None) -> ObjectInputFile:
         """Open an input file for random access reading."""
     def open_output_stream(
         self, path: str, metadata: dict[str, str] | None = None

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -205,7 +205,12 @@ class ObjectOutputStream:
 class DeltaFileSystemHandler:
     """Implementation of pyarrow.fs.FileSystemHandler for use with pyarrow.fs.PyFileSystem"""
 
-    def __init__(self, root: str, options: dict[str, str] | None = None) -> None: ...
+    def __init__(
+        self,
+        root: str,
+        options: dict[str, str] | None = None,
+        known_sizes: dict[str, int] | None = None,
+    ) -> None: ...
     def get_type_name(self) -> str: ...
     def copy_file(self, src: str, dst: str) -> None:
         """Copy a file.

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -259,7 +259,7 @@ class DeltaFileSystemHandler:
         """
     def normalize_path(self, path: str) -> str:
         """Normalize filesystem path."""
-    def open_input_file(self, path: str, size: int | None = None) -> ObjectInputFile:
+    def open_input_file(self, path: str) -> ObjectInputFile:
         """Open an input file for random access reading."""
     def open_output_stream(
         self, path: str, metadata: dict[str, str] | None = None

--- a/python/deltalake/fs.py
+++ b/python/deltalake/fs.py
@@ -12,47 +12,23 @@ class DeltaStorageHandler(DeltaFileSystemHandler, FileSystemHandler):
     DeltaStorageHandler is a concrete implementations of a PyArrow FileSystemHandler.
     """
 
-    known_sizes: Dict[str, int] = {}
-
-    def __new__(  # type:ignore
-        cls,
-        table_uri: str,
-        storage_options: Optional[Dict[str, str]] = None,
-        known_sizes: Optional[Dict[str, int]] = None,
-    ):
-        return super().__new__(
-            cls, table_uri=table_uri, options=storage_options  # type:ignore
-        )
-
-    def __init__(
-        self,
-        table_uri: str,
-        storage_options: Optional[Dict[str, str]] = None,
-        known_sizes: Optional[Dict[str, int]] = None,
-    ):
-        if known_sizes:
-            self.known_sizes = known_sizes
-        return
-
-    def open_input_file(self, path: str, size: Optional[int] = None) -> pa.PythonFile:
+    def open_input_file(self, path: str) -> pa.PythonFile:
         """
         Open an input file for random access reading.
 
         :param source: The source to open for reading.
         :return:  NativeFile
         """
-        size = self.known_sizes.get(path)
-        return pa.PythonFile(DeltaFileSystemHandler.open_input_file(self, path, size))
+        return pa.PythonFile(DeltaFileSystemHandler.open_input_file(self, path))
 
-    def open_input_stream(self, path: str, size: Optional[int] = None) -> pa.PythonFile:
+    def open_input_stream(self, path: str) -> pa.PythonFile:
         """
         Open an input stream for sequential reading.
 
         :param source: The source to open for reading.
         :return:  NativeFile
         """
-        size = self.known_sizes.get(path)
-        return pa.PythonFile(DeltaFileSystemHandler.open_input_file(self, path, size))
+        return pa.PythonFile(DeltaFileSystemHandler.open_input_file(self, path))
 
     def open_output_stream(
         self, path: str, metadata: Optional[Dict[str, str]] = None

--- a/python/deltalake/fs.py
+++ b/python/deltalake/fs.py
@@ -12,23 +12,47 @@ class DeltaStorageHandler(DeltaFileSystemHandler, FileSystemHandler):
     DeltaStorageHandler is a concrete implementations of a PyArrow FileSystemHandler.
     """
 
-    def open_input_file(self, path: str) -> pa.PythonFile:
+    known_sizes: Dict[str, int] = {}
+
+    def __new__(  # type:ignore
+        cls,
+        table_uri: str,
+        storage_options: Optional[Dict[str, str]] = None,
+        known_sizes: Optional[Dict[str, int]] = None,
+    ):
+        return super().__new__(
+            cls, table_uri=table_uri, options=storage_options  # type:ignore
+        )
+
+    def __init__(
+        self,
+        table_uri: str,
+        storage_options: Optional[Dict[str, str]] = None,
+        known_sizes: Optional[Dict[str, int]] = None,
+    ):
+        if known_sizes:
+            self.known_sizes = known_sizes
+        return
+
+    def open_input_file(self, path: str, size: Optional[int] = None) -> pa.PythonFile:
         """
         Open an input file for random access reading.
 
         :param source: The source to open for reading.
         :return:  NativeFile
         """
-        return pa.PythonFile(DeltaFileSystemHandler.open_input_file(self, path))
+        size = self.known_sizes.get(path)
+        return pa.PythonFile(DeltaFileSystemHandler.open_input_file(self, path, size))
 
-    def open_input_stream(self, path: str) -> pa.PythonFile:
+    def open_input_stream(self, path: str, size: Optional[int] = None) -> pa.PythonFile:
         """
         Open an input stream for sequential reading.
 
         :param source: The source to open for reading.
         :return:  NativeFile
         """
-        return pa.PythonFile(DeltaFileSystemHandler.open_input_file(self, path))
+        size = self.known_sizes.get(path)
+        return pa.PythonFile(DeltaFileSystemHandler.open_input_file(self, path, size))
 
     def open_output_stream(
         self, path: str, metadata: Optional[Dict[str, str]] = None

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -522,10 +522,13 @@ given filters.
             )
 
         if not filesystem:
+            file_sizes = self.get_add_actions().to_pydict()
+            file_sizes = {
+                x: y for x, y in zip(file_sizes["path"], file_sizes["size_bytes"])
+            }
             filesystem = pa_fs.PyFileSystem(
                 DeltaStorageHandler(
-                    self._table.table_uri(),
-                    self._storage_options,
+                    self._table.table_uri(), self._storage_options, file_sizes
                 )
             )
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -562,6 +562,7 @@ impl RawDeltaTable {
             inner: self._table.object_store(),
             rt: Arc::new(rt()?),
             config: self._config.clone(),
+            known_sizes: None,
         })
     }
 

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 from threading import Barrier, Thread
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 from packaging import version
@@ -102,6 +103,25 @@ def test_read_simple_table_update_incremental():
     assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"id": [0, 1, 2, 3, 4]}
     dt.update_incremental()
     assert dt.to_pyarrow_dataset().to_table().to_pydict() == {"id": [5, 7, 9]}
+
+
+def test_read_simple_table_file_sizes_failure():
+    table_path = "../rust/tests/data/simple_table"
+    dt = DeltaTable(table_path)
+    add_actions = dt.get_add_actions().to_pydict()
+
+    # set all sizes to -1, the idea is to break the reading, to check
+    # that input file sizes are actually used
+    add_actions_modified = {
+        x: [-1 for item in x] if x == "size_bytes" else y
+        for x, y in add_actions.items()
+    }
+    dt.get_add_actions = lambda: SimpleNamespace(
+        to_pydict=lambda: add_actions_modified
+    )  # type:ignore
+
+    with pytest.raises(OSError, match="Cannot seek past end of file."):
+        dt.to_pyarrow_dataset().to_table().to_pydict()
 
 
 def test_read_partitioned_table_to_dict():


### PR DESCRIPTION
# Description
Currently the Filesystem implementation always makes a HEAD request when opening a file, to determine the file size. The proposed change is to read the file sizes from the delta log instead, and to pass them down to the `open_input_file` call, eliminating the HEAD request.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
