### PR TITLE
fix: canonicalize config keys

### DIFF
--- a/crates/aws/src/storage.rs
+++ b/crates/aws/src/storage.rs
@@ -423,242 +423,291 @@ mod tests {
     use maplit::hashmap;
     use serial_test::serial;
 
+    struct ScopedEnv {
+        vars: HashMap<std::ffi::OsString, std::ffi::OsString>,
+    }
+
+    impl ScopedEnv {
+        pub fn new() -> Self {
+            let vars = std::env::vars_os().collect();
+            Self { vars }
+        }
+
+        pub fn run<T>(mut f: impl FnMut() -> T) -> T {
+            let env_scope = Self::new();
+            f()
+        }
+    }
+
+    impl Drop for ScopedEnv {
+        fn drop(&mut self) {
+            let to_remove: Vec<_> = std::env::vars_os()
+                .map(|kv| kv.0)
+                .filter(|k| !self.vars.contains_key(k))
+                .collect();
+            for k in to_remove {
+                std::env::remove_var(k);
+            }
+            for (key, value) in self.vars.drain() {
+                std::env::set_var(key, value);
+            }
+        }
+    }
+
     #[test]
     #[serial]
     fn storage_options_default_test() {
-        std::env::set_var(s3_constants::AWS_ENDPOINT_URL, "http://localhost");
-        std::env::set_var(s3_constants::AWS_REGION, "us-west-1");
-        std::env::set_var(s3_constants::AWS_PROFILE, "default");
-        std::env::set_var(s3_constants::AWS_ACCESS_KEY_ID, "default_key_id");
-        std::env::set_var(s3_constants::AWS_SECRET_ACCESS_KEY, "default_secret_key");
-        std::env::set_var(s3_constants::AWS_S3_LOCKING_PROVIDER, "dynamodb");
-        std::env::set_var(
-            s3_constants::AWS_S3_ASSUME_ROLE_ARN,
-            "arn:aws:iam::123456789012:role/some_role",
-        );
-        std::env::set_var(s3_constants::AWS_S3_ROLE_SESSION_NAME, "session_name");
-        std::env::set_var(s3_constants::AWS_WEB_IDENTITY_TOKEN_FILE, "token_file");
-        std::env::remove_var(s3_constants::AWS_S3_POOL_IDLE_TIMEOUT_SECONDS);
-        std::env::remove_var(s3_constants::AWS_STS_POOL_IDLE_TIMEOUT_SECONDS);
-        std::env::remove_var(s3_constants::AWS_S3_GET_INTERNAL_SERVER_ERROR_RETRIES);
+        ScopedEnv::run(|| {
+            std::env::set_var(s3_constants::AWS_ENDPOINT_URL, "http://localhost");
+            std::env::set_var(s3_constants::AWS_REGION, "us-west-1");
+            std::env::set_var(s3_constants::AWS_PROFILE, "default");
+            std::env::set_var(s3_constants::AWS_ACCESS_KEY_ID, "default_key_id");
+            std::env::set_var(s3_constants::AWS_SECRET_ACCESS_KEY, "default_secret_key");
+            std::env::set_var(s3_constants::AWS_S3_LOCKING_PROVIDER, "dynamodb");
+            std::env::set_var(
+                s3_constants::AWS_S3_ASSUME_ROLE_ARN,
+                "arn:aws:iam::123456789012:role/some_role",
+            );
+            std::env::set_var(s3_constants::AWS_S3_ROLE_SESSION_NAME, "session_name");
+            std::env::set_var(s3_constants::AWS_WEB_IDENTITY_TOKEN_FILE, "token_file");
+            std::env::remove_var(s3_constants::AWS_S3_POOL_IDLE_TIMEOUT_SECONDS);
+            std::env::remove_var(s3_constants::AWS_STS_POOL_IDLE_TIMEOUT_SECONDS);
+            std::env::remove_var(s3_constants::AWS_S3_GET_INTERNAL_SERVER_ERROR_RETRIES);
 
-        let options = S3StorageOptions::default();
+            let options = S3StorageOptions::default();
 
-        assert_eq!(
-            S3StorageOptions {
-                endpoint_url: Some("http://localhost".to_string()),
-                region: Region::Custom {
-                    name: "us-west-1".to_string(),
-                    endpoint: "http://localhost".to_string()
+            assert_eq!(
+                S3StorageOptions {
+                    endpoint_url: Some("http://localhost".to_string()),
+                    region: Region::Custom {
+                        name: "us-west-1".to_string(),
+                        endpoint: "http://localhost".to_string()
+                    },
+                    profile: Some("default".to_string()),
+                    aws_access_key_id: Some("default_key_id".to_string()),
+                    aws_secret_access_key: Some("default_secret_key".to_string()),
+                    aws_session_token: None,
+                    virtual_hosted_style_request: false,
+                    assume_role_arn: Some("arn:aws:iam::123456789012:role/some_role".to_string()),
+                    assume_role_session_name: Some("session_name".to_string()),
+                    use_web_identity: true,
+                    locking_provider: Some("dynamodb".to_string()),
+                    s3_pool_idle_timeout: Duration::from_secs(15),
+                    sts_pool_idle_timeout: Duration::from_secs(10),
+                    s3_get_internal_server_error_retries: 10,
+                    extra_opts: HashMap::new(),
+                    allow_unsafe_rename: false,
                 },
-                profile: Some("default".to_string()),
-                aws_access_key_id: Some("default_key_id".to_string()),
-                aws_secret_access_key: Some("default_secret_key".to_string()),
-                aws_session_token: None,
-                virtual_hosted_style_request: false,
-                assume_role_arn: Some("arn:aws:iam::123456789012:role/some_role".to_string()),
-                assume_role_session_name: Some("session_name".to_string()),
-                use_web_identity: true,
-                locking_provider: Some("dynamodb".to_string()),
-                s3_pool_idle_timeout: Duration::from_secs(15),
-                sts_pool_idle_timeout: Duration::from_secs(10),
-                s3_get_internal_server_error_retries: 10,
-                extra_opts: HashMap::new(),
-                allow_unsafe_rename: false,
-            },
-            options
-        );
+                options
+            );
+        })
     }
 
     #[test]
     #[serial]
     fn storage_options_with_only_region_and_credentials() {
-        std::env::remove_var(s3_constants::AWS_ENDPOINT_URL);
-        let options = S3StorageOptions::from_map(&hashmap! {
-            s3_constants::AWS_REGION.to_string() => "eu-west-1".to_string(),
-            s3_constants::AWS_ACCESS_KEY_ID.to_string() => "test".to_string(),
-            s3_constants::AWS_SECRET_ACCESS_KEY.to_string() => "test_secret".to_string(),
-        });
+        ScopedEnv::run(|| {
+            std::env::remove_var(s3_constants::AWS_ENDPOINT_URL);
+            let options = S3StorageOptions::from_map(&hashmap! {
+                s3_constants::AWS_REGION.to_string() => "eu-west-1".to_string(),
+                s3_constants::AWS_ACCESS_KEY_ID.to_string() => "test".to_string(),
+                s3_constants::AWS_SECRET_ACCESS_KEY.to_string() => "test_secret".to_string(),
+            });
 
-        assert_eq!(
-            S3StorageOptions {
-                endpoint_url: None,
-                region: Region::default(),
-                aws_access_key_id: Some("test".to_string()),
-                aws_secret_access_key: Some("test_secret".to_string()),
-                ..Default::default()
-            },
-            options
-        );
+            assert_eq!(
+                S3StorageOptions {
+                    endpoint_url: None,
+                    region: Region::default(),
+                    aws_access_key_id: Some("test".to_string()),
+                    aws_secret_access_key: Some("test_secret".to_string()),
+                    ..Default::default()
+                },
+                options
+            );
+        })
     }
 
     #[test]
     #[serial]
     fn storage_options_from_map_test() {
-        let options = S3StorageOptions::from_map(&hashmap! {
-            s3_constants::AWS_ENDPOINT_URL.to_string() => "http://localhost:1234".to_string(),
-            s3_constants::AWS_REGION.to_string() => "us-west-2".to_string(),
-            s3_constants::AWS_PROFILE.to_string() => "default".to_string(),
-            s3_constants::AWS_S3_ADDRESSING_STYLE.to_string() => "virtual".to_string(),
-            s3_constants::AWS_S3_LOCKING_PROVIDER.to_string() => "another_locking_provider".to_string(),
-            s3_constants::AWS_S3_ASSUME_ROLE_ARN.to_string() => "arn:aws:iam::123456789012:role/another_role".to_string(),
-            s3_constants::AWS_S3_ROLE_SESSION_NAME.to_string() => "another_session_name".to_string(),
-            s3_constants::AWS_WEB_IDENTITY_TOKEN_FILE.to_string() => "another_token_file".to_string(),
-            s3_constants::AWS_S3_POOL_IDLE_TIMEOUT_SECONDS.to_string() => "1".to_string(),
-            s3_constants::AWS_STS_POOL_IDLE_TIMEOUT_SECONDS.to_string() => "2".to_string(),
-            s3_constants::AWS_S3_GET_INTERNAL_SERVER_ERROR_RETRIES.to_string() => "3".to_string(),
-            s3_constants::AWS_ACCESS_KEY_ID.to_string() => "test_id".to_string(),
-            s3_constants::AWS_SECRET_ACCESS_KEY.to_string() => "test_secret".to_string(),
-        });
+        ScopedEnv::run(|| {
+            let options = S3StorageOptions::from_map(&hashmap! {
+                s3_constants::AWS_ENDPOINT_URL.to_string() => "http://localhost:1234".to_string(),
+                s3_constants::AWS_REGION.to_string() => "us-west-2".to_string(),
+                s3_constants::AWS_PROFILE.to_string() => "default".to_string(),
+                s3_constants::AWS_S3_ADDRESSING_STYLE.to_string() => "virtual".to_string(),
+                s3_constants::AWS_S3_LOCKING_PROVIDER.to_string() => "another_locking_provider".to_string(),
+                s3_constants::AWS_S3_ASSUME_ROLE_ARN.to_string() => "arn:aws:iam::123456789012:role/another_role".to_string(),
+                s3_constants::AWS_S3_ROLE_SESSION_NAME.to_string() => "another_session_name".to_string(),
+                s3_constants::AWS_WEB_IDENTITY_TOKEN_FILE.to_string() => "another_token_file".to_string(),
+                s3_constants::AWS_S3_POOL_IDLE_TIMEOUT_SECONDS.to_string() => "1".to_string(),
+                s3_constants::AWS_STS_POOL_IDLE_TIMEOUT_SECONDS.to_string() => "2".to_string(),
+                s3_constants::AWS_S3_GET_INTERNAL_SERVER_ERROR_RETRIES.to_string() => "3".to_string(),
+                s3_constants::AWS_ACCESS_KEY_ID.to_string() => "test_id".to_string(),
+                s3_constants::AWS_SECRET_ACCESS_KEY.to_string() => "test_secret".to_string(),
+            });
 
-        assert_eq!(
-            S3StorageOptions {
-                endpoint_url: Some("http://localhost:1234".to_string()),
-                region: Region::Custom {
-                    name: "us-west-2".to_string(),
-                    endpoint: "http://localhost:1234".to_string()
+            assert_eq!(
+                S3StorageOptions {
+                    endpoint_url: Some("http://localhost:1234".to_string()),
+                    region: Region::Custom {
+                        name: "us-west-2".to_string(),
+                        endpoint: "http://localhost:1234".to_string()
+                    },
+                    profile: Some("default".to_string()),
+                    aws_access_key_id: Some("test_id".to_string()),
+                    aws_secret_access_key: Some("test_secret".to_string()),
+                    aws_session_token: None,
+                    virtual_hosted_style_request: true,
+                    assume_role_arn: Some(
+                        "arn:aws:iam::123456789012:role/another_role".to_string()
+                    ),
+                    assume_role_session_name: Some("another_session_name".to_string()),
+                    use_web_identity: true,
+                    locking_provider: Some("another_locking_provider".to_string()),
+                    s3_pool_idle_timeout: Duration::from_secs(1),
+                    sts_pool_idle_timeout: Duration::from_secs(2),
+                    s3_get_internal_server_error_retries: 3,
+                    extra_opts: hashmap! {
+                        s3_constants::AWS_S3_ADDRESSING_STYLE.to_string() => "virtual".to_string()
+                    },
+                    allow_unsafe_rename: false,
                 },
-                profile: Some("default".to_string()),
-                aws_access_key_id: Some("test_id".to_string()),
-                aws_secret_access_key: Some("test_secret".to_string()),
-                aws_session_token: None,
-                virtual_hosted_style_request: true,
-                assume_role_arn: Some("arn:aws:iam::123456789012:role/another_role".to_string()),
-                assume_role_session_name: Some("another_session_name".to_string()),
-                use_web_identity: true,
-                locking_provider: Some("another_locking_provider".to_string()),
-                s3_pool_idle_timeout: Duration::from_secs(1),
-                sts_pool_idle_timeout: Duration::from_secs(2),
-                s3_get_internal_server_error_retries: 3,
-                extra_opts: hashmap! {
-                    s3_constants::AWS_S3_ADDRESSING_STYLE.to_string() => "virtual".to_string()
-                },
-                allow_unsafe_rename: false,
-            },
-            options
-        );
+                options
+            );
+        })
     }
 
     #[test]
     #[serial]
     fn storage_options_mixed_test() {
-        std::env::set_var(s3_constants::AWS_ENDPOINT_URL, "http://localhost");
-        std::env::set_var(s3_constants::AWS_REGION, "us-west-1");
-        std::env::set_var(s3_constants::AWS_PROFILE, "default");
-        std::env::set_var(s3_constants::AWS_ACCESS_KEY_ID, "wrong_key_id");
-        std::env::set_var(s3_constants::AWS_SECRET_ACCESS_KEY, "wrong_secret_key");
-        std::env::set_var(s3_constants::AWS_S3_LOCKING_PROVIDER, "dynamodb");
-        std::env::set_var(
-            s3_constants::AWS_S3_ASSUME_ROLE_ARN,
-            "arn:aws:iam::123456789012:role/some_role",
-        );
-        std::env::set_var(s3_constants::AWS_S3_ROLE_SESSION_NAME, "session_name");
-        std::env::set_var(s3_constants::AWS_WEB_IDENTITY_TOKEN_FILE, "token_file");
+        ScopedEnv::run(|| {
+            std::env::set_var(s3_constants::AWS_ENDPOINT_URL, "http://localhost");
+            std::env::set_var(s3_constants::AWS_REGION, "us-west-1");
+            std::env::set_var(s3_constants::AWS_PROFILE, "default");
+            std::env::set_var(s3_constants::AWS_ACCESS_KEY_ID, "wrong_key_id");
+            std::env::set_var(s3_constants::AWS_SECRET_ACCESS_KEY, "wrong_secret_key");
+            std::env::set_var(s3_constants::AWS_S3_LOCKING_PROVIDER, "dynamodb");
+            std::env::set_var(
+                s3_constants::AWS_S3_ASSUME_ROLE_ARN,
+                "arn:aws:iam::123456789012:role/some_role",
+            );
+            std::env::set_var(s3_constants::AWS_S3_ROLE_SESSION_NAME, "session_name");
+            std::env::set_var(s3_constants::AWS_WEB_IDENTITY_TOKEN_FILE, "token_file");
 
-        std::env::set_var(s3_constants::AWS_S3_POOL_IDLE_TIMEOUT_SECONDS, "1");
-        std::env::set_var(s3_constants::AWS_STS_POOL_IDLE_TIMEOUT_SECONDS, "2");
-        std::env::set_var(s3_constants::AWS_S3_GET_INTERNAL_SERVER_ERROR_RETRIES, "3");
-        let options = S3StorageOptions::from_map(&hashmap! {
-            s3_constants::AWS_ACCESS_KEY_ID.to_string() => "test_id_mixed".to_string(),
-            s3_constants::AWS_SECRET_ACCESS_KEY.to_string() => "test_secret_mixed".to_string(),
-            s3_constants::AWS_REGION.to_string() => "us-west-2".to_string(),
-            "AWS_S3_GET_INTERNAL_SERVER_ERROR_RETRIES".to_string() => "3".to_string(),
-        });
+            std::env::set_var(s3_constants::AWS_S3_POOL_IDLE_TIMEOUT_SECONDS, "1");
+            std::env::set_var(s3_constants::AWS_STS_POOL_IDLE_TIMEOUT_SECONDS, "2");
+            std::env::set_var(s3_constants::AWS_S3_GET_INTERNAL_SERVER_ERROR_RETRIES, "3");
+            let options = S3StorageOptions::from_map(&hashmap! {
+                s3_constants::AWS_ACCESS_KEY_ID.to_string() => "test_id_mixed".to_string(),
+                s3_constants::AWS_SECRET_ACCESS_KEY.to_string() => "test_secret_mixed".to_string(),
+                s3_constants::AWS_REGION.to_string() => "us-west-2".to_string(),
+                "AWS_S3_GET_INTERNAL_SERVER_ERROR_RETRIES".to_string() => "3".to_string(),
+            });
 
-        assert_eq!(
-            S3StorageOptions {
-                endpoint_url: Some("http://localhost".to_string()),
-                region: Region::Custom {
-                    name: "us-west-2".to_string(),
-                    endpoint: "http://localhost".to_string()
+            assert_eq!(
+                S3StorageOptions {
+                    endpoint_url: Some("http://localhost".to_string()),
+                    region: Region::Custom {
+                        name: "us-west-2".to_string(),
+                        endpoint: "http://localhost".to_string()
+                    },
+                    profile: Some("default".to_string()),
+                    aws_access_key_id: Some("test_id_mixed".to_string()),
+                    aws_secret_access_key: Some("test_secret_mixed".to_string()),
+                    aws_session_token: None,
+                    virtual_hosted_style_request: false,
+                    assume_role_arn: Some("arn:aws:iam::123456789012:role/some_role".to_string()),
+                    assume_role_session_name: Some("session_name".to_string()),
+                    use_web_identity: true,
+                    locking_provider: Some("dynamodb".to_string()),
+                    s3_pool_idle_timeout: Duration::from_secs(1),
+                    sts_pool_idle_timeout: Duration::from_secs(2),
+                    s3_get_internal_server_error_retries: 3,
+                    extra_opts: hashmap! {},
+                    allow_unsafe_rename: false,
                 },
-                profile: Some("default".to_string()),
-                aws_access_key_id: Some("test_id_mixed".to_string()),
-                aws_secret_access_key: Some("test_secret_mixed".to_string()),
-                aws_session_token: None,
-                virtual_hosted_style_request: false,
-                assume_role_arn: Some("arn:aws:iam::123456789012:role/some_role".to_string()),
-                assume_role_session_name: Some("session_name".to_string()),
-                use_web_identity: true,
-                locking_provider: Some("dynamodb".to_string()),
-                s3_pool_idle_timeout: Duration::from_secs(1),
-                sts_pool_idle_timeout: Duration::from_secs(2),
-                s3_get_internal_server_error_retries: 3,
-                extra_opts: hashmap! {},
-                allow_unsafe_rename: false,
-            },
-            options
-        );
+                options
+            );
+        })
     }
     #[test]
     #[serial]
     fn storage_options_web_identity_test() {
-        let _options = S3StorageOptions::from_map(&hashmap! {
-            s3_constants::AWS_REGION.to_string() => "eu-west-1".to_string(),
-            s3_constants::AWS_WEB_IDENTITY_TOKEN_FILE.to_string() => "web_identity_token_file".to_string(),
-            s3_constants::AWS_ROLE_ARN.to_string() => "arn:aws:iam::123456789012:role/web_identity_role".to_string(),
-            s3_constants::AWS_ROLE_SESSION_NAME.to_string() => "web_identity_session_name".to_string(),
-        });
+        ScopedEnv::run(|| {
+            let _options = S3StorageOptions::from_map(&hashmap! {
+                s3_constants::AWS_REGION.to_string() => "eu-west-1".to_string(),
+                s3_constants::AWS_WEB_IDENTITY_TOKEN_FILE.to_string() => "web_identity_token_file".to_string(),
+                s3_constants::AWS_ROLE_ARN.to_string() => "arn:aws:iam::123456789012:role/web_identity_role".to_string(),
+                s3_constants::AWS_ROLE_SESSION_NAME.to_string() => "web_identity_session_name".to_string(),
+            });
 
-        assert_eq!(
-            "eu-west-1",
-            std::env::var(s3_constants::AWS_REGION).unwrap()
-        );
+            assert_eq!(
+                "eu-west-1",
+                std::env::var(s3_constants::AWS_REGION).unwrap()
+            );
 
-        assert_eq!(
-            "web_identity_token_file",
-            std::env::var(s3_constants::AWS_WEB_IDENTITY_TOKEN_FILE).unwrap()
-        );
+            assert_eq!(
+                "web_identity_token_file",
+                std::env::var(s3_constants::AWS_WEB_IDENTITY_TOKEN_FILE).unwrap()
+            );
 
-        assert_eq!(
-            "arn:aws:iam::123456789012:role/web_identity_role",
-            std::env::var(s3_constants::AWS_ROLE_ARN).unwrap()
-        );
+            assert_eq!(
+                "arn:aws:iam::123456789012:role/web_identity_role",
+                std::env::var(s3_constants::AWS_ROLE_ARN).unwrap()
+            );
 
-        assert_eq!(
-            "web_identity_session_name",
-            std::env::var(s3_constants::AWS_ROLE_SESSION_NAME).unwrap()
-        );
+            assert_eq!(
+                "web_identity_session_name",
+                std::env::var(s3_constants::AWS_ROLE_SESSION_NAME).unwrap()
+            );
+        })
     }
 
     #[test]
     #[serial]
     fn when_merging_with_env_unsupplied_options_are_added() {
-        let raw_options = hashmap! {};
+        ScopedEnv::run(|| {
+            let raw_options = hashmap! {};
 
-        std::env::set_var(s3_constants::AWS_ACCESS_KEY_ID, "env_key");
-        std::env::set_var(s3_constants::AWS_ENDPOINT_URL, "env_key");
-        std::env::set_var(s3_constants::AWS_SECRET_ACCESS_KEY, "env_key");
-        std::env::set_var(s3_constants::AWS_REGION, "env_key");
+            std::env::set_var(s3_constants::AWS_ACCESS_KEY_ID, "env_key");
+            std::env::set_var(s3_constants::AWS_ENDPOINT_URL, "env_key");
+            std::env::set_var(s3_constants::AWS_SECRET_ACCESS_KEY, "env_key");
+            std::env::set_var(s3_constants::AWS_REGION, "env_key");
 
-        let combined_options = S3ObjectStoreFactory {}.with_env_s3(&StorageOptions(raw_options));
+            let combined_options =
+                S3ObjectStoreFactory {}.with_env_s3(&StorageOptions(raw_options));
 
-        assert_eq!(combined_options.0.len(), 4);
+            assert_eq!(combined_options.0.len(), 4);
 
-        for v in combined_options.0.values() {
-            assert_eq!(v, "env_key");
-        }
+            for v in combined_options.0.values() {
+                assert_eq!(v, "env_key");
+            }
+        })
     }
 
     #[test]
     #[serial]
     fn when_merging_with_env_supplied_options_take_precedence() {
-        let raw_options = hashmap! {
-            "AWS_ACCESS_KEY_ID".to_string() => "options_key".to_string(),
-            "AWS_ENDPOINT_URL".to_string() => "options_key".to_string(),
-            "AWS_SECRET_ACCESS_KEY".to_string() => "options_key".to_string(),
-            "AWS_REGION".to_string() => "options_key".to_string()
-        };
+        ScopedEnv::run(|| {
+            let raw_options = hashmap! {
+                "AWS_ACCESS_KEY_ID".to_string() => "options_key".to_string(),
+                "AWS_ENDPOINT_URL".to_string() => "options_key".to_string(),
+                "AWS_SECRET_ACCESS_KEY".to_string() => "options_key".to_string(),
+                "AWS_REGION".to_string() => "options_key".to_string()
+            };
 
-        std::env::set_var("aws_access_key_id", "env_key");
-        std::env::set_var("aws_endpoint", "env_key");
-        std::env::set_var("aws_secret_access_key", "env_key");
-        std::env::set_var("aws_region", "env_key");
+            std::env::set_var("aws_access_key_id", "env_key");
+            std::env::set_var("aws_endpoint", "env_key");
+            std::env::set_var("aws_secret_access_key", "env_key");
+            std::env::set_var("aws_region", "env_key");
 
-        let combined_options = S3ObjectStoreFactory {}.with_env_s3(&StorageOptions(raw_options));
+            let combined_options =
+                S3ObjectStoreFactory {}.with_env_s3(&StorageOptions(raw_options));
 
-        for v in combined_options.0.values() {
-            assert_eq!(v, "options_key");
-        }
+            for v in combined_options.0.values() {
+                assert_eq!(v, "options_key");
+            }
+        });
     }
 }

--- a/crates/aws/src/storage.rs
+++ b/crates/aws/src/storage.rs
@@ -669,19 +669,23 @@ mod tests {
     fn when_merging_with_env_unsupplied_options_are_added() {
         ScopedEnv::run(|| {
             let raw_options = hashmap! {};
+            let keys_under_test = vec![
+                AmazonS3ConfigKey::Endpoint,
+                AmazonS3ConfigKey::SecretAccessKey,
+                AmazonS3ConfigKey::Region,
+                AmazonS3ConfigKey::AccessKeyId,
+            ];
 
-            std::env::set_var(s3_constants::AWS_ACCESS_KEY_ID, "env_key");
-            std::env::set_var(s3_constants::AWS_ENDPOINT_URL, "env_key");
-            std::env::set_var(s3_constants::AWS_SECRET_ACCESS_KEY, "env_key");
-            std::env::set_var(s3_constants::AWS_REGION, "env_key");
+            for k in keys_under_test.iter() {
+                std::env::set_var(k.as_ref(), "env_key");
+            }
 
             let combined_options =
                 S3ObjectStoreFactory {}.with_env_s3(&StorageOptions(raw_options));
 
-            assert_eq!(combined_options.0.len(), 4);
-
-            for v in combined_options.0.values() {
-                assert_eq!(v, "env_key");
+            for k in keys_under_test.iter() {
+                assert!(combined_options.0.contains_key(k.as_ref()));
+                assert_eq!(&combined_options.0[k.as_ref()], "env_key");
             }
         })
     }
@@ -690,23 +694,28 @@ mod tests {
     #[serial]
     fn when_merging_with_env_supplied_options_take_precedence() {
         ScopedEnv::run(|| {
-            let raw_options = hashmap! {
-                "AWS_ACCESS_KEY_ID".to_string() => "options_key".to_string(),
-                "AWS_ENDPOINT_URL".to_string() => "options_key".to_string(),
-                "AWS_SECRET_ACCESS_KEY".to_string() => "options_key".to_string(),
-                "AWS_REGION".to_string() => "options_key".to_string()
-            };
+            let keys_under_test = vec![
+                AmazonS3ConfigKey::Endpoint,
+                AmazonS3ConfigKey::SecretAccessKey,
+                AmazonS3ConfigKey::Region,
+                AmazonS3ConfigKey::AccessKeyId,
+            ];
 
-            std::env::set_var("aws_access_key_id", "env_key");
-            std::env::set_var("aws_endpoint", "env_key");
-            std::env::set_var("aws_secret_access_key", "env_key");
-            std::env::set_var("aws_region", "env_key");
+            let raw_options = keys_under_test
+                .iter()
+                .map(|k| (k.as_ref().to_string(), "options_key".to_string()))
+                .collect();
+
+            for k in keys_under_test.iter() {
+                std::env::set_var(k.as_ref(), "env_key");
+            }
 
             let combined_options =
                 S3ObjectStoreFactory {}.with_env_s3(&StorageOptions(raw_options));
 
-            for v in combined_options.0.values() {
-                assert_eq!(v, "options_key");
+            for k in keys_under_test.iter() {
+                assert!(combined_options.0.contains_key(k.as_ref()));
+                assert_eq!(&combined_options.0[k.as_ref()], "options_key");
             }
         });
     }


### PR DESCRIPTION
# Description
When merging supplied storage options with environment variables, we need to canonicalize the items in the storage options first. This is because for some keys there is multiple valid definitions (`AWS_ENDPOINT_URL`, `AWS_ENDPOINT`) and also casing (`AWS_ACCESS_KEY_ID`, `aws_access_key_id`). It seems like the 'more canonical' lowercase versions win, which can cause surprise if you have one set of access keys in your environment and one in your storage options. This is exacerbated as the `S3StorageOptions` construction also _sets_ envrionment variables, and it always does so into the canonical lowercase versions. I found this when opening two buckets with different credentials, and the credentials for the first were being used to open the second.