### PR TITLE
docs: add writer properties to docs

### DIFF
--- a/docs/api/delta_writer.md
+++ b/docs/api/delta_writer.md
@@ -8,6 +8,8 @@ search:
 
 ::: deltalake.write_deltalake
 
+::: deltalake.WriterProperties
+
 ## Convert to Delta Tables
 ::: deltalake.convert_to_deltalake
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1176,7 +1176,10 @@ class TableMerger:
         write_batch_size: Optional[int] = None,
         max_row_group_size: Optional[int] = None,
     ) -> "TableMerger":
-        """Pass writer properties to the Rust parquet writer, see options https://arrow.apache.org/rust/parquet/file/properties/struct.WriterProperties.html:
+        """
+        !!! warning "Deprecated"
+            Use `.merge(writer_properties = WriterProperties())` instead
+        Pass writer properties to the Rust parquet writer, see options https://arrow.apache.org/rust/parquet/file/properties/struct.WriterProperties.html:
 
         Args:
             data_page_size_limit: Limit DataPage size to this in bytes.


### PR DESCRIPTION
# Description
Forgot to add WriterProperties to the docs page and mark a deprecation in the docs.