### PR TITLE
docs: fix typo

### DIFF
--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -462,7 +462,7 @@ impl DeltaTable {
             .map(|path| self.log_store.to_uri(&path)))
     }
 
-    /// Get the number of files in the table - retrn 0 if no metadata is loaded
+    /// Get the number of files in the table - returns 0 if no metadata is loaded
     pub fn get_files_count(&self) -> usize {
         self.state.as_ref().map(|s| s.files_count()).unwrap_or(0)
     }


### PR DESCRIPTION
# Description
Typo in the Rust docs for `get_files_count`

# Related Issue(s)

# Documentation
