### PR TITLE
docs: add docstring to protocol method

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -411,6 +411,11 @@ given filters.
         return self._metadata
 
     def protocol(self) -> ProtocolVersions:
+        """
+        Get the reader and writer protocol versions of the DeltaTable.
+
+        :return: the current ProtocolVersions registered in the transaction log
+        """
         return ProtocolVersions(*self._table.protocol_versions())
 
     def history(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:


### PR DESCRIPTION
# Description

Adds a docstring to the `DeltaTable#protocol()` method, so it shows up in the documentation.

# Related Issue(s)

Partially addresses #1657

We will want to update the `protocol()` method to return the list of table features that are supported by a given table.

# Documentation

N/A