### PR TITLE
fix: add data_type and nullable to StructField hash (#2045)

### DIFF
--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -270,6 +270,12 @@ impl ConvertToDeltaBuilder {
         // Iterate over the parquet files. Parse partition columns, generate add actions and collect parquet file schemas
         let mut arrow_schemas = Vec::new();
         let mut actions = Vec::new();
+        // partition columns that were defined by caller and are expected to apply on this table
+        let mut expected_partitions: HashMap<String, StructField> = self.partition_schema
+            .clone()
+            .into_iter()
+            .map(|field| (field.name.clone(), field))
+            .collect();
         // A HashSet of all unique partition columns in a Parquet table
         let mut partition_columns = HashSet::new();
         // A vector of StructField of all unique partition columns in a Parquet table
@@ -290,7 +296,8 @@ impl ConvertToDeltaBuilder {
                     .ok_or(Error::MissingPartitionSchema)?;
 
                 if partition_columns.insert(key.to_string()) {
-                    if let Some(schema) = self.partition_schema.take(key) {
+                    if let Some(schema) = expected_partitions.remove(key) {
+                    // if let Some(schema) = self.partition_schema.take(key) {
                         partition_schema_fields.insert(key.to_string(), schema);
                     } else {
                         // Return an error if the schema of a partition column is not provided by user
@@ -360,7 +367,7 @@ impl ConvertToDeltaBuilder {
             arrow_schemas.push(arrow_schema);
         }
 
-        if !self.partition_schema.is_empty() {
+        if !expected_partitions.is_empty() {
             // Partition column provided by the user does not exist in the parquet files
             return Err(Error::PartitionColumnNotExist(self.partition_schema));
         }

--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -297,7 +297,6 @@ impl ConvertToDeltaBuilder {
 
                 if partition_columns.insert(key.to_string()) {
                     if let Some(schema) = expected_partitions.remove(key) {
-                    // if let Some(schema) = self.partition_schema.take(key) {
                         partition_schema_fields.insert(key.to_string(), schema);
                     } else {
                         // Return an error if the schema of a partition column is not provided by user

--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -271,7 +271,8 @@ impl ConvertToDeltaBuilder {
         let mut arrow_schemas = Vec::new();
         let mut actions = Vec::new();
         // partition columns that were defined by caller and are expected to apply on this table
-        let mut expected_partitions: HashMap<String, StructField> = self.partition_schema
+        let mut expected_partitions: HashMap<String, StructField> = self
+            .partition_schema
             .clone()
             .into_iter()
             .map(|field| (field.name.clone(), field))


### PR DESCRIPTION
# Description
Correct hashing of StructField and add tests.
- Current:  Two StructFields with the same name but different `data_type` or different `nullable` are considered to hash equivalently.
- To be: `name`, `data_type` and `nullability` should match for a field to be considered equivalent.

# Related Issue(s)
closes #2045 
