### PR TITLE
fix: clean up some non-datafusion builds

### DIFF
--- a/crates/core/src/operations/transaction/conflict_checker.rs
+++ b/crates/core/src/operations/transaction/conflict_checker.rs
@@ -2,6 +2,7 @@
 use std::collections::HashSet;
 
 use super::CommitInfo;
+#[cfg(feature = "datafusion")]
 use crate::delta_datafusion::DataFusionMixins;
 use crate::errors::DeltaResult;
 use crate::kernel::EagerSnapshot;
@@ -192,7 +193,7 @@ impl<'a> TransactionInfo<'a> {
 
     #[cfg(not(feature = "datafusion"))]
     /// Files read by the transaction
-    pub fn read_files(&self) -> Result<impl Iterator<Item = Add>, CommitConflictError> {
+    pub fn read_files(&self) -> Result<impl Iterator<Item = Add> + '_, CommitConflictError> {
         Ok(self.read_snapshot.file_actions().unwrap().into_iter())
     }
 


### PR DESCRIPTION
Not sure when this regressed but the lack of datafusion broke the core build

```
error[E0432]: unresolved import `crate::delta_datafusion`
 --> crates/core/src/operations/transaction/conflict_checker.rs:5:12
  |
5 | use crate::delta_datafusion::DataFusionMixins;
  |            ^^^^^^^^^^^^^^^^ could not find `delta_datafusion` in the crate root

error[E0700]: hidden type for `impl Iterator<Item = actions::Add>` captures lifetime that does not appear in bounds
   --> crates/core/src/operations/transaction/conflict_checker.rs:196:9
    |
109 | impl<'a> TransactionInfo<'a> {
    |      -- hidden type `impl Iterator<Item = actions::Add> + 'a` captures the lifetime `'a` as defined here
...
195 |     pub fn read_files(&self) -> Result<impl Iterator<Item = Add>, CommitConflictError> {
    |                                        ------------------------- opaque type defined here
196 |         Ok(self.read_snapshot.file_actions().unwrap().into_iter())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Some errors have detailed explanations: E0432, E0700.
```