### PR TITLE
feat: support time type

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -890,6 +890,10 @@ pub(crate) fn get_null_of_arrow_type(t: &ArrowDataType) -> DeltaResult<ScalarVal
             precision.to_owned(),
             scale.to_owned(),
         )),
+        ArrowDataType::Time32(TimeUnit::Second) => Ok(ScalarValue::Time32Second(None)),
+        ArrowDataType::Time32(TimeUnit::Millisecond) => Ok(ScalarValue::Time32Millisecond(None)),
+        ArrowDataType::Time64(TimeUnit::Microsecond) => Ok(ScalarValue::Time64Microsecond(None)),
+        ArrowDataType::Time64(TimeUnit::Nanosecond) => Ok(ScalarValue::Time64Nanosecond(None)),
         ArrowDataType::Timestamp(unit, tz) => {
             let tz = tz.to_owned();
             Ok(match unit {

--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -271,7 +271,7 @@ impl TryFrom<&ArrowDataType> for DataType {
             }
             ArrowDataType::Dictionary(_, value_type) => Ok(value_type.as_ref().try_into()?),
             s => Err(ArrowError::SchemaError(format!(
-                "Invalid data type for Delta Lake: {s}"
+                "Invalid data type for Delta Lake {s}"
             ))),
         }
     }

--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -135,6 +135,7 @@ impl TryFrom<&DataType> for ArrowDataType {
                         // timezone. Stored as 4 bytes integer representing days since 1970-01-01
                         Ok(ArrowDataType::Date32)
                     }
+                    PrimitiveType::Time64 => Ok(ArrowDataType::Time64(TimeUnit::Microsecond)),
                     PrimitiveType::Timestamp => Ok(ArrowDataType::Timestamp(
                         TimeUnit::Microsecond,
                         Some("UTC".into()),

--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -805,6 +805,8 @@ mod tests {
             .unwrap_err(),
             _
         ));
+    }
+
     fn test_arrow_from_delta_time64_type() {
         let time_field = DataType::Primitive(PrimitiveType::Time);
         assert_eq!(

--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -224,6 +224,9 @@ impl TryFrom<&ArrowDataType> for DataType {
             }),
             ArrowDataType::Date32 => Ok(DataType::Primitive(PrimitiveType::Date)),
             ArrowDataType::Date64 => Ok(DataType::Primitive(PrimitiveType::Date)),
+            ArrowDataType::Time64(TimeUnit::Microsecond) => {
+                Ok(DataType::Primitive(PrimitiveType::Time64))
+            }
             ArrowDataType::Timestamp(TimeUnit::Microsecond, None) => {
                 Ok(DataType::Primitive(PrimitiveType::TimestampNtz))
             }
@@ -802,6 +805,12 @@ mod tests {
             .unwrap_err(),
             _
         ));
+    fn test_arrow_from_delta_time64_type() {
+        let time_field = DataType::Primitive(PrimitiveType::Time64);
+        assert_eq!(
+            <ArrowDataType as TryFrom<&DataType>>::try_from(&time_field).unwrap(),
+            ArrowDataType::Time64(TimeUnit::Microsecond)
+        );
     }
 
     #[test]

--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -135,7 +135,7 @@ impl TryFrom<&DataType> for ArrowDataType {
                         // timezone. Stored as 4 bytes integer representing days since 1970-01-01
                         Ok(ArrowDataType::Date32)
                     }
-                    PrimitiveType::Time64 => Ok(ArrowDataType::Time64(TimeUnit::Microsecond)),
+                    PrimitiveType::Time => Ok(ArrowDataType::Time64(TimeUnit::Nanosecond)),
                     PrimitiveType::Timestamp => Ok(ArrowDataType::Timestamp(
                         TimeUnit::Microsecond,
                         Some("UTC".into()),
@@ -224,8 +224,8 @@ impl TryFrom<&ArrowDataType> for DataType {
             }),
             ArrowDataType::Date32 => Ok(DataType::Primitive(PrimitiveType::Date)),
             ArrowDataType::Date64 => Ok(DataType::Primitive(PrimitiveType::Date)),
-            ArrowDataType::Time64(TimeUnit::Microsecond) => {
-                Ok(DataType::Primitive(PrimitiveType::Time64))
+            ArrowDataType::Time64(TimeUnit::Nanosecond) => {
+                Ok(DataType::Primitive(PrimitiveType::Time))
             }
             ArrowDataType::Timestamp(TimeUnit::Microsecond, None) => {
                 Ok(DataType::Primitive(PrimitiveType::TimestampNtz))
@@ -806,10 +806,10 @@ mod tests {
             _
         ));
     fn test_arrow_from_delta_time64_type() {
-        let time_field = DataType::Primitive(PrimitiveType::Time64);
+        let time_field = DataType::Primitive(PrimitiveType::Time);
         assert_eq!(
             <ArrowDataType as TryFrom<&DataType>>::try_from(&time_field).unwrap(),
-            ArrowDataType::Time64(TimeUnit::Microsecond)
+            ArrowDataType::Time64(TimeUnit::Nanosecond)
         );
     }
 

--- a/crates/core/src/kernel/expressions/eval.rs
+++ b/crates/core/src/kernel/expressions/eval.rs
@@ -9,7 +9,7 @@ use arrow_arith::numeric::{add, div, mul, sub};
 use arrow_array::{
     Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Datum, Decimal128Array, Float32Array,
     Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,
-    StructArray, TimestampMicrosecondArray,
+    StructArray, Time64MicrosecondArray, TimestampMicrosecondArray,
 };
 use arrow_ord::cmp::{eq, gt, gt_eq, lt, lt_eq, neq};
 use arrow_schema::{ArrowError, Field as ArrowField, Schema as ArrowSchema};
@@ -46,6 +46,7 @@ impl Scalar {
             Double(val) => Arc::new(Float64Array::from_value(*val, num_rows)),
             String(val) => Arc::new(StringArray::from(vec![val.clone(); num_rows])),
             Boolean(val) => Arc::new(BooleanArray::from(vec![*val; num_rows])),
+            Time64(val) => Arc::new(Time64MicrosecondArray::from_value(*val, num_rows)),
             Timestamp(val) => {
                 Arc::new(TimestampMicrosecondArray::from_value(*val, num_rows).with_timezone("UTC"))
             }
@@ -66,6 +67,7 @@ impl Scalar {
                     PrimitiveType::Double => Arc::new(Float64Array::new_null(num_rows)),
                     PrimitiveType::String => Arc::new(StringArray::new_null(num_rows)),
                     PrimitiveType::Boolean => Arc::new(BooleanArray::new_null(num_rows)),
+                    PrimitiveType::Time64 => Arc::new(Time64MicrosecondArray::new_null(num_rows)),
                     PrimitiveType::Timestamp => {
                         Arc::new(TimestampMicrosecondArray::new_null(num_rows).with_timezone("UTC"))
                     }

--- a/crates/core/src/kernel/expressions/eval.rs
+++ b/crates/core/src/kernel/expressions/eval.rs
@@ -9,7 +9,7 @@ use arrow_arith::numeric::{add, div, mul, sub};
 use arrow_array::{
     Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Datum, Decimal128Array, Float32Array,
     Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,
-    StructArray, Time64MicrosecondArray, TimestampMicrosecondArray,
+    StructArray, Time64NanosecondArray, TimestampMicrosecondArray,
 };
 use arrow_ord::cmp::{eq, gt, gt_eq, lt, lt_eq, neq};
 use arrow_schema::{ArrowError, Field as ArrowField, Schema as ArrowSchema};
@@ -46,7 +46,7 @@ impl Scalar {
             Double(val) => Arc::new(Float64Array::from_value(*val, num_rows)),
             String(val) => Arc::new(StringArray::from(vec![val.clone(); num_rows])),
             Boolean(val) => Arc::new(BooleanArray::from(vec![*val; num_rows])),
-            Time64(val) => Arc::new(Time64MicrosecondArray::from_value(*val, num_rows)),
+            Time(val) => Arc::new(Time64NanosecondArray::from_value(*val, num_rows)),
             Timestamp(val) => {
                 Arc::new(TimestampMicrosecondArray::from_value(*val, num_rows).with_timezone("UTC"))
             }
@@ -67,7 +67,7 @@ impl Scalar {
                     PrimitiveType::Double => Arc::new(Float64Array::new_null(num_rows)),
                     PrimitiveType::String => Arc::new(StringArray::new_null(num_rows)),
                     PrimitiveType::Boolean => Arc::new(BooleanArray::new_null(num_rows)),
-                    PrimitiveType::Time64 => Arc::new(Time64MicrosecondArray::new_null(num_rows)),
+                    PrimitiveType::Time => Arc::new(Time64NanosecondArray::new_null(num_rows)),
                     PrimitiveType::Timestamp => {
                         Arc::new(TimestampMicrosecondArray::new_null(num_rows).with_timezone("UTC"))
                     }

--- a/crates/core/src/kernel/expressions/scalars.rs
+++ b/crates/core/src/kernel/expressions/scalars.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter};
 
 use arrow_array::Array;
 use arrow_schema::TimeUnit;
-use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeDelta, TimeZone, Timelike, Utc};
 use object_store::path::Path;
 
 use crate::kernel::{DataType, Error, PrimitiveType, StructField};
@@ -31,6 +31,8 @@ pub enum Scalar {
     String(String),
     /// true or false value
     Boolean(bool),
+    /// Microseconds since midnight
+    Time64(i64),
     /// Microsecond precision timestamp, adjusted to UTC.
     Timestamp(i64),
     /// Microsecond precision timestamp, with no timezone.
@@ -51,6 +53,7 @@ impl Scalar {
     /// Returns the data type of this scalar.
     pub fn data_type(&self) -> DataType {
         match self {
+            Self::Boolean(_) => DataType::Primitive(PrimitiveType::Boolean),
             Self::Integer(_) => DataType::Primitive(PrimitiveType::Integer),
             Self::Long(_) => DataType::Primitive(PrimitiveType::Long),
             Self::Short(_) => DataType::Primitive(PrimitiveType::Short),
@@ -58,7 +61,7 @@ impl Scalar {
             Self::Float(_) => DataType::Primitive(PrimitiveType::Float),
             Self::Double(_) => DataType::Primitive(PrimitiveType::Double),
             Self::String(_) => DataType::Primitive(PrimitiveType::String),
-            Self::Boolean(_) => DataType::Primitive(PrimitiveType::Boolean),
+            Self::Time64(_) => DataType::Primitive(PrimitiveType::Time64),
             Self::Timestamp(_) => DataType::Primitive(PrimitiveType::Timestamp),
             Self::TimestampNtz(_) => DataType::Primitive(PrimitiveType::TimestampNtz),
             Self::Date(_) => DataType::Primitive(PrimitiveType::Date),
@@ -91,6 +94,11 @@ impl Scalar {
                 } else {
                     "false".to_string()
                 }
+            }
+            Self::Time64(t) => {
+                let time_delta = TimeDelta::milliseconds(*t);
+                let time = NaiveTime::from_hms_micro_opt(0, 0, 0, 0).unwrap() + time_delta;
+                time.format("%H:%M:%S%.6f").to_string()
             }
             Self::TimestampNtz(ts) | Self::Timestamp(ts) => {
                 let ts = Utc.timestamp_micros(*ts).single().unwrap();
@@ -223,6 +231,10 @@ impl Scalar {
                 .as_any()
                 .downcast_ref::<Date32Array>()
                 .map(|v| Self::Date(v.value(index))),
+            Time64(TimeUnit::Microsecond) => arr
+                .as_any()
+                .downcast_ref::<Time64MicrosecondArray>()
+                .map(|v| Self::Time64(v.value(index))),
             // TODO handle timezones when implementing timestamp ntz feature.
             Timestamp(TimeUnit::Microsecond, tz) => match tz {
                 None => arr
@@ -291,6 +303,7 @@ impl PartialOrd for Scalar {
             (Double(a), Double(b)) => a.partial_cmp(b),
             (String(a), String(b)) => a.partial_cmp(b),
             (Boolean(a), Boolean(b)) => a.partial_cmp(b),
+            (Time64(a), Time64(b)) => a.partial_cmp(b),
             (Timestamp(a), Timestamp(b)) => a.partial_cmp(b),
             (TimestampNtz(a), TimestampNtz(b)) => a.partial_cmp(b),
             (Date(a), Date(b)) => a.partial_cmp(b),
@@ -317,6 +330,7 @@ impl Display for Scalar {
             Self::Double(fl) => write!(f, "{}", fl),
             Self::String(s) => write!(f, "'{}'", s),
             Self::Boolean(b) => write!(f, "{}", b),
+            Self::Time64(t) => write!(f, "{}", t),
             Self::Timestamp(ts) => write!(f, "{}", ts),
             Self::TimestampNtz(ts) => write!(f, "{}", ts),
             Self::Date(d) => write!(f, "{}", d),
@@ -433,6 +447,18 @@ impl PrimitiveType {
                 let date = Utc.from_utc_datetime(&date);
                 let days = date.signed_duration_since(*UNIX_EPOCH).num_days() as i32;
                 Ok(Scalar::Date(days))
+            }
+            Time64 => {
+                const NANOS_IN_MICRO: u32 = 1_000;
+                const MICROS_IN_SEC: u32 = 1_000_000;
+
+                let time = NaiveTime::parse_from_str(raw, "%H:%M:%S%.f")
+                    .map_err(|_| self.parse_error(raw))?;
+                let seconds_from_midnight = time.num_seconds_from_midnight();
+                let microseconds = time.nanosecond() / NANOS_IN_MICRO;
+                let total_micros = seconds_from_midnight * MICROS_IN_SEC + microseconds;
+
+                Ok(Scalar::Time64(total_micros as i64))
             }
             Timestamp => {
                 let timestamp = NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S%.f")

--- a/crates/core/src/kernel/models/schema.rs
+++ b/crates/core/src/kernel/models/schema.rs
@@ -498,6 +498,8 @@ pub enum PrimitiveType {
     Binary,
     /// Date: Calendar date (year, month, day)
     Date,
+    /// Microsecond precision time
+    Time64,
     /// Microsecond precision timestamp, adjusted to UTC.
     Timestamp,
     /// Micrsoecond precision timestamp with no timezone
@@ -567,6 +569,7 @@ impl Display for PrimitiveType {
             PrimitiveType::Boolean => write!(f, "boolean"),
             PrimitiveType::Binary => write!(f, "binary"),
             PrimitiveType::Date => write!(f, "date"),
+            PrimitiveType::Time64 => write!(f, "time64"),
             PrimitiveType::Timestamp => write!(f, "timestamp"),
             PrimitiveType::TimestampNtz => write!(f, "timestampNtz"),
             PrimitiveType::Decimal(precision, scale) => {
@@ -622,6 +625,7 @@ impl DataType {
     pub const BOOLEAN: Self = DataType::Primitive(PrimitiveType::Boolean);
     pub const BINARY: Self = DataType::Primitive(PrimitiveType::Binary);
     pub const DATE: Self = DataType::Primitive(PrimitiveType::Date);
+    pub const TIME64: Self = DataType::Primitive(PrimitiveType::Time64);
     pub const TIMESTAMP: Self = DataType::Primitive(PrimitiveType::Timestamp);
     pub const TIMESTAMPNTZ: Self = DataType::Primitive(PrimitiveType::TimestampNtz);
 

--- a/crates/core/src/kernel/models/schema.rs
+++ b/crates/core/src/kernel/models/schema.rs
@@ -499,7 +499,7 @@ pub enum PrimitiveType {
     /// Date: Calendar date (year, month, day)
     Date,
     /// Microsecond precision time
-    Time64,
+    Time,
     /// Microsecond precision timestamp, adjusted to UTC.
     Timestamp,
     /// Micrsoecond precision timestamp with no timezone
@@ -569,7 +569,7 @@ impl Display for PrimitiveType {
             PrimitiveType::Boolean => write!(f, "boolean"),
             PrimitiveType::Binary => write!(f, "binary"),
             PrimitiveType::Date => write!(f, "date"),
-            PrimitiveType::Time64 => write!(f, "time64"),
+            PrimitiveType::Time => write!(f, "time"),
             PrimitiveType::Timestamp => write!(f, "timestamp"),
             PrimitiveType::TimestampNtz => write!(f, "timestampNtz"),
             PrimitiveType::Decimal(precision, scale) => {
@@ -625,7 +625,7 @@ impl DataType {
     pub const BOOLEAN: Self = DataType::Primitive(PrimitiveType::Boolean);
     pub const BINARY: Self = DataType::Primitive(PrimitiveType::Binary);
     pub const DATE: Self = DataType::Primitive(PrimitiveType::Date);
-    pub const TIME64: Self = DataType::Primitive(PrimitiveType::Time64);
+    pub const TIME: Self = DataType::Primitive(PrimitiveType::Time);
     pub const TIMESTAMP: Self = DataType::Primitive(PrimitiveType::Timestamp);
     pub const TIMESTAMPNTZ: Self = DataType::Primitive(PrimitiveType::TimestampNtz);
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1179,7 +1179,7 @@ fn scalar_to_py(value: &Scalar, py_date: &PyAny, py: Python) -> PyResult<PyObjec
         Long(val) => val.to_object(py),
         Float(val) => val.to_object(py),
         Double(val) => val.to_object(py),
-        Time64(_) => {
+        Time(_) => {
             let value = value.serialize();
             value.to_object(py)
         }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1179,6 +1179,10 @@ fn scalar_to_py(value: &Scalar, py_date: &PyAny, py: Python) -> PyResult<PyObjec
         Long(val) => val.to_object(py),
         Float(val) => val.to_object(py),
         Double(val) => val.to_object(py),
+        Time64(_) => {
+            let value = value.serialize();
+            value.to_object(py)
+        }
         Timestamp(_) => {
             // We need to manually append 'Z' add to end so that pyarrow can cast the
             // the scalar value to pa.timestamp("us","UTC")


### PR DESCRIPTION
# Description
This PR adds a `Time` `PrimitiveType` so that `DeltaTable`s support the Arrow time type. Nanosecond precision was chosen to align with DataFusion's default time precision.

I'm opening this as draft since there was discussion in the related issue about how time is not supported by the delta protocol. I'm curious to understand what the consequences of that would be wrt merging this PR -- please let me know in the comments!

# Related Issue(s)

- closes #2272 

# Documentation

