### PR TITLE
feat: add metadata for reader\writer features

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -190,6 +190,8 @@ mod tests {
         assert_eq!(table.version(), 3);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
+        assert_eq!(table.get_reader_features().len(), 0);
+        assert_eq!(table.get_writer_features().len(), 0);
         assert_eq!(
             table.get_files(),
             vec![
@@ -232,6 +234,8 @@ mod tests {
         assert_eq!(table.version(), 0);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
+        assert_eq!(table.get_reader_features().len(), 0);
+        assert_eq!(table.get_writer_features().len(), 0);
         assert_eq!(
             table.get_files(),
             vec![
@@ -246,6 +250,8 @@ mod tests {
         assert_eq!(table.version(), 2);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
+        assert_eq!(table.get_reader_features().len(), 0);
+        assert_eq!(table.get_writer_features().len(), 0);
         assert_eq!(
             table.get_files(),
             vec![
@@ -260,6 +266,8 @@ mod tests {
         assert_eq!(table.version(), 3);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
+        assert_eq!(table.get_reader_features().len(), 0);
+        assert_eq!(table.get_writer_features().len(), 0);
         assert_eq!(
             table.get_files(),
             vec![
@@ -276,6 +284,8 @@ mod tests {
         assert_eq!(table.version(), 1);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
+        assert_eq!(table.get_reader_features().len(), 0);
+        assert_eq!(table.get_writer_features().len(), 0);
         assert_eq!(
             table.get_files(),
             vec![
@@ -319,6 +329,8 @@ mod tests {
         assert_eq!(table.version(), 1);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
+        assert_eq!(table.get_reader_features().len(), 0);
+        assert_eq!(table.get_writer_features().len(), 0);
         assert_eq!(
             table.get_files(),
             vec![
@@ -330,6 +342,8 @@ mod tests {
         assert_eq!(table.version(), 0);
         assert_eq!(table.get_min_writer_version(), 2);
         assert_eq!(table.get_min_reader_version(), 1);
+        assert_eq!(table.get_reader_features().len(), 0);
+        assert_eq!(table.get_writer_features().len(), 0);
         assert_eq!(
             table.get_files(),
             vec![
@@ -664,5 +678,23 @@ mod tests {
                 "part-00000-7444aec4-710a-4a4c-8abe-3323499043e9.c000.snappy.parquet"
             ),]
         );
+    }
+
+    #[tokio::test]
+    async fn read_delta_table_with_reader_writer_features() {
+        let table = crate::open_table("./tests/data/simple_table_with_reader_writer_features")
+            .await
+            .unwrap();
+        assert_eq!(table.get_min_writer_version(), 7);
+        assert_eq!(table.get_min_reader_version(), 3);
+
+        let reader_features = table.get_reader_features();
+        assert_eq!(reader_features.len(), 1);
+        assert!(reader_features.contains(&"columnMapping".to_string()));
+
+        let writer_features = table.get_writer_features();
+        assert_eq!(writer_features.len(), 2);
+        assert!(writer_features.contains(&"columnMapping".to_string()));
+        assert!(writer_features.contains(&"identityColumns".to_string()));
     }
 }

--- a/rust/src/operations/create.rs
+++ b/rust/src/operations/create.rs
@@ -250,6 +250,7 @@ impl CreateBuilder {
             .unwrap_or_else(|| Protocol {
                 min_reader_version: MAX_SUPPORTED_READER_VERSION,
                 min_writer_version: MAX_SUPPORTED_WRITER_VERSION,
+                ..Default::default()
             });
 
         let metadata = DeltaTableMetaData::new(
@@ -393,12 +394,15 @@ mod tests {
         assert_eq!(table.version(), 0);
         assert_eq!(table.get_min_reader_version(), MAX_SUPPORTED_READER_VERSION);
         assert_eq!(table.get_min_writer_version(), MAX_SUPPORTED_WRITER_VERSION);
+        assert!(table.get_reader_features().is_empty());
+        assert!(table.get_writer_features().is_empty());
         assert_eq!(table.schema().unwrap(), &schema);
 
         // check we can overwrite default settings via adding actions
         let protocol = Protocol {
             min_reader_version: 0,
             min_writer_version: 0,
+            ..Default::default()
         };
         let table = CreateBuilder::new()
             .with_location("memory://")

--- a/rust/src/operations/restore.rs
+++ b/rust/src/operations/restore.rs
@@ -218,8 +218,16 @@ async fn execute(
                 table.get_min_writer_version(),
                 snapshot.min_writer_version(),
             ),
-            reader_features: table.get_reader_features().into_iter().cloned().collect(),
-            writer_features: table.get_writer_features().into_iter().cloned().collect(),
+            reader_features: table
+                .get_reader_features()
+                .union(snapshot.reader_features())
+                .cloned()
+                .collect(),
+            writer_features: table
+                .get_writer_features()
+                .union(snapshot.writer_features())
+                .cloned()
+                .collect(),
         }
     };
     actions.push(Action::protocol(protocol));

--- a/rust/src/operations/restore.rs
+++ b/rust/src/operations/restore.rs
@@ -205,6 +205,8 @@ async fn execute(
         Protocol {
             min_reader_version: table.get_min_reader_version(),
             min_writer_version: table.get_min_writer_version(),
+            reader_features: table.get_reader_features().into_iter().cloned().collect(),
+            writer_features: table.get_writer_features().into_iter().cloned().collect(),
         }
     } else {
         Protocol {
@@ -216,6 +218,8 @@ async fn execute(
                 table.get_min_writer_version(),
                 snapshot.min_writer_version(),
             ),
+            reader_features: table.get_reader_features().into_iter().cloned().collect(),
+            writer_features: table.get_writer_features().into_iter().cloned().collect(),
         }
     };
     actions.push(Action::protocol(protocol));

--- a/rust/src/operations/transaction/test_utils.rs
+++ b/rust/src/operations/transaction/test_utils.rs
@@ -33,6 +33,7 @@ pub fn create_protocol_action(max_reader: Option<i32>, max_writer: Option<i32>) 
     let protocol = Protocol {
         min_reader_version: max_reader.unwrap_or(crate::operations::MAX_SUPPORTED_READER_VERSION),
         min_writer_version: max_writer.unwrap_or(crate::operations::MAX_SUPPORTED_WRITER_VERSION),
+        ..Default::default()
     };
     Action::protocol(protocol)
 }
@@ -134,6 +135,7 @@ pub async fn create_initialized_table(
         protocol: Protocol {
             min_reader_version: 1,
             min_writer_version: 1,
+            ..Default::default()
         },
         metadata: DeltaTableMetaData::new(
             None,

--- a/rust/src/protocol/checkpoints.rs
+++ b/rust/src/protocol/checkpoints.rs
@@ -321,6 +321,8 @@ fn parquet_bytes_from_state(
     let jsons = std::iter::once(Action::protocol(Protocol {
         min_reader_version: state.min_reader_version(),
         min_writer_version: state.min_writer_version(),
+        reader_features: state.reader_features().into_iter().cloned().collect(),
+        writer_features: state.writer_features().into_iter().cloned().collect(),
     }))
     // metaData
     .chain(std::iter::once(Action::metaData(MetaData::try_from(

--- a/rust/src/protocol/mod.rs
+++ b/rust/src/protocol/mod.rs
@@ -21,7 +21,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::borrow::Borrow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::mem::take;
 use std::str::FromStr;
@@ -637,9 +637,15 @@ pub struct Protocol {
     /// Minimum version of the Delta read protocol a client must implement to correctly read the
     /// table.
     pub min_reader_version: i32,
-    /// Minimum version of the Delta write protocol a client must implement to correctly read the
+    /// Minimum version of the Delta write protocol a client must implement to correctly write the
     /// table.
     pub min_writer_version: i32,
+    /// A collection of reader features that a client must implement in order to correctly read the table.
+    #[serde(skip_serializing_if = "HashSet::is_empty", default)]
+    pub reader_features: HashSet<String>,
+    /// A collection of writer features that a client must implement in order to correctly write the table.
+    #[serde(skip_serializing_if = "HashSet::is_empty", default)]
+    pub writer_features: HashSet<String>,
 }
 
 /// The commitInfo is a fairly flexible action within the delta specification, where arbitrary data can be stored.

--- a/rust/src/table/mod.rs
+++ b/rust/src/table/mod.rs
@@ -818,6 +818,16 @@ impl DeltaTable {
         self.state.min_writer_version()
     }
 
+    /// Returns a collection of reader features supported by the DeltaTable based on the loaded metadata.
+    pub fn get_reader_features(&self) -> &HashSet<String> {
+        self.state.reader_features()
+    }
+
+    /// Returns a collection of writer features supported by the DeltaTable based on the loaded metadata.
+    pub fn get_writer_features(&self) -> &HashSet<String> {
+        self.state.writer_features()
+    }
+
     /// Return table schema parsed from transaction log. Return None if table hasn't been loaded or
     /// no metadata was found in the log.
     pub fn schema(&self) -> Option<&Schema> {

--- a/rust/tests/data/simple_table_with_reader_writer_features/_delta_log/00000000000000000000.json
+++ b/rust/tests/data/simple_table_with_reader_writer_features/_delta_log/00000000000000000000.json
@@ -1,0 +1,3 @@
+{"commitInfo":{"timestamp":1564524295023,"operation":"CREATE TABLE","operationParameters":{"isManaged":"false","description":null,"partitionBy":"[]","properties":"{}"},"isBlindAppend":true}}
+{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["columnMapping"],"writerFeatures":["columnMapping","identityColumns"]}}
+{"metaData":{"id":"22ef18ba-191c-4c36-a606-3dad5cdf3830","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1564524294376}}


### PR DESCRIPTION
# Description
Rust client should be able to understand if given table contains any reader\writer features

# Use case
Given delta file that was written by other client (possibly a more advanced one), try to understand if it requres any of the advanced features that might be specified in reader\writer features section of the protocol

# Documentation

https://github.com/delta-io/delta/blob/master/PROTOCOL.md#protocol-evolution
