### PR TITLE
docs: fixing example in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to delta-rs
 
-Development on this project is mostly driven by volunteer contributors. We welcome new contributors, including not only those who develop new features, but also those who are able to help with documentation and provide detailed bug reports. 
+Development on this project is mostly driven by volunteer contributors. We welcome new contributors, including not only those who develop new features, but also those who are able to help with documentation and provide detailed bug reports.
 
 Please take note of our [code of conduct](CODE_OF_CONDUCT.md).
 
@@ -31,7 +31,7 @@ python -m pytest tests/test_writer.py -s -k "test_with_deltalake_schema"
 - Run some Rust code, e.g. run an example
 ```
 cd crates/deltalake
-cargo run --examples basic_operations
+cargo run --example basic_operations --features="datafusion"
 ```
 
 ## Run the docs locally


### PR DESCRIPTION
# Description
**The current example rust tests do not work:**

```bash
$ cargo run --examples basic_operations

error: unexpected argument '--examples' found

  tip: a similar argument exists: '--example'

Usage: cargo run --example [<NAME>] [args]...

For more information, try '--help'.

```

**This also does not work:**
```bash
$ cargo run --example basic_operations 
error: target `basic_operations` in package `deltalake` requires the features: `datafusion`
Consider enabling them by passing, e.g., `--features="datafusion"`

```

**This does work:**

```
$ cargo run --example basic_operations --features="datafusion"
   Compiling deltalake-core v0.17.0 (/Users/gautham/src/delta-rs/crates/core)
...
...
```

Making a quick update to the docs so that the example works out of the box. 