### PR TITLE
docs: add a message to old docs with a link new docs

### DIFF
--- a/python/index.html
+++ b/python/index.html
@@ -72,7 +72,9 @@
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
            <div itemprop="articleBody">
-             
+            <div style="padding:.75rem 1.25rem;margin-bottom:1rem;border:1px solid #ffeeba;border-radius:.25rem;color:#856404;background-color:#fff3cd;">
+              <strong>Attention!</strong> Our new documentation is available <a href="https://delta-io.github.io/delta-rs">here</a>. This version is no longer maintained.
+            </div>
   <section id="python-deltalake-package">
 <h1>Python deltalake package<a class="headerlink" href="#python-deltalake-package" title="Permalink to this headline"></a></h1>
 <p>This is the documentation for the native Python implementation of deltalake. It


### PR DESCRIPTION
# Description
Old (sphynx) docs are not longer updated during the release so adding a message directly to home page of the old docs

closes: #1865