### PR TITLE
feat(python): expose custom metadata to writers

### DIFF
--- a/crates/deltalake-core/src/operations/create.rs
+++ b/crates/deltalake-core/src/operations/create.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 use super::transaction::{commit, PROTOCOL};
 use crate::errors::{DeltaResult, DeltaTableError};
@@ -56,7 +56,7 @@ pub struct CreateBuilder {
     actions: Vec<Action>,
     log_store: Option<LogStoreRef>,
     configuration: HashMap<String, Option<String>>,
-    metadata: Option<Map<String, Value>>,
+    metadata: Option<HashMap<String, Value>>,
 }
 
 impl Default for CreateBuilder {
@@ -181,8 +181,11 @@ impl CreateBuilder {
     ///
     /// This might include provenance information such as an id of the
     /// user that made the commit or the program that created it.
-    pub fn with_metadata(mut self, metadata: Map<String, Value>) -> Self {
-        self.metadata = Some(metadata);
+    pub fn with_metadata(
+        mut self,
+        metadata: impl IntoIterator<Item = (String, serde_json::Value)>,
+    ) -> Self {
+        self.metadata = Some(HashMap::from_iter(metadata));
         self
     }
 
@@ -286,6 +289,7 @@ impl std::future::IntoFuture for CreateBuilder {
         let this = self;
         Box::pin(async move {
             let mode = this.mode.clone();
+            let app_metadata = this.metadata.clone();
             let (mut table, actions, operation) = this.into_table_and_actions()?;
             let log_store = table.log_store();
             let table_state = if log_store.is_delta_table_location().await? {
@@ -310,7 +314,7 @@ impl std::future::IntoFuture for CreateBuilder {
                 &actions,
                 operation,
                 table_state,
-                None,
+                app_metadata,
             )
             .await?;
             table.load_version(version).await?;

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -135,6 +135,7 @@ class RawDeltaTable:
         partition_by: List[str],
         schema: pyarrow.Schema,
         partitions_filters: Optional[FilterType],
+        custom_metadata: Optional[Dict[str, str]],
     ) -> None: ...
     def cleanup_metadata(self) -> None: ...
 
@@ -149,6 +150,7 @@ def write_new_deltalake(
     description: Optional[str],
     configuration: Optional[Mapping[str, Optional[str]]],
     storage_options: Optional[Dict[str, str]],
+    custom_metadata: Optional[Dict[str, str]],
 ) -> None: ...
 def write_to_deltalake(
     table_uri: str,

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -163,6 +163,7 @@ def write_to_deltalake(
     configuration: Optional[Mapping[str, Optional[str]]],
     storage_options: Optional[Dict[str, str]],
     writer_properties: Optional[Dict[str, Optional[str]]],
+    custom_metadata: Optional[Dict[str, str]],
 ) -> None: ...
 def convert_to_deltalake(
     uri: str,

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -128,6 +128,7 @@ def write_deltalake(
     large_dtypes: bool = ...,
     engine: Literal["rust"],
     writer_properties: WriterProperties = ...,
+    custom_metadata: Optional[Dict[str, str]] = ...,
 ) -> None:
     ...
 
@@ -163,6 +164,7 @@ def write_deltalake(
     large_dtypes: bool = False,
     engine: Literal["pyarrow", "rust"] = "pyarrow",
     writer_properties: Optional[WriterProperties] = None,
+    custom_metadata: Optional[Dict[str, str]] = None,
 ) -> None:
     """Write to a Delta Lake table
 
@@ -236,6 +238,7 @@ def write_deltalake(
         engine: writer engine to write the delta table. `Rust` engine is still experimental but you may
             see up to 4x performance improvements over pyarrow.
         writer_properties: Pass writer properties to the Rust parquet writer.
+        custom_metadata: Custom metadata to add to the commitInfo, rust writer only.
     """
     table, table_uri = try_get_table_and_table_uri(table_or_uri, storage_options)
     if table is not None:
@@ -300,6 +303,7 @@ def write_deltalake(
             writer_properties=writer_properties._to_dict()
             if writer_properties
             else None,
+            custom_metadata=custom_metadata,
         )
         if table:
             table.update_incremental()

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -100,6 +100,7 @@ def write_deltalake(
     partition_filters: Optional[List[Tuple[str, str, Any]]] = ...,
     large_dtypes: bool = ...,
     engine: Literal["pyarrow"] = ...,
+    custom_metadata: Optional[Dict[str, str]] = ...,
 ) -> None:
     ...
 
@@ -238,7 +239,7 @@ def write_deltalake(
         engine: writer engine to write the delta table. `Rust` engine is still experimental but you may
             see up to 4x performance improvements over pyarrow.
         writer_properties: Pass writer properties to the Rust parquet writer.
-        custom_metadata: Custom metadata to add to the commitInfo, rust writer only.
+        custom_metadata: Custom metadata to add to the commitInfo.
     """
     table, table_uri = try_get_table_and_table_uri(table_or_uri, storage_options)
     if table is not None:
@@ -496,6 +497,7 @@ def write_deltalake(
                 description,
                 configuration,
                 storage_options,
+                custom_metadata,
             )
         else:
             table._table.create_write_transaction(
@@ -504,6 +506,7 @@ def write_deltalake(
                 partition_by or [],
                 schema,
                 partition_filters,
+                custom_metadata,
             )
             table.update_incremental()
     else:

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1173,6 +1173,7 @@ fn write_to_deltalake(
     configuration: Option<HashMap<String, Option<String>>>,
     storage_options: Option<HashMap<String, String>>,
     writer_properties: Option<HashMap<String, Option<String>>>,
+    custom_metadata: Option<HashMap<String, String>>,
 ) -> PyResult<()> {
     let batches = data.0.map(|batch| batch.unwrap()).collect::<Vec<_>>();
     let save_mode = mode.parse().map_err(PythonError::from)?;
@@ -1214,6 +1215,12 @@ fn write_to_deltalake(
 
     if let Some(config) = configuration {
         builder = builder.with_configuration(config);
+    };
+
+    if let Some(metadata) = custom_metadata {
+        let json_metadata: Map<String, Value> =
+            metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
+        builder = builder.with_metadata(json_metadata);
     };
 
     rt()?


### PR DESCRIPTION
# Description
- exposes the custom_metadata to pyarrow and rust writer
- addresses a bug in the create operation, we were not passing the app_metadata to the actual commit

# Related Issue(s)
- closes https://github.com/delta-io/delta-rs/issues/1990
