### PR TITLE
feat: add support for multiple partition columns and filters in to_pyarrow_dataset() and OR filters in write_datalake()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tlaplus/*.toolbox/*/[0-9]*-[0-9]*-[0-9]*-[0-9]*-[0-9]*-[0-9]*/
 /.idea
 .vscode
 .env
+/python/.venv
 **/.DS_Store
 **/.python-version
 .coverage

--- a/python/deltalake/_util.py
+++ b/python/deltalake/_util.py
@@ -13,10 +13,10 @@ def encode_partition_value(val: Any) -> str:
         return val
     elif isinstance(val, (int, float)):
         return str(val)
-    elif isinstance(val, date):
-        return val.isoformat()
     elif isinstance(val, datetime):
         return val.isoformat(sep=" ")
+    elif isinstance(val, date):
+        return val.isoformat()
     elif isinstance(val, bytes):
         return val.decode("unicode_escape", "backslashreplace")
     else:

--- a/python/deltalake/_util.py
+++ b/python/deltalake/_util.py
@@ -1,5 +1,8 @@
 from datetime import date, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any, Optional, cast
+
+if TYPE_CHECKING:
+    from deltalake.table import FilterType
 
 
 def encode_partition_value(val: Any) -> str:
@@ -18,3 +21,77 @@ def encode_partition_value(val: Any) -> str:
         return val.decode("unicode_escape", "backslashreplace")
     else:
         raise ValueError(f"Could not encode partition value for type: {val}")
+
+
+def validate_filters(filters: Optional["FilterType"]) -> Optional["FilterType"]:
+    """Ensures that the filters are in the correct DNF format which is a list of
+    tuples or a list of list of tuples
+
+    :param filters: Filters to be validated
+
+    Examples:
+        >>> validate_filters([("a", "=", 1), ("b", "=", 2)])
+        >>> validate_filters([[("a", "=", 1), ("b", "=", 2)], [("c", "=", 3)]])
+        >>> validate_filters([("a", "=", 1)])
+        >>> validate_filters([[("a", "=", 1)], [("b", "=", 2)], [("c", "=", 3)]])
+
+    """
+    from deltalake.table import FilterType
+
+    if filters is None:
+        return None
+
+    if not isinstance(filters, list) or len(filters) == 0:
+        raise ValueError("Filters must be a non-empty list.")
+
+    if all(isinstance(item, tuple) and len(item) == 3 for item in filters):
+        return cast(FilterType, [filters])
+
+    elif all(
+        isinstance(conjunction, list)
+        and len(conjunction) > 0
+        and all(
+            isinstance(literal, tuple) and len(literal) == 3 for literal in conjunction
+        )
+        for conjunction in filters
+    ):
+        if len(filters) == 0 or any(len(c) == 0 for c in filters):
+            raise ValueError("Malformed DNF")
+        return filters
+
+    else:
+        raise ValueError(
+            "Filters must be a list of tuples, or a list of lists of tuples"
+        )
+
+
+def stringify_partition_values(
+    partition_filters: Optional["FilterType"],
+) -> Optional["FilterType"]:
+    if partition_filters is None:
+        return None
+
+    if all(isinstance(item, tuple) for item in partition_filters):
+        return [  # type: ignore
+            (
+                field,
+                op,
+                [encode_partition_value(val) for val in value]
+                if isinstance(value, (list, tuple))
+                else encode_partition_value(value),
+            )
+            for field, op, value in partition_filters
+        ]
+    return [
+        [
+            (
+                field,
+                op,
+                [encode_partition_value(val) for val in value]
+                if isinstance(value, (list, tuple))
+                else encode_partition_value(value),
+            )
+            for field, op, value in sublist
+        ]
+        for sublist in partition_filters
+    ]

--- a/python/deltalake/_util.py
+++ b/python/deltalake/_util.py
@@ -24,8 +24,7 @@ def encode_partition_value(val: Any) -> str:
 
 
 def validate_filters(filters: Optional["FilterType"]) -> Optional["FilterType"]:
-    """Ensures that the filters are in the correct DNF format which is a list of
-    tuples or a list of list of tuples
+    """Ensures that the filters are a list of list of tuples in DNF format.
 
     :param filters: Filters to be validated
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -610,7 +610,7 @@ given filters.
         if partitions is None:
             partition_filters = None
         else:
-            if isinstance(partitions, list):
+            if partitions and isinstance(partitions, list):
                 partition_count = len(partitions)
                 partition_type = type(partitions[0])
 

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -778,6 +778,36 @@ def test_issue_1653_filter_bool_partition(tmp_path: Path):
 
 
 @pytest.mark.parametrize(
+    "input_value, expected",
+    [
+        (True, "true"),
+        (False, "false"),
+        (1, "1"),
+        (1.5, "1.5"),
+        ("string", "string"),
+        (date(2023, 10, 17), "2023-10-17"),
+        (datetime(2023, 10, 17, 12, 34, 56), "2023-10-17 12:34:56"),
+        (b"bytes", "bytes"),
+        ([True, False], ["true", "false"]),
+        ([1, 2], ["1", "2"]),
+        ([1.5, 2.5], ["1.5", "2.5"]),
+        (["a", "b"], ["a", "b"]),
+        ([date(2023, 10, 17), date(2023, 10, 18)], ["2023-10-17", "2023-10-18"]),
+        (
+            [datetime(2023, 10, 17, 12, 34, 56), datetime(2023, 10, 18, 12, 34, 56)],
+            ["2023-10-17 12:34:56", "2023-10-18 12:34:56"],
+        ),
+        ([b"bytes", b"testbytes"], ["bytes", "testbytes"]),
+    ],
+)
+def test_encode_partition_value(input_value: Any, expected: str) -> None:
+    if isinstance(input_value, list):
+        assert [encode_partition_value(val) for val in input_value] == expected
+    else:
+        assert encode_partition_value(input_value) == expected
+
+
+@pytest.mark.parametrize(
     "filters, expected",
     [
         (

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -852,6 +852,7 @@ def test_filters_to_expression(filters: FilterType, expected: ds.Expression) -> 
             [[("a", "=", 1)], [("b", "=", 2)], [("c", "=", 3)]],
             [[("a", "=", 1)], [("b", "=", 2)], [("c", "=", 3)]],
         ),
+        ([("a", "=", 1)], [[("a", "=", 1)]]),
     ],
 )
 def test_validate_filters(filters: FilterType, expected: FilterType) -> None:

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -746,6 +746,186 @@ def test_partition_overwrite_with_non_partitioned_data(
         )
 
 
+@pytest.fixture()
+def sample_data_for_multiple_partitions() -> pa.Table:
+    data = {
+        "id": [1, 2, 3, 4, 5],
+        "account": [
+            "account_a",
+            "account_b",
+            "account_a",
+            "account_c",
+            "account_b",
+        ],
+        "created_date": [
+            date(2023, 8, 25),
+            date(2023, 9, 5),
+            date(2023, 9, 7),
+            date(2023, 9, 21),
+            date(2023, 10, 2),
+        ],
+        "updated_at": [
+            datetime(2023, 8, 25, 0, 0, 0),
+            datetime(2023, 9, 5, 0, 0, 0),
+            datetime(2023, 9, 7, 0, 0, 0),
+            datetime(2023, 9, 21, 0, 0, 0),
+            datetime(2023, 10, 2, 0, 0, 0),
+        ],
+        "value": [10.5, 20.5, 30.5, 40.5, 50.5],
+    }
+
+    return pa.Table.from_pydict(data)
+
+
+@pytest.fixture()
+def sample_data_for_overwrite_partitions(
+    id_values: list[int],
+    account_values: list[str],
+    created_date_values: list[date],
+    updated_at_values: list[datetime],
+    value_values: list[float],
+) -> pa.Table:
+    data = {
+        "id": id_values,
+        "account": account_values,
+        "created_date": created_date_values,
+        "updated_at": updated_at_values,
+        "value": value_values,
+    }
+
+    return pa.Table.from_pydict(data)
+
+
+@pytest.mark.parametrize(
+    "id_values, account_values, created_date_values, updated_at_values, value_values, partition_by, partition_filters",
+    [
+        # Test filtering for multiple dates (OR condition)
+        (
+            [1, 3, 4],
+            ["account_a", "account_b", "account_a"],
+            [date(2023, 8, 25), date(2023, 9, 7), date(2023, 9, 21)],
+            [datetime.utcnow(), datetime.utcnow(), datetime.utcnow()],
+            [44.5, 68, 11.5],
+            ["created_date"],
+            [
+                [("created_date", "=", "2023-08-25")],
+                [("created_date", "=", "2023-09-07")],
+                [("created_date", "=", "2023-09-21")],
+            ],
+        ),
+        # Test filtering for date or account (OR condition)
+        (
+            [3, 4, 5],
+            ["account_a", "account_c", "account_b"],
+            [date(2023, 9, 7), date(2023, 9, 21), date(2023, 10, 2)],
+            [datetime.utcnow(), datetime.utcnow(), datetime.utcnow()],
+            [0.1, 5.2, 100],
+            ["created_date", "account"],
+            [
+                [("created_date", "=", "2023-09-21")],
+                [("account", "in", ["account_a", "account_b"])],
+            ],
+        ),
+        # Test date range (AND condition) or account (OR condition)
+        (
+            [1, 2, 3, 4, 5],
+            ["account_a", "account_b", "account_a", "account_c", "account_b"],
+            [
+                date(2023, 8, 25),
+                date(2023, 9, 5),
+                date(2023, 9, 7),
+                date(2023, 9, 21),
+                date(2023, 10, 2),
+            ],
+            [
+                datetime.utcnow(),
+                datetime.utcnow(),
+                datetime.utcnow(),
+                datetime.utcnow(),
+                datetime.utcnow(),
+            ],
+            [0.1, 0.2, 0.3, 0.4, 0.5],
+            ["created_date", "account"],
+            [
+                [
+                    ("created_date", ">", "2023-08-01"),
+                    ("created_date", "<", "2023-12-31"),
+                ],
+                [("account", "=", "account_b")],
+            ],
+        ),
+        # Test date and account (AND condition))
+        (
+            [4],
+            ["account_c"],
+            [date(2023, 9, 21)],
+            [datetime.utcnow()],
+            [352.5],
+            ["created_date", "account"],
+            [
+                [
+                    ("created_date", "=", "2023-09-21"),
+                    ("account", "=", "account_c"),
+                ],
+            ],
+        ),
+    ],
+)
+def test_overwriting_multiple_partitions(
+    tmp_path: pathlib.Path,
+    sample_data_for_multiple_partitions: pa.Table,
+    sample_data_for_overwrite_partitions: pa.Table,
+    partition_by: list[str],
+    partition_filters: list[list[tuple[str, str, Any]]],
+    id_values: list[int],
+    value_values: list[float],
+):
+    # Write initial data
+    write_deltalake(
+        tmp_path,
+        sample_data_for_multiple_partitions,
+        mode="overwrite",
+        partition_by=partition_by,
+    )
+
+    # Append new data
+    write_deltalake(
+        tmp_path,
+        sample_data_for_overwrite_partitions,
+        mode="append",
+        partition_by=partition_by,
+    )
+
+    # Filter data using partition filters
+    delta_table = DeltaTable(tmp_path)
+    filtered_table = delta_table.to_pyarrow_table(partitions=partition_filters)
+
+    # Sort data by id and updated_at, find latest record for each id
+    combined_df = filtered_table.to_pandas().sort_values(by=["id", "updated_at"])
+    deduplicated_df = combined_df.drop_duplicates(subset=["id"], keep="last")
+    deduplicated_data = pa.table(deduplicated_df, schema=filtered_table.schema)
+
+    # Overwrite data using partition filters
+    write_deltalake(
+        tmp_path,
+        deduplicated_data,
+        mode="overwrite",
+        partition_by=partition_by,
+        partition_filters=partition_filters,
+    )
+
+    delta_table = DeltaTable(tmp_path)
+    actual_data = delta_table.to_pyarrow_table().sort_by([("id", "ascending")])
+
+    for id_val, value_val in zip(id_values, value_values):
+        id_condition = pa.compute.equal(actual_data["id"], id_val)
+        value_condition = pa.compute.equal(actual_data["value"], value_val)
+        combined_condition = pa.compute.and_(id_condition, value_condition)
+        combined_list = combined_condition.to_pylist()
+        assert True in combined_list
+        assert set(actual_data["id"].to_pylist()) == set([1, 2, 3, 4, 5])
+
+
 def test_partition_overwrite_with_wrong_partition(
     tmp_path: pathlib.Path, sample_data_for_partitioning: pa.Table
 ):

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -796,6 +796,7 @@ def sample_data_for_overwrite_partitions(
     return pa.Table.from_pydict(data)
 
 
+@pytest.mark.pandas
 @pytest.mark.parametrize(
     "id_values, account_values, created_date_values, updated_at_values, value_values, partition_by, partition_filters",
     [


### PR DESCRIPTION
# Description
This provides support for passing lists of DNF tuples to the to_pyarrow_dataset() method. I didn't want to touch the `dataset_partitions()` Rust code, so this can probably be further simplified and improved. My use case was to be able to create a pyarrow dataset from the DeltaTable and then use polars.scan_pyarrow_dataset().


# Related Issue(s)
<!---
Somewhat related to #1479. I want to look into that next since I need to be able to overwrite partitions which have multiple partition columns.
--->

# Documentation

Here are some examples (which are part of the pytests as well):

Lists of lists of tuples in DNF format will create OR expressions:
```python
    multiple_partitions_multiple_columns = [
        [("year", "=", "2020"), ("month", "=", "2"), ("day", "=", "5")],
        [("year", "=", "2021"), ("month", "=", "4"), ("day", "=", "5")],
        [("year", "=", "2021"), ("month", "=", "3"), ("day", "=", "1")],
    ]
    dataset_filtered = dt.to_pyarrow_dataset(
        partitions=multiple_partitions_multiple_columns
    )
```

A single list of tuples will create an AND expression:
```python
    single_partition_multiple_columns = [("month", "=", "2"), ("day", "=", "5")]
    dataset_filtered = dt.to_pyarrow_dataset(
        partitions=single_partition_multiple_columns
    )
```

