### PR TITLE
fix: add config for parquet pushdown on delta scan

### DIFF
--- a/crates/benchmarks/src/bin/merge.rs
+++ b/crates/benchmarks/src/bin/merge.rs
@@ -199,8 +199,8 @@ async fn benchmark_merge_tpcds(
         table.snapshot()?.clone(),
         table.log_store(),
         DeltaScanConfig {
-            wrap_partition_values: true,
             file_column_name: Some("file_path".to_string()),
+            ..Default::default()
         },
     )
     .unwrap();

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -983,6 +983,7 @@ async fn execute(
 
     let scan_config = DeltaScanConfigBuilder::default()
         .with_file_column(true)
+        .with_parquet_pushdown(false)
         .build(snapshot)?;
 
     let target_provider = Arc::new(DeltaTableProvider::try_new(

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -2974,6 +2974,129 @@ mod tests {
         assert_batches_sorted_eq!(&expected, &actual);
     }
 
+
+    #[tokio::test]
+    async fn test_merge_row_groups_parquet_pushdown() {
+        //See https://github.com/delta-io/delta-rs/issues/2362
+        let schema = vec![
+            StructField::new(
+                "id".to_string(),
+                DataType::Primitive(PrimitiveType::String),
+                true,
+            ),
+            StructField::new(
+                "cost".to_string(),
+                DataType::Primitive(PrimitiveType::Float),
+                true,
+            ),
+            StructField::new(
+                "month".to_string(),
+                DataType::Primitive(PrimitiveType::String),
+                true,
+            ),
+        ];
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", ArrowDataType::Utf8, true),
+            Field::new("cost", ArrowDataType::Float32, true),
+            Field::new("month", ArrowDataType::Utf8, true),
+        ]));
+
+        let table = DeltaOps::new_in_memory()
+            .create()
+            .with_columns(schema)
+            .await
+            .unwrap();
+
+        let ctx = SessionContext::new();
+        let batch1 = RecordBatch::try_new(
+            Arc::clone(&arrow_schema.clone()),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["A", "B"])),
+                Arc::new(arrow::array::Float32Array::from(vec![Some(10.15), None])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "2023-07-04",
+                    "2023-07-04",
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let batch2 = RecordBatch::try_new(
+            Arc::clone(&arrow_schema.clone()),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["C", "D"])),
+                Arc::new(arrow::array::Float32Array::from(vec![Some(11.0), Some(12.0)])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "2023-07-04",
+                    "2023-07-04",
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let table = DeltaOps(table)
+            .write(vec![batch1, batch2])
+            .with_write_batch_size(2)
+            .with_save_mode(SaveMode::Append)
+            .await
+            .unwrap();
+        assert_eq!(table.version(), 1);
+        assert_eq!(table.get_files_count(), 1);
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&arrow_schema.clone()),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["C", "E"])),
+                Arc::new(arrow::array::Float32Array::from(vec![
+                    Some(12.15),
+                    Some(11.15),
+                ])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "2023-07-04",
+                    "2023-07-04",
+                ])),
+            ],
+        )
+        .unwrap();
+        let source = ctx.read_batch(batch).unwrap();
+
+        let (table, _metrics) = DeltaOps(table)
+            .merge(source, "target.id = source.id and target.id >= 'C'")
+            .with_source_alias("source")
+            .with_target_alias("target")
+            .when_matched_update(|insert| {
+                insert
+                    .update("id", "target.id")
+                    .update("cost", "source.cost")
+                    .update("month", "target.month")
+            })
+            .unwrap()
+            .when_not_matched_insert(|insert|
+                insert
+                    .set("id", "source.id")
+                    .set("cost", "source.cost")
+                    .set("month", "source.month")
+            )
+            .unwrap()
+            .await
+            .unwrap();
+
+        let expected = vec![
+    "+----+-------+------------+",
+    "| id | cost  | month      |",
+    "+----+-------+------------+",
+    "| A  | 10.15 | 2023-07-04 |",
+    "| B  |       | 2023-07-04 |",
+    "| C  | 12.15 | 2023-07-04 |",
+    "| D  | 12.0  | 2023-07-04 |",
+    "| E  | 11.15 | 2023-07-04 |",
+    "+----+-------+------------+",
+];
+        let actual = get_data(&table).await;
+        assert_batches_sorted_eq!(&expected, &actual);
+    }
+
     #[tokio::test]
     async fn test_merge_pushdowns_partitioned() {
         //See #2158

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -2974,7 +2974,6 @@ mod tests {
         assert_batches_sorted_eq!(&expected, &actual);
     }
 
-
     #[tokio::test]
     async fn test_merge_row_groups_parquet_pushdown() {
         //See https://github.com/delta-io/delta-rs/issues/2362
@@ -3026,7 +3025,10 @@ mod tests {
             Arc::clone(&arrow_schema.clone()),
             vec![
                 Arc::new(arrow::array::StringArray::from(vec!["C", "D"])),
-                Arc::new(arrow::array::Float32Array::from(vec![Some(11.0), Some(12.0)])),
+                Arc::new(arrow::array::Float32Array::from(vec![
+                    Some(11.0),
+                    Some(12.0),
+                ])),
                 Arc::new(arrow::array::StringArray::from(vec![
                     "2023-07-04",
                     "2023-07-04",
@@ -3072,27 +3074,27 @@ mod tests {
                     .update("month", "target.month")
             })
             .unwrap()
-            .when_not_matched_insert(|insert|
+            .when_not_matched_insert(|insert| {
                 insert
                     .set("id", "source.id")
                     .set("cost", "source.cost")
                     .set("month", "source.month")
-            )
+            })
             .unwrap()
             .await
             .unwrap();
 
         let expected = vec![
-    "+----+-------+------------+",
-    "| id | cost  | month      |",
-    "+----+-------+------------+",
-    "| A  | 10.15 | 2023-07-04 |",
-    "| B  |       | 2023-07-04 |",
-    "| C  | 12.15 | 2023-07-04 |",
-    "| D  | 12.0  | 2023-07-04 |",
-    "| E  | 11.15 | 2023-07-04 |",
-    "+----+-------+------------+",
-];
+            "+----+-------+------------+",
+            "| id | cost  | month      |",
+            "+----+-------+------------+",
+            "| A  | 10.15 | 2023-07-04 |",
+            "| B  |       | 2023-07-04 |",
+            "| C  | 12.15 | 2023-07-04 |",
+            "| D  | 12.0  | 2023-07-04 |",
+            "| E  | 11.15 | 2023-07-04 |",
+            "+----+-------+------------+",
+        ];
         let actual = get_data(&table).await;
         assert_batches_sorted_eq!(&expected, &actual);
     }


### PR DESCRIPTION
# Description
Delta scan will push filter to the parquet scan when possible. Added a new configuration for the special case where operations need to operate on an entire file  but still want to perform pruning.

# Related Issue(s)
- fixes #2362 

