### PR TITLE
feat: expose stats schema on Snapshot

### DIFF
--- a/crates/deltalake-core/src/kernel/snapshot/mod.rs
+++ b/crates/deltalake-core/src/kernel/snapshot/mod.rs
@@ -28,7 +28,7 @@ use object_store::ObjectStore;
 use self::log_segment::{CommitData, LogSegment, PathExt};
 use self::parse::{read_adds, read_removes};
 use self::replay::{LogMapper, LogReplayScanner, ReplayStream};
-use super::{Action, Add, CommitInfo, Metadata, Protocol, Remove};
+use super::{Action, Add, CommitInfo, DataType, Metadata, Protocol, Remove, StructField};
 use crate::kernel::StructType;
 use crate::table::config::TableConfig;
 use crate::{DeltaResult, DeltaTableConfig, DeltaTableError};
@@ -69,8 +69,7 @@ impl Snapshot {
                 "Cannot read metadata from log segment".into(),
             ));
         };
-        let metadata = metadata.unwrap();
-        let protocol = protocol.unwrap();
+        let (metadata, protocol) = (metadata.unwrap(), protocol.unwrap());
         let schema = serde_json::from_str(&metadata.schema_string)?;
         Ok(Self {
             log_segment,
@@ -212,12 +211,7 @@ impl Snapshot {
             &log_segment::CHECKPOINT_SCHEMA,
             &self.config,
         );
-        ReplayStream::try_new(
-            log_stream,
-            checkpoint_stream,
-            &self.schema,
-            self.config.clone(),
-        )
+        ReplayStream::try_new(log_stream, checkpoint_stream, &self)
     }
 
     /// Get the commit infos in the snapshot
@@ -288,6 +282,59 @@ impl Snapshot {
             })
             .boxed())
     }
+
+    /// Get the statistics schema of the snapshot
+    pub fn stats_schema(&self) -> DeltaResult<StructType> {
+        let stats_fields = if let Some(stats_cols) = self.table_config().stats_columns() {
+            stats_cols
+                .iter()
+                .map(|col| match self.schema().field_with_name(col) {
+                    Ok(field) => match field.data_type() {
+                        DataType::Map(_) | DataType::Array(_) | &DataType::BINARY => {
+                            Err(DeltaTableError::Generic(format!(
+                                "Stats column {} has unsupported type {}",
+                                col,
+                                field.data_type()
+                            )))
+                        }
+                        _ => Ok(StructField::new(
+                            field.name(),
+                            field.data_type().clone(),
+                            true,
+                        )),
+                    },
+                    _ => Err(DeltaTableError::Generic(format!(
+                        "Stats column {} not found in schema",
+                        col
+                    ))),
+                })
+                .collect::<Result<Vec<_>, _>>()?
+        } else {
+            let num_indexed_cols = self.table_config().num_indexed_cols();
+            self.schema()
+                .fields
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, f)| match f.data_type() {
+                    DataType::Map(_) | DataType::Array(_) | &DataType::BINARY => None,
+                    _ if num_indexed_cols < 0 || (idx as i32) < num_indexed_cols => {
+                        Some(StructField::new(f.name(), f.data_type().clone(), true))
+                    }
+                    _ => None,
+                })
+                .collect()
+        };
+        Ok(StructType::new(vec![
+            StructField::new("numRecords", DataType::LONG, true),
+            StructField::new("minValues", StructType::new(stats_fields.clone()), true),
+            StructField::new("maxValues", StructType::new(stats_fields.clone()), true),
+            StructField::new(
+                "nullCount",
+                StructType::new(stats_fields.iter().filter_map(to_count_field).collect()),
+                true,
+            ),
+        ]))
+    }
 }
 
 /// A snapshot of a Delta table that has been eagerly loaded into memory.
@@ -318,7 +365,7 @@ impl EagerSnapshot {
         let mut files = Vec::new();
         let mut scanner = LogReplayScanner::new();
         files.push(scanner.process_files_batch(&batch, true)?);
-        let mapper = LogMapper::try_new(snapshot.schema(), snapshot.config.clone())?;
+        let mapper = LogMapper::try_new(&snapshot)?;
         files = files
             .into_iter()
             .map(|b| mapper.map_batch(b))
@@ -357,16 +404,11 @@ impl EagerSnapshot {
                     )
                     .boxed()
             };
-            let mapper = LogMapper::try_new(self.snapshot.schema(), self.snapshot.config.clone())?;
-            let files = ReplayStream::try_new(
-                log_stream,
-                checkpoint_stream,
-                self.schema(),
-                self.snapshot.config.clone(),
-            )?
-            .map(|batch| batch.and_then(|b| mapper.map_batch(b)))
-            .try_collect()
-            .await?;
+            let mapper = LogMapper::try_new(&self.snapshot)?;
+            let files = ReplayStream::try_new(log_stream, checkpoint_stream, &self.snapshot)?
+                .map(|batch| batch.and_then(|b| mapper.map_batch(b)))
+                .try_collect()
+                .await?;
 
             self.files = files;
         }
@@ -473,7 +515,7 @@ impl EagerSnapshot {
             files.push(scanner.process_files_batch(&batch?, true)?);
         }
 
-        let mapper = LogMapper::try_new(self.snapshot.schema(), self.snapshot.config.clone())?;
+        let mapper = LogMapper::try_new(&self.snapshot)?;
         self.files = files
             .into_iter()
             .chain(
@@ -493,6 +535,23 @@ impl EagerSnapshot {
         }
 
         Ok(self.snapshot.version())
+    }
+}
+
+fn to_count_field(field: &StructField) -> Option<StructField> {
+    match field.data_type() {
+        DataType::Map(_) | DataType::Array(_) | &DataType::BINARY => None,
+        DataType::Struct(s) => Some(StructField::new(
+            field.name(),
+            StructType::new(
+                s.fields()
+                    .iter()
+                    .filter_map(to_count_field)
+                    .collect::<Vec<_>>(),
+            ),
+            true,
+        )),
+        _ => Some(StructField::new(field.name(), DataType::LONG, true)),
     }
 }
 


### PR DESCRIPTION
# Description

The new table config `delta.dataSkippingStatsColumns` changes the logic which columns should be considered when computing file statistics. Here we expose (and use) a new method on `Snapshot` which reflects the updated logic.

This PR does not contain any tests for the new code paths, but I'll test this against the reference implementation once the new checkpoint writer lands.
