### PR TITLE
chore: upgrade to DataFusion 35.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,28 +19,27 @@ debug = "line-tables-only"
 
 [workspace.dependencies]
 # arrow
-arrow = { version = "49" }
-arrow-arith = { version = "49" }
-arrow-array = { version = "49" }
-arrow-buffer = { version = "49" }
-arrow-cast = { version = "49" }
-arrow-ipc = { version = "49" }
-arrow-json = { version = "49" }
-arrow-ord = { version = "49" }
-arrow-row = { version = "49" }
-arrow-schema = { version = "49" }
-arrow-select = { version = "49" }
+arrow = { version = "50" }
+arrow-arith = { version = "50" }
+arrow-array = { version = "50" }
+arrow-buffer = { version = "50" }
+arrow-cast = { version = "50" }
+arrow-ipc = { version = "50" }
+arrow-json = { version = "50" }
+arrow-ord = { version = "50" }
+arrow-row = { version = "50" }
+arrow-schema = { version = "50" }
+arrow-select = { version = "50" }
 object_store = { version = "0.8" }
-parquet = { version = "49" }
+parquet = { version = "50" }
 
 # datafusion
-datafusion = { version = "34" }
-datafusion-expr = { version = "34" }
-datafusion-common = { version = "34" }
-datafusion-proto = { version = "34" }
-datafusion-sql = { version = "34" }
-datafusion-physical-expr = { version = "34" }
-
+datafusion = { version = "35" }
+datafusion-expr = { version = "35" }
+datafusion-common = { version = "35" }
+datafusion-proto = { version = "35" }
+datafusion-sql = { version = "35" }
+datafusion-physical-expr = { version = "35" }
 
 # serde
 serde = { version = "1.0.194", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ arrow-ord = { version = "50" }
 arrow-row = { version = "50" }
 arrow-schema = { version = "50" }
 arrow-select = { version = "50" }
-object_store = { version = "0.8" }
+object_store = { version = "0.9" }
 parquet = { version = "50" }
 
 # datafusion

--- a/crates/azure/src/config.rs
+++ b/crates/azure/src/config.rs
@@ -35,6 +35,7 @@ enum AzureCredential {
     /// Authorizing with secret
     ClientSecret,
     /// Using a shared access signature
+    #[allow(dead_code)]
     ManagedIdentity,
     /// Using a shared access signature
     SasKey,

--- a/crates/azure/src/error.rs
+++ b/crates/azure/src/error.rs
@@ -4,6 +4,7 @@ pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {
+    #[allow(dead_code)]
     #[error("failed to parse config: {0}")]
     Parse(String),
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -97,7 +97,7 @@ reqwest = { version = "0.11.18", default-features = false, features = [
     "rustls-tls",
     "json",
 ], optional = true }
-sqlparser = { version = "0.40", optional = true }
+sqlparser = { version = "0.41", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -247,7 +247,7 @@ impl LogicalFile<'_> {
                 .is_valid(self.index)
                 .then_some(DeletionVectorView {
                     data: arr,
-                    index: self.index
+                    index: self.index,
                 })
         })
     }

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -245,9 +245,9 @@ impl LogicalFile<'_> {
         self.deletion_vector.as_ref().and_then(|arr| {
             arr.storage_type
                 .is_valid(self.index)
-                .then(|| DeletionVectorView {
+                .then_some(DeletionVectorView {
                     data: arr,
-                    index: self.index,
+                    index: self.index
                 })
         })
     }

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -152,7 +152,6 @@ async fn excute_non_empty_expr(
     let predicate_expr = create_physical_expr(
         &negated_expression,
         &input_dfschema,
-        &input_schema,
         state.execution_props(),
     )?;
     let filter: Arc<dyn ExecutionPlan> =

--- a/crates/core/src/operations/merge/barrier.rs
+++ b/crates/core/src/operations/merge/barrier.rs
@@ -293,7 +293,7 @@ impl Stream for MergeBarrierStream {
                                             .iter()
                                             .map(|c| {
                                                 arrow::compute::take(c.as_ref(), &indices, None)
-                                                    .map_err(DataFusionError::ArrowError)
+                                                    .map_err(|err| DataFusionError::ArrowError(err, None))
                                             })
                                             .collect::<DataFusionResult<Vec<ArrayRef>>>()?;
 

--- a/crates/core/src/operations/merge/barrier.rs
+++ b/crates/core/src/operations/merge/barrier.rs
@@ -293,7 +293,9 @@ impl Stream for MergeBarrierStream {
                                             .iter()
                                             .map(|c| {
                                                 arrow::compute::take(c.as_ref(), &indices, None)
-                                                    .map_err(|err| DataFusionError::ArrowError(err, None))
+                                                    .map_err(|err| {
+                                                        DataFusionError::ArrowError(err, None)
+                                                    })
                                             })
                                             .collect::<DataFusionResult<Vec<ArrayRef>>>()?;
 

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1416,9 +1416,7 @@ impl std::future::IntoFuture for MergeBuilder {
             PROTOCOL.can_write_to(&this.snapshot)?;
 
             let state = this.state.unwrap_or_else(|| {
-                //TODO: Datafusion's Hashjoin has some memory issues. Running with all cores results in a OoM. Can be removed when upstream improvemetns are made.
                 let config: SessionConfig = DeltaSessionConfig::default().into();
-                let config = config.with_target_partitions(1);
                 let session = SessionContext::new_with_config(config);
 
                 // If a user provides their own their DF state then they must register the store themselves

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -32,7 +32,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-use arrow_schema::Schema as ArrowSchema;
 use async_trait::async_trait;
 use datafusion::datasource::provider_as_source;
 use datafusion::error::Result as DataFusionResult;
@@ -657,7 +656,6 @@ impl ExtensionPlanner for MergeMetricExtensionPlanner {
 
         if let Some(barrier) = node.as_any().downcast_ref::<MergeBarrier>() {
             let schema = barrier.input.schema();
-            let exec_schema: ArrowSchema = schema.as_ref().to_owned().into();
             return Ok(Some(Arc::new(MergeBarrierExec::new(
                 physical_inputs.first().unwrap().clone(),
                 barrier.file_column.clone(),

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -661,7 +661,7 @@ impl ExtensionPlanner for MergeMetricExtensionPlanner {
             return Ok(Some(Arc::new(MergeBarrierExec::new(
                 physical_inputs.first().unwrap().clone(),
                 barrier.file_column.clone(),
-                planner.create_physical_expr(&barrier.expr, schema, &exec_schema, session_state)?,
+                planner.create_physical_expr(&barrier.expr, schema, session_state)?,
             ))));
         }
 

--- a/crates/core/src/operations/transaction/state.rs
+++ b/crates/core/src/operations/transaction/state.rs
@@ -1,6 +1,7 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
-use arrow::array::ArrayRef;
+use arrow::array::{ArrayRef, BooleanArray};
 use arrow::datatypes::{
     DataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
 };
@@ -296,6 +297,12 @@ impl<'a> PruningStatistics for AddContainer<'a> {
         });
         ScalarValue::iter_to_array(values).ok()
     }
+
+    // This function is required since DataFusion 35.0, but is implemented as a no-op
+    // https://github.com/apache/arrow-datafusion/blob/ec6abece2dcfa68007b87c69eefa6b0d7333f628/datafusion/core/src/datasource/physical_plan/parquet/page_filter.rs#L550
+    fn contained(&self, _column: &Column, _value: &HashSet<ScalarValue>) -> Option<BooleanArray> {
+        None
+    }
 }
 
 impl PruningStatistics for DeltaTableState {
@@ -332,6 +339,12 @@ impl PruningStatistics for DeltaTableState {
         let partition_columns = &self.metadata().partition_columns;
         let container = AddContainer::new(&files, partition_columns, self.arrow_schema().ok()?);
         container.null_counts(column)
+    }
+
+    // This function is required since DataFusion 35.0, but is implemented as a no-op
+    // https://github.com/apache/arrow-datafusion/blob/ec6abece2dcfa68007b87c69eefa6b0d7333f628/datafusion/core/src/datasource/physical_plan/parquet/page_filter.rs#L550
+    fn contained(&self, _column: &Column, _value: &HashSet<ScalarValue>) -> Option<BooleanArray> {
+        None
     }
 }
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -266,7 +266,6 @@ async fn execute(
     let predicate_expr = create_physical_expr(
         &predicate_null,
         &input_dfschema,
-        &input_schema,
         execution_props,
     )?;
     expressions.push((predicate_expr, "__delta_rs_update_predicate".to_string()));
@@ -316,7 +315,7 @@ async fn execute(
             .when(lit(true), expr.to_owned())
             .otherwise(col(column.to_owned()))?;
         let predicate_expr =
-            create_physical_expr(&expr, &input_dfschema, &input_schema, execution_props)?;
+            create_physical_expr(&expr, &input_dfschema,  execution_props)?;
         map.insert(column.name.clone(), expressions.len());
         let c = "__delta_rs_".to_string() + &column.name;
         expressions.push((predicate_expr, c.clone()));

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -263,11 +263,7 @@ async fn execute(
 
     let predicate_null =
         when(predicate.clone(), lit(true)).otherwise(lit(ScalarValue::Boolean(None)))?;
-    let predicate_expr = create_physical_expr(
-        &predicate_null,
-        &input_dfschema,
-        execution_props,
-    )?;
+    let predicate_expr = create_physical_expr(&predicate_null, &input_dfschema, execution_props)?;
     expressions.push((predicate_expr, "__delta_rs_update_predicate".to_string()));
 
     let projection_predicate: Arc<dyn ExecutionPlan> =
@@ -314,8 +310,7 @@ async fn execute(
         let expr = case(col("__delta_rs_update_predicate"))
             .when(lit(true), expr.to_owned())
             .otherwise(col(column.to_owned()))?;
-        let predicate_expr =
-            create_physical_expr(&expr, &input_dfschema,  execution_props)?;
+        let predicate_expr = create_physical_expr(&expr, &input_dfschema, execution_props)?;
         map.insert(column.name.clone(), expressions.len());
         let c = "__delta_rs_".to_string() + &column.name;
         expressions.push((predicate_expr, c.clone()));

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -44,7 +44,7 @@ use deltalake_core::{
 use std::error::Error;
 
 mod local {
-    use datafusion_common::stats::Precision;
+    use datafusion::common::stats::Precision;
     use deltalake_core::{logstore::default_logstore, writer::JsonWriter};
     use object_store::local::LocalFileSystem;
 

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -44,7 +44,7 @@ use deltalake_core::{
 use std::error::Error;
 
 mod local {
-    use datafusion::common::stats::Precision;
+    use datafusion_common::stats::Precision;
     use deltalake_core::{logstore::default_logstore, writer::JsonWriter};
     use object_store::local::LocalFileSystem;
 

--- a/crates/gcp/src/error.rs
+++ b/crates/gcp/src/error.rs
@@ -4,6 +4,7 @@ pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {
+    #[allow(dead_code)]
     #[error("failed to parse config: {0}")]
     Parse(String),
 


### PR DESCRIPTION
# Description
This PR upgrades `delta-rs` to using DataFusion 35.0, which was recently released. In order to do this, I had to fix a few breaking changes, and also upgrade Arrow to 50 and `sqlparser` to 0.41.

# Related Issue(s)
N/A

# Documentation
See here for the list of PRs which required code change:
- https://github.com/apache/arrow-datafusion/pull/8703
- https://github.com/apache/arrow-datafusion/blob/ec6abece2dcfa68007b87c69eefa6b0d7333f628/dev/changelog/35.0.0.md?plain=1#L227
