### PR TITLE
fix(python): return serialized optimize metrics as is

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1893,7 +1893,7 @@ class TableOptimizer:
         min_commit_interval: Optional[Union[int, timedelta]] = None,
         writer_properties: Optional[WriterProperties] = None,
         custom_metadata: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, Any]:
+    ) -> str:
         """
         Compacts small files to reduce the total number of files in the table.
 
@@ -1918,7 +1918,7 @@ class TableOptimizer:
             custom_metadata: custom metadata that will be added to the transaction commit.
 
         Returns:
-            the metrics from optimize
+            the metrics from optimize as a string
 
         Example:
             Use a timedelta object to specify the seconds, minutes or hours of the interval.
@@ -1948,7 +1948,7 @@ class TableOptimizer:
             custom_metadata,
         )
         self.table.update_incremental()
-        return json.loads(metrics)
+        return metrics
 
     def z_order(
         self,
@@ -1960,7 +1960,7 @@ class TableOptimizer:
         min_commit_interval: Optional[Union[int, timedelta]] = None,
         writer_properties: Optional[WriterProperties] = None,
         custom_metadata: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, Any]:
+    ) -> str:
         """
         Reorders the data using a Z-order curve to improve data skipping.
 
@@ -1983,7 +1983,7 @@ class TableOptimizer:
             custom_metadata: custom metadata that will be added to the transaction commit.
 
         Returns:
-            the metrics from optimize
+            the metrics from optimize as a string
 
         Example:
             Use a timedelta object to specify the seconds, minutes or hours of the interval.
@@ -2015,4 +2015,4 @@ class TableOptimizer:
             custom_metadata,
         )
         self.table.update_incremental()
-        return json.loads(metrics)
+        return metrics

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1871,7 +1871,7 @@ class TableOptimizer:
         partition_filters: Optional[FilterType] = None,
         target_size: Optional[int] = None,
         max_concurrent_tasks: Optional[int] = None,
-    ) -> Dict[str, Any]:
+    ) -> str:
         """
         !!! warning "DEPRECATED 0.10.0"
             Use [compact][deltalake.table.DeltaTable.compact] instead, which has the same signature.


### PR DESCRIPTION
# Description
The rust compact / z-order optimize calls already serialize the structured metrics before they're passed back to the Python callers. In the Python the structured metrics are deserialized back into a structured dict which is not compatible by a lot of query engines.

I'm open to changing this anywhere else it may be needed, but wanted to start small.

# Related Issue(s)
- for https://github.com/delta-io/delta-rs/issues/2087

# Documentation

N/A
