### PR TITLE
feat: implement string representation for PartitionFilter

### DIFF
--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -296,13 +296,14 @@ impl<'a> std::future::IntoFuture for OptimizeBuilder<'a> {
 #[derive(Debug, Clone)]
 struct OptimizeInput {
     target_size: i64,
+    predicate: Option<String>,
 }
 
 impl From<OptimizeInput> for DeltaOperation {
     fn from(opt_input: OptimizeInput) -> Self {
         DeltaOperation::Optimize {
             target_size: opt_input.target_size,
-            predicate: None,
+            predicate: opt_input.predicate,
         }
     }
 }
@@ -783,7 +784,10 @@ pub fn create_merge_plan(
         }
     };
 
-    let input_parameters = OptimizeInput { target_size };
+    let input_parameters = OptimizeInput {
+        target_size,
+        predicate: serde_json::to_string(filters).ok(),
+    };
     let file_schema =
         arrow_schema_without_partitions(&Arc::new(snapshot.schema().try_into()?), partitions_keys);
 

--- a/crates/core/src/schema/partitions.rs
+++ b/crates/core/src/schema/partitions.rs
@@ -140,8 +140,16 @@ impl Serialize for PartitionFilter {
             PartitionValue::LessThan(value) => format!("{} < '{}'", self.key, value),
             PartitionValue::LessThanOrEqual(value) => format!("{} <= '{}'", self.key, value),
             // used upper case for IN and NOT similar to SQL
-            PartitionValue::In(values) => format!("{} IN ({})", self.key, values.join(", ")),
-            PartitionValue::NotIn(values) => format!("{} NOT IN ({})", self.key, values.join(", ")),
+            PartitionValue::In(values) => {
+                let quoted_values: Vec<String> =
+                    values.iter().map(|v| format!("'{}'", v)).collect();
+                format!("{} IN ({})", self.key, quoted_values.join(", "))
+            }
+            PartitionValue::NotIn(values) => {
+                let quoted_values: Vec<String> =
+                    values.iter().map(|v| format!("'{}'", v)).collect();
+                format!("{} NOT IN ({})", self.key, quoted_values.join(", "))
+            }
         };
         serializer.serialize_str(&s)
     }
@@ -237,8 +245,6 @@ mod tests {
     use serde_json::json;
 
     fn check_json_serialize(filter: PartitionFilter, expected_json: &str) {
-        println!("Debug: {filter:?}");
-        println!("Json: {}", serde_json::to_string(&filter).unwrap());
         assert_eq!(serde_json::to_value(&filter).unwrap(), json!(expected_json))
     }
 

--- a/crates/core/tests/command_optimize.rs
+++ b/crates/core/tests/command_optimize.rs
@@ -180,6 +180,12 @@ async fn test_optimize_non_partitioned_table() -> Result<(), Box<dyn Error>> {
     assert_eq!(metrics.partitions_optimized, 1);
     assert_eq!(dt.get_files_count(), 2);
 
+    let commit_info = dt.history(None).await?;
+    let last_commit = &commit_info[0];
+    let parameters = last_commit.operation_parameters.clone().unwrap();
+    assert_eq!(parameters["targetSize"], json!("2000000"));
+    assert_eq!(parameters["predicate"], "[]");
+
     Ok(())
 }
 
@@ -613,8 +619,7 @@ async fn test_commit_info() -> Result<(), Box<dyn Error>> {
     assert_eq!(last_commit.read_version, Some(version));
     let parameters = last_commit.operation_parameters.clone().unwrap();
     assert_eq!(parameters["targetSize"], json!("2000000"));
-    // TODO: Requires a string representation for PartitionFilter
-    // assert_eq!(parameters["predicate"], None);
+    assert_eq!(parameters["predicate"], "[\"date = '2022-05-22'\"]");
 
     Ok(())
 }


### PR DESCRIPTION
# Description
Implement string representation for PartitionFilter and add it to optimize command commit info for a TODO.

Following json representations of CommitInfo from delta scala project were found:
```
"operationParameters":{"predicate":"[\"(id#480 < 50)\"]"}
"operationParameters":{"predicate":"[\"(col1#1939 = 2)\"]"}
"operationParameters":{"predicate":"[\"`col2` LIKE 'data-2-%'\"]"}
"operationParameters":{"predicate":"[\"(id#378L < 2)\"]"}
"operationParameters":{
  "predicate":"[\"(spark_catalog.delta.`/table-uuid`.id IN (0, 180, 308, 225, 756, 1007, 1503))\"]"
}
```

So I think representing predicate as a list of filters in string representation would be logical, for example:
```
// single PartitionFilter
"operationParameters":{"predicate":"[\"date = '2022-05-22'\"]"}
// two filters
"operationParameters":{"predicate":"[\"date = '2022-05-22'\", \"country = 'US'\"]"}
```

# Related Issue(s)
implement TODO in #607 

