### PR TITLE
fix: pin dynamodb_lock to 0.4

### DIFF
--- a/crates/deltalake-core/Cargo.toml
+++ b/crates/deltalake-core/Cargo.toml
@@ -117,7 +117,7 @@ sqlparser = { version = "0.38", optional = true }
 fs_extra = { version = "1.3.0", optional = true }
 tempdir = { version = "0", optional = true }
 
-dynamodb_lock = { version = "0", default-features = false, optional = true }
+dynamodb_lock = { version = "0.4", default-features = false, optional = true }
 
 [dev-dependencies]
 dotenvy = "0"


### PR DESCRIPTION
# Description
Having the dependency pointed at 0 means anything depending on deltalake uses the latest version of dynamodb_lock. There are breaking changes between 0.4 and 0.6, causing all prior versions of deltalake to fail to build, along with projects depending on them. This is pointed at main, but should probably be ported back as a patch release to all prior deltalake versions.