### PR TITLE
feat: implementation for replaceWhere

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -878,6 +878,12 @@ impl DeltaDataChecker {
         self
     }
 
+    /// Add the specified set of constraints to the current DeltaDataChecker's constraints
+    pub fn with_extra_constraints(mut self, constraints: Vec<Constraint>) -> Self {
+        self.constraints.extend(constraints);
+        self
+    }
+
     /// Create a new DeltaDataChecker
     pub fn new(snapshot: &DeltaTableState) -> Self {
         let invariants = snapshot.schema().get_invariants().unwrap_or_default();

--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -437,7 +437,6 @@ async fn execute_non_empty_expr(
     let predicate_expr = create_physical_expr(
         &negated_expression,
         &input_dfschema,
-        &input_schema,
         state.execution_props(),
     )?;
     let filter: Arc<dyn ExecutionPlan> =

--- a/crates/core/src/writer/test_utils.rs
+++ b/crates/core/src/writer/test_utils.rs
@@ -327,6 +327,24 @@ pub mod datafusion {
             .unwrap()
     }
 
+    pub async fn get_data_sorted(table: &DeltaTable, columns: &str) -> Vec<RecordBatch> {
+        let table = DeltaTable::new_with_state(
+            table.log_store.clone(),
+            table.state.as_ref().unwrap().clone(),
+        );
+        let ctx = SessionContext::new();
+        ctx.register_table("test", Arc::new(table)).unwrap();
+        ctx.sql(&format!(
+            "select {} from test order by {}",
+            columns, columns
+        ))
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap()
+    }
+
     pub async fn write_batch(table: DeltaTable, batch: RecordBatch) -> DeltaTable {
         DeltaOps(table)
             .write(vec![batch.clone()])

--- a/docs/_build/links.yml
+++ b/docs/_build/links.yml
@@ -1,4 +1,6 @@
 python:
   DeltaTable: PYTHON_API_URL/delta_table
+  replaceWhere: https://delta-io.github.io/delta-rs/api/delta_writer/
 rust:
   DeltaTable: https://docs.rs/deltalake/latest/deltalake/table/struct.DeltaTable.html
+  replaceWhere: https://docs.rs/deltalake/latest/deltalake/operations/write/struct.WriteBuilder.html#method.with_replace_where 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # The deltalake package
 
-This is the documentation for the native Rust/Python implementation of Delta Lake. It is based on the delta-rs Rust library and requires no Spark or JVM dependencies. For the PySpark implementation, see [delta-spark](https://docs.delta.io/latest/api/python/index.html) instead.
+This is the documentation for the native Rust/Python implementation of Delta Lake. It is based on the delta-rs Rust library and requires no Spark or JVM dependencies. For the PySpark implementation, see [delta-spark](https://docs.delta.io/latest/api/python/spark/index.html) instead.
 
 This module provides the capability to read, write, and manage [Delta Lake](https://delta.io/) tables with Python or Rust without Spark or Java. It uses [Apache Arrow](https://arrow.apache.org/) under the hood, so is compatible with other Arrow-native or integrated libraries such as [pandas](https://pandas.pydata.org/), [DuckDB](https://duckdb.org/), and [Polars](https://www.pola.rs/).
 

--- a/docs/src/python/operations.py
+++ b/docs/src/python/operations.py
@@ -1,0 +1,21 @@
+def replace_where():
+    # --8<-- [start:replace_where]
+    import pyarrow as pa
+    from deltalake import write_deltalake
+
+    # Assuming there is already a table in this location with some records where `id = '1'` which we want to overwrite
+    table_path = "/tmp/my_table"
+    data = pa.table(
+        {
+            "id": pa.array(["1", "1"], pa.string()),
+            "value": pa.array([11, 12], pa.int64()),
+        }
+    )
+    write_deltalake(
+        table_path,
+        data,
+        mode="overwrite",
+        predicate="id = '1'",
+        engine="rust",
+    )
+    # --8<-- [end:replace_where]

--- a/docs/src/rust/operations.rs
+++ b/docs/src/rust/operations.rs
@@ -1,0 +1,32 @@
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // --8<-- [start:replace_where]
+    // Assuming there is already a table in this location with some records where `id = '1'` which we want to overwrite
+    use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+    use arrow_array::RecordBatch;
+    import deltalake::protocol::SaveMode;
+
+    let schema = ArrowSchema::new(vec![
+        Field::new("id", DataType::Utf8, true),
+        Field::new("value", DataType::Int32, true),
+    ]);
+
+    let data = RecordBatch::try_new(
+        &schema,
+        vec![
+            Arc::new(arrow::array::StringArray::from(vec!["1", "1"])),
+            Arc::new(arrow::array::Int32Array::from(vec![11, 12])),
+        ],
+    )
+    .unwrap();
+
+    let table = deltalake::open_table("/tmp/my_table").await.unwrap();
+    let table = DeltaOps(table)
+        .write(vec![data])
+        .with_save_mode(SaveMode::Overwrite)
+        .with_replace_where(col("id").eq(lit("1")))
+        .await;
+    // --8<-- [end:replace_where]
+
+    Ok(())
+}

--- a/docs/usage/writing/index.md
+++ b/docs/usage/writing/index.md
@@ -51,3 +51,20 @@ that partition or else the method will raise an error.
 
 This method could also be used to insert a new partition if one doesn't
 already exist, making this operation idempotent.
+
+## Overwriting part of the table data using a predicate
+
+!!! note
+
+    This predicate is often called a `replaceWhere` predicate
+
+When you don’t specify the `predicate`, the overwrite save mode will replace the entire table. 
+Instead of replacing the entire table (which is costly!), you may want to overwrite only the specific parts of the table that should be changed. 
+In this case, you can use a `predicate` to overwrite only the relevant records or partitions.
+
+!!! note
+
+    Data written must conform to the same predicate, i.e. not contain any records that don't match the `predicate` condition, 
+    otherwise the operation will fail 
+
+{{ code_example('operations', 'replace_where', ['replaceWhere'])}}

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -118,7 +118,35 @@ def write_deltalake(
     *,
     schema: Optional[Union[pa.Schema, DeltaSchema]] = ...,
     partition_by: Optional[Union[List[str], str]] = ...,
-    mode: Literal["error", "append", "overwrite", "ignore"] = ...,
+    mode: Literal["error", "append", "ignore"] = ...,
+    name: Optional[str] = ...,
+    description: Optional[str] = ...,
+    configuration: Optional[Mapping[str, Optional[str]]] = ...,
+    overwrite_schema: bool = ...,
+    storage_options: Optional[Dict[str, str]] = ...,
+    large_dtypes: bool = ...,
+    engine: Literal["rust"],
+    writer_properties: WriterProperties = ...,
+    custom_metadata: Optional[Dict[str, str]] = ...,
+) -> None:
+    ...
+
+
+@overload
+def write_deltalake(
+    table_or_uri: Union[str, Path, DeltaTable],
+    data: Union[
+        "pd.DataFrame",
+        ds.Dataset,
+        pa.Table,
+        pa.RecordBatch,
+        Iterable[pa.RecordBatch],
+        RecordBatchReader,
+    ],
+    *,
+    schema: Optional[Union[pa.Schema, DeltaSchema]] = ...,
+    partition_by: Optional[Union[List[str], str]] = ...,
+    mode: Literal["overwrite"],
     name: Optional[str] = ...,
     description: Optional[str] = ...,
     configuration: Optional[Mapping[str, Optional[str]]] = ...,

--- a/python/docs/source/index.rst
+++ b/python/docs/source/index.rst
@@ -16,7 +16,7 @@ Pandas_, DuckDB_, and Polars_.
    It is not yet as feature-complete as the PySpark implementation of Delta
    Lake. If you encounter a bug, please let us know in our `GitHub repo`_.
 
-.. _delta-spark: https://docs.delta.io/latest/api/python/index.html
+.. _delta-spark: https://docs.delta.io/latest/api/python/spark/index.html
 .. _Delta Lake: https://delta.io/
 .. _Apache Arrow: https://arrow.apache.org/
 .. _Pandas: https://pandas.pydata.org/

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1386,7 +1386,7 @@ fn write_to_deltalake(
         builder = builder.with_description(description);
     };
 
-    if let Some(predicate) = &predicate {
+    if let Some(predicate) = predicate {
         builder = builder.with_replace_where(predicate);
     };
 

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -869,6 +869,8 @@ def test_replace_where_overwrite(
     value_type: pa.DataType,
     filter_string: str,
 ):
+    table_path = tmp_path
+
     sample_data = pa.table(
         {
             "p1": pa.array(["1", "1", "2", "2"], pa.string()),
@@ -876,9 +878,9 @@ def test_replace_where_overwrite(
             "val": pa.array([1, 1, 1, 1], pa.int64()),
         }
     )
-    write_deltalake(tmp_path, sample_data, mode="overwrite", partition_by=["p1", "p2"])
+    write_deltalake(table_path, sample_data, mode="overwrite")
 
-    delta_table = DeltaTable(tmp_path)
+    delta_table = DeltaTable(table_path)
     assert (
         delta_table.to_pyarrow_table().sort_by(
             [("p1", "ascending"), ("p2", "ascending")]
@@ -890,36 +892,101 @@ def test_replace_where_overwrite(
         {
             "p1": pa.array(["1", "1"], pa.string()),
             "p2": pa.array([value_2, value_1], value_type),
-            "val": pa.array([2, 2], pa.int64()),
+            "val": pa.array([2, 3], pa.int64()),
         }
     )
     expected_data = pa.table(
         {
             "p1": pa.array(["1", "1", "2", "2"], pa.string()),
             "p2": pa.array([value_1, value_2, value_1, value_2], value_type),
-            "val": pa.array([2, 2, 1, 1], pa.int64()),
+            "val": pa.array([3, 2, 1, 1], pa.int64()),
         }
     )
 
-    with pytest.raises(
-        DeltaError,
-        match="Generic DeltaTable error: Overwriting data based on predicate is not yet implemented",
-    ):
-        write_deltalake(
-            tmp_path,
-            sample_data,
-            mode="overwrite",
-            predicate="`p1` = 1",
-            engine="rust",
-        )
+    write_deltalake(
+        table_path,
+        sample_data,
+        mode="overwrite",
+        predicate="p1 = '1'",
+        engine="rust",
+    )
 
-        delta_table.update_incremental()
-        assert (
-            delta_table.to_pyarrow_table().sort_by(
-                [("p1", "ascending"), ("p2", "ascending")]
-            )
-            == expected_data
+    delta_table.update_incremental()
+    assert (
+        delta_table.to_pyarrow_table().sort_by(
+            [("p1", "ascending"), ("p2", "ascending")]
         )
+        == expected_data
+    )
+
+
+@pytest.mark.parametrize(
+    "value_1,value_2,value_type,filter_string",
+    [
+        (1, 2, pa.int64(), "1"),
+        (False, True, pa.bool_(), "false"),
+        (date(2022, 1, 1), date(2022, 1, 2), pa.date32(), "2022-01-01"),
+    ],
+)
+def test_replace_where_overwrite_partitioned(
+    tmp_path: pathlib.Path,
+    value_1: Any,
+    value_2: Any,
+    value_type: pa.DataType,
+    filter_string: str,
+):
+    table_path = tmp_path
+
+    sample_data = pa.table(
+        {
+            "p1": pa.array(["1", "1", "2", "2"], pa.string()),
+            "p2": pa.array([value_1, value_2, value_1, value_2], value_type),
+            "val": pa.array([1, 1, 1, 1], pa.int64()),
+        }
+    )
+    write_deltalake(
+        table_path, sample_data, mode="overwrite", partition_by=["p1", "p2"]
+    )
+
+    delta_table = DeltaTable(table_path)
+    assert (
+        delta_table.to_pyarrow_table().sort_by(
+            [("p1", "ascending"), ("p2", "ascending")]
+        )
+        == sample_data
+    )
+
+    replace_data = pa.table(
+        {
+            "p1": pa.array(["1", "1"], pa.string()),
+            "p2": pa.array([value_2, value_1], value_type),
+            "val": pa.array([2, 3], pa.int64()),
+        }
+    )
+    expected_data = pa.table(
+        {
+            "p1": pa.array(["1", "1", "2", "2"], pa.string()),
+            "p2": pa.array([value_1, value_2, value_1, value_2], value_type),
+            "val": pa.array([3, 2, 1, 1], pa.int64()),
+        }
+    )
+
+    write_deltalake(
+        table_path,
+        replace_data,
+        mode="overwrite",
+        partition_by=["p1", "p2"],
+        predicate="p1 = '1'",
+        engine="rust",
+    )
+
+    delta_table.update_incremental()
+    assert (
+        delta_table.to_pyarrow_table().sort_by(
+            [("p1", "ascending"), ("p2", "ascending")]
+        )
+        == expected_data
+    )
 
 
 def test_partition_overwrite_with_new_partition(


### PR DESCRIPTION
# Description
First/naive implementation of `replaceWhere` for `write`. Code compiles and there is a test to verify the outcome. I would appreciate any feedback on improving the structure/implementation. For example, I copied the part of code from `delete` operation because there is no way to call that code in `delete` directly from `write` - should I look into extracting that code from `delete` to somewhere central?

Seems to also works with partitions columns.

# Related Issue(s)
https://github.com/delta-io/delta-rs/issues/1957

# Documentation
Added a section in docs
