### PR TITLE
docs: add Rust installation instructions

### DIFF
--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -1,5 +1,7 @@
 # Installation
 
+The `deltalake` project can be installed via Pip for Python or Cargo for Rust.
+
 ## Using Pip
 
 ``` bash
@@ -7,3 +9,9 @@ pip install deltalake
 ```
 
 NOTE: official binary wheels are linked against openssl statically for remote objection store communication. Please file Github issue to request for critical openssl upgrade.
+
+## Using Cargo
+
+``` bash
+cargo add deltalake
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,8 +16,8 @@ theme:
     - content.tabs.link
 nav:
   - Home: index.md
-  - Installation: installation.md
   - Usage:
+    - Installation: usage/installation.md
     - Overview: usage/index.md
     - Loading a Delta Table: usage/loading-table.md
     - Examining a Delta Table: usage/examining-table.md


### PR DESCRIPTION
# Description

Move installation instructions to usage and include instructions for installing `deltalake` via Cargo.
