### PR TITLE
feat: allow to set large dtypes for the schema check in `write_deltalake`

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -142,6 +142,7 @@ def write_deltalake(
     :param overwrite_schema: If True, allows updating the schema of the table.
     :param storage_options: options passed to the native delta filesystem. Unused if 'filesystem' is defined.
     :param partition_filters: the partition filters that will be used for partition overwrite.
+    :param large_dtypes: If True, the table schema is checked against large_dtypes
     """
     if _has_pandas and isinstance(data, pd.DataFrame):
         if schema is not None:

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -92,6 +92,7 @@ def write_deltalake(
     overwrite_schema: bool = False,
     storage_options: Optional[Dict[str, str]] = None,
     partition_filters: Optional[List[Tuple[str, str, Any]]] = None,
+    large_dtypes: bool = False,
 ) -> None:
     """Write to a Delta Lake table
 
@@ -177,12 +178,12 @@ def write_deltalake(
         partition_by = [partition_by]
 
     if table:  # already exists
-        if schema != table.schema().to_pyarrow() and not (
+        if schema != table.schema().to_pyarrow(as_large_types=large_dtypes) and not (
             mode == "overwrite" and overwrite_schema
         ):
             raise ValueError(
                 "Schema of data does not match table schema\n"
-                f"Data schema:\n{schema}\nTable Schema:\n{table.schema().to_pyarrow()}"
+                f"Data schema:\n{schema}\nTable Schema:\n{table.schema().to_pyarrow(as_large_types=large_dtypes)}"
             )
 
         if mode == "error":


### PR DESCRIPTION
# Description
Currently it was always checking the schema for non-large types, I didn't know before we could change it so in polars we added some schema casting from large to non-large, this however became a problem today when I wanted to write 200M records at once because the array was too big the fit in normal string type.

```python
ArrowInvalid: Failed casting from large_string to string: input array too large
```

Adding this flag will allow libraries like polars to write directly with their large dtypes in arrow. If this is merged, I can work on fix in polars to remove the schema casting for these large types.


