### PR TITLE
chore: relocate cast_record_batch into its own module to shed the datafusion dependency

### DIFF
--- a/crates/deltalake-core/Cargo.toml
+++ b/crates/deltalake-core/Cargo.toml
@@ -146,6 +146,7 @@ arrow = [
 ]
 default = ["arrow", "parquet"]
 datafusion = [
+    "dep:arrow",
     "dep:datafusion",
     "datafusion-expr",
     "datafusion-common",

--- a/crates/deltalake-core/src/operations/cast.rs
+++ b/crates/deltalake-core/src/operations/cast.rs
@@ -1,0 +1,53 @@
+//! Provide common cast functionality for callers
+//!
+use arrow_array::{Array, ArrayRef, RecordBatch, StructArray};
+use arrow_cast::{cast_with_options, CastOptions};
+use arrow_schema::{DataType, Fields, SchemaRef as ArrowSchemaRef};
+
+use std::sync::Arc;
+
+use crate::DeltaResult;
+
+fn cast_record_batch_columns(
+    batch: &RecordBatch,
+    fields: &Fields,
+    cast_options: &CastOptions,
+) -> Result<Vec<Arc<(dyn Array)>>, arrow_schema::ArrowError> {
+    fields
+        .iter()
+        .map(|f| {
+            let col = batch.column_by_name(f.name()).unwrap();
+            if let (DataType::Struct(_), DataType::Struct(child_fields)) =
+                (col.data_type(), f.data_type())
+            {
+                let child_batch = RecordBatch::from(StructArray::from(col.into_data()));
+                let child_columns =
+                    cast_record_batch_columns(&child_batch, child_fields, cast_options)?;
+                Ok(Arc::new(StructArray::new(
+                    child_fields.clone(),
+                    child_columns.clone(),
+                    None,
+                )) as ArrayRef)
+            } else if !col.data_type().equals_datatype(f.data_type()) {
+                cast_with_options(col, f.data_type(), cast_options)
+            } else {
+                Ok(col.clone())
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
+/// Cast recordbatch to a new target_schema, by casting each column array
+pub fn cast_record_batch(
+    batch: &RecordBatch,
+    target_schema: ArrowSchemaRef,
+    safe: bool,
+) -> DeltaResult<RecordBatch> {
+    let cast_options = CastOptions {
+        safe,
+        ..Default::default()
+    };
+
+    let columns = cast_record_batch_columns(batch, target_schema.fields(), &cast_options)?;
+    Ok(RecordBatch::try_new(target_schema, columns)?)
+}

--- a/crates/deltalake-core/src/operations/mod.rs
+++ b/crates/deltalake-core/src/operations/mod.rs
@@ -15,6 +15,8 @@ use crate::table::builder::DeltaTableBuilder;
 use crate::DeltaTable;
 use std::collections::HashMap;
 
+#[cfg(feature = "arrow")]
+pub mod cast;
 #[cfg(all(feature = "arrow", feature = "parquet"))]
 pub mod convert_to_delta;
 pub mod create;

--- a/crates/deltalake-core/src/operations/optimize.rs
+++ b/crates/deltalake-core/src/operations/optimize.rs
@@ -39,7 +39,6 @@ use parquet::file::properties::WriterProperties;
 use serde::{Deserialize, Serialize};
 
 use super::transaction::{commit, PROTOCOL};
-use super::write::cast_record_batch;
 use super::writer::{PartitionWriter, PartitionWriterConfig};
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::{Action, Remove};
@@ -442,7 +441,8 @@ impl MergePlan {
         while let Some(maybe_batch) = read_stream.next().await {
             let mut batch = maybe_batch?;
 
-            batch = cast_record_batch(&batch, task_parameters.file_schema.clone(), false)?;
+            batch =
+                super::cast::cast_record_batch(&batch, task_parameters.file_schema.clone(), false)?;
             partial_metrics.num_batches += 1;
             writer.write(&batch).await.map_err(DeltaTableError::from)?;
         }

--- a/crates/deltalake-core/src/operations/write.rs
+++ b/crates/deltalake-core/src/operations/write.rs
@@ -29,8 +29,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use arrow_array::{Array, ArrayRef, RecordBatch, StructArray};
-use arrow_cast::{can_cast_types, cast_with_options, CastOptions};
+use arrow_array::RecordBatch;
+use arrow_cast::can_cast_types;
 use arrow_schema::{DataType, Fields, SchemaRef as ArrowSchemaRef};
 use datafusion::execution::context::{SessionContext, SessionState, TaskContext};
 use datafusion::physical_plan::{memory::MemoryExec, ExecutionPlan};
@@ -341,7 +341,8 @@ pub(crate) async fn write_execution_plan(
                 while let Some(maybe_batch) = stream.next().await {
                     let batch = maybe_batch?;
                     checker_stream.check_batch(&batch).await?;
-                    let arr = cast_record_batch(&batch, inner_schema.clone(), safe_cast)?;
+                    let arr =
+                        super::cast::cast_record_batch(&batch, inner_schema.clone(), safe_cast)?;
                     writer.write(&arr).await?;
                 }
                 writer.close().await
@@ -594,50 +595,6 @@ fn can_cast_batch(from_fields: &Fields, to_fields: &Fields) -> bool {
             false
         }
     })
-}
-
-fn cast_record_batch_columns(
-    batch: &RecordBatch,
-    fields: &Fields,
-    cast_options: &CastOptions,
-) -> Result<Vec<Arc<(dyn Array)>>, arrow_schema::ArrowError> {
-    fields
-        .iter()
-        .map(|f| {
-            let col = batch.column_by_name(f.name()).unwrap();
-            if let (DataType::Struct(_), DataType::Struct(child_fields)) =
-                (col.data_type(), f.data_type())
-            {
-                let child_batch = RecordBatch::from(StructArray::from(col.into_data()));
-                let child_columns =
-                    cast_record_batch_columns(&child_batch, child_fields, cast_options)?;
-                Ok(Arc::new(StructArray::new(
-                    child_fields.clone(),
-                    child_columns.clone(),
-                    None,
-                )) as ArrayRef)
-            } else if !col.data_type().equals_datatype(f.data_type()) {
-                cast_with_options(col, f.data_type(), cast_options)
-            } else {
-                Ok(col.clone())
-            }
-        })
-        .collect::<Result<Vec<_>, _>>()
-}
-
-/// Cast recordbatch to a new target_schema, by casting each column array
-pub fn cast_record_batch(
-    batch: &RecordBatch,
-    target_schema: ArrowSchemaRef,
-    safe: bool,
-) -> DeltaResult<RecordBatch> {
-    let cast_options = CastOptions {
-        safe,
-        ..Default::default()
-    };
-
-    let columns = cast_record_batch_columns(batch, target_schema.fields(), &cast_options)?;
-    Ok(RecordBatch::try_new(target_schema, columns)?)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
A dependency from optimize on the cast_record_batch function was added which cannot be met without the `datafusion` feature enabled

See #1926 