### PR TITLE
fix: support os.PathLike for table references

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1,6 +1,5 @@
 import json
 import operator
-import os
 import warnings
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -32,6 +31,8 @@ from pyarrow.dataset import (
 )
 
 if TYPE_CHECKING:
+    import os
+
     import pandas
 
 from deltalake._internal import DeltaDataChecker as _DeltaDataChecker
@@ -226,7 +227,7 @@ class DeltaTable:
 
     def __init__(
         self,
-        table_uri: Union[str, Path, os.PathLike],
+        table_uri: Union[str, Path, "os.PathLike[str]"],
         version: Optional[int] = None,
         storage_options: Optional[Dict[str, str]] = None,
         without_files: bool = False,

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1,5 +1,6 @@
 import json
 import operator
+import os
 import warnings
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -225,7 +226,7 @@ class DeltaTable:
 
     def __init__(
         self,
-        table_uri: Union[str, Path],
+        table_uri: Union[str, Path, os.PathLike],
         version: Optional[int] = None,
         storage_options: Optional[Dict[str, str]] = None,
         without_files: bool = False,


### PR DESCRIPTION
# Description

This change is mainly for typing purposes so that downstream usage can supply a Path or PathLike object rather than just Path. 

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
