### PR TITLE
fix: prevent empty stats struct during parquet write

### DIFF
--- a/crates/deltalake-core/src/kernel/arrow/mod.rs
+++ b/crates/deltalake-core/src/kernel/arrow/mod.rs
@@ -590,13 +590,11 @@ fn null_count_schema_for_fields(dest: &mut Vec<ArrowField>, f: &ArrowField) {
                 null_count_schema_for_fields(&mut child_dest, f);
             }
 
-            if !child_dest.is_empty() {
-                dest.push(ArrowField::new(
-                    f.name(),
-                    ArrowDataType::Struct(child_dest.into()),
-                    true,
-                ));
-            }
+            dest.push(ArrowField::new(
+                f.name(),
+                ArrowDataType::Struct(child_dest.into()),
+                true,
+            ));
         }
         _ => {
             let f = ArrowField::new(f.name(), ArrowDataType::Int64, true);

--- a/crates/deltalake-core/src/kernel/arrow/mod.rs
+++ b/crates/deltalake-core/src/kernel/arrow/mod.rs
@@ -564,11 +564,13 @@ fn max_min_schema_for_fields(dest: &mut Vec<ArrowField>, f: &ArrowField) {
                 max_min_schema_for_fields(&mut child_dest, f);
             }
 
-            dest.push(ArrowField::new(
-                f.name(),
-                ArrowDataType::Struct(child_dest.into()),
-                true,
-            ));
+            if !child_dest.is_empty() {
+                dest.push(ArrowField::new(
+                    f.name(),
+                    ArrowDataType::Struct(child_dest.into()),
+                    true,
+                ));
+            }
         }
         // don't compute min or max for list, map or binary types
         ArrowDataType::List(_) | ArrowDataType::Map(_, _) | ArrowDataType::Binary => { /* noop */ }
@@ -588,11 +590,13 @@ fn null_count_schema_for_fields(dest: &mut Vec<ArrowField>, f: &ArrowField) {
                 null_count_schema_for_fields(&mut child_dest, f);
             }
 
-            dest.push(ArrowField::new(
-                f.name(),
-                ArrowDataType::Struct(child_dest.into()),
-                true,
-            ));
+            if !child_dest.is_empty() {
+                dest.push(ArrowField::new(
+                    f.name(),
+                    ArrowDataType::Struct(child_dest.into()),
+                    true,
+                ));
+            }
         }
         _ => {
             let f = ArrowField::new(f.name(), ArrowDataType::Int64, true);


### PR DESCRIPTION
# Description
When building the arrow schema for delta checkpoints, List, Map, and Binary max/min stats are not collected. If you have a Struct column with only a List Map, or Binary field, then the arrow schema gets an empty Struct. Parquet writer fails with this:

```
ParquetParseError { source: ArrowError("Parquet does not support writing empty structs") }
```