### PR TITLE
fix: replace assert and AssertionError with appropriate exceptions

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -354,16 +354,18 @@ def write_deltalake(
                     f"Data schema:\n{schema}\nTable Schema:\n{table.schema().to_pyarrow(as_large_types=large_dtypes)}"
                 )
             if mode == "error":
-                raise AssertionError("DeltaTable already exists.")
+                raise FileExistsError(
+                    "Delta table already exists, write mode set to error."
+                )
             elif mode == "ignore":
                 return
 
             current_version = table.version()
 
-            if partition_by:
-                assert (
-                    partition_by == table.metadata().partition_columns
-                ), f"Partition columns should be {table.metadata().partition_columns} but is {partition_by}"
+            if partition_by and partition_by != table.metadata().partition_columns:
+                raise ValueError(
+                    f"Partition columns should be {table.metadata().partition_columns} but is {partition_by}"
+                )
             else:
                 partition_by = table.metadata().partition_columns
 

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -421,7 +421,7 @@ def test_write_modes(tmp_path: pathlib.Path, sample_data: pa.Table, engine):
     assert DeltaTable(tmp_path).to_pyarrow_table() == sample_data
 
     if engine == "pyarrow":
-        with pytest.raises(AssertionError):
+        with pytest.raises(FileExistsError):
             write_deltalake(tmp_path, sample_data, mode="error")
     elif engine == "rust":
         with pytest.raises(DeltaError):
@@ -481,7 +481,7 @@ def test_fails_wrong_partitioning(
     existing_table: DeltaTable, sample_data: pa.Table, engine
 ):
     if engine == "pyarrow":
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             write_deltalake(
                 existing_table,
                 sample_data,


### PR DESCRIPTION
# Description

- Replaces assert and AssertionError with built-in exceptions
- Amended tests to reference new exception types
- Following conventions in file of using built-in exceptions rather than custom exceptions

# Related Issue(s)
Closes https://github.com/delta-io/delta-rs/issues/2242

# Documentation

<!---
Share links to useful documentation
--->
