### PR TITLE
fix: improve catalog failure error message, add missing Glue native-tls feature dependency

### DIFF
--- a/crates/deltalake-core/src/data_catalog/mod.rs
+++ b/crates/deltalake-core/src/data_catalog/mod.rs
@@ -7,7 +7,7 @@ pub use unity::*;
 
 #[cfg(feature = "unity-experimental")]
 pub mod client;
-#[cfg(feature = "glue")]
+#[cfg(any(feature = "glue", feature = "glue-native-tls"))]
 pub mod glue;
 #[cfg(feature = "datafusion")]
 pub mod storage;
@@ -49,7 +49,7 @@ pub enum DataCatalogError {
     },
 
     /// Missing metadata in the catalog
-    #[cfg(feature = "glue")]
+    #[cfg(any(feature = "glue", feature = "glue-native-tls"))]
     #[error("Missing Metadata {metadata} in the Data Catalog ")]
     MissingMetadata {
         /// The missing metadata property
@@ -57,7 +57,7 @@ pub enum DataCatalogError {
     },
 
     /// Glue Glue Data Catalog Error
-    #[cfg(feature = "glue")]
+    #[cfg(any(feature = "glue", feature = "glue-native-tls"))]
     #[error("Catalog glue error: {source}")]
     GlueError {
         /// The underlying Glue Data Catalog Error
@@ -66,7 +66,7 @@ pub enum DataCatalogError {
     },
 
     /// Error caused by the http request dispatcher not being able to be created.
-    #[cfg(feature = "glue")]
+    #[cfg(any(feature = "glue", feature = "glue-native-tls"))]
     #[error("Failed to create request dispatcher: {source}")]
     AWSHttpClient {
         /// The underlying Rusoto TlsError
@@ -75,7 +75,7 @@ pub enum DataCatalogError {
     },
 
     /// Error representing a failure to retrieve AWS credentials.
-    #[cfg(feature = "glue")]
+    #[cfg(any(feature = "glue", feature = "glue-native-tls"))]
     #[error("Failed to retrieve AWS credentials: {source}")]
     AWSCredentials {
         /// The underlying Rusoto CredentialsError
@@ -138,7 +138,7 @@ pub fn get_data_catalog(
         "azure" => unimplemented!("Azure Data Catalog is not implemented"),
         #[cfg(feature = "hdfs")]
         "hdfs" => unimplemented!("HDFS Data Catalog is not implemented"),
-        #[cfg(feature = "glue")]
+        #[cfg(any(feature = "glue", feature = "glue-native-tls"))]
         "glue" => Ok(Box::new(glue::GlueDataCatalog::new()?)),
         #[cfg(feature = "unity-experimental")]
         "unity" => {

--- a/crates/deltalake-core/src/lib.rs
+++ b/crates/deltalake-core/src/lib.rs
@@ -82,6 +82,11 @@ compile_error!(
     "Features s3 and s3-native-tls are mutually exclusive and cannot be enabled together"
 );
 
+#[cfg(all(feature = "glue", feature = "glue-native-tls"))]
+compile_error!(
+    "Features glue and glue-native-tls are mutually exclusive and cannot be enabled together"
+);
+
 pub mod data_catalog;
 pub mod errors;
 pub mod kernel;

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -132,9 +132,7 @@ impl RawDeltaTable {
         catalog_options: Option<HashMap<String, String>>,
     ) -> PyResult<String> {
         let data_catalog = deltalake::data_catalog::get_data_catalog(data_catalog, catalog_options)
-            .map_err(|_| {
-                PyValueError::new_err(format!("Catalog '{}' not available.", data_catalog))
-            })?;
+            .map_err(|e| PyValueError::new_err(format!("{}", e)))?;
         let table_uri = rt()?
             .block_on(data_catalog.get_table_storage_location(
                 data_catalog_id,


### PR DESCRIPTION
# Description
- Improved error message on catalog lookup failure
- Added `native-tls` feature dependency to Glue feature
- Added error preventing using `glue` and `glue-native-tls` in the same build

# Related Issue(s)

- closes #1860


# Documentation
