### PR TITLE
fix: correct map field names

### DIFF
--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -14,8 +14,8 @@ pub(crate) mod extract;
 pub(crate) mod json;
 
 const MAP_ROOT_DEFAULT: &str = "entries";
-const MAP_KEY_DEFAULT: &str = "keys";
-const MAP_VALUE_DEFAULT: &str = "values";
+const MAP_KEY_DEFAULT: &str = "key";
+const MAP_VALUE_DEFAULT: &str = "value";
 const LIST_ROOT_DEFAULT: &str = "item";
 
 impl TryFrom<ActionType> for ArrowField {

--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -846,9 +846,9 @@ mod tests {
             let entry_offsets_buffer = Buffer::from(entry_offsets.to_byte_slice());
             let keys_data = StringArray::from_iter_values(keys);
 
-            let keys_field = Arc::new(Field::new("keys", ArrowDataType::Utf8, false));
+            let keys_field = Arc::new(Field::new("key", ArrowDataType::Utf8, false));
             let values_field = Arc::new(Field::new(
-                "values",
+                "value",
                 values.data_type().clone(),
                 values.null_count() > 0,
             ));


### PR DESCRIPTION
# Description
This changes the field names inside map types to be `key` and `value` instead of `keys` and `values`. This matches the parquet spec for encoding map columns: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps 

I found this while trying to load a checkpoint from a table where it was failing with spurious errors. Pyarrow is tolerant of this to a degree but other readers like parquet4s (used in e.g delta standalone) took issue with it. 
