### PR TITLE
docs: update README code samples for newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ write_deltalake("./data/delta", df)
 dt = DeltaTable("./data/delta")
 df2 = dt.to_pandas()
 
-assert df == df2
+assert df.equals(df2)
 ```
 
 The same table can also be loaded using the core Rust crate:
@@ -91,7 +91,7 @@ async fn main() -> Result<(), DeltaTableError> {
     let table = open_table("./data/delta").await?;
 
     // show all active files in the table
-    let files = table.get_files();
+    let files: Vec<_> = table.get_file_uris()?.collect();
     println!("{:?}", files);
 
     Ok(())


### PR DESCRIPTION
Rust `deltalake` version 0.17 no longer has `.get_files()`.

Newer pandas versions raise a ValueError when comparing dataframes using `==`.

# Description
While updating our code to 0.17, I noticed that `.get_files()` was no longer present on `DeltaTable`. The README here and on crates.io still refers to it.
