### PR TITLE
fix: merge predicate for concurrent writes

### DIFF
--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -2720,7 +2720,6 @@ mod tests {
         assert_eq!(generalized, expected_filter);
     }
 
-
     #[tokio::test]
     async fn test_generalize_filter_keeps_only_static_target_references() {
         let source = TableReference::parse_str("source");

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1576,6 +1576,7 @@ mod tests {
     use datafusion_expr::LogicalPlanBuilder;
     use datafusion_expr::Operator;
     use itertools::Itertools;
+    use regex::Regex;
     use serde_json::json;
     use std::collections::HashMap;
     use std::ops::Neg;
@@ -2128,10 +2129,9 @@ mod tests {
         let commit_info = table.history(None).await.unwrap();
         let last_commit = &commit_info[0];
         let parameters = last_commit.operation_parameters.clone().unwrap();
-        assert_eq!(
-            parameters["predicate"],
-            json!("id = 'C' OR id = 'X' OR id = 'B'")
-        );
+        let predicate = parameters["predicate"].as_str().unwrap();
+        let re = Regex::new(r"^id = '(C|X|B)' OR id = '(C|X|B)' OR id = '(C|X|B)'$").unwrap();
+        assert!(re.is_match(predicate));
 
         let expected = vec![
             "+-------+------------+----+",

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1988,6 +1988,10 @@ mod tests {
         let last_commit = &commit_info[0];
         let parameters = last_commit.operation_parameters.clone().unwrap();
         assert!(!parameters.contains_key("predicate"));
+        assert_eq!(
+            parameters["mergePredicate"],
+            "target.id = source.id AND target.modified = '2021-02-02'"
+        );
 
         let expected = vec![
             "+----+-------+------------+",
@@ -2058,6 +2062,10 @@ mod tests {
         let last_commit = &commit_info[0];
         let parameters = last_commit.operation_parameters.clone().unwrap();
         assert_eq!(parameters["predicate"], "modified = '2021-02-02'");
+        assert_eq!(
+            parameters["mergePredicate"],
+            "target.id = source.id AND target.modified = '2021-02-02'"
+        );
     }
 
     #[tokio::test]
@@ -2472,6 +2480,11 @@ mod tests {
         assert_eq!(metrics.num_target_rows_deleted, 0);
         assert_eq!(metrics.num_output_rows, 3);
         assert_eq!(metrics.num_source_rows, 3);
+
+        let commit_info = table.history(None).await.unwrap();
+        let last_commit = &commit_info[0];
+        let parameters = last_commit.operation_parameters.clone().unwrap();
+        assert_eq!(parameters["predicate"], json!("modified = '2021-02-02'"));
 
         let expected = vec![
             "+----+-------+------------+",

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -493,8 +493,7 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                             read_snapshot,
                             this.data.operation.read_predicate(),
                             &this.data.actions,
-                            // TODO allow tainting whole table
-                            false,
+                            this.data.operation.read_whole_table(),
                         )?;
                         let conflict_checker = ConflictChecker::new(
                             transaction_info,

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -380,8 +380,11 @@ pub enum DeltaOperation {
     /// Merge data with a source data with the following predicate
     #[serde(rename_all = "camelCase")]
     Merge {
-        /// The merge predicate
+        /// Cleaned merge predicate for conflict checks
         predicate: Option<String>,
+
+        /// The original merge predicate
+        merge_predicate: Option<String>,
 
         /// Match operations performed
         matched_predicates: Vec<MergePredicate>,
@@ -541,9 +544,8 @@ impl DeltaOperation {
     /// Denotes if the operation reads the entire table
     pub fn read_whole_table(&self) -> bool {
         match self {
-            // TODO just adding one operation example, as currently none of the
-            // implemented operations scan the entire table.
-            Self::Write { predicate, .. } if predicate.is_none() => false,
+            // Predicate is none -> Merge operation had to join full source and target
+            Self::Merge { predicate, .. } if predicate.is_none() => true,
             _ => false,
         }
     }

--- a/crates/core/tests/command_merge.rs
+++ b/crates/core/tests/command_merge.rs
@@ -1,0 +1,248 @@
+#![allow(dead_code)]
+mod fs_common;
+
+use arrow_array::RecordBatch;
+use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+use datafusion::dataframe::DataFrame;
+use datafusion::prelude::SessionContext;
+use datafusion_expr::{col, Expr, lit};
+use deltalake_core::kernel::{DataType as DeltaDataType, PrimitiveType, StructField, StructType};
+use deltalake_core::operations::merge::MergeMetrics;
+use deltalake_core::operations::transaction::TransactionError;
+use deltalake_core::protocol::SaveMode;
+use deltalake_core::{open_table, DeltaOps, DeltaResult, DeltaTable, DeltaTableError};
+use std::sync::Arc;
+use datafusion_common::Column;
+
+async fn create_table(table_uri: &String, partition: Option<Vec<&str>>) -> DeltaTable {
+    let table_schema = get_delta_schema();
+    let ops = DeltaOps::try_from_uri(table_uri.clone()).await.unwrap();
+    let table = ops
+        .create()
+        .with_columns(table_schema.fields().clone())
+        .with_partition_columns(partition.unwrap_or_default())
+        .await
+        .expect("Failed to create table");
+
+    let schema = get_arrow_schema();
+    return write_data(table, &schema).await;
+}
+
+fn get_delta_schema() -> StructType {
+    StructType::new(vec![
+        StructField::new(
+            "id".to_string(),
+            DeltaDataType::Primitive(PrimitiveType::String),
+            true,
+        ),
+        StructField::new(
+            "value".to_string(),
+            DeltaDataType::Primitive(PrimitiveType::Integer),
+            true,
+        ),
+        StructField::new(
+            "event_date".to_string(),
+            DeltaDataType::Primitive(PrimitiveType::String),
+            true,
+        ),
+    ])
+}
+
+fn get_arrow_schema() -> Arc<ArrowSchema> {
+    return Arc::new(ArrowSchema::new(vec![
+        Field::new("id", DataType::Utf8, true),
+        Field::new("value", DataType::Int32, true),
+        Field::new("event_date", DataType::Utf8, true),
+    ]));
+}
+
+async fn write_data(table: DeltaTable, schema: &Arc<ArrowSchema>) -> DeltaTable {
+    let batch = RecordBatch::try_new(
+        Arc::clone(schema),
+        vec![
+            Arc::new(arrow::array::StringArray::from(vec!["A", "B", "C", "D"])),
+            Arc::new(arrow::array::Int32Array::from(vec![1, 10, 10, 100])),
+            Arc::new(arrow::array::StringArray::from(vec![
+                "2021-02-01",
+                "2021-02-01",
+                "2021-02-02",
+                "2021-02-02",
+            ])),
+        ],
+    )
+    .unwrap();
+    // write some data
+    DeltaOps(table)
+        .write(vec![batch.clone()])
+        .with_save_mode(SaveMode::Append)
+        .await
+        .unwrap()
+}
+
+fn create_test_data() -> (DataFrame, DataFrame) {
+    let schema = get_arrow_schema();
+    let ctx = SessionContext::new();
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(arrow::array::StringArray::from(vec!["C", "D"])),
+            Arc::new(arrow::array::Int32Array::from(vec![10, 20])),
+            Arc::new(arrow::array::StringArray::from(vec![
+                "2021-02-02",
+                "2021-02-02",
+            ])),
+        ],
+    )
+    .unwrap();
+    let df1 = ctx.read_batch(batch).unwrap();
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(arrow::array::StringArray::from(vec!["E", "F"])),
+            Arc::new(arrow::array::Int32Array::from(vec![10, 20])),
+            Arc::new(arrow::array::StringArray::from(vec![
+                "2021-02-03",
+                "2021-02-03",
+            ])),
+        ],
+    )
+    .unwrap();
+    let df2 = ctx.read_batch(batch).unwrap();
+    return (df1, df2);
+}
+
+async fn merge(
+    table: DeltaTable,
+    df: DataFrame,
+    predicate: Expr,
+) -> DeltaResult<(DeltaTable, MergeMetrics)> {
+    return DeltaOps(table)
+        .merge(df, predicate)
+        .with_source_alias("source")
+        .with_target_alias("target")
+        .when_matched_update(|update| {
+            update
+                .update("value", col("source.value"))
+                .update("event_date", col("source.event_date"))
+        })
+        .unwrap()
+        .when_not_matched_insert(|insert| {
+            insert
+                .set("id", col("source.id"))
+                .set("value", col("source.value"))
+                .set("event_date", col("source.event_date"))
+        })
+        .unwrap()
+        .await;
+}
+
+#[tokio::test]
+async fn test_merge_concurrent_conflict() {
+    // No partition key or filter predicate -> Commit conflict
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let table_uri = tmp_dir.path().to_str().to_owned().unwrap();
+
+    let table_ref1 = create_table(&table_uri.to_string(), Some(vec!["event_date"])).await;
+    let table_ref2 = open_table(table_uri).await.unwrap();
+    let (df1, df2) = create_test_data();
+
+    let expr = col("target.id").eq(col("source.id"));
+    let (_table_ref1, _metrics) = merge(table_ref1, df1, expr.clone()).await.unwrap();
+    let result = merge(table_ref2, df2, expr).await;
+
+    assert!(matches!(
+        result.as_ref().unwrap_err(),
+        DeltaTableError::Transaction { .. }
+    ));
+    if let DeltaTableError::Transaction { source } = result.unwrap_err() {
+        assert!(matches!(source, TransactionError::CommitConflict(_)));
+    }
+}
+
+#[tokio::test]
+async fn test_merge_concurrent_different_partition() {
+    // partition key in predicate -> Successful merge
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let table_uri = tmp_dir.path().to_str().to_owned().unwrap();
+
+    let table_ref1 = create_table(&table_uri.to_string(), Some(vec!["event_date"])).await;
+    let table_ref2 = open_table(table_uri).await.unwrap();
+    let (df1, df2) = create_test_data();
+
+    let expr = col("target.id")
+        .eq(col("source.id"))
+        .and(col("target.event_date").eq(col("source.event_date")));
+    let (_table_ref1, _metrics) = merge(table_ref1, df1, expr.clone()).await.unwrap();
+    let result = merge(table_ref2, df2, expr).await;
+
+    // TODO: Currently it throws a Version mismatch error, but the merge commit was successfully
+    // This bug needs to be fixed, see pull request #2280
+    assert!(!matches!(
+        result.as_ref().unwrap_err(),
+        DeltaTableError::Transaction { .. }
+    ));
+    assert!(matches!(
+        result.as_ref().unwrap_err(),
+        DeltaTableError::Generic(_)
+    ));
+    if let DeltaTableError::Generic(msg) = result.unwrap_err() {
+        assert_eq!(msg, "Version mismatch");
+    }
+}
+
+
+#[tokio::test]
+async fn test_merge_concurrent_no_overlapping_files() {
+    // predicate contains filter and files are not overlapping -> No conflict
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let table_uri = tmp_dir.path().to_str().to_owned().unwrap();
+
+    let table_ref1 = create_table(&table_uri.to_string(), None).await;
+    let table_ref2 = open_table(table_uri).await.unwrap();
+    let (df1, df2) = create_test_data();
+
+    let expr = col("target.id")
+        .eq(col("source.id"));
+    let (_table_ref1, _metrics) = merge(table_ref1, df2, expr.clone().and(col(Column::from_qualified_name("target.event_date")).eq(lit("2021-02-03")))).await.unwrap();
+    let result = merge(table_ref2, df1, expr.and(col(Column::from_qualified_name("target.event_date")).eq(lit("2021-02-02")))).await;
+
+    // TODO: Currently it throws a Version mismatch error, but the merge commit was successfully
+    // This bug needs to be fixed, see pull request #2280
+    assert!(!matches!(
+        result.as_ref().unwrap_err(),
+        DeltaTableError::Transaction { .. }
+    ));
+    assert!(matches!(
+        result.as_ref().unwrap_err(),
+        DeltaTableError::Generic(_)
+    ));
+    if let DeltaTableError::Generic(msg) = result.unwrap_err() {
+        assert_eq!(msg, "Version mismatch");
+    }
+}
+
+
+#[tokio::test]
+async fn test_merge_concurrent_with_overlapping_files() {
+    // predicate contains filter and files are overlapping -> Commit conflict
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let table_uri = tmp_dir.path().to_str().to_owned().unwrap();
+
+    let table_ref1 = create_table(&table_uri.to_string(), None).await;
+    let table_ref2 = open_table(table_uri).await.unwrap();
+    let (df1, _df2) = create_test_data();
+
+    let expr = col("target.id")
+        .eq(col("source.id"));
+    let (_table_ref1, _metrics) = merge(table_ref1, df1.clone(), expr.clone().and(col(Column::from_qualified_name("target.event_date")).lt_eq(lit("2021-02-02")))).await.unwrap();
+    let result = merge(table_ref2, df1, expr.and(col(Column::from_qualified_name("target.event_date")).eq(lit("2021-02-02")))).await;
+
+
+    assert!(matches!(
+        result.as_ref().unwrap_err(),
+        DeltaTableError::Transaction { .. }
+    ));
+    if let DeltaTableError::Transaction { source } = result.unwrap_err() {
+        assert!(matches!(source, TransactionError::CommitConflict(_)));
+    }
+}


### PR DESCRIPTION
# Description
This merge request will change the commitInfo.operationParameters.predicate of the merge operation. This is required to allow conflict checking on concurrent commits. Before, the predicate was just the simple merge predicate like `source.eventId = target.eventId`, but the conflict checker doesn't know these aliases and doesn't have access to the source df. 
So I now use the early_filter, which is also used before to filter a subset of the target table. Basically, the early_filter only contains static filters and partition filters that are converted to fixed values based on the source data.  The early_filter can be None if no column/partition pre-filtering is possible, or if the merge contains a not_match_source operation. (See the generalize_filter function in the file).
The commitInfo predicate uses exactly this filter, except that the target alias is removed.  

The predicate is used by the conflict checker, for example when there are multiple concurrent merges. If there is a predicate, the conflict checker will check whether the concurrent commit wrote or deleted data within that predicate. If the predicate is None, the conflict checker will treat the commit as a `read_whole_table' and interpret any concurrent updates as a conflict. 

Example:
Target table with partition country
Merge with predicate `source.id = target.id AND target.country='DE'` -> CommitInfo predicate `country='DE'`
Merge with predicate `source.id = target.id AND target.country=source.country` -> CommitInfo predicate `country='DE' OR country='US'`
Merge with predicate `source.id = target.id` -> CommitInfo predicate None (As full target table join is required)


# Related Issue(s)
- closes #2084
- closes #2227

