### PR TITLE
fix(python): ignore infinity in stats

### DIFF
--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -5,6 +5,7 @@ import pathlib
 import random
 import threading
 from datetime import date, datetime
+from math import inf
 from typing import Any, Dict, Iterable, List
 from unittest.mock import Mock
 
@@ -924,3 +925,26 @@ def test_issue_1651_roundtrip_timestamp(tmp_path: pathlib.Path):
     dataset = dt.to_pyarrow_dataset()
 
     assert dataset.count_rows() == 1
+
+
+def test_float_values(tmp_path: pathlib.Path):
+    data = pa.table(
+        {
+            "id": pa.array(range(4)),
+            "x1": pa.array([0.0, inf, None, 1.0]),
+            "x2": pa.array([0.0, -inf, None, 1.0]),
+        }
+    )
+    write_deltalake(tmp_path, data)
+    dt = DeltaTable(tmp_path)
+    assert dt.to_pyarrow_table() == data
+
+    actions = dt.get_add_actions()
+    # x1 has no max, since inf was the highest value
+    assert actions["min"].field("x1")[0].as_py() == -0.0
+    assert actions["max"].field("x1")[0].as_py() is None
+    assert actions["null_count"].field("x1")[0].as_py() == 1
+    # x2 has no min, since -inf was the lowest value
+    assert actions["min"].field("x2")[0].as_py() is None
+    assert actions["max"].field("x2")[0].as_py() == 1.0
+    assert actions["null_count"].field("x2")[0].as_py() == 1


### PR DESCRIPTION
# Description
Infinity can't be represented in JSON, so it should not be placed in statistics. It's also not semantically different from not having a min/max, so we can safely omit it.

# Related Issue(s)

- closes #1411

# Documentation

<!---
Share links to useful documentation
--->
