### PR TITLE
chore: pin the chrono dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "1"
 
 # "stdlib"
 bytes = { version = "1" }
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono = { version = "=0.4.30", default-features = false, features = ["clock"] }
 regex = { version = "1" }
 thiserror = { version = "1" }
 url = { version = "2" }


### PR DESCRIPTION
0.4.31 deprecates timestamp_nanos() which we'll have to figure out what to do with.