### PR TITLE
feat: handle protocol compatibility

### DIFF
--- a/crates/deltalake-core/Cargo.toml
+++ b/crates/deltalake-core/Cargo.toml
@@ -130,6 +130,7 @@ tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 utime = "0.3"
 hyper = { version = "0.14", features = ["server"] }
+criterion = "0.5"
 
 [features]
 azure = ["object_store/azure"]

--- a/crates/deltalake-core/benches/read_checkpoint.rs
+++ b/crates/deltalake-core/benches/read_checkpoint.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use deltalake::table::state::DeltaTableState;
-use deltalake::DeltaTableConfig;
+use deltalake_core::table::state::DeltaTableState;
+use deltalake_core::DeltaTableConfig;
 use std::fs::File;
 use std::io::Read;
 

--- a/crates/deltalake-core/src/kernel/actions/types.rs
+++ b/crates/deltalake-core/src/kernel/actions/types.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::str::FromStr;
 // use std::io::{Cursor, Read};
 // use std::sync::Arc;
@@ -225,6 +226,24 @@ impl From<String> for ReaderFeatures {
     }
 }
 
+impl AsRef<str> for ReaderFeatures {
+    fn as_ref(&self) -> &str {
+        match self {
+            ReaderFeatures::ColumnMapping => "columnMapping",
+            ReaderFeatures::DeleteionVecotrs => "deletionVectors",
+            ReaderFeatures::TimestampWithoutTimezone => "timestampNtz",
+            ReaderFeatures::V2Checkpoint => "v2Checkpoint",
+            ReaderFeatures::Other(f) => f,
+        }
+    }
+}
+
+impl fmt::Display for ReaderFeatures {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
 /// Features table writers can support as well as let users know
 /// what is supported
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash)]
@@ -300,6 +319,33 @@ impl From<String> for WriterFeatures {
             "icebergCompatV1" => WriterFeatures::IcebergCompatV1,
             f => WriterFeatures::Other(f.to_string()),
         }
+    }
+}
+
+impl AsRef<str> for WriterFeatures {
+    fn as_ref(&self) -> &str {
+        match self {
+            WriterFeatures::AppendOnly => "appendOnly",
+            WriterFeatures::Invariants => "invariants",
+            WriterFeatures::CheckConstraints => "checkConstraints",
+            WriterFeatures::ChangeDataFeed => "changeDataFeed",
+            WriterFeatures::GeneratedColumns => "generatedColumns",
+            WriterFeatures::ColumnMapping => "columnMapping",
+            WriterFeatures::IdentityColumns => "identityColumns",
+            WriterFeatures::DeleteionVecotrs => "deletionVectors",
+            WriterFeatures::RowTracking => "rowTracking",
+            WriterFeatures::TimestampWithoutTimezone => "timestampNtz",
+            WriterFeatures::DomainMetadata => "domainMetadata",
+            WriterFeatures::V2Checkpoint => "v2Checkpoint",
+            WriterFeatures::IcebergCompatV1 => "icebergCompatV1",
+            WriterFeatures::Other(f) => f,
+        }
+    }
+}
+
+impl fmt::Display for WriterFeatures {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_ref())
     }
 }
 

--- a/crates/deltalake-core/src/operations/create.rs
+++ b/crates/deltalake-core/src/operations/create.rs
@@ -7,8 +7,7 @@ use std::sync::Arc;
 use futures::future::BoxFuture;
 use serde_json::{Map, Value};
 
-use super::transaction::commit;
-use super::{MAX_SUPPORTED_READER_VERSION, MAX_SUPPORTED_WRITER_VERSION};
+use super::transaction::{commit, PROTOCOL};
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::{Action, DataType, Metadata, Protocol, StructField, StructType};
 use crate::logstore::{LogStore, LogStoreRef};
@@ -245,8 +244,8 @@ impl CreateBuilder {
                 _ => unreachable!(),
             })
             .unwrap_or_else(|| Protocol {
-                min_reader_version: MAX_SUPPORTED_READER_VERSION,
-                min_writer_version: MAX_SUPPORTED_WRITER_VERSION,
+                min_reader_version: PROTOCOL.default_reader_version(),
+                min_writer_version: PROTOCOL.default_writer_version(),
                 writer_features: None,
                 reader_features: None,
             });
@@ -391,8 +390,14 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), 0);
-        assert_eq!(table.get_min_reader_version(), MAX_SUPPORTED_READER_VERSION);
-        assert_eq!(table.get_min_writer_version(), MAX_SUPPORTED_WRITER_VERSION);
+        assert_eq!(
+            table.get_min_reader_version(),
+            PROTOCOL.default_reader_version()
+        );
+        assert_eq!(
+            table.get_min_writer_version(),
+            PROTOCOL.default_writer_version()
+        );
         assert_eq!(table.schema().unwrap(), &schema);
 
         // check we can overwrite default settings via adding actions

--- a/crates/deltalake-core/src/operations/delete.rs
+++ b/crates/deltalake-core/src/operations/delete.rs
@@ -34,6 +34,8 @@ use parquet::file::properties::WriterProperties;
 use serde::Serialize;
 use serde_json::Value;
 
+use super::datafusion_utils::Expression;
+use super::transaction::PROTOCOL;
 use crate::delta_datafusion::expr::fmt_expr_to_sql;
 use crate::delta_datafusion::{find_files, register_store, DeltaScanBuilder};
 use crate::errors::{DeltaResult, DeltaTableError};
@@ -43,8 +45,6 @@ use crate::operations::write::write_execution_plan;
 use crate::protocol::DeltaOperation;
 use crate::table::state::DeltaTableState;
 use crate::DeltaTable;
-
-use super::datafusion_utils::Expression;
 
 /// Delete Records from the Delta Table.
 /// See this module's documentation for more information
@@ -274,6 +274,8 @@ impl std::future::IntoFuture for DeleteBuilder {
         let mut this = self;
 
         Box::pin(async move {
+            PROTOCOL.can_write_to(&this.snapshot)?;
+
             let state = this.state.unwrap_or_else(|| {
                 let session = SessionContext::new();
 

--- a/crates/deltalake-core/src/operations/load.rs
+++ b/crates/deltalake-core/src/operations/load.rs
@@ -6,6 +6,7 @@ use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use futures::future::BoxFuture;
 
+use super::transaction::PROTOCOL;
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::logstore::LogStoreRef;
 use crate::table::state::DeltaTableState;
@@ -46,6 +47,8 @@ impl std::future::IntoFuture for LoadBuilder {
         let this = self;
 
         Box::pin(async move {
+            PROTOCOL.can_read_from(&this.snapshot)?;
+
             let table = DeltaTable::new_with_state(this.log_store, this.snapshot);
             let schema = table.state.arrow_schema()?;
             let projection = this

--- a/crates/deltalake-core/src/operations/merge.rs
+++ b/crates/deltalake-core/src/operations/merge.rs
@@ -64,7 +64,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::datafusion_utils::{into_expr, maybe_into_expr, Expression};
-use super::transaction::commit;
+use super::transaction::{commit, PROTOCOL};
 use crate::delta_datafusion::expr::{fmt_expr_to_sql, parse_predicate_expression};
 use crate::delta_datafusion::{register_store, DeltaScanBuilder};
 use crate::kernel::{Action, Remove};
@@ -1208,6 +1208,8 @@ impl std::future::IntoFuture for MergeBuilder {
         let mut this = self;
 
         Box::pin(async move {
+            PROTOCOL.can_write_to(&this.snapshot)?;
+
             let state = this.state.unwrap_or_else(|| {
                 let session = SessionContext::new();
 

--- a/crates/deltalake-core/src/operations/mod.rs
+++ b/crates/deltalake-core/src/operations/mod.rs
@@ -50,11 +50,6 @@ pub mod write;
 #[cfg(all(feature = "arrow", feature = "parquet"))]
 pub mod writer;
 
-/// Maximum supported writer version
-pub const MAX_SUPPORTED_WRITER_VERSION: i32 = 1;
-/// Maximum supported reader version
-pub const MAX_SUPPORTED_READER_VERSION: i32 = 1;
-
 /// High level interface for executing commands against a DeltaTable
 pub struct DeltaOps(pub DeltaTable);
 

--- a/crates/deltalake-core/src/operations/optimize.rs
+++ b/crates/deltalake-core/src/operations/optimize.rs
@@ -38,7 +38,7 @@ use parquet::errors::ParquetError;
 use parquet::file::properties::WriterProperties;
 use serde::{Deserialize, Serialize};
 
-use super::transaction::commit;
+use super::transaction::{commit, PROTOCOL};
 use super::writer::{PartitionWriter, PartitionWriterConfig};
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::{Action, Remove};
@@ -260,6 +260,8 @@ impl<'a> std::future::IntoFuture for OptimizeBuilder<'a> {
         let this = self;
 
         Box::pin(async move {
+            PROTOCOL.can_write_to(&this.snapshot)?;
+
             let writer_properties = this.writer_properties.unwrap_or_else(|| {
                 WriterProperties::builder()
                     .set_compression(Compression::ZSTD(ZstdLevel::try_new(4).unwrap()))

--- a/crates/deltalake-core/src/operations/restore.rs
+++ b/crates/deltalake-core/src/operations/restore.rs
@@ -245,7 +245,6 @@ async fn execute(
             datetime: datetime_to_restore.map(|time| -> i64 { time.timestamp_millis() }),
         },
         &actions,
-        &snapshot,
         None,
     )
     .await?;

--- a/crates/deltalake-core/src/operations/transaction/protocol.rs
+++ b/crates/deltalake-core/src/operations/transaction/protocol.rs
@@ -1,0 +1,273 @@
+use std::collections::HashSet;
+
+use once_cell::sync::Lazy;
+
+use super::TransactionError;
+use crate::kernel::{ReaderFeatures, WriterFeatures};
+use crate::table::state::DeltaTableState;
+
+static READER_V2: Lazy<HashSet<ReaderFeatures>> = Lazy::new(|| {
+    let mut set = HashSet::new();
+    set.insert(ReaderFeatures::ColumnMapping);
+    set
+});
+
+static WRITER_V2: Lazy<HashSet<WriterFeatures>> = Lazy::new(|| {
+    let mut set = HashSet::new();
+    set.insert(WriterFeatures::AppendOnly);
+    set.insert(WriterFeatures::Invariants);
+    set
+});
+static WRITER_V3: Lazy<HashSet<WriterFeatures>> = Lazy::new(|| {
+    let mut set = WRITER_V2.clone();
+    set.insert(WriterFeatures::CheckConstraints);
+    set
+});
+static WRITER_V4: Lazy<HashSet<WriterFeatures>> = Lazy::new(|| {
+    let mut set = WRITER_V3.clone();
+    set.insert(WriterFeatures::ChangeDataFeed);
+    set.insert(WriterFeatures::GeneratedColumns);
+    set
+});
+static WRITER_V5: Lazy<HashSet<WriterFeatures>> = Lazy::new(|| {
+    let mut set = WRITER_V4.clone();
+    set.insert(WriterFeatures::ColumnMapping);
+    set
+});
+static WRITER_V6: Lazy<HashSet<WriterFeatures>> = Lazy::new(|| {
+    let mut set = WRITER_V5.clone();
+    set.insert(WriterFeatures::IdentityColumns);
+    set
+});
+
+pub struct ProtocolChecker {
+    reader_features: HashSet<ReaderFeatures>,
+    writer_features: HashSet<WriterFeatures>,
+}
+
+impl ProtocolChecker {
+    /// Create a new protocol checker.
+    pub fn new(
+        reader_features: HashSet<ReaderFeatures>,
+        writer_features: HashSet<WriterFeatures>,
+    ) -> Self {
+        Self {
+            reader_features,
+            writer_features,
+        }
+    }
+
+    pub fn default_reader_version(&self) -> i32 {
+        1
+    }
+
+    pub fn default_writer_version(&self) -> i32 {
+        1
+    }
+
+    /// Check if delta-rs can read form the given delta table.
+    pub fn can_read_from(&self, snapshot: &DeltaTableState) -> Result<(), TransactionError> {
+        let required_features = match snapshot.min_reader_version() {
+            0 | 1 => None,
+            2 => Some(READER_V2.clone()),
+            _ => snapshot.reader_features().cloned(),
+        };
+
+        if let Some(features) = required_features {
+            let diff: Vec<_> = features
+                .difference(&self.reader_features)
+                .cloned()
+                .collect();
+            if !diff.is_empty() {
+                return Err(TransactionError::UnsupportedReaderFeatures(diff));
+            }
+        };
+        Ok(())
+    }
+
+    /// Check if delta-rs can write to the given delta table.
+    pub fn can_write_to(&self, snapshot: &DeltaTableState) -> Result<(), TransactionError> {
+        // NOTE: writers must always support all required reader features
+        self.can_read_from(snapshot)?;
+
+        let required_features = match snapshot.min_writer_version() {
+            0 | 1 => None,
+            2 => Some(WRITER_V2.clone()),
+            3 => Some(WRITER_V3.clone()),
+            4 => Some(WRITER_V4.clone()),
+            5 => Some(WRITER_V5.clone()),
+            6 => Some(WRITER_V6.clone()),
+            _ => snapshot.writer_features().cloned(),
+        };
+
+        if let Some(features) = required_features {
+            let diff: Vec<_> = features
+                .difference(&self.writer_features)
+                .cloned()
+                .collect();
+            if !diff.is_empty() {
+                return Err(TransactionError::UnsupportedWriterFeatures(diff));
+            }
+        };
+        Ok(())
+    }
+}
+
+/// The global protocol checker instance to validate table versions and features.
+pub static INSTANCE: Lazy<ProtocolChecker> = Lazy::new(|| {
+    let reader_features = HashSet::new();
+    // reader_features.insert(ReaderFeatures::ColumnMapping);
+
+    let mut writer_features = HashSet::new();
+    writer_features.insert(WriterFeatures::AppendOnly);
+    writer_features.insert(WriterFeatures::Invariants);
+    // writer_features.insert(WriterFeatures::CheckConstraints);
+    // writer_features.insert(WriterFeatures::ChangeDataFeed);
+    // writer_features.insert(WriterFeatures::GeneratedColumns);
+    // writer_features.insert(WriterFeatures::ColumnMapping);
+    // writer_features.insert(WriterFeatures::IdentityColumns);
+
+    ProtocolChecker::new(reader_features, writer_features)
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::{Action, Protocol};
+
+    #[test]
+    fn test_versions() {
+        let checker_1 = ProtocolChecker::new(HashSet::new(), HashSet::new());
+        let actions = vec![Action::Protocol(Protocol {
+            min_reader_version: 1,
+            min_writer_version: 1,
+            ..Default::default()
+        })];
+        let snapshot_1 = DeltaTableState::from_actions(actions, 1).unwrap();
+        assert!(checker_1.can_read_from(&snapshot_1).is_ok());
+        assert!(checker_1.can_write_to(&snapshot_1).is_ok());
+
+        let checker_2 = ProtocolChecker::new(READER_V2.clone(), HashSet::new());
+        let actions = vec![Action::Protocol(Protocol {
+            min_reader_version: 2,
+            min_writer_version: 1,
+            ..Default::default()
+        })];
+        let snapshot_2 = DeltaTableState::from_actions(actions, 1).unwrap();
+        assert!(checker_1.can_read_from(&snapshot_2).is_err());
+        assert!(checker_1.can_write_to(&snapshot_2).is_err());
+        assert!(checker_2.can_read_from(&snapshot_1).is_ok());
+        assert!(checker_2.can_read_from(&snapshot_2).is_ok());
+        assert!(checker_2.can_write_to(&snapshot_2).is_ok());
+
+        let checker_3 = ProtocolChecker::new(READER_V2.clone(), WRITER_V2.clone());
+        let actions = vec![Action::Protocol(Protocol {
+            min_reader_version: 2,
+            min_writer_version: 2,
+            ..Default::default()
+        })];
+        let snapshot_3 = DeltaTableState::from_actions(actions, 1).unwrap();
+        assert!(checker_1.can_read_from(&snapshot_3).is_err());
+        assert!(checker_1.can_write_to(&snapshot_3).is_err());
+        assert!(checker_2.can_read_from(&snapshot_3).is_ok());
+        assert!(checker_2.can_write_to(&snapshot_3).is_err());
+        assert!(checker_3.can_read_from(&snapshot_1).is_ok());
+        assert!(checker_3.can_read_from(&snapshot_2).is_ok());
+        assert!(checker_3.can_read_from(&snapshot_3).is_ok());
+        assert!(checker_3.can_write_to(&snapshot_3).is_ok());
+
+        let checker_4 = ProtocolChecker::new(READER_V2.clone(), WRITER_V3.clone());
+        let actions = vec![Action::Protocol(Protocol {
+            min_reader_version: 2,
+            min_writer_version: 3,
+            ..Default::default()
+        })];
+        let snapshot_4 = DeltaTableState::from_actions(actions, 1).unwrap();
+        assert!(checker_1.can_read_from(&snapshot_4).is_err());
+        assert!(checker_1.can_write_to(&snapshot_4).is_err());
+        assert!(checker_2.can_read_from(&snapshot_4).is_ok());
+        assert!(checker_2.can_write_to(&snapshot_4).is_err());
+        assert!(checker_3.can_read_from(&snapshot_4).is_ok());
+        assert!(checker_3.can_write_to(&snapshot_4).is_err());
+        assert!(checker_4.can_read_from(&snapshot_1).is_ok());
+        assert!(checker_4.can_read_from(&snapshot_2).is_ok());
+        assert!(checker_4.can_read_from(&snapshot_3).is_ok());
+        assert!(checker_4.can_read_from(&snapshot_4).is_ok());
+        assert!(checker_4.can_write_to(&snapshot_4).is_ok());
+
+        let checker_5 = ProtocolChecker::new(READER_V2.clone(), WRITER_V4.clone());
+        let actions = vec![Action::Protocol(Protocol {
+            min_reader_version: 2,
+            min_writer_version: 4,
+            ..Default::default()
+        })];
+        let snapshot_5 = DeltaTableState::from_actions(actions, 1).unwrap();
+        assert!(checker_1.can_read_from(&snapshot_5).is_err());
+        assert!(checker_1.can_write_to(&snapshot_5).is_err());
+        assert!(checker_2.can_read_from(&snapshot_5).is_ok());
+        assert!(checker_2.can_write_to(&snapshot_5).is_err());
+        assert!(checker_3.can_read_from(&snapshot_5).is_ok());
+        assert!(checker_3.can_write_to(&snapshot_5).is_err());
+        assert!(checker_4.can_read_from(&snapshot_5).is_ok());
+        assert!(checker_4.can_write_to(&snapshot_5).is_err());
+        assert!(checker_5.can_read_from(&snapshot_1).is_ok());
+        assert!(checker_5.can_read_from(&snapshot_2).is_ok());
+        assert!(checker_5.can_read_from(&snapshot_3).is_ok());
+        assert!(checker_5.can_read_from(&snapshot_4).is_ok());
+        assert!(checker_5.can_read_from(&snapshot_5).is_ok());
+        assert!(checker_5.can_write_to(&snapshot_5).is_ok());
+
+        let checker_6 = ProtocolChecker::new(READER_V2.clone(), WRITER_V5.clone());
+        let actions = vec![Action::Protocol(Protocol {
+            min_reader_version: 2,
+            min_writer_version: 5,
+            ..Default::default()
+        })];
+        let snapshot_6 = DeltaTableState::from_actions(actions, 1).unwrap();
+        assert!(checker_1.can_read_from(&snapshot_6).is_err());
+        assert!(checker_1.can_write_to(&snapshot_6).is_err());
+        assert!(checker_2.can_read_from(&snapshot_6).is_ok());
+        assert!(checker_2.can_write_to(&snapshot_6).is_err());
+        assert!(checker_3.can_read_from(&snapshot_6).is_ok());
+        assert!(checker_3.can_write_to(&snapshot_6).is_err());
+        assert!(checker_4.can_read_from(&snapshot_6).is_ok());
+        assert!(checker_4.can_write_to(&snapshot_6).is_err());
+        assert!(checker_5.can_read_from(&snapshot_6).is_ok());
+        assert!(checker_5.can_write_to(&snapshot_6).is_err());
+        assert!(checker_6.can_read_from(&snapshot_1).is_ok());
+        assert!(checker_6.can_read_from(&snapshot_2).is_ok());
+        assert!(checker_6.can_read_from(&snapshot_3).is_ok());
+        assert!(checker_6.can_read_from(&snapshot_4).is_ok());
+        assert!(checker_6.can_read_from(&snapshot_5).is_ok());
+        assert!(checker_6.can_read_from(&snapshot_6).is_ok());
+        assert!(checker_6.can_write_to(&snapshot_6).is_ok());
+
+        let checker_7 = ProtocolChecker::new(READER_V2.clone(), WRITER_V6.clone());
+        let actions = vec![Action::Protocol(Protocol {
+            min_reader_version: 2,
+            min_writer_version: 6,
+            ..Default::default()
+        })];
+        let snapshot_7 = DeltaTableState::from_actions(actions, 1).unwrap();
+        assert!(checker_1.can_read_from(&snapshot_7).is_err());
+        assert!(checker_1.can_write_to(&snapshot_7).is_err());
+        assert!(checker_2.can_read_from(&snapshot_7).is_ok());
+        assert!(checker_2.can_write_to(&snapshot_7).is_err());
+        assert!(checker_3.can_read_from(&snapshot_7).is_ok());
+        assert!(checker_3.can_write_to(&snapshot_7).is_err());
+        assert!(checker_4.can_read_from(&snapshot_7).is_ok());
+        assert!(checker_4.can_write_to(&snapshot_7).is_err());
+        assert!(checker_5.can_read_from(&snapshot_7).is_ok());
+        assert!(checker_5.can_write_to(&snapshot_7).is_err());
+        assert!(checker_6.can_read_from(&snapshot_7).is_ok());
+        assert!(checker_6.can_write_to(&snapshot_7).is_err());
+        assert!(checker_7.can_read_from(&snapshot_1).is_ok());
+        assert!(checker_7.can_read_from(&snapshot_2).is_ok());
+        assert!(checker_7.can_read_from(&snapshot_3).is_ok());
+        assert!(checker_7.can_read_from(&snapshot_4).is_ok());
+        assert!(checker_7.can_read_from(&snapshot_5).is_ok());
+        assert!(checker_7.can_read_from(&snapshot_6).is_ok());
+        assert!(checker_7.can_read_from(&snapshot_7).is_ok());
+        assert!(checker_7.can_write_to(&snapshot_7).is_ok());
+    }
+}

--- a/crates/deltalake-core/src/operations/transaction/test_utils.rs
+++ b/crates/deltalake-core/src/operations/transaction/test_utils.rs
@@ -166,7 +166,6 @@ pub async fn create_initialized_table(
         log_store.object_store().as_ref(),
         &operation,
         &actions,
-        &state,
         None,
     )
     .await

--- a/crates/deltalake-core/src/operations/transaction/test_utils.rs
+++ b/crates/deltalake-core/src/operations/transaction/test_utils.rs
@@ -6,6 +6,7 @@ use crate::kernel::{
     Action, Add, CommitInfo, DataType, Metadata, PrimitiveType, Protocol, Remove, StructField,
     StructType,
 };
+use crate::operations::transaction::PROTOCOL;
 use crate::protocol::{DeltaOperation, SaveMode};
 use crate::table::state::DeltaTableState;
 use crate::table::DeltaTableMetaData;
@@ -49,8 +50,8 @@ pub fn create_remove_action(path: impl Into<String>, data_change: bool) -> Actio
 
 pub fn create_protocol_action(max_reader: Option<i32>, max_writer: Option<i32>) -> Action {
     let protocol = Protocol {
-        min_reader_version: max_reader.unwrap_or(crate::operations::MAX_SUPPORTED_READER_VERSION),
-        min_writer_version: max_writer.unwrap_or(crate::operations::MAX_SUPPORTED_WRITER_VERSION),
+        min_reader_version: max_reader.unwrap_or(PROTOCOL.default_reader_version()),
+        min_writer_version: max_writer.unwrap_or(PROTOCOL.default_writer_version()),
         writer_features: None,
         reader_features: None,
     };

--- a/crates/deltalake-core/src/operations/update.rs
+++ b/crates/deltalake-core/src/operations/update.rs
@@ -44,7 +44,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::datafusion_utils::{Expression, MetricObserverExec};
-use super::transaction::commit;
+use super::transaction::{commit, PROTOCOL};
 use super::write::write_execution_plan;
 use crate::delta_datafusion::expr::fmt_expr_to_sql;
 use crate::delta_datafusion::{find_files, register_store, DeltaScanBuilder};
@@ -426,6 +426,8 @@ impl std::future::IntoFuture for UpdateBuilder {
         let mut this = self;
 
         Box::pin(async move {
+            PROTOCOL.can_write_to(&this.snapshot)?;
+
             let state = this.state.unwrap_or_else(|| {
                 let session = SessionContext::new();
 

--- a/crates/deltalake-core/tests/integration_concurrent_writes.rs
+++ b/crates/deltalake-core/tests/integration_concurrent_writes.rs
@@ -69,7 +69,7 @@ async fn prepare_table(
 
     assert_eq!(0, table.version());
     assert_eq!(1, table.get_min_reader_version());
-    assert_eq!(1, table.get_min_writer_version());
+    assert_eq!(2, table.get_min_writer_version());
     assert_eq!(0, table.get_files().len());
 
     Ok((table, table_uri))


### PR DESCRIPTION
# Description

In preparation for further improvements to protocol support, this PR introduces a `ProtocolChecker` which validates that we can read form / write to / commit to a specific table. So far everything is expressed in table features in the hopes, that this keeps on giving correct behaviours as we add more table features. 

The existing support for append only is integrated and extended to handle enablement logic according to the protocol.