### PR TITLE
fix: avoid excess listing of log files

### DIFF
--- a/rust/src/delta.rs
+++ b/rust/src/delta.rs
@@ -427,7 +427,9 @@ impl DeltaTable {
             }
         };
 
-        debug!("start with latest checkpoint version: {version_start}");
+        debug!("latest checkpoint version: {version_start}");
+
+        let version_start = max(self.version(), version_start);
 
         lazy_static! {
             static ref DELTA_LOG_REGEX: Regex =


### PR DESCRIPTION
# Description
In `get_latest_version`, start listing from the currently loaded version when it's newer than the last checkpoint.

# Related Issue(s)
<!---
For example:

- closes #106
--->
- closes https://github.com/delta-io/delta-rs/issues/1643

# Documentation

<!---
Share links to useful documentation
--->
