### PR TITLE
fix(python): add write support explicitly for pyarrow dataset

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -65,6 +65,7 @@ def write_deltalake(
     table_or_uri: Union[str, Path, DeltaTable],
     data: Union[
         "pd.DataFrame",
+        ds.Dataset,
         pa.Table,
         pa.RecordBatch,
         Iterable[pa.RecordBatch],
@@ -330,6 +331,8 @@ def write_deltalake(
         elif isinstance(data, pa.RecordBatch):
             batch_iter = [data]
         elif isinstance(data, pa.Table):
+            batch_iter = data.to_batches()
+        elif isinstance(data, ds.Dataset):
             batch_iter = data.to_batches()
         else:
             batch_iter = data


### PR DESCRIPTION
# Description
Adds explicitly write support for pyarrow.dataset.Dataset. Currently, it would work on the first write because the writer wouldn't go inside if the table is not None condition, so it would not return an error, and since pyarrow.write_dataset supports Datasets it worked for the first write but not the second write.

# Related Issue(s)
<!---
For example:

- closes #106
--->
- Closes https://github.com/delta-io/delta-rs/issues/1779

