### PR TITLE
fix: implement consistent formatting for constraint expressions

### DIFF
--- a/crates/deltalake-core/src/delta_datafusion/expr.rs
+++ b/crates/deltalake-core/src/delta_datafusion/expr.rs
@@ -347,9 +347,10 @@ impl<'a> fmt::Display for ScalarValueFormat<'a> {
 mod test {
     use arrow_schema::DataType as ArrowDataType;
     use datafusion::prelude::SessionContext;
-    use datafusion_common::{DFSchema, ScalarValue};
+    use datafusion_common::{Column, DFSchema, ScalarValue};
     use datafusion_expr::{col, decode, lit, substring, Cast, Expr, ExprSchemable};
 
+    use crate::delta_datafusion::DeltaSessionContext;
     use crate::kernel::{DataType, PrimitiveType, StructField, StructType};
     use crate::{DeltaOps, DeltaTable};
 
@@ -385,6 +386,11 @@ mod test {
             ),
             StructField::new(
                 "value2".to_string(),
+                DataType::Primitive(PrimitiveType::Integer),
+                true,
+            ),
+            StructField::new(
+                "Value3".to_string(),
                 DataType::Primitive(PrimitiveType::Integer),
                 true,
             ),
@@ -442,7 +448,10 @@ mod test {
                 }),
                 "arrow_cast(1, 'Int32')".to_string()
             ),
-            simple!(col("value").eq(lit(3_i64)), "value = 3".to_string()),
+            simple!(
+                Expr::Column(Column::from_qualified_name_ignore_case("Value3")).eq(lit(3_i64)),
+                "Value3 = 3".to_string()
+            ),
             simple!(col("active").is_true(), "active IS TRUE".to_string()),
             simple!(col("active"), "active".to_string()),
             simple!(col("active").eq(lit(true)), "active = true".to_string()),
@@ -536,7 +545,7 @@ mod test {
             ),
         ];
 
-        let session = SessionContext::new();
+        let session: SessionContext = DeltaSessionContext::default().into();
 
         for test in tests {
             let actual = fmt_expr_to_sql(&test.expr).unwrap();

--- a/crates/deltalake-core/src/delta_datafusion/mod.rs
+++ b/crates/deltalake-core/src/delta_datafusion/mod.rs
@@ -1033,7 +1033,7 @@ impl DeltaDataChecker {
         Self {
             invariants,
             constraints: vec![],
-            ctx: SessionContext::new(),
+            ctx: DeltaSessionContext::default().into(),
         }
     }
 
@@ -1044,6 +1044,12 @@ impl DeltaDataChecker {
             invariants: vec![],
             ctx: SessionContext::new(),
         }
+    }
+
+    /// Specify the Datafusion context
+    pub fn with_session_context(mut self, context: SessionContext) -> Self {
+        self.ctx = context;
+        self
     }
 
     /// Create a new DeltaDataChecker

--- a/crates/deltalake-core/src/delta_datafusion/mod.rs
+++ b/crates/deltalake-core/src/delta_datafusion/mod.rs
@@ -1042,7 +1042,7 @@ impl DeltaDataChecker {
         Self {
             constraints,
             invariants: vec![],
-            ctx: SessionContext::new(),
+            ctx: DeltaSessionContext::default().into(),
         }
     }
 
@@ -1065,7 +1065,7 @@ impl DeltaDataChecker {
         Self {
             invariants,
             constraints,
-            ctx: SessionContext::new(),
+            ctx: DeltaSessionContext::default().into(),
         }
     }
 

--- a/crates/deltalake-core/src/operations/constraints.rs
+++ b/crates/deltalake-core/src/operations/constraints.rs
@@ -319,7 +319,7 @@ mod tests {
 
         let mut table = DeltaOps(table)
             .add_constraint()
-            .with_constraint("valid_values", col("vAlue").lt(lit(1000)))
+            .with_constraint("valid_values", "vAlue < 1000")
             .await?;
         let version = table.version();
         assert_eq!(version, 1);


### PR DESCRIPTION
# Description
Implements consistent formatting for constraint expressions so something like `value      <             1000` is normalized to `value < 1000`


Also includes drive by improvements.
 1. Test & Fix that Datafusion expressions can actually be used when adding a constraint
 2. Test & Fix that constraints can be added to column with capitalization
 
# Related Issue(s)
- closes #1971
