### PR TITLE
fix: order logical schema to match physical schema

### DIFF
--- a/crates/deltalake-core/src/table/mod.rs
+++ b/crates/deltalake-core/src/table/mod.rs
@@ -425,7 +425,6 @@ impl DeltaTable {
         &self,
         filters: &[PartitionFilter],
     ) -> Result<Vec<Path>, DeltaTableError> {
-        println!("get_files_by_partitions ----------->");
         Ok(self
             .get_active_add_actions_by_partitions(filters)?
             .collect::<Result<Vec<_>, _>>()?


### PR DESCRIPTION
# Description
When using logical plans with DF, the order & location of partitioned columns did not match with physical schema. This would cause errors when logical relations were converted to physical relations.

# Related Issue(s)
- closes #2104 

