### PR TITLE
fix: checkpoint error with Azure Synapse

### DIFF
--- a/crates/deltalake-core/src/operations/update.rs
+++ b/crates/deltalake-core/src/operations/update.rs
@@ -737,7 +737,6 @@ mod tests {
             .with_update("value", col("value") + lit(1))
             .await
             .unwrap();
-
         assert_eq!(table.version(), 1);
         assert_eq!(table.get_file_uris().count(), 1);
         assert_eq!(metrics.num_added_files, 1);


### PR DESCRIPTION
# Description
Modify Checkpoint stuct not to serialize optional fields if null.

# Related Issue(s)
- closes #1847 

