### PR TITLE
fix: try to fix timeouts

### DIFF
--- a/crates/core/src/operations/writer.rs
+++ b/crates/core/src/operations/writer.rs
@@ -386,7 +386,7 @@ impl PartitionWriter {
                 self.flush_arrow_writer().await?;
             }
         }
-
+        self.arrow_writer.flush();
         Ok(())
     }
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.16.2"
+version = "0.16.3"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"


### PR DESCRIPTION
# Description
I ran this version in a pipeline at work and now it didn't give this anymore:

`OSError: Generic MicrosoftAzure error: Error after 0 retries in 30.000943594s, max_retries:10, retry_timeout:180s, source:error sending request for url (https://<redacted>.blob.core.windows.net/dev-preprocessed/<redacted>/product_line_code=<redacted>/event_year_month_clt=202209/part-00001-874ec394-72d0-44fb-8cbb-2b7b73b41ede-c000.snappy.parquet): operation timed out`
