### PR TITLE
fix: explicitly require chrono 0.4.31 or greater

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "1"
 
 # "stdlib"
 bytes = { version = "1" }
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 regex = { version = "1" }
 thiserror = { version = "1" }
 url = { version = "2" }


### PR DESCRIPTION
The Python binding relies on `timestamp_nanos_opt()` which requires 0.4.31 or greater from chroni since it did not previously exist.

As a [cargo dependency refresher](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio) this version range is >=0.4.31, < 0.5.0 which is I believe what we need for optimal downstream compatibility.

Related to #1635 and #1631


(silly chrono!)

