### PR TITLE
docs: make replaceWhere example compile

### DIFF
--- a/docs/src/rust/operations.rs
+++ b/docs/src/rust/operations.rs
@@ -1,10 +1,14 @@
+use std::sync::Arc;
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:replace_where]
     // Assuming there is already a table in this location with some records where `id = '1'` which we want to overwrite
-    use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use arrow_array::RecordBatch;
-    import deltalake::protocol::SaveMode;
+    use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+    use deltalake::datafusion::logical_expr::{col, lit};
+    use deltalake::protocol::SaveMode;
+    use deltalake::DeltaOps;
 
     let schema = ArrowSchema::new(vec![
         Field::new("id", DataType::Utf8, true),
@@ -12,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ]);
 
     let data = RecordBatch::try_new(
-        &schema,
+        schema.into(),
         vec![
             Arc::new(arrow::array::StringArray::from(vec!["1", "1"])),
             Arc::new(arrow::array::Int32Array::from(vec![11, 12])),
@@ -21,11 +25,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .unwrap();
 
     let table = deltalake::open_table("/tmp/my_table").await.unwrap();
-    let table = DeltaOps(table)
+    let _table = DeltaOps(table)
         .write(vec![data])
         .with_save_mode(SaveMode::Overwrite)
         .with_replace_where(col("id").eq(lit("1")))
-        .await;
+        .await
+        .unwrap();
     // --8<-- [end:replace_where]
 
     Ok(())


### PR DESCRIPTION
# Description
Fix for Rust example in ['Overwriting part of the table data using a predicate' part of the delta-rs webpage](https://delta-io.github.io/delta-rs/usage/writing/#overwriting-part-of-the-table-data-using-a-predicate)

The current example uses a keyword, `import` that does not exist in Rust. It also doesn't wrap the `Schema` in an `Arc`.

# Related Issue(s)
<!---
--->

# Documentation

<!---
--->
