### PR TITLE
chore: upgrade to the latest dynamodb-lock crate

### DIFF
--- a/crates/deltalake-core/Cargo.toml
+++ b/crates/deltalake-core/Cargo.toml
@@ -117,7 +117,7 @@ sqlparser = { version = "0.38", optional = true }
 fs_extra = { version = "1.3.0", optional = true }
 tempdir = { version = "0", optional = true }
 
-dynamodb_lock = { version = "0", default-features = false, optional = true }
+dynamodb_lock = { version = "0.6.0", default-features = false, optional = true }
 
 [dev-dependencies]
 dotenvy = "0"


### PR DESCRIPTION
The new version of this crate properly sets a lease duration such that the locks can actually expire
