### PR TITLE
ci: adopt `ruff format` for formatting

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -53,8 +53,8 @@ format: ## Format the code
 	$(info --- Rust format ---)
 	cargo fmt
 	$(info --- Python format ---)
-	black .
 	ruff . --fix
+	ruff format .
 
 .PHONY: check-rust
 check-rust: ## Run check on Rust
@@ -65,9 +65,9 @@ check-rust: ## Run check on Rust
 
 .PHONY: check-python
 check-python: ## Run check on Python
-	$(info Check Python black)
-	black --check --diff .
-	$(info Check Python ruff)
+	$(info Check Python format)
+	ruff format --check --diff .
+	$(info Check Python linting)
 	ruff check .
 	$(info Check Python mypy)
 	mypy

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,8 +27,7 @@ pandas = [
 ]
 devel = [
     "mypy",
-    "black",
-    "ruff",
+    "ruff>=0.1.5",
     "packaging>=20",
     "pytest",
     "pytest-mock",

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -118,9 +118,7 @@ def test_read_simple_table_file_sizes_failure():
         x: [-1 for item in x] if x == "size_bytes" else y
         for x, y in add_actions.items()
     }
-    dt.get_add_actions = lambda: SimpleNamespace(
-        to_pydict=lambda: add_actions_modified
-    )  # type:ignore
+    dt.get_add_actions = lambda: SimpleNamespace(to_pydict=lambda: add_actions_modified)  # type:ignore
 
     with pytest.raises(OSError, match="Cannot seek past end of file."):
         dt.to_pyarrow_dataset().to_table().to_pydict()


### PR DESCRIPTION
# Description
 
Not a terribly important change, but since its one less dependency and behaves more or less like `black`, I thought maybe using the somewhat recently released `ruff format` command for formatting makes sense.