### PR TITLE
fix: replace BTreeMap with IndexMap to preserve insertion order

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -77,6 +77,7 @@ errno = "0.3"
 either = "1.8"
 fix-hidden-lifetime-bug = "0.2"
 hyper = { version = "0.14", optional = true }
+indexmap = "2.2.1"
 itertools = "0.12"
 lazy_static = "1"
 libc = ">=0.2.90, <1"

--- a/crates/core/src/operations/writer.rs
+++ b/crates/core/src/operations/writer.rs
@@ -1,11 +1,12 @@
 //! Abstractions and implementations for writing data to delta tables
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 use bytes::Bytes;
+use indexmap::IndexMap;
 use object_store::{path::Path, ObjectStore};
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
@@ -155,7 +156,7 @@ impl DeltaWriter {
     pub async fn write_partition(
         &mut self,
         record_batch: RecordBatch,
-        partition_values: &BTreeMap<String, Scalar>,
+        partition_values: &IndexMap<String, Scalar>,
     ) -> DeltaResult<()> {
         let partition_key = Path::parse(partition_values.hive_partition_path())?;
 
@@ -217,7 +218,7 @@ pub(crate) struct PartitionWriterConfig {
     /// Prefix applied to all paths
     prefix: Path,
     /// Values for all partition columns
-    partition_values: BTreeMap<String, Scalar>,
+    partition_values: IndexMap<String, Scalar>,
     /// Properties passed to underlying parquet writer
     writer_properties: WriterProperties,
     /// Size above which we will write a buffered parquet file to disk.
@@ -230,7 +231,7 @@ pub(crate) struct PartitionWriterConfig {
 impl PartitionWriterConfig {
     pub fn try_new(
         file_schema: ArrowSchemaRef,
-        partition_values: BTreeMap<String, Scalar>,
+        partition_values: IndexMap<String, Scalar>,
         writer_properties: Option<WriterProperties>,
         target_file_size: Option<usize>,
         write_batch_size: Option<usize>,
@@ -514,7 +515,7 @@ mod tests {
     ) -> PartitionWriter {
         let config = PartitionWriterConfig::try_new(
             batch.schema(),
-            BTreeMap::new(),
+            IndexMap::new(),
             writer_properties,
             target_file_size,
             write_batch_size,

--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -1,8 +1,8 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashMap, ops::AddAssign};
 
+use indexmap::IndexMap;
 use parquet::format::FileMetaData;
 use parquet::schema::types::{ColumnDescriptor, SchemaDescriptor};
 use parquet::{basic::LogicalType, errors::ParquetError};
@@ -17,7 +17,7 @@ use crate::protocol::{ColumnValueStat, Stats};
 
 /// Creates an [`Add`] log action struct.
 pub fn create_add(
-    partition_values: &BTreeMap<String, Scalar>,
+    partition_values: &IndexMap<String, Scalar>,
     path: String,
     size: i64,
     file_metadata: &FileMetaData,
@@ -59,7 +59,7 @@ pub fn create_add(
 }
 
 fn stats_from_file_metadata(
-    partition_values: &BTreeMap<String, Scalar>,
+    partition_values: &IndexMap<String, Scalar>,
     file_metadata: &FileMetaData,
 ) -> Result<Stats, DeltaWriterError> {
     let type_ptr = parquet::schema::types::from_thrift(file_metadata.schema.as_slice());


### PR DESCRIPTION
# Description

When switching to using `BTreeMap` for representing partition values, I introduced a bug, thinking `BTreeMap` would preserve insertion order. While it is ordered, it is ordered based on keys.

This PR moves to using `IndexMap`, which actually preserves insertion order.
