### PR TITLE
fix(rust): raise schema mismatch when decimal is not subset

### DIFF
--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -858,7 +858,7 @@ fn try_cast_batch(from_fields: &Fields, to_fields: &Fields) -> Result<(), ArrowE
                             }
                         },
                         (
-                            DataType::Decimal256(_, _),
+                            _,
                             DataType::Decimal256(_, _),
                         ) => {
                             unreachable!("Target field can never be Decimal 256. According to the protocol: 'The precision and scale can be up to 38.'")

--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -845,7 +845,6 @@ fn try_cast_batch(from_fields: &Fields, to_fields: &Fields) -> Result<(), ArrowE
                         (
                             DataType::Decimal128(left_precision, left_scale),
                             DataType::Decimal128(right_precision, right_scale)
-                            | DataType::Decimal256(right_precision, right_scale),
                         ) => {
                             if left_precision <= right_precision && left_scale <= right_scale {
                                 Ok(())
@@ -859,21 +858,14 @@ fn try_cast_batch(from_fields: &Fields, to_fields: &Fields) -> Result<(), ArrowE
                             }
                         }
                         (
-                            DataType::Decimal256(left_precision, left_scale),
-                            DataType::Decimal256(right_precision, right_scale),
+                            DataType::Decimal256(_, _),
+                            DataType::Decimal256(_, _),
                         ) => {
-                            if left_precision <= right_precision && left_scale <= right_scale {
-                                Ok(())
-                            } else {
-                                Err(ArrowError::SchemaError(format!(
-                                    "Cannot cast field {} from {} to {}",
-                                    f.name(),
-                                    f.data_type(),
-                                    target_field.data_type()
-                                )))
-                            }
+                            unreachable!("Target field can never be Decimal 256. According to the protocol: 'The precision and scale can be up to 38.'")
                         }
-                        (DataType::Decimal256(_, _), DataType::Decimal128(_, _)) => {
+                        (DataType::Decimal256(left_precision, left_scale), DataType::Decimal128(right_precision, right_scale)) => if left_precision <= right_precision && left_scale <= right_scale {
+                            Ok(())
+                        } else {
                             Err(ArrowError::SchemaError(format!(
                                 "Cannot cast field {} from {} to {}",
                                 f.name(),

--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -842,43 +842,59 @@ fn try_cast_batch(from_fields: &Fields, to_fields: &Fields) -> Result<(), ArrowE
                     try_cast_batch(fields0, fields1)
                 } else {
                     match (f.data_type(), target_field.data_type()) {
-                        (DataType::Decimal128(left_precision,left_scale), DataType::Decimal128(right_precision,right_scale) | DataType::Decimal256(right_precision,right_scale)) => if left_precision <= right_precision && left_scale <= right_scale { 
-                            Ok(())
-                        } else {
-                            Err(ArrowError::SchemaError(format!(
-                                "Cannot cast field {} from {} to {}",
-                                f.name(),
-                                f.data_type(),
-                                target_field.data_type()
-                            )))
-                        },
-                        (DataType::Decimal256(left_precision,left_scale), DataType::Decimal256(right_precision,right_scale)) => if left_precision <= right_precision && left_scale <= right_scale { 
-                            Ok(())
-                        } else {
-                            Err(ArrowError::SchemaError(format!(
-                                "Cannot cast field {} from {} to {}",
-                                f.name(),
-                                f.data_type(),
-                                target_field.data_type()
-                            )))
-                        },
-                        (DataType::Decimal256(_,_), DataType::Decimal128(_,_)) =>  Err(ArrowError::SchemaError(format!(
-                            "Cannot cast field {} from {} to {}",
-                            f.name(),
-                            f.data_type(),
-                            target_field.data_type()
-                        ))),
-                        (left, right) => if !can_cast_types(left, right) {
-                            Err(ArrowError::SchemaError(format!(
-                                "Cannot cast field {} from {} to {}",
-                                f.name(),
-                                f.data_type(),
-                                target_field.data_type()
-                            )))
+                        (
+                            DataType::Decimal128(left_precision, left_scale),
+                            DataType::Decimal128(right_precision, right_scale)
+                            | DataType::Decimal256(right_precision, right_scale),
+                        ) => {
+                            if left_precision <= right_precision && left_scale <= right_scale {
+                                Ok(())
                             } else {
-                        Ok(())
+                                Err(ArrowError::SchemaError(format!(
+                                    "Cannot cast field {} from {} to {}",
+                                    f.name(),
+                                    f.data_type(),
+                                    target_field.data_type()
+                                )))
+                            }
+                        }
+                        (
+                            DataType::Decimal256(left_precision, left_scale),
+                            DataType::Decimal256(right_precision, right_scale),
+                        ) => {
+                            if left_precision <= right_precision && left_scale <= right_scale {
+                                Ok(())
+                            } else {
+                                Err(ArrowError::SchemaError(format!(
+                                    "Cannot cast field {} from {} to {}",
+                                    f.name(),
+                                    f.data_type(),
+                                    target_field.data_type()
+                                )))
+                            }
+                        }
+                        (DataType::Decimal256(_, _), DataType::Decimal128(_, _)) => {
+                            Err(ArrowError::SchemaError(format!(
+                                "Cannot cast field {} from {} to {}",
+                                f.name(),
+                                f.data_type(),
+                                target_field.data_type()
+                            )))
+                        }
+                        (left, right) => {
+                            if !can_cast_types(left, right) {
+                                Err(ArrowError::SchemaError(format!(
+                                    "Cannot cast field {} from {} to {}",
+                                    f.name(),
+                                    f.data_type(),
+                                    target_field.data_type()
+                                )))
+                            } else {
+                                Ok(())
+                            }
+                        }
                     }
-                }}
+                }
             } else {
                 Err(ArrowError::SchemaError(format!(
                     "Field {} not found in schema",

--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -843,7 +843,7 @@ fn try_cast_batch(from_fields: &Fields, to_fields: &Fields) -> Result<(), ArrowE
                 } else {
                     match (f.data_type(), target_field.data_type()) {
                         (
-                            DataType::Decimal128(left_precision, left_scale),
+                            DataType::Decimal128(left_precision, left_scale) | DataType::Decimal256(left_precision, left_scale),
                             DataType::Decimal128(right_precision, right_scale)
                         ) => {
                             if left_precision <= right_precision && left_scale <= right_scale {
@@ -856,23 +856,13 @@ fn try_cast_batch(from_fields: &Fields, to_fields: &Fields) -> Result<(), ArrowE
                                     target_field.data_type()
                                 )))
                             }
-                        }
+                        },
                         (
                             DataType::Decimal256(_, _),
                             DataType::Decimal256(_, _),
                         ) => {
                             unreachable!("Target field can never be Decimal 256. According to the protocol: 'The precision and scale can be up to 38.'")
-                        }
-                        (DataType::Decimal256(left_precision, left_scale), DataType::Decimal128(right_precision, right_scale)) => if left_precision <= right_precision && left_scale <= right_scale {
-                            Ok(())
-                        } else {
-                            Err(ArrowError::SchemaError(format!(
-                                "Cannot cast field {} from {} to {}",
-                                f.name(),
-                                f.data_type(),
-                                target_field.data_type()
-                            )))
-                        }
+                        },
                         (left, right) => {
                             if !can_cast_types(left, right) {
                                 Err(ArrowError::SchemaError(format!(

--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -840,16 +840,45 @@ fn try_cast_batch(from_fields: &Fields, to_fields: &Fields) -> Result<(), ArrowE
                     (f.data_type(), target_field.data_type())
                 {
                     try_cast_batch(fields0, fields1)
-                } else if !can_cast_types(f.data_type(), target_field.data_type()) {
-                    Err(ArrowError::SchemaError(format!(
-                        "Cannot cast field {} from {} to {}",
-                        f.name(),
-                        f.data_type(),
-                        target_field.data_type()
-                    )))
                 } else {
-                    Ok(())
-                }
+                    match (f.data_type(), target_field.data_type()) {
+                        (DataType::Decimal128(left_precision,left_scale), DataType::Decimal128(right_precision,right_scale) | DataType::Decimal256(right_precision,right_scale)) => if left_precision <= right_precision && left_scale <= right_scale { 
+                            Ok(())
+                        } else {
+                            Err(ArrowError::SchemaError(format!(
+                                "Cannot cast field {} from {} to {}",
+                                f.name(),
+                                f.data_type(),
+                                target_field.data_type()
+                            )))
+                        },
+                        (DataType::Decimal256(left_precision,left_scale), DataType::Decimal256(right_precision,right_scale)) => if left_precision <= right_precision && left_scale <= right_scale { 
+                            Ok(())
+                        } else {
+                            Err(ArrowError::SchemaError(format!(
+                                "Cannot cast field {} from {} to {}",
+                                f.name(),
+                                f.data_type(),
+                                target_field.data_type()
+                            )))
+                        },
+                        (DataType::Decimal256(_,_), DataType::Decimal128(_,_)) =>  Err(ArrowError::SchemaError(format!(
+                            "Cannot cast field {} from {} to {}",
+                            f.name(),
+                            f.data_type(),
+                            target_field.data_type()
+                        ))),
+                        (left, right) => if !can_cast_types(left, right) {
+                            Err(ArrowError::SchemaError(format!(
+                                "Cannot cast field {} from {} to {}",
+                                f.name(),
+                                f.data_type(),
+                                target_field.data_type()
+                            )))
+                            } else {
+                        Ok(())
+                    }
+                }}
             } else {
                 Err(ArrowError::SchemaError(format!(
                     "Field {} not found in schema",

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1508,7 +1508,9 @@ def test_rust_decimal_cast(tmp_path: pathlib.Path):
 
     write_deltalake(tmp_path, data, mode="append", engine="rust")
 
-    assert DeltaTable(tmp_path).to_pandas()["x"][0] == Decimal("100.1")
+    assert DeltaTable("test-table").to_pyarrow_table()["x"][0].as_py() == Decimal(
+        "100.1"
+    )
 
     # Write smaller decimal,  works since it's fits in the previous decimal precision, scale
     data = pa.table({"x": pa.array([Decimal("10.1")])})

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1524,3 +1524,6 @@ def test_rust_decimal_cast(tmp_path: pathlib.Path):
         ),
     ):
         write_deltalake(tmp_path, df, mode="append", engine="rust")
+
+    with pytest.raises(SchemaMismatchError, match="Cannot merge types decimal"):
+        write_deltalake(tmp_path, df, mode="append", schema_mode="merge", engine="rust")

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1508,9 +1508,7 @@ def test_rust_decimal_cast(tmp_path: pathlib.Path):
 
     write_deltalake(tmp_path, data, mode="append", engine="rust")
 
-    assert DeltaTable("test-table").to_pyarrow_table()["x"][0].as_py() == Decimal(
-        "100.1"
-    )
+    assert DeltaTable(tmp_path).to_pyarrow_table()["x"][0].as_py() == Decimal("100.1")
 
     # Write smaller decimal,  works since it's fits in the previous decimal precision, scale
     data = pa.table({"x": pa.array([Decimal("10.1")])})


### PR DESCRIPTION
# Description
The `can_cast_types` is a bit to flexible with decimals, since we define the decimal type in the table metadata. So if the source data contains a decimal that is larger than the decimal in the table metadata, we should throw an error. Before we would let our writer just write because `can_cast_types `does not check precision and scale for casting so Decimal(30.1) could  be  written after the table was  set to only  allow precision=1,  scale=1. 

After the write, the json parser would not be able to read the table anymore since it throws a decimal overflow, and rightfully so. This fix will prevent tables to get in these invalid states.

- fixes https://github.com/delta-io/delta-rs/issues/2275