### PR TITLE
fix(rust): update snapshot when having concurrent writers

### DIFF
--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -812,6 +812,11 @@ impl std::future::IntoFuture for WriteBuilder {
             // created actions, it may be safe to assume, that we want to include all actions.
             // then again, having only some tombstones may be misleading.
             if let Some(mut snapshot) = this.snapshot {
+                if snapshot.version() != commit.version - 1 {
+                    snapshot
+                        .update(this.log_store.clone(), Some(commit.version - 1))
+                        .await?;
+                }
                 snapshot.merge(commit.data.actions, &commit.data.operation, commit.version)?;
                 Ok(DeltaTable::new_with_state(this.log_store, snapshot))
             } else {


### PR DESCRIPTION
# Description
This PR handles the case of updating the snapshot when having concurrent writers. The issue is apparent when the data store supports concurrent writes (e.g. `S3DynamoDbLogStore`). 

Since our log store implementation guarantees no data loss, it can be the case that two (or more) writers starting from the same snapshot (e.g. version 10), both manage to commit their changes. One will write version 11, while the other version 12. However the latter will not be able to update the snapshot from version 10 to version 12 (because it lacks information about version 11) and will fail even when the write succeeds. In such cases we update the snapshot to version = committed_version - 1, so that the writer knows how to merge the snapshot.

# Related Issue(s)
<!---
For example:

- closes #106
--->
- fixes #2279
- fixes https://github.com/delta-io/delta-rs/issues/2262

# Documentation

<!---
Share links to useful documentation
--->
