### PR TITLE
fix: checkpoint features format below v3,7

### DIFF
--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -1,6 +1,6 @@
 //! Implementation for writing delta checkpoints.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::iter::Iterator;
 
 use arrow_json::ReaderBuilder;

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.16.1"
+version = "0.16.2"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"

--- a/python/tests/pyspark_integration/test_writer_readable.py
+++ b/python/tests/pyspark_integration/test_writer_readable.py
@@ -111,7 +111,7 @@ def test_read_checkpointed_table(tmp_path: pathlib.Path):
     dt = DeltaTable(tmp_path)
     dt.create_checkpoint()
 
-    assert_spark_read_equal(data, str(tmp_path))
+    assert_spark_read_equal(data, str(tmp_path), ["int"])
 
 
 @pytest.mark.pyspark
@@ -129,4 +129,4 @@ def test_read_checkpointed_features_table(tmp_path: pathlib.Path):
     dt = DeltaTable(tmp_path)
     dt.create_checkpoint()
 
-    assert_spark_read_equal(data, str(tmp_path))
+    assert_spark_read_equal(data, str(tmp_path), ["timestamp"])

--- a/python/tests/pyspark_integration/test_writer_readable.py
+++ b/python/tests/pyspark_integration/test_writer_readable.py
@@ -96,3 +96,37 @@ def test_issue_1591_roundtrip_special_characters(tmp_path: pathlib.Path):
 
     loaded = DeltaTable(spark_path).to_pandas()
     assert loaded.shape == data.shape
+
+
+@pytest.mark.pyspark
+@pytest.mark.integration
+def test_read_checkpointed_table(tmp_path: pathlib.Path):
+    data = pa.table(
+        {
+            "int": pa.array([1]),
+        }
+    )
+    write_deltalake(tmp_path, data)
+
+    dt = DeltaTable(tmp_path)
+    dt.create_checkpoint()
+
+    assert_spark_read_equal(data, str(tmp_path))
+
+
+@pytest.mark.pyspark
+@pytest.mark.integration
+def test_read_checkpointed_features_table(tmp_path: pathlib.Path):
+    from datetime import datetime
+
+    data = pa.table(
+        {
+            "timestamp": pa.array([datetime(2010, 1, 1)]),
+        }
+    )
+    write_deltalake(tmp_path, data)
+
+    dt = DeltaTable(tmp_path)
+    dt.create_checkpoint()
+
+    assert_spark_read_equal(data, str(tmp_path))

--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -128,7 +128,9 @@ def test_features_null_on_below_v3_v7(tmp_path: pathlib.Path):
     assert protocol_after_checkpoint.writer_features is None
     assert current_protocol == protocol_after_checkpoint
 
-    checkpoint = pq.read_table(os.path.join(tmp_path, "_delta_log/00000000000000000000.checkpoint.parquet"))
-    
-    assert checkpoint['protocol'][0]['writerFeatures'].as_py() is None
-    assert checkpoint['protocol'][0]['readerFeatures'].as_py() is None
+    checkpoint = pq.read_table(
+        os.path.join(tmp_path, "_delta_log/00000000000000000000.checkpoint.parquet")
+    )
+
+    assert checkpoint["protocol"][0]["writerFeatures"].as_py() is None
+    assert checkpoint["protocol"][0]["readerFeatures"].as_py() is None

--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 
 import pyarrow as pa
+import pyarrow.parquet as pq
 
 from deltalake import DeltaTable, write_deltalake
 
@@ -105,3 +106,29 @@ def test_features_maintained_after_checkpoint(tmp_path: pathlib.Path):
 
     assert protocol_after_checkpoint.reader_features == ["timestampNtz"]
     assert current_protocol == protocol_after_checkpoint
+
+
+def test_features_null_on_below_v3_v7(tmp_path: pathlib.Path):
+    data = pa.table(
+        {
+            "int": pa.array([1]),
+        }
+    )
+    write_deltalake(tmp_path, data)
+
+    dt = DeltaTable(tmp_path)
+    current_protocol = dt.protocol()
+
+    dt.create_checkpoint()
+
+    dt = DeltaTable(tmp_path)
+    protocol_after_checkpoint = dt.protocol()
+
+    assert protocol_after_checkpoint.reader_features is None
+    assert protocol_after_checkpoint.writer_features is None
+    assert current_protocol == protocol_after_checkpoint
+
+    checkpoint = pq.read_table(os.path.join(tmp_path, "_delta_log/00000000000000000000.checkpoint.parquet"))
+    
+    assert checkpoint['protocol'][0]['writerFeatures'].as_py() is None
+    assert checkpoint['protocol'][0]['readerFeatures'].as_py() is None


### PR DESCRIPTION
# Description
Misread the protocol before but the columns readerFeatures or writerFeatures should be null and not empty list when you are below v3 or v7.

Also will immediately push a patch release since checkpoints with python v0.16.1 breaks reader compatibility with Spark