### PR TITLE
fix: github actions for releasing docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Build documentation
+name: Build (and maybe release) the documentation
 
 on:
   pull_request:

--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -1,4 +1,4 @@
-name: docs_release
+name: Release documentation
 
 on:
   pull_request:
@@ -12,6 +12,8 @@ on:
 jobs:
   release-docs:
     if: github.event.pull_request.merged == true
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Trigger the docs release event

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -1,4 +1,4 @@
-name: Release to PyPI
+name: Release to PyPI and documentation
 
 on:
   push:
@@ -103,6 +103,8 @@ jobs:
         release-pypi-mac,
         release-pypi-windows,
       ]
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Trigger the docs release event


### PR DESCRIPTION
# Description
Added a `write` permission to jobs triggering the docs release process. The job itself already had it but those triggering it did not, which was likely the cause for them faling

# Related Issue(s)
#2025
