### PR TITLE
fix: exception string in writer.py

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -182,7 +182,7 @@ def write_deltalake(
         ):
             raise ValueError(
                 "Schema of data does not match table schema\n"
-                f"Table schema:\n{schema}\nData Schema:\n{table.schema().to_pyarrow()}"
+                f"Data schema:\n{schema}\nTable Schema:\n{table.schema().to_pyarrow()}"
             )
 
         if mode == "error":


### PR DESCRIPTION
# Description

The exception message when comparing schemas in `deltalake.writer.write_deltalake` is ambiguous as it interchanges the table and data schemas.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
