### PR TITLE
chore: removed unnecessary print statement from update method

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -841,7 +841,6 @@ class DeltaTable:
                 updates[key] = value
         elif updates is not None and new_values is None:
             for key, value in updates.items():
-                print(type(key), type(value))
                 if not isinstance(value, str) or not isinstance(key, str):
                     raise TypeError(
                         f"The values of the updates parameter must all be SQL strings. Got {updates}. Did you mean to use the new_values parameter?"


### PR DESCRIPTION
# Description
There is a print statement in the update method of tables.py. It is not needed now. So I have removed it.

# Related Issue(s)

- closes #2110
