### PR TITLE
fix: docs deployment action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,13 +35,15 @@ jobs:
         with:
           src: docs/src/python
 
-  build:
+  build-deploy:
     needs:
       [
         lint,
         markdown-link-check,
       ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -128,8 +128,6 @@ jobs:
         release-pypi-windows,
       ]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Trigger the docs release event
         uses: peter-evans/repository-dispatch@v2


### PR DESCRIPTION
# Description
Moved the requirement for contents write permission from release action to docs deployment. The same permission was  used in the previous release action (sphinx) so I'm not introducing any extra permission requirements. 

One thing I don't really like here is that such permission is only needed for the `Deploy` step but the lowest level it can be defined is job. This should be fine because other steps in the job don't do any git operations.

Alternative would be creating a separate Deploy job but then I'd have to duplicate all the steps from the Build part which would effectively be the same thing as now but with a longer/redundant config.

Deployment logic remains the same - docs are deployed only when the Build Documentation is run manually or via the Release Python action.

# Related Issue(s)
 #1867

I am unable to fully test this in my environment because the failing version was actually working in my repo - I don't see how things are configured in the main repo.
