### PR TITLE
fix: failing test est_restore_by_datetime

### DIFF
--- a/crates/deltalake-core/src/operations/restore.rs
+++ b/crates/deltalake-core/src/operations/restore.rs
@@ -150,7 +150,7 @@ async fn execute(
             table.version()
         }
     };
-
+    println!("--> Found version to restore: {}", version);
     if version >= snapshot.version() {
         return Err(DeltaTableError::from(RestoreError::TooLargeRestoreVersion(
             version,
@@ -163,6 +163,12 @@ async fn execute(
         HashSet::<Add>::from_iter(state_to_restore_files.iter().cloned());
     let latest_state_files_set = HashSet::<Add>::from_iter(latest_state_files.iter().cloned());
 
+    println!(
+        "--> Files to add before filter[{}]: {:?}",
+        &state_to_restore_files.len(),
+        &state_to_restore_files
+    );
+
     let files_to_add: Vec<Add> = state_to_restore_files
         .into_iter()
         .filter(|a: &Add| !latest_state_files_set.contains(a))
@@ -171,6 +177,12 @@ async fn execute(
             a
         })
         .collect();
+
+    println!(
+        "--> Files to add[{}]: {:?}",
+        &files_to_add.len(),
+        &files_to_add
+    );
 
     let deletion_timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -198,6 +210,12 @@ async fn execute(
     if !ignore_missing_files {
         check_files_available(log_store.object_store().as_ref(), &files_to_add).await?;
     }
+
+    println!(
+        "--> Files to add after check_files_available[{}]: {:?}",
+        &files_to_add.len(),
+        &files_to_add
+    );
 
     let metrics = RestoreMetrics {
         num_removed_file: files_to_remove.len(),

--- a/crates/deltalake-core/src/operations/restore.rs
+++ b/crates/deltalake-core/src/operations/restore.rs
@@ -150,7 +150,6 @@ async fn execute(
             table.version()
         }
     };
-    println!("--> Found version to restore: {}", version);
     if version >= snapshot.version() {
         return Err(DeltaTableError::from(RestoreError::TooLargeRestoreVersion(
             version,
@@ -163,12 +162,6 @@ async fn execute(
         HashSet::<Add>::from_iter(state_to_restore_files.iter().cloned());
     let latest_state_files_set = HashSet::<Add>::from_iter(latest_state_files.iter().cloned());
 
-    println!(
-        "--> Files to add before filter[{}]: {:?}",
-        &state_to_restore_files.len(),
-        &state_to_restore_files
-    );
-
     let files_to_add: Vec<Add> = state_to_restore_files
         .into_iter()
         .filter(|a: &Add| !latest_state_files_set.contains(a))
@@ -177,12 +170,6 @@ async fn execute(
             a
         })
         .collect();
-
-    println!(
-        "--> Files to add[{}]: {:?}",
-        &files_to_add.len(),
-        &files_to_add
-    );
 
     let deletion_timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -210,12 +197,6 @@ async fn execute(
     if !ignore_missing_files {
         check_files_available(log_store.object_store().as_ref(), &files_to_add).await?;
     }
-
-    println!(
-        "--> Files to add after check_files_available[{}]: {:?}",
-        &files_to_add.len(),
-        &files_to_add
-    );
 
     let metrics = RestoreMetrics {
         num_removed_file: files_to_remove.len(),

--- a/crates/deltalake-core/tests/command_restore.rs
+++ b/crates/deltalake-core/tests/command_restore.rs
@@ -123,7 +123,10 @@ async fn test_restore_by_datetime() -> Result<(), Box<dyn Error>> {
     let naive = NaiveDateTime::from_timestamp_millis(timestamp).unwrap();
     let datetime: DateTime<Utc> = Utc.from_utc_datetime(&naive);
 
-    let mut table_ts = history.iter().map(|h| h.timestamp.unwrap()).collect::<Vec<_>>();
+    let mut table_ts = history
+        .iter()
+        .map(|h| h.timestamp.unwrap())
+        .collect::<Vec<_>>();
     table_ts.extend(vec![timestamp, datetime.timestamp_millis()]);
     let random_ts = vec![0, 1, 2, 3, 4, 5, 6];
     println!("--> Can i see this without nocapture?");

--- a/crates/deltalake-core/tests/command_restore.rs
+++ b/crates/deltalake-core/tests/command_restore.rs
@@ -123,14 +123,16 @@ async fn test_restore_by_datetime() -> Result<(), Box<dyn Error>> {
     let naive = NaiveDateTime::from_timestamp_millis(timestamp).unwrap();
     let datetime: DateTime<Utc> = Utc.from_utc_datetime(&naive);
 
-    let mut table_ts = history
+    let table_ts = history
         .iter()
         .map(|h| h.timestamp.unwrap())
         .collect::<Vec<_>>();
-    table_ts.extend(vec![timestamp, datetime.timestamp_millis()]);
-    let random_ts = vec![0, 1, 2, 3, 4, 5, 6];
-    println!("--> Can i see this without nocapture?");
-    assert_eq!(table_ts, random_ts);
+    println!(
+        "--> All: {:?}, looking for: {} (from datetime: {})",
+        table_ts,
+        timestamp,
+        datetime.timestamp_millis()
+    );
 
     let result = DeltaOps(table)
         .restore()

--- a/crates/deltalake-core/tests/command_restore.rs
+++ b/crates/deltalake-core/tests/command_restore.rs
@@ -123,6 +123,12 @@ async fn test_restore_by_datetime() -> Result<(), Box<dyn Error>> {
     let naive = NaiveDateTime::from_timestamp_millis(timestamp).unwrap();
     let datetime: DateTime<Utc> = Utc.from_utc_datetime(&naive);
 
+    let mut table_ts = history.iter().map(|h| h.timestamp.unwrap()).collect::<Vec<_>>();
+    table_ts.extend(vec![timestamp, datetime.timestamp_millis()]);
+    let random_ts = vec![0, 1, 2, 3, 4, 5, 6];
+    println!("--> Can i see this without nocapture?");
+    assert_eq!(table_ts, random_ts);
+
     let result = DeltaOps(table)
         .restore()
         .with_datetime_to_restore(datetime)

--- a/crates/deltalake-core/tests/time_travel.rs
+++ b/crates/deltalake-core/tests/time_travel.rs
@@ -12,9 +12,19 @@ async fn time_travel_by_ds() {
         ("00000000000000000003.json", "2020-05-04T22:47:31-07:00"),
         ("00000000000000000004.json", "2020-05-05T22:47:31-07:00"),
     ];
+
+    // Need to set both the commit timestamp in each log file and, as a secondary, the modifed time of the file in case the timestamp is not defined
+    let log_dir_path = Path::new(log_dir);
     for (fname, ds) in log_mtime_pair {
         let ts = ds_to_ts(ds);
-        utime::set_file_times(Path::new(log_dir).join(fname), ts, ts).unwrap();
+        let file = log_dir_path.join(fname);
+        let contents = std::fs::read_to_string(&file).unwrap();
+        let my_reg = regex::Regex::new(r#"("timestamp"):\s*\d+([\s,}])"#).unwrap();
+        let new_contents = my_reg
+            .replace(&contents, format!("$1:{}$2", ts))
+            .to_string();
+        std::fs::write(&file, new_contents).unwrap();
+        utime::set_file_times(file, ts, ts).unwrap();
     }
 
     let mut table = deltalake_core::open_table_with_ds(
@@ -85,5 +95,5 @@ async fn time_travel_by_ds() {
 
 fn ds_to_ts(ds: &str) -> i64 {
     let fixed_dt = DateTime::<FixedOffset>::parse_from_rfc3339(ds).unwrap();
-    DateTime::<Utc>::from(fixed_dt).timestamp()
+    DateTime::<Utc>::from(fixed_dt).timestamp_millis()
 }

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -91,7 +91,10 @@ def test_load_as_version_datetime(date_value: str, expected_version):
         new_contents = re.sub(regex, rf"\1:{dt_epoch}\2", contents)
         with open(file_path, "w") as out:
             out.write(new_contents)
-        os.utime(file_path, (dt_epoch, dt_epoch))
+
+        # File timestamps are in seconds
+        file_ts = dt_epoch / 1000
+        os.utime(file_path, (file_ts, file_ts))
 
     table_path = "../crates/deltalake-core/tests/data/simple_table"
     dt = DeltaTable(table_path)


### PR DESCRIPTION
# Description
This started as a fix for the issue occurring on CI Mac only. Turns out it is not Mac only but could also happen in other systems if commit takes more than a millisecond. Fix changes the following:

1. Previous logic: `get_version_timestamp` would get the timestamp from the `last_modified` property of the log entry file
2. New logic: `get_version_timestamp` will first attempt to get the timestamp from `CommitInfo` and will revert to previous logic of getting the timestamp from file's `last_modified` if `CommitInfo` does not contain a timestamp. This will also help restoring a correct version for tables which get copied to a different location (e.g. for in case of DR)

# Related Issue(s)
https://github.com/delta-io/delta-rs/issues/1925