### PR TITLE
fix: ignore binary columns for stats generation

### DIFF
--- a/rust/src/schema/arrow_convert.rs
+++ b/rust/src/schema/arrow_convert.rs
@@ -601,8 +601,8 @@ fn max_min_schema_for_fields(dest: &mut Vec<ArrowField>, f: &ArrowField) {
                 true,
             ));
         }
-        // don't compute min or max for list or map types
-        ArrowDataType::List(_) | ArrowDataType::Map(_, _) => { /* noop */ }
+        // don't compute min or max for list, map or binary types
+        ArrowDataType::List(_) | ArrowDataType::Map(_, _) | ArrowDataType::Binary => { /* noop */ }
         _ => {
             let f = f.clone();
             dest.push(f);
@@ -989,6 +989,7 @@ mod tests {
                 ),
                 true,
             ),
+            ArrowField::new("binary", ArrowDataType::Binary, true),
         ];
 
         let expected = vec![fields[0].clone(), fields[1].clone()];


### PR DESCRIPTION
# Description
Currently when trying to checkpoint a table with a binary column, this will fail with `data type Binary not supported`. This appears to be due to an arrow transformation into JSON to serialize the checkpoint format, and that `arrow-json` doesn't support binary (https://github.com/apache/arrow-rs/blob/master/arrow-json/src/writer.rs#L213).

This is a targeted fix that just disables stats generation for binary columns, which (at least to me) doesn't really make sense anyhow. This is a more targeted fix than #1498 and currently all the tests pass.

# Related Issue(s)
#1498 

