### PR TITLE
chore: upgrade to DataFusion 36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,12 +46,12 @@ object_store = { version = "0.9" }
 parquet = { version = "50" }
 
 # datafusion
-datafusion = { version = "35" }
-datafusion-expr = { version = "35" }
-datafusion-common = { version = "35" }
-datafusion-proto = { version = "35" }
-datafusion-sql = { version = "35" }
-datafusion-physical-expr = { version = "35" }
+datafusion = { version = "36" }
+datafusion-expr = { version = "36" }
+datafusion-common = { version = "36" }
+datafusion-proto = { version = "36" }
+datafusion-sql = { version = "36" }
+datafusion-physical-expr = { version = "36" }
 
 # serde
 serde = { version = "1.0.194", features = ["derive"] }


### PR DESCRIPTION
# Description
DataFusion 36 is out! This upgrades `delta-rs` to use it.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
