### PR TITLE
fix: set partition values for added files when building compaction plan

### DIFF
--- a/crates/deltalake-core/src/operations/optimize.rs
+++ b/crates/deltalake-core/src/operations/optimize.rs
@@ -859,10 +859,15 @@ fn build_compaction_plan(
             metrics.total_files_skipped += 1;
             continue;
         }
+        let partition_values = add
+            .partition_values()?
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect::<BTreeMap<_, _>>();
 
         partition_files
             .entry(add.partition_values()?.hive_partition_path())
-            .or_default()
+            .or_insert_with(|| (partition_values, vec![]))
             .1
             .push(object_meta);
     }

--- a/crates/deltalake-core/tests/command_optimize.rs
+++ b/crates/deltalake-core/tests/command_optimize.rs
@@ -236,10 +236,17 @@ async fn test_optimize_with_partitions() -> Result<(), Box<dyn Error>> {
     assert_eq!(metrics.num_files_removed, 2);
     assert_eq!(dt.get_files_count(), 3);
 
-    let partition_adds = dt.get_active_add_actions_by_partitions(&filter)?.collect::<Result<Vec<_>, _>>()?;
+    let partition_adds = dt
+        .get_active_add_actions_by_partitions(&filter)?
+        .collect::<Result<Vec<_>, _>>()?;
     assert_eq!(partition_adds.len(), 1);
     let partition_values = partition_adds[0].partition_values()?;
-    assert_eq!(partition_values.get("date"), Some(&deltalake_core::kernel::Scalar::String("2022-05-22".to_string())));
+    assert_eq!(
+        partition_values.get("date"),
+        Some(&deltalake_core::kernel::Scalar::String(
+            "2022-05-22".to_string()
+        ))
+    );
 
     Ok(())
 }

--- a/crates/deltalake-core/tests/command_optimize.rs
+++ b/crates/deltalake-core/tests/command_optimize.rs
@@ -236,6 +236,11 @@ async fn test_optimize_with_partitions() -> Result<(), Box<dyn Error>> {
     assert_eq!(metrics.num_files_removed, 2);
     assert_eq!(dt.get_files_count(), 3);
 
+    let partition_adds = dt.get_active_add_actions_by_partitions(&filter)?.collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(partition_adds.len(), 1);
+    let partition_values = partition_adds[0].partition_values()?;
+    assert_eq!(partition_values.get("date"), Some(&deltalake_core::kernel::Scalar::String("2022-05-22".to_string())));
+
     Ok(())
 }
 


### PR DESCRIPTION
# Description
After the table state refactor optimize, compaction, was not writing files to the partition directory properly nor setting the partitionValues field in the Add action.