### PR TITLE
docs: add auto-release when docs are merged to main

### DIFF
--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -1,0 +1,24 @@
+name: docs_release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches: [main]
+    paths:
+      - docs/**
+      - mkdocs.yml
+
+jobs:
+  release-docs:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger the docs release event
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: release-docs
+          client-payload: >
+            {
+              "tag": "${{ github.ref_name }}"
+            }


### PR DESCRIPTION
# Description
This will trigger a release action for docs when a pull request to docs (`mkdocs.yml` or anything in `docs/` is changed) is merged to main. This would help with more frequent releases to docs without waiting for a full release or bothering admins to run the docs release manually, especially handy at this time when lots of changes are being made to the docs.

One caveat is that this will replace the current public docs (which is what we intend to achieve with this) including the Python API docs which may not be a desirable outcome for API docstrings which are on the `main` branch but not in the latest Python release.
