### PR TITLE
fix: prune each merge bin with only 1 file

### DIFF
--- a/crates/deltalake-core/src/operations/optimize.rs
+++ b/crates/deltalake-core/src/operations/optimize.rs
@@ -900,10 +900,14 @@ fn build_compaction_plan(
 
     // Prune merge bins with only 1 file, since they have no effect
     for (_, bins) in operations.iter_mut() {
-        if bins.len() == 1 && bins[0].len() == 1 {
-            metrics.total_files_skipped += 1;
-            bins.clear();
-        }
+        bins.retain(|bin| {
+            if bin.len() == 1 {
+                metrics.total_files_skipped += 1;
+                false
+            } else {
+                true
+            }
+        })
     }
     operations.retain(|_, files| !files.is_empty());
 


### PR DESCRIPTION
# Description
This PR prunes each merge bin with only 1 file, even though there are multiple merge bins.

# Related Issue(s)
- closes #1901 

# Documentation
This PR adds test_idempotent_with_multiple_bins() for testing.