### PR TITLE
fix: relax `pyarrow` pin

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11"
 ]
 dependencies = [
-    "pyarrow>=8,<=12",
+    "pyarrow>=8,<13",
     'typing-extensions;python_version<"3.8"',
 ]
 


### PR DESCRIPTION
# Description
Relaxes the `pyarrow` pin to allow *any* version 12 as it was likely unintended to *only* allow 12.0.0 and no other 12.* versions.

# Related Issue(s)

Resolves #1701
