### PR TITLE
docs: make docs.rs build docs with all features enabled

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/delta-io/delta.rs"
 readme = "README.md"
 edition = "2021"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 # arrow
 arrow = { workspace = true, optional = true }


### PR DESCRIPTION
# Description
I was confused that I could not find the documentation integrating datafusion with delta-rs.

With this PR, everything should show up. Perhaps docs for a feature gated method should also mention which feature is required. Similar to what Tokio does. Perhaps it could be done in followup PRs. 

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
