### PR TITLE
feat: improve read performance by 7x with prebuffer

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -24,6 +24,7 @@ from pyarrow.dataset import (
     Expression,
     FileSystemDataset,
     ParquetFileFormat,
+    ParquetFragmentScanOptions,
     ParquetReadOptions,
 )
 
@@ -538,7 +539,10 @@ given filters.
                 )
             )
 
-        format = ParquetFileFormat(read_options=parquet_read_options)
+        format = ParquetFileFormat(
+            read_options=parquet_read_options,
+            default_fragment_scan_options=ParquetFragmentScanOptions(pre_buffer=True),
+        )
 
         fragments = [
             format.make_fragment(

--- a/python/stubs/pyarrow/dataset.pyi
+++ b/python/stubs/pyarrow/dataset.pyi
@@ -6,6 +6,7 @@ Expression: Any
 field: Any
 partitioning: Any
 FileSystemDataset: Any
+ParquetFragmentScanOptions: Any
 ParquetFileFormat: Any
 ParquetReadOptions: Any
 ParquetFileWriteOptions: Any


### PR DESCRIPTION
# Description
Enable prebuffer in the pyarrow.dataset.ParquetFragmentScanOptions. Relevant PR in [Arrow ](https://github.com/apache/arrow/pull/37854)repo, where they changed it to be default behavior. However, this won't be the case for older versions for PyArrow, so we need to set it to True.: 


It improves read speed by 6-7x on Azure in one dataset that I have.

Before:
1min 4s ± 3.48 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

After:
8.99 s ± 786 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)


# Related Issue(s)
<!---
For example:

- closes #106
--->

Closes #https://github.com/delta-io/delta-rs/issues/1569


