### PR TITLE
chore: add binary field back into test checkpoint

### DIFF
--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -13,9 +13,6 @@ def test_checkpoint(tmp_path: pathlib.Path, sample_data: pa.Table):
     last_checkpoint_path = (
         tmp_table_path / "_delta_log" / "00000000000000000000.checkpoint.parquet"
     )
-
-    # TODO: Include binary after fixing issue "Json error: binary type is not supported"
-    sample_data = sample_data.drop(["binary"])
     write_deltalake(str(tmp_table_path), sample_data)
 
     assert not checkpoint_path.exists()
@@ -32,9 +29,6 @@ def setup_cleanup_metadata(tmp_path: pathlib.Path, sample_data: pa.Table):
     first_log_path = tmp_table_path / "_delta_log" / "00000000000000000000.json"
     second_log_path = tmp_table_path / "_delta_log" / "00000000000000000001.json"
     third_log_path = tmp_table_path / "_delta_log" / "00000000000000000002.json"
-
-    # TODO: Include binary after fixing issue "Json error: binary type is not supported"
-    sample_data = sample_data.drop(["binary"])
 
     # Create few log files
     write_deltalake(str(tmp_table_path), sample_data)


### PR DESCRIPTION
# Description
Resolving TODO in python test by adding binary field back into test checkpoint

