### PR TITLE
feat: add lazy loading of tables

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -122,6 +122,14 @@ impl RawDeltaTable {
     }
 
     #[classmethod]
+    fn load_lazy(_cls: &PyType, table_uri: &str) -> PyResult<Self> {
+        let be = storage::get_backend_for_uri(table_uri).unwrap();
+        let table = DeltaTable::new(table_uri, be, DeltaTableConfig::default())
+            .map_err(PyDeltaTableError::from_raw)?;
+        Ok(RawDeltaTable { _table: table })
+    }
+
+    #[classmethod]
     #[pyo3(signature = (data_catalog, database_name, table_name, data_catalog_id, catalog_options = None))]
     fn get_table_uri_from_data_catalog(
         _cls: &PyType,


### PR DESCRIPTION
# Description
Add lazy loading of tables. When preforming streaming operations we don't need any version of the table loaded. Large tables are slow to load, so we see a huge performance boost by avoiding CPU time spent loading the table metadata.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
