### PR TITLE
fix: reorder encode_partition_value() checks and add tests

### DIFF
--- a/python/deltalake/_util.py
+++ b/python/deltalake/_util.py
@@ -10,10 +10,10 @@ def encode_partition_value(val: Any) -> str:
         return val
     elif isinstance(val, (int, float)):
         return str(val)
-    elif isinstance(val, date):
-        return val.isoformat()
     elif isinstance(val, datetime):
         return val.isoformat(sep=" ")
+    elif isinstance(val, date):
+        return val.isoformat()
     elif isinstance(val, bytes):
         return val.decode("unicode_escape", "backslashreplace")
     else:

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -697,6 +697,8 @@ def test_issue_1653_filter_bool_partition(tmp_path: Path):
         )
         == 1
     )
+
+
 @pytest.mark.parametrize(
     "input_value, expected",
     [

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1,12 +1,14 @@
 import os
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from threading import Barrier, Thread
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock
 
 from packaging import version
 
+from deltalake._util import encode_partition_value
 from deltalake.exceptions import DeltaProtocolError
 from deltalake.table import ProtocolVersions
 from deltalake.writer import write_deltalake
@@ -695,3 +697,31 @@ def test_issue_1653_filter_bool_partition(tmp_path: Path):
         )
         == 1
     )
+@pytest.mark.parametrize(
+    "input_value, expected",
+    [
+        (True, "true"),
+        (False, "false"),
+        (1, "1"),
+        (1.5, "1.5"),
+        ("string", "string"),
+        (date(2023, 10, 17), "2023-10-17"),
+        (datetime(2023, 10, 17, 12, 34, 56), "2023-10-17 12:34:56"),
+        (b"bytes", "bytes"),
+        ([True, False], ["true", "false"]),
+        ([1, 2], ["1", "2"]),
+        ([1.5, 2.5], ["1.5", "2.5"]),
+        (["a", "b"], ["a", "b"]),
+        ([date(2023, 10, 17), date(2023, 10, 18)], ["2023-10-17", "2023-10-18"]),
+        (
+            [datetime(2023, 10, 17, 12, 34, 56), datetime(2023, 10, 18, 12, 34, 56)],
+            ["2023-10-17 12:34:56", "2023-10-18 12:34:56"],
+        ),
+        ([b"bytes", b"testbytes"], ["bytes", "testbytes"]),
+    ],
+)
+def test_encode_partition_value(input_value: Any, expected: str) -> None:
+    if isinstance(input_value, list):
+        assert [encode_partition_value(val) for val in input_value] == expected
+    else:
+        assert encode_partition_value(input_value) == expected


### PR DESCRIPTION
# Description
The `isinstance(val, datetime)` check was after `isinstance(val, date)` which meant that it was never found. I added a test for each encoding type. 


