### PR TITLE
docs: get docs.rs configured correctly again

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,9 @@ readme = "README.md"
 edition = "2021"
 
 [package.metadata.docs.rs]
-all-features = true
+# We cannot use all_features because TLS features are mutually exclusive.
+# We cannot use hdfs feature because it requires Java to be installed.
+features = ["azure", "datafusion", "gcs", "glue", "hdfs", "json", "python", "s3", "unity-experimental"]
 
 [dependencies]
 # arrow


### PR DESCRIPTION
# Description

The docs build was changed in #1658 to compile on docs.rs with all features, but our crate cannot compile with all-features due to the TLS features, which are mutually exclusive.

# Related Issue(s)

For example:

- closes #1692

This has been tested locally with the following command:

```
cargo doc --features azure,datafusion,datafusion,gcs,glue,json,python,s3,unity-experimental
```
