### PR TITLE
fix(#2143): keep specific error type when writing fails

### DIFF
--- a/crates/core/src/writer/mod.rs
+++ b/crates/core/src/writer/mod.rs
@@ -115,6 +115,7 @@ impl From<DeltaWriterError> for DeltaTableError {
             DeltaWriterError::Io { source } => DeltaTableError::Io { source },
             DeltaWriterError::ObjectStore { source } => DeltaTableError::ObjectStore { source },
             DeltaWriterError::Parquet { source } => DeltaTableError::Parquet { source },
+            DeltaWriterError::DeltaTable(e) => e,
             _ => DeltaTableError::Generic(err.to_string()),
         }
     }


### PR DESCRIPTION
# Description
Add case to error conversion implementation to preserve structured parsing error instead of converting to plain string.

# Related Issue(s)
- closes #2143