### PR TITLE
docs: update docs for merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ of features outlined in the Delta [protocol][protocol] is also [tracked](#protoc
 | Delete - predicates   |         ![done]          |         ![done]          | Delete data based on a predicate            |
 | Optimize - compaction |         ![done]          |         ![done]          | Harmonize the size of data file             |
 | Optimize - Z-order    |         ![done]          |         ![done]          | Place similar data into the same file       |
-| Merge                 | [![semi-done]][merge-rs] | [![semi-done]][merge-py] | Merge two tables (limited to full re-write) |
+| Merge                 |         ![done]          |         ![done]          | Merge a target Delta table with source data |
 | FS check              |         ![done]          |         ![done]          | Remove corrupted files from table           |
 
 ### Protocol Support Level
@@ -182,8 +182,6 @@ of features outlined in the Delta [protocol][protocol] is also [tracked](#protoc
 [semi-done]: https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChangesGrey.svg
 [done]: https://cdn.jsdelivr.net/gh/Readme-Workflows/Readme-Icons@main/icons/octicons/ApprovedChanges.svg
 [roadmap]: https://github.com/delta-io/delta-rs/issues/1128
-[merge-py]: https://github.com/delta-io/delta-rs/issues/1357
-[merge-rs]: https://github.com/delta-io/delta-rs/issues/850
 [writer-rs]: https://github.com/delta-io/delta-rs/issues/851
 [check-constraints]: https://github.com/delta-io/delta-rs/issues/1881
 [onelake-rs]: https://github.com/delta-io/delta-rs/issues/1418

--- a/crates/deltalake-core/src/operations/merge/mod.rs
+++ b/crates/deltalake-core/src/operations/merge/mod.rs
@@ -7,10 +7,6 @@
 //! and specify additional predicates for finer control. The order of operations
 //! specified matter.  See [`MergeBuilder`] for more information
 //!
-//! *WARNING* The current implementation rewrites the entire delta table so only
-//! use on small to medium sized tables.
-//! Enhancements tracked at #850
-//!
 //! # Example
 //! ```rust ignore
 //! let table = open_table("../path/to/table")?;


### PR DESCRIPTION
# Description
Update documentation to reflect the current state of merge. Since merge now supports upserts without performing a full rewrite I'd let to mark it as "done".

There is of course further optimizations that can be performed but it is now in a usable state.

# Related Issue(s)
- closes #850 

