### PR TITLE
chore: remove caches from github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,6 @@ jobs:
           toolchain: stable
           override: true
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: build and lint with clippy
         run: cargo clippy --features azure,datafusion,s3,gcs,glue --tests
 
@@ -82,8 +80,6 @@ jobs:
           toolchain: "stable"
           override: true
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Run tests
         run: cargo test --verbose --features datafusion,azure
 
@@ -117,22 +113,6 @@ jobs:
           profile: default
           toolchain: stable
           override: true
-
-      # - uses: actions/setup-java@v3
-      #   with:
-      #     distribution: "zulu"
-      #     java-version: "17"
-
-      # - uses: beyondstorage/setup-hdfs@master
-      #   with:
-      #     hdfs-version: "3.3.2"
-
-      # - name: Set Hadoop env
-      #   run: |
-      #     echo "CLASSPATH=$CLASSPATH:`hadoop classpath --glob`" >> $GITHUB_ENV
-      #     echo "LD_LIBRARY_PATH=$JAVA_HOME/lib/server" >> $GITHUB_ENV
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Start emulated services
         run: docker-compose up -d


### PR DESCRIPTION
These caches cause more problems than they're worth and cause runners to exhaust their disk space
