### PR TITLE
fix!: ensure predicates are parsable

### DIFF
--- a/rust/src/delta_datafusion/expr.rs
+++ b/rust/src/delta_datafusion/expr.rs
@@ -1,0 +1,483 @@
+//! Utility functions for Datafusion's Expressions
+//!
+
+use std::fmt::{self, Display, Formatter, Write};
+
+use datafusion_common::ScalarValue;
+use datafusion_expr::{
+    expr::{InList, ScalarUDF},
+    Between, BinaryExpr, Cast, Expr, Like, TryCast,
+};
+use sqlparser::ast::escape_quoted_string;
+
+struct SqlFormat<'a> {
+    expr: &'a Expr,
+}
+
+macro_rules! expr_vec_fmt {
+    ( $ARRAY:expr ) => {{
+        $ARRAY
+            .iter()
+            .map(|e| format!("{}", SqlFormat { expr: e }))
+            .collect::<Vec<String>>()
+            .join(", ")
+    }};
+}
+
+struct BinaryExprFormat<'a> {
+    expr: &'a BinaryExpr,
+}
+
+impl<'a> Display for BinaryExprFormat<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Put parentheses around child binary expressions so that we can see the difference
+        // between `(a OR b) AND c` and `a OR (b AND c)`. We only insert parentheses when needed,
+        // based on operator precedence. For example, `(a AND b) OR c` and `a AND b OR c` are
+        // equivalent and the parentheses are not necessary.
+
+        fn write_child(f: &mut Formatter<'_>, expr: &Expr, precedence: u8) -> fmt::Result {
+            match expr {
+                Expr::BinaryExpr(child) => {
+                    let p = child.op.precedence();
+                    if p == 0 || p < precedence {
+                        write!(f, "({})", BinaryExprFormat { expr: child })?;
+                    } else {
+                        write!(f, "{}", BinaryExprFormat { expr: child })?;
+                    }
+                }
+                _ => write!(f, "{}", SqlFormat { expr })?,
+            }
+            Ok(())
+        }
+
+        let precedence = self.expr.op.precedence();
+        write_child(f, self.expr.left.as_ref(), precedence)?;
+        write!(f, " {} ", self.expr.op)?;
+        write_child(f, self.expr.right.as_ref(), precedence)
+    }
+}
+
+impl<'a> Display for SqlFormat<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.expr {
+            Expr::Column(c) => write!(f, "{c}"),
+            Expr::Literal(v) => write!(f, "{}", ScalarValueFormat { scalar: v }),
+            Expr::Case(case) => {
+                write!(f, "CASE ")?;
+                if let Some(e) = &case.expr {
+                    write!(f, "{} ", SqlFormat { expr: e })?;
+                }
+                for (w, t) in &case.when_then_expr {
+                    write!(
+                        f,
+                        "WHEN {} THEN {} ",
+                        SqlFormat { expr: w },
+                        SqlFormat { expr: t }
+                    )?;
+                }
+                if let Some(e) = &case.else_expr {
+                    write!(f, "ELSE {} ", SqlFormat { expr: e })?;
+                }
+                write!(f, "END")
+            }
+            Expr::Cast(Cast { expr, data_type }) => {
+                write!(f, "CAST({} AS {data_type:?})", SqlFormat { expr })
+            }
+            Expr::TryCast(TryCast { expr, data_type }) => {
+                write!(f, "TRY_CAST({expr} AS {data_type:?})")
+            }
+            Expr::Not(expr) => write!(f, "NOT {}", SqlFormat { expr }),
+            Expr::Negative(expr) => write!(f, "(- {})", SqlFormat { expr }),
+            Expr::IsNull(expr) => write!(f, "{} IS NULL", SqlFormat { expr }),
+            Expr::IsNotNull(expr) => write!(f, "{} IS NOT NULL", SqlFormat { expr }),
+            Expr::IsTrue(expr) => write!(f, "{} IS TRUE", SqlFormat { expr }),
+            Expr::IsFalse(expr) => write!(f, "{} IS FALSE", SqlFormat { expr }),
+            Expr::IsUnknown(expr) => write!(f, "{} IS UNKNOWN", SqlFormat { expr }),
+            Expr::IsNotTrue(expr) => write!(f, "{} IS NOT TRUE", SqlFormat { expr }),
+            Expr::IsNotFalse(expr) => write!(f, "{} IS NOT FALSE", SqlFormat { expr }),
+            Expr::IsNotUnknown(expr) => write!(f, "{} IS NOT UNKNOWN", SqlFormat { expr }),
+            Expr::BinaryExpr(expr) => write!(f, "{}", BinaryExprFormat { expr }),
+            Expr::ScalarFunction(func) => {
+                fmt_function(f, &func.fun.to_string(), false, &func.args, true)
+            }
+            Expr::ScalarUDF(ScalarUDF { fun, args }) => {
+                fmt_function(f, &fun.name, false, args, true)
+            }
+            Expr::Between(Between {
+                expr,
+                negated,
+                low,
+                high,
+            }) => {
+                if *negated {
+                    write!(
+                        f,
+                        "{} NOT BETWEEN {} AND {}",
+                        SqlFormat { expr },
+                        SqlFormat { expr: low },
+                        SqlFormat { expr: high }
+                    )
+                } else {
+                    write!(
+                        f,
+                        "{} BETWEEN {} AND {}",
+                        SqlFormat { expr },
+                        SqlFormat { expr: low },
+                        SqlFormat { expr: high }
+                    )
+                }
+            }
+            Expr::Like(Like {
+                negated,
+                expr,
+                pattern,
+                escape_char,
+                case_insensitive,
+            }) => {
+                write!(f, "{}", SqlFormat { expr })?;
+                let op_name = if *case_insensitive { "ILIKE" } else { "LIKE" };
+                if *negated {
+                    write!(f, " NOT")?;
+                }
+                if let Some(char) = escape_char {
+                    write!(
+                        f,
+                        " {op_name} {} ESCAPE '{char}'",
+                        SqlFormat { expr: pattern }
+                    )
+                } else {
+                    write!(f, " {op_name} {}", SqlFormat { expr: pattern })
+                }
+            }
+            Expr::SimilarTo(Like {
+                negated,
+                expr,
+                pattern,
+                escape_char,
+                case_insensitive: _,
+            }) => {
+                write!(f, "{expr}")?;
+                if *negated {
+                    write!(f, " NOT")?;
+                }
+                if let Some(char) = escape_char {
+                    write!(f, " SIMILAR TO {pattern} ESCAPE '{char}'")
+                } else {
+                    write!(f, " SIMILAR TO {pattern}")
+                }
+            }
+            Expr::InList(InList {
+                expr,
+                list,
+                negated,
+            }) => {
+                if *negated {
+                    write!(f, "{expr} NOT IN ({})", expr_vec_fmt!(list))
+                } else {
+                    write!(f, "{expr} IN ({})", expr_vec_fmt!(list))
+                }
+            }
+            _ => Err(fmt::Error),
+        }
+    }
+}
+
+/// Format an `Expr` to a parsable SQL expression
+pub fn fmt_expr_to_sql(expr: &Expr) -> Result<String, std::fmt::Error> {
+    let mut s = String::new();
+    write!(&mut s, "{}", SqlFormat { expr })?;
+    Ok(s)
+}
+
+fn fmt_function(
+    f: &mut fmt::Formatter,
+    fun: &str,
+    distinct: bool,
+    args: &[Expr],
+    display: bool,
+) -> fmt::Result {
+    let args: Vec<String> = match display {
+        true => args
+            .iter()
+            .map(|arg| format!("{}", SqlFormat { expr: arg }))
+            .collect(),
+        false => todo!("fmt function"),
+    };
+
+    // let args: Vec<String> = args.iter().map(|arg| format!("{:?}", arg)).collect();
+    let distinct_str = match distinct {
+        true => "DISTINCT ",
+        false => "",
+    };
+    write!(f, "{}({}{})", fun, distinct_str, args.join(", "))
+}
+
+macro_rules! format_option {
+    ($F:expr, $EXPR:expr) => {{
+        match $EXPR {
+            Some(e) => write!($F, "{e}"),
+            None => write!($F, "NULL"),
+        }
+    }};
+}
+
+struct ScalarValueFormat<'a> {
+    scalar: &'a ScalarValue,
+}
+
+impl<'a> fmt::Display for ScalarValueFormat<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.scalar {
+            ScalarValue::Boolean(e) => format_option!(f, e)?,
+            ScalarValue::Float32(e) => format_option!(f, e)?,
+            ScalarValue::Float64(e) => format_option!(f, e)?,
+            ScalarValue::Int8(e) => format_option!(f, e)?,
+            ScalarValue::Int16(e) => format_option!(f, e)?,
+            ScalarValue::Int32(e) => format_option!(f, e)?,
+            ScalarValue::Int64(e) => format_option!(f, e)?,
+            ScalarValue::UInt8(e) => format_option!(f, e)?,
+            ScalarValue::UInt16(e) => format_option!(f, e)?,
+            ScalarValue::UInt32(e) => format_option!(f, e)?,
+            ScalarValue::UInt64(e) => format_option!(f, e)?,
+            ScalarValue::Utf8(e) | ScalarValue::LargeUtf8(e) => match e {
+                Some(e) => write!(f, "'{}'", escape_quoted_string(e, '\''))?,
+                None => write!(f, "NULL")?,
+            },
+            ScalarValue::Binary(e)
+            | ScalarValue::FixedSizeBinary(_, e)
+            | ScalarValue::LargeBinary(e) => match e {
+                Some(l) => write!(
+                    f,
+                    "decode('{}', 'hex')",
+                    l.iter()
+                        .map(|v| format!("{v:02x}"))
+                        .collect::<Vec<_>>()
+                        .join("")
+                )?,
+                None => write!(f, "NULL")?,
+            },
+            ScalarValue::Null => write!(f, "NULL")?,
+            _ => return Err(fmt::Error)
+        };
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use datafusion::prelude::SessionContext;
+    use datafusion_common::ScalarValue;
+    use datafusion_expr::{col, decode, lit, substring, Expr};
+
+    use crate::{DeltaOps, DeltaTable, Schema, SchemaDataType, SchemaField};
+
+    use super::fmt_expr_to_sql;
+
+    struct ParseTest {
+        expr: Expr,
+        expected: String,
+        override_expected_expr: Option<Expr>,
+    }
+
+    macro_rules! simple {
+        ( $EXPR:expr, $STR:expr ) => {{
+            ParseTest {
+                expr: $EXPR,
+                expected: $STR,
+                override_expected_expr: None,
+            }
+        }};
+    }
+
+    async fn setup_table() -> DeltaTable {
+        let schema = Schema::new(vec![
+            SchemaField::new(
+                "id".to_string(),
+                SchemaDataType::primitive("string".to_string()),
+                true,
+                HashMap::new(),
+            ),
+            SchemaField::new(
+                "value".to_string(),
+                SchemaDataType::primitive("integer".to_string()),
+                true,
+                HashMap::new(),
+            ),
+            SchemaField::new(
+                "value2".to_string(),
+                SchemaDataType::primitive("integer".to_string()),
+                true,
+                HashMap::new(),
+            ),
+            SchemaField::new(
+                "modified".to_string(),
+                SchemaDataType::primitive("string".to_string()),
+                true,
+                HashMap::new(),
+            ),
+            SchemaField::new(
+                "active".to_string(),
+                SchemaDataType::primitive("boolean".to_string()),
+                true,
+                HashMap::new(),
+            ),
+            SchemaField::new(
+                "money".to_string(),
+                SchemaDataType::primitive("decimal(12,2)".to_string()),
+                true,
+                HashMap::new(),
+            ),
+            SchemaField::new(
+                "_date".to_string(),
+                SchemaDataType::primitive("date".to_string()),
+                true,
+                HashMap::new(),
+            ),
+            SchemaField::new(
+                "_timestamp".to_string(),
+                SchemaDataType::primitive("timestamp".to_string()),
+                true,
+                HashMap::new(),
+            ),
+            SchemaField::new(
+                "_binary".to_string(),
+                SchemaDataType::primitive("binary".to_string()),
+                true,
+                HashMap::new(),
+            ),
+        ]);
+
+        let table = DeltaOps::new_in_memory()
+            .create()
+            .with_columns(schema.get_fields().clone())
+            .await
+            .unwrap();
+        assert_eq!(table.version(), 0);
+        table
+    }
+
+    #[tokio::test]
+    async fn test_expr_sql() {
+        let table = setup_table().await;
+
+        // String expression that we output must be parsable for conflict resolution.
+        let tests = vec![
+            // TODO: sql parser will default to i64 by default where just lit(3) is be a i32
+            simple!(col("value").eq(lit(3_i64)), "value = 3".to_string()),
+            simple!(col("active").is_true(), "active IS TRUE".to_string()),
+            simple!(col("active"), "active".to_string()),
+            simple!(col("active").eq(lit(true)), "active = true".to_string()),
+            simple!(col("active").is_null(), "active IS NULL".to_string()),
+            simple!(
+                col("modified").eq(lit("2021-02-03")),
+                "modified = '2021-02-03'".to_string()
+            ),
+            simple!(
+                col("modified").eq(lit("'validate ' escapi\\ng'")),
+                "modified = '''validate '' escapi\\ng'''".to_string()
+            ),
+            simple!(col("money").gt(lit(0.10)), "money > 0.1".to_string()),
+            ParseTest {
+                expr: col("_binary").eq(lit(ScalarValue::Binary(Some(vec![0xAA, 0x00, 0xFF])))),
+                expected: "_binary = decode('aa00ff', 'hex')".to_string(),
+                override_expected_expr: Some(col("_binary").eq(decode(lit("aa00ff"), lit("hex")))),
+            },
+            simple!(
+                col("value").between(lit(20_i64), lit(30_i64)),
+                "value BETWEEN 20 AND 30".to_string()
+            ),
+            simple!(
+                col("value").not_between(lit(20_i64), lit(30_i64)),
+                "value NOT BETWEEN 20 AND 30".to_string()
+            ),
+            simple!(
+                col("modified").like(lit("abc%")),
+                "modified LIKE 'abc%'".to_string()
+            ),
+            simple!(
+                col("modified").not_like(lit("abc%")),
+                "modified NOT LIKE 'abc%'".to_string()
+            ),
+            simple!(
+                (((col("value") * lit(2_i64) + col("value2")) / lit(3_i64)) - col("value"))
+                    .gt(lit(0_i64)),
+                "(value * 2 + value2) / 3 - value > 0".to_string()
+            ),
+            simple!(
+                col("modified").in_list(vec![lit("a"), lit("c")], false),
+                "modified IN ('a', 'c')".to_string()
+            ),
+            simple!(
+                col("modified").in_list(vec![lit("a"), lit("c")], true),
+                "modified NOT IN ('a', 'c')".to_string()
+            ),
+            // Validate order of operations is maintained
+            simple!(
+                col("modified")
+                    .eq(lit("value"))
+                    .and(col("value").eq(lit(1_i64)))
+                    .or(col("modified")
+                        .eq(lit("value2"))
+                        .and(col("value").gt(lit(1_i64)))),
+                "modified = 'value' AND value = 1 OR modified = 'value2' AND value > 1".to_string()
+            ),
+            simple!(
+                col("modified")
+                    .eq(lit("value"))
+                    .or(col("value").eq(lit(1_i64)))
+                    .and(
+                        col("modified")
+                            .eq(lit("value2"))
+                            .or(col("value").gt(lit(1_i64))),
+                    ),
+                "(modified = 'value' OR value = 1) AND (modified = 'value2' OR value > 1)"
+                    .to_string()
+            ),
+            // TODO: Need to refactor parse_predicate for this...
+            simple!(
+                substring(col("modified"), lit(0_i64), lit(4_i64)).eq(lit("2021")),
+                "substr(modified, 0, 4) = '2021'".to_string()
+            ),
+        ];
+
+        let session = SessionContext::new();
+
+        for test in tests {
+            let actual = fmt_expr_to_sql(&test.expr).unwrap();
+            assert_eq!(test.expected, actual);
+
+            let actual_expr = table
+                .state
+                .parse_predicate_expression(actual, &session.state())
+                .unwrap();
+
+            match test.override_expected_expr {
+                None => assert_eq!(test.expr, actual_expr),
+                Some(expr) => assert_eq!(expr, actual_expr)
+            }
+        }
+
+
+        let unsupported_types = vec! [
+            /* TODO: Determine proper way to display decimal, date, and datetime values in an sql expression*/
+            simple! (
+                col("money").gt(lit(ScalarValue::Decimal128(Some(100), 12, 2))),
+                "money > 0.1".to_string()
+            ),
+            simple! (
+                col("_timestamp").gt(lit(ScalarValue::TimestampMillisecond(Some(100), None))),
+                "".to_string()
+            ),
+            simple! (
+                col("_timestamp").gt(lit(ScalarValue::TimestampMillisecond(Some(100), Some("UTC".into())))),
+                "".to_string()
+            ),
+        ];
+
+        for test in unsupported_types {
+            assert!(fmt_expr_to_sql(&test.expr).is_err());
+        }
+    }
+}

--- a/rust/src/delta_datafusion/expr.rs
+++ b/rust/src/delta_datafusion/expr.rs
@@ -14,6 +14,10 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+//
+// This product includes software from the Datafusion project (Apache 2.0)
+// https://github.com/apache/arrow-datafusion
+// Display functions and required macros were pulled from https://github.com/apache/arrow-datafusion/blob/ddb95497e2792015d5a5998eec79aac8d37df1eb/datafusion/expr/src/expr.rs
 
 //! Utility functions for Datafusion's Expressions
 

--- a/rust/src/delta_datafusion/expr.rs
+++ b/rust/src/delta_datafusion/expr.rs
@@ -67,18 +67,18 @@ impl<'a> Display for SqlFormat<'a> {
             Expr::Case(case) => {
                 write!(f, "CASE ")?;
                 if let Some(e) = &case.expr {
-                    write!(f, "{} ", SqlFormat { expr: &e })?;
+                    write!(f, "{} ", SqlFormat { expr: e })?;
                 }
                 for (w, t) in &case.when_then_expr {
                     write!(
                         f,
                         "WHEN {} THEN {} ",
-                        SqlFormat { expr: &w },
-                        SqlFormat { expr: &t }
+                        SqlFormat { expr: w },
+                        SqlFormat { expr: t }
                     )?;
                 }
                 if let Some(e) = &case.else_expr {
-                    write!(f, "ELSE {} ", SqlFormat { expr: &e })?;
+                    write!(f, "ELSE {} ", SqlFormat { expr: e })?;
                 }
                 write!(f, "END")
             }
@@ -111,7 +111,7 @@ impl<'a> Display for SqlFormat<'a> {
                     write!(
                         f,
                         "{} NOT BETWEEN {} AND {}",
-                        SqlFormat { expr: expr },
+                        SqlFormat { expr },
                         SqlFormat { expr: low },
                         SqlFormat { expr: high }
                     )
@@ -119,7 +119,7 @@ impl<'a> Display for SqlFormat<'a> {
                     write!(
                         f,
                         "{} BETWEEN {} AND {}",
-                        SqlFormat { expr: expr },
+                        SqlFormat { expr },
                         SqlFormat { expr: low },
                         SqlFormat { expr: high }
                     )
@@ -192,7 +192,7 @@ pub fn fmt_expr_to_sql(expr: &Expr) -> Result<String, DeltaTableError> {
 fn fmt_function(f: &mut fmt::Formatter, fun: &str, distinct: bool, args: &[Expr]) -> fmt::Result {
     let args: Vec<String> = args
         .iter()
-        .map(|arg| format!("{}", SqlFormat { expr: &arg }))
+        .map(|arg| format!("{}", SqlFormat { expr: arg }))
         .collect();
 
     let distinct_str = match distinct {
@@ -354,7 +354,7 @@ mod test {
 
         // String expression that we output must be parsable for conflict resolution.
         let tests = vec![
-            simple!(col("value").eq(lit(3 as i64)), "value = 3".to_string()),
+            simple!(col("value").eq(lit(3_i64)), "value = 3".to_string()),
             simple!(col("active").is_true(), "active IS TRUE".to_string()),
             simple!(col("active"), "active".to_string()),
             simple!(col("active").eq(lit(true)), "active = true".to_string()),
@@ -374,11 +374,11 @@ mod test {
                 override_expected_expr: Some(col("_binary").eq(decode(lit("aa00ff"), lit("hex")))),
             },
             simple!(
-                col("value").between(lit(20 as i64), lit(30 as i64)),
+                col("value").between(lit(20_i64), lit(30_i64)),
                 "value BETWEEN 20 AND 30".to_string()
             ),
             simple!(
-                col("value").not_between(lit(20 as i64), lit(30 as i64)),
+                col("value").not_between(lit(20_i64), lit(30_i64)),
                 "value NOT BETWEEN 20 AND 30".to_string()
             ),
             simple!(
@@ -390,8 +390,8 @@ mod test {
                 "modified NOT LIKE 'abc%'".to_string()
             ),
             simple!(
-                (((col("value") * lit(2 as i64) + col("value2")) / lit(3 as i64)) - col("value"))
-                    .gt(lit(0 as i64)),
+                (((col("value") * lit(2_i64) + col("value2")) / lit(3_i64)) - col("value"))
+                    .gt(lit(0_i64)),
                 "(value * 2 + value2) / 3 - value > 0".to_string()
             ),
             simple!(
@@ -406,27 +406,27 @@ mod test {
             simple!(
                 col("modified")
                     .eq(lit("value"))
-                    .and(col("value").eq(lit(1 as i64)))
+                    .and(col("value").eq(lit(1_i64)))
                     .or(col("modified")
                         .eq(lit("value2"))
-                        .and(col("value").gt(lit(1 as i64)))),
+                        .and(col("value").gt(lit(1_i64)))),
                 "modified = 'value' AND value = 1 OR modified = 'value2' AND value > 1".to_string()
             ),
             simple!(
                 col("modified")
                     .eq(lit("value"))
-                    .or(col("value").eq(lit(1 as i64)))
+                    .or(col("value").eq(lit(1_i64)))
                     .and(
                         col("modified")
                             .eq(lit("value2"))
-                            .or(col("value").gt(lit(1 as i64))),
+                            .or(col("value").gt(lit(1_i64))),
                     ),
                 "(modified = 'value' OR value = 1) AND (modified = 'value2' OR value > 1)"
                     .to_string()
             ),
             // Validate functions are correctly parsed
             simple!(
-                substring(col("modified"), lit(0 as i64), lit(4 as i64)).eq(lit("2021")),
+                substring(col("modified"), lit(0_i64), lit(4_i64)).eq(lit("2021")),
                 "substr(modified, 0, 4) = '2021'".to_string()
             ),
         ];

--- a/rust/src/delta_datafusion/mod.rs
+++ b/rust/src/delta_datafusion/mod.rs
@@ -76,6 +76,8 @@ use crate::{open_table, open_table_with_storage_options, DeltaTable, Invariant, 
 
 const PATH_COLUMN: &str = "__delta_rs_path";
 
+pub mod expr;
+
 impl From<DeltaTableError> for DataFusionError {
     fn from(err: DeltaTableError) -> Self {
         match err {

--- a/rust/src/operations/delete.rs
+++ b/rust/src/operations/delete.rs
@@ -298,7 +298,9 @@ impl std::future::IntoFuture for DeleteBuilder {
             let predicate = match this.predicate {
                 Some(predicate) => match predicate {
                     Expression::DataFusion(expr) => Some(expr),
-                    Expression::String(s) => Some(this.snapshot.parse_predicate_expression(s)?),
+                    Expression::String(s) => {
+                        Some(this.snapshot.parse_predicate_expression(s, &state)?)
+                    }
                 },
                 None => None,
             };

--- a/rust/src/operations/delete.rs
+++ b/rust/src/operations/delete.rs
@@ -20,6 +20,7 @@
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
+use crate::delta_datafusion::expr::fmt_expr_to_sql;
 use crate::protocol::{Action, Add, Remove};
 use datafusion::execution::context::{SessionContext, SessionState};
 use datafusion::physical_expr::create_physical_expr;
@@ -263,7 +264,7 @@ async fn execute(
     // Do not make a commit when there are zero updates to the state
     if !actions.is_empty() {
         let operation = DeltaOperation::Delete {
-            predicate: Some(predicate.canonical_name()),
+            predicate: Some(fmt_expr_to_sql(&predicate)?),
         };
         version = commit(
             object_store.as_ref(),
@@ -337,6 +338,7 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use datafusion::assert_batches_sorted_eq;
     use datafusion::prelude::*;
+    use serde_json::json;
     use std::sync::Arc;
 
     async fn setup_table(partitions: Option<Vec<&str>>) -> DeltaTable {
@@ -458,7 +460,7 @@ mod tests {
         assert_eq!(table.version(), 2);
         assert_eq!(table.get_file_uris().count(), 2);
 
-        let (table, metrics) = DeltaOps(table)
+        let (mut table, metrics) = DeltaOps(table)
             .delete()
             .with_predicate(col("value").eq(lit(1)))
             .await
@@ -471,6 +473,11 @@ mod tests {
         assert!(metrics.scan_time_ms > 0);
         assert_eq!(metrics.num_deleted_rows, Some(1));
         assert_eq!(metrics.num_copied_rows, Some(3));
+
+        let commit_info = table.history(None).await.unwrap();
+        let last_commit = &commit_info[commit_info.len() - 1];
+        let parameters = last_commit.operation_parameters.clone().unwrap();
+        assert_eq!(parameters["predicate"], json!("value = 1"));
 
         let expected = vec![
             "+----+-------+------------+",

--- a/rust/src/operations/merge.rs
+++ b/rust/src/operations/merge.rs
@@ -1237,7 +1237,6 @@ mod tests {
             parameters["notMatchedPredicates"],
             json!(r#"[{"actionType":"insert"}]"#)
         );
-        // Todo: Expected this predicate to actually be 'value = 1'. Predicate should contain a valid sql expression
         assert_eq!(
             parameters["notMatchedBySourcePredicates"],
             json!(r#"[{"actionType":"update","predicate":"value = 1"}]"#)

--- a/rust/src/operations/mod.rs
+++ b/rust/src/operations/mod.rs
@@ -205,6 +205,7 @@ mod datafusion_utils {
     use arrow_schema::SchemaRef;
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::error::Result as DataFusionResult;
+    use datafusion::execution::context::SessionState;
     use datafusion::physical_plan::DisplayAs;
     use datafusion::physical_plan::{
         metrics::{ExecutionPlanMetricsSet, MetricsSet},
@@ -240,19 +241,24 @@ mod datafusion_utils {
         }
     }
 
-    pub(crate) fn into_expr(expr: Expression, snapshot: &DeltaTableState) -> DeltaResult<Expr> {
+    pub(crate) fn into_expr(
+        expr: Expression,
+        snapshot: &DeltaTableState,
+        df_state: &SessionState,
+    ) -> DeltaResult<Expr> {
         match expr {
             Expression::DataFusion(expr) => Ok(expr),
-            Expression::String(s) => snapshot.parse_predicate_expression(s),
+            Expression::String(s) => snapshot.parse_predicate_expression(s, df_state),
         }
     }
 
     pub(crate) fn maybe_into_expr(
         expr: Option<Expression>,
         snapshot: &DeltaTableState,
+        df_state: &SessionState,
     ) -> DeltaResult<Option<Expr>> {
         Ok(match expr {
-            Some(predicate) => Some(into_expr(predicate, snapshot)?),
+            Some(predicate) => Some(into_expr(predicate, snapshot, df_state)?),
             None => None,
         })
     }

--- a/rust/src/operations/transaction/conflict_checker.rs
+++ b/rust/src/operations/transaction/conflict_checker.rs
@@ -114,8 +114,11 @@ impl<'a> TransactionInfo<'a> {
         actions: &'a Vec<Action>,
         read_whole_table: bool,
     ) -> DeltaResult<Self> {
+        use datafusion::prelude::SessionContext;
+
+        let session = SessionContext::new();
         let read_predicates = read_predicates
-            .map(|pred| read_snapshot.parse_predicate_expression(pred))
+            .map(|pred| read_snapshot.parse_predicate_expression(pred, &session.state()))
             .transpose()?;
         Ok(Self {
             txn_id: "".into(),

--- a/rust/src/operations/update.rs
+++ b/rust/src/operations/update.rs
@@ -194,7 +194,7 @@ async fn execute(
     let predicate = match predicate {
         Some(predicate) => match predicate {
             Expression::DataFusion(expr) => Some(expr),
-            Expression::String(s) => Some(snapshot.parse_predicate_expression(s)?),
+            Expression::String(s) => Some(snapshot.parse_predicate_expression(s, &state)?),
         },
         None => None,
     };
@@ -203,7 +203,9 @@ async fn execute(
         .into_iter()
         .map(|(key, expr)| match expr {
             Expression::DataFusion(e) => Ok((key, e)),
-            Expression::String(s) => snapshot.parse_predicate_expression(s).map(|e| (key, e)),
+            Expression::String(s) => snapshot
+                .parse_predicate_expression(s, &state)
+                .map(|e| (key, e)),
         })
         .collect::<Result<HashMap<Column, Expr>, _>>()?;
 


### PR DESCRIPTION
# Description
Resolves two issues that impact Datafusion implemented operators

1. When a user has an expression with a scalar built-in scalar function we are unable parse the output predicate since the `DummyContextProvider`'s methods are unimplemented. The provider now uses the user provided state or a default. More work is required in the future to allow a user provided Datafusion state to be used during the conflict checker.

2. The string representation was not parsable by sqlparser since it was not valid SQL. New code was written to transform an expression into a parsable sql string. Current implementation is not exhaustive however common use cases are covered. 

The delta_datafusion.rs file is getting large so I transformed it into a module.

This implementation makes reuse of some code from Datafusion. I've added the Apache License at the top of the file. Let me know if any else is required to be compliant.


# Related Issue(s)
- closes #1625 

