### PR TITLE
fix: object_store 0.9.0 since 0.9.1 causes CI failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ arrow-ord = { version = "50" }
 arrow-row = { version = "50" }
 arrow-schema = { version = "50" }
 arrow-select = { version = "50" }
-object_store = { version = "0.9" }
+object_store = { version = "=0.9.0" }
 parquet = { version = "50" }
 
 # datafusion


### PR DESCRIPTION
# Description
See https://github.com/delta-io/delta-rs/pull/2229#issuecomment-1978658659 

This fixes object_store to use 0.9.0 for now, 

