### PR TITLE
fix: reinstate copy-if-not-exists passthrough

### DIFF
--- a/crates/deltalake-aws/src/lib.rs
+++ b/crates/deltalake-aws/src/lib.rs
@@ -43,6 +43,13 @@ impl LogStoreFactory for S3LogStoreFactory {
         let store = url_prefix_handler(store, Path::parse(location.path())?)?;
         let s3_options = S3StorageOptions::from_map(&options.0);
 
+        if s3_options.copy_if_not_exists.is_some() {
+            debug!("S3LogStoreFactory has been asked to create a LogStore where the underlying store has copy-if-not-exists enabled - no locking provider required");
+            return Ok(deltalake_core::logstore::default_logstore(
+                store, location, options,
+            ));
+        }
+
         if s3_options.locking_provider.as_deref() != Some("dynamodb") {
             debug!("S3LogStoreFactory has been asked to create a LogStore without the dynamodb locking provider");
             return Ok(deltalake_core::logstore::default_logstore(

--- a/crates/deltalake-aws/src/lib.rs
+++ b/crates/deltalake-aws/src/lib.rs
@@ -5,6 +5,7 @@ pub mod logstore;
 pub mod storage;
 
 use lazy_static::lazy_static;
+use object_store::aws::AmazonS3ConfigKey;
 use regex::Regex;
 use std::{
     collections::HashMap,
@@ -41,14 +42,18 @@ impl LogStoreFactory for S3LogStoreFactory {
         options: &StorageOptions,
     ) -> DeltaResult<Arc<dyn LogStore>> {
         let store = url_prefix_handler(store, Path::parse(location.path())?)?;
-        let s3_options = S3StorageOptions::from_map(&options.0);
 
-        if s3_options.copy_if_not_exists.is_some() {
+        if options
+            .0
+            .contains_key(AmazonS3ConfigKey::CopyIfNotExists.as_ref())
+        {
             debug!("S3LogStoreFactory has been asked to create a LogStore where the underlying store has copy-if-not-exists enabled - no locking provider required");
             return Ok(deltalake_core::logstore::default_logstore(
                 store, location, options,
             ));
         }
+
+        let s3_options = S3StorageOptions::from_map(&options.0);
 
         if s3_options.locking_provider.as_deref() != Some("dynamodb") {
             debug!("S3LogStoreFactory has been asked to create a LogStore without the dynamodb locking provider");

--- a/crates/deltalake-aws/src/storage.rs
+++ b/crates/deltalake-aws/src/storage.rs
@@ -375,10 +375,6 @@ pub mod s3_constants {
     /// Only safe if there is one writer to a given table.
     pub const AWS_S3_ALLOW_UNSAFE_RENAME: &str = "AWS_S3_ALLOW_UNSAFE_RENAME";
 
-    /// If set, specifies how to enable copy-if-not-exists on the S3 endpoint. Allows
-    /// bypassing the use of a lock client like DynamoDB.
-    pub const AWS_COPY_IF_NOT_EXISTS: &str = "AWS_COPY_IF_NOT_EXISTS";
-
     /// The list of option keys owned by the S3 module.
     /// Option keys not contained in this list will be added to the `extra_opts`
     /// field of [crate::storage::s3::S3StorageOptions].

--- a/crates/deltalake-aws/src/storage.rs
+++ b/crates/deltalake-aws/src/storage.rs
@@ -59,7 +59,7 @@ impl ObjectStoreFactory for S3ObjectStoreFactory {
         let options = S3StorageOptions::from_map(&options.0);
         if options.copy_if_not_exists.is_some() {
             // If the copy-if-not-exists env var is set, we don't need to instantiate a locking client or check for allow-unsafe-rename.
-            return Ok((Arc::new(*store), prefix));
+            return Ok((Arc::from(store), prefix));
         }
         let store = S3StorageBackend::try_new(
             store.into(),


### PR DESCRIPTION
# Description
If the `AWS_COPY_IF_NOT_EXISTS` key exists, then we don't require instantiating a lock client or setting allow-unsafe-rename.

