### PR TITLE
fix: schema evolution not coercing with large arrow types

### DIFF
--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -260,7 +260,8 @@ impl TryFrom<&ArrowDataType> for DataType {
                 } else {
                     panic!("DataType::Map should contain a struct field child");
                 }
-            }
+            },
+            ArrowDataType::Dictionary(_, value_type) => Ok(value_type.as_ref().try_into()?),
             s => Err(ArrowError::SchemaError(format!(
                 "Invalid data type for Delta Lake: {s}"
             ))),

--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -260,7 +260,7 @@ impl TryFrom<&ArrowDataType> for DataType {
                 } else {
                     panic!("DataType::Map should contain a struct field child");
                 }
-            },
+            }
             ArrowDataType::Dictionary(_, value_type) => Ok(value_type.as_ref().try_into()?),
             s => Err(ArrowError::SchemaError(format!(
                 "Invalid data type for Delta Lake: {s}"

--- a/crates/core/src/operations/cast.rs
+++ b/crates/core/src/operations/cast.rs
@@ -162,10 +162,7 @@ mod tests {
     fn test_merge_schema_with_dict() {
         let left_schema = Schema::new(vec![Field::new(
             "f",
-            DataType::Dictionary(
-                Box::new(DataType::Int32),
-                Box::new(DataType::Utf8),
-            ),
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
             false,
         )]);
         let right_schema = Schema::new(vec![Field::new("f", DataType::LargeUtf8, true)]);

--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -623,10 +623,8 @@ impl std::future::IntoFuture for WriteBuilder {
                             if this.mode == SaveMode::Overwrite && this.schema_mode.is_some() {
                                 new_schema = None // we overwrite anyway, so no need to cast
                             } else if this.schema_mode == Some(SchemaMode::Merge) {
-                                new_schema = Some(Arc::new(merge_schema(
-                                    table_schema.as_ref().clone(),
-                                    schema.as_ref().clone(),
-                                )?));
+                                new_schema =
+                                    Some(merge_schema(table_schema.clone(), schema.clone())?);
                             } else {
                                 return Err(schema_err.into());
                             }

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -306,11 +306,9 @@ impl PartitionWriter {
                 WriteMode::MergeSchema => {
                     debug!("The writer and record batch schemas do not match, merging");
 
-                    let merged = merge_schema(
-                        self.arrow_schema.as_ref().clone(),
-                        record_batch.schema().as_ref().clone(),
-                    )?;
-                    self.arrow_schema = Arc::new(merged);
+                    let merged =
+                        merge_schema(self.arrow_schema.clone(), record_batch.schema().clone())?;
+                    self.arrow_schema = merged;
 
                     let mut cols = vec![];
                     for field in self.arrow_schema.fields() {

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -259,7 +259,7 @@ def test_update_schema_rust_writer_append(existing_table: DeltaTable):
         )
     with pytest.raises(
         SchemaMismatchError,
-        match="Schema error: Fail to merge schema field 'utf8' because the from data_type = Int64 does not equal Utf8",
+        match="Schema error: Cannot merge types string and long",
     ):
         write_deltalake(
             existing_table,


### PR DESCRIPTION
# Description
This fixes schema merge for large arrow types in combination with dictionary types. Basically we just allow merging any arrow data type that is the same delta type

# Related Issue(s)
Fixes #2298

# Documentation

<!---
Share links to useful documentation
--->
