### PR TITLE
[#1831]: Testing loading Delta table

### DIFF
--- a/crates/deltalake-core/src/lib.rs
+++ b/crates/deltalake-core/src/lib.rs
@@ -675,4 +675,20 @@ mod tests {
             ),]
         );
     }
+
+    #[tokio::test()]
+    async fn test_version_zero_table_load() {
+        let path = "./tests/data/COVID-19_NYT";
+        let mut latest_table: DeltaTable = crate::open_table(path).await.unwrap();
+
+        let mut version_0_table = crate::open_table_with_version(path, 0).await.unwrap();
+
+        let version_0_history = version_0_table.history(None).await.expect("Cannot get table history");
+        let latest_table_history = latest_table
+            .history(None)
+            .await
+            .expect("Cannot get table history");
+
+        assert_eq!(latest_table_history, version_0_history);
+    }
 }


### PR DESCRIPTION
# Description
According to the issue test should fail to load table without snapshot (version 0) but test is written to test that it is possible to read and load Delta Table with version 0 into the Rust (functions open_table and open_table_with_version work)

# Related Issue(s)
- closes #1831
