### PR TITLE
chore: bump chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ serde_json = "1"
 
 # "stdlib"
 bytes = { version = "1" }
-chrono = { version = "=0.4.34", default-features = false, features = ["clock"] }
+chrono = { version = ">0.4.34", default-features = false, features = ["clock"] }
 tracing = { version = "0.1", features = ["log"] }
 regex = { version = "1" }
 thiserror = { version = "1" }

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -955,8 +955,11 @@ pub(crate) fn partitioned_file_from_action(
 
     let ts_secs = action.modification_time / 1000;
     let ts_ns = (action.modification_time % 1000) * 1_000_000;
-    let last_modified =
-        Utc.from_utc_datetime(&DateTime::from_timestamp(ts_secs, ts_ns as u32).unwrap().naive_utc());
+    let last_modified = Utc.from_utc_datetime(
+        &DateTime::from_timestamp(ts_secs, ts_ns as u32)
+            .unwrap()
+            .naive_utc(),
+    );
     PartitionedFile {
         object_meta: ObjectMeta {
             last_modified,

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -39,7 +39,7 @@ use arrow_cast::display::array_value_to_string;
 
 use arrow_schema::Field;
 use async_trait::async_trait;
-use chrono::{NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use datafusion::datasource::file_format::{parquet::ParquetFormat, FileFormat};
 use datafusion::datasource::physical_plan::{
     wrap_partition_type_in_dict, wrap_partition_value_in_dict, FileScanConfig,
@@ -956,7 +956,7 @@ pub(crate) fn partitioned_file_from_action(
     let ts_secs = action.modification_time / 1000;
     let ts_ns = (action.modification_time % 1000) * 1_000_000;
     let last_modified =
-        Utc.from_utc_datetime(&NaiveDateTime::from_timestamp_opt(ts_secs, ts_ns as u32).unwrap());
+        Utc.from_utc_datetime(&DateTime::from_timestamp(ts_secs, ts_ns as u32).unwrap().naive_utc());
     PartitionedFile {
         object_meta: ObjectMeta {
             last_modified,

--- a/crates/core/src/kernel/expressions/scalars.rs
+++ b/crates/core/src/kernel/expressions/scalars.rs
@@ -97,9 +97,7 @@ impl Scalar {
                 ts.format("%Y-%m-%d %H:%M:%S%.6f").to_string()
             }
             Self::Date(days) => {
-                let date = Utc.from_utc_datetime(
-                    &NaiveDateTime::from_timestamp_opt(*days as i64 * 24 * 3600, 0).unwrap(),
-                );
+                let date = DateTime::from_timestamp(*days as i64 * 24 * 3600, 0).unwrap();
                 date.format("%Y-%m-%d").to_string()
             }
             Self::Decimal(value, _, scale) => match scale.cmp(&0) {

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow_array::{Array, Int32Array, Int64Array, MapArray, RecordBatch, StringArray, StructArray};
-use chrono::{NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
 use object_store::path::Path;
 use object_store::ObjectMeta;
@@ -178,13 +178,11 @@ impl LogicalFile<'_> {
 
     /// Datetime of the last modification time of the file.
     pub fn modification_datetime(&self) -> DeltaResult<chrono::DateTime<Utc>> {
-        Ok(Utc.from_utc_datetime(
-            &NaiveDateTime::from_timestamp_millis(self.modification_time()).ok_or(
-                DeltaTableError::from(crate::protocol::ProtocolError::InvalidField(format!(
-                    "invalid modification_time: {:?}",
-                    self.modification_time()
-                ))),
-            )?,
+        DateTime::from_timestamp_millis(self.modification_time()).ok_or(DeltaTableError::from(
+            crate::protocol::ProtocolError::InvalidField(format!(
+                "invalid modification_time: {:?}",
+                self.modification_time()
+            )),
         ))
     }
 

--- a/crates/core/src/kernel/snapshot/serde.rs
+++ b/crates/core/src/kernel/snapshot/serde.rs
@@ -1,6 +1,6 @@
 use arrow_ipc::reader::FileReader;
 use arrow_ipc::writer::FileWriter;
-use chrono::{TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use object_store::ObjectMeta;
 use serde::de::{self, Deserializer, SeqAccess, Visitor};
 use serde::{ser::SerializeSeq, Deserialize, Serialize};
@@ -99,9 +99,8 @@ impl<'de> Visitor<'de> for LogSegmentVisitor {
                 .map(|f| ObjectMeta {
                     location: f.path.into(),
                     size: f.size,
-                    last_modified: Utc.from_utc_datetime(
-                        &chrono::NaiveDateTime::from_timestamp_millis(f.last_modified).unwrap(),
-                    ),
+                    last_modified: DateTime::from_timestamp_millis(f.last_modified).unwrap(),
+
                     version: None,
                     e_tag: None,
                 })

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -6,7 +6,7 @@ use std::iter::Iterator;
 use arrow_json::ReaderBuilder;
 use arrow_schema::ArrowError;
 
-use chrono::{DateTime, Datelike, Utc};
+use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, Utc};
 use futures::{StreamExt, TryStreamExt};
 use lazy_static::lazy_static;
 use object_store::{Error, ObjectStore};
@@ -435,19 +435,17 @@ fn typed_partition_value_from_string(
                 .map_err(|_| CheckpointError::PartitionValueNotParseable(string_value.to_owned()))?
                 .into()),
             PrimitiveType::Date => {
-                let d = chrono::naive::NaiveDate::parse_from_str(string_value, "%Y-%m-%d")
-                    .map_err(|_| {
-                        CheckpointError::PartitionValueNotParseable(string_value.to_owned())
-                    })?;
+                let d = NaiveDate::parse_from_str(string_value, "%Y-%m-%d").map_err(|_| {
+                    CheckpointError::PartitionValueNotParseable(string_value.to_owned())
+                })?;
                 // day 0 is 1970-01-01 (719163 days from ce)
                 Ok((d.num_days_from_ce() - 719_163).into())
             }
             PrimitiveType::Timestamp => {
-                let ts =
-                    DateTime::parse_from_str(string_value, "%Y-%m-%d %H:%M:%S").map_err(|_| {
-                        CheckpointError::PartitionValueNotParseable(string_value.to_owned())
-                    })?;
-                Ok((ts.timestamp_millis() * 1000).into())
+                let ts = NaiveDateTime::parse_from_str(string_value, "%Y-%m-%d %H:%M:%S").map_err(
+                    |_| CheckpointError::PartitionValueNotParseable(string_value.to_owned()),
+                )?;
+                Ok((ts.and_utc().timestamp_millis() * 1000).into())
             }
             s => unimplemented!(
                 "Primitive type {} is not supported for partition column values.",

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -6,7 +6,7 @@ use std::iter::Iterator;
 use arrow_json::ReaderBuilder;
 use arrow_schema::ArrowError;
 
-use chrono::{Datelike, Utc};
+use chrono::{DateTime, Datelike, Utc};
 use futures::{StreamExt, TryStreamExt};
 use lazy_static::lazy_static;
 use object_store::{Error, ObjectStore};
@@ -444,10 +444,9 @@ fn typed_partition_value_from_string(
             }
             PrimitiveType::Timestamp => {
                 let ts =
-                    chrono::naive::NaiveDateTime::parse_from_str(string_value, "%Y-%m-%d %H:%M:%S")
-                        .map_err(|_| {
-                            CheckpointError::PartitionValueNotParseable(string_value.to_owned())
-                        })?;
+                    DateTime::parse_from_str(string_value, "%Y-%m-%d %H:%M:%S").map_err(|_| {
+                        CheckpointError::PartitionValueNotParseable(string_value.to_owned())
+                    })?;
                 Ok((ts.timestamp_millis() * 1000).into())
             }
             s => unimplemented!(

--- a/crates/core/src/storage/utils.rs
+++ b/crates/core/src/storage/utils.rs
@@ -1,6 +1,6 @@
 //! Utility functions for working across Delta tables
 
-use chrono::{NaiveDateTime, TimeZone, Utc};
+use chrono::DateTime;
 use futures::TryStreamExt;
 use object_store::path::Path;
 use object_store::{DynObjectStore, ObjectMeta, Result as ObjectStoreResult};
@@ -32,14 +32,13 @@ impl TryFrom<&Add> for ObjectMeta {
     type Error = DeltaTableError;
 
     fn try_from(value: &Add) -> DeltaResult<Self> {
-        let last_modified = Utc.from_utc_datetime(
-            &NaiveDateTime::from_timestamp_millis(value.modification_time).ok_or(
-                DeltaTableError::from(crate::protocol::ProtocolError::InvalidField(format!(
-                    "invalid modification_time: {:?}",
-                    value.modification_time
-                ))),
-            )?,
-        );
+        let last_modified = DateTime::from_timestamp_millis(value.modification_time).ok_or(
+            DeltaTableError::from(crate::protocol::ProtocolError::InvalidField(format!(
+                "invalid modification_time: {:?}",
+                value.modification_time
+            ))),
+        )?;
+
         Ok(Self {
             // TODO this won't work for absolute paths, since Paths are always relative to store.
             location: Path::parse(value.path.as_str())?,

--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -180,19 +180,19 @@ impl StatsScalar {
                 // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#timestamp-without-timezone-timestampntz
                 let v = get_stat!(v);
                 let timestamp = match unit {
-                    TimeUnit::MILLIS(_) => chrono::NaiveDateTime::from_timestamp_millis(v),
-                    TimeUnit::MICROS(_) => chrono::NaiveDateTime::from_timestamp_micros(v),
+                    TimeUnit::MILLIS(_) => chrono::DateTime::from_timestamp_millis(v),
+                    TimeUnit::MICROS(_) => chrono::DateTime::from_timestamp_micros(v),
                     TimeUnit::NANOS(_) => {
                         let secs = v / 1_000_000_000;
                         let nanosecs = (v % 1_000_000_000) as u32;
-                        chrono::NaiveDateTime::from_timestamp_opt(secs, nanosecs)
+                        chrono::DateTime::from_timestamp(secs, nanosecs)
                     }
                 };
                 let timestamp = timestamp.ok_or(DeltaWriterError::StatsParsingFailed {
                     debug_value: v.to_string(),
                     logical_type: logical_type.clone(),
                 })?;
-                Ok(Self::Timestamp(timestamp))
+                Ok(Self::Timestamp(timestamp.naive_utc()))
             }
             (Statistics::Int64(v), Some(LogicalType::Decimal { scale, .. })) => {
                 let val = get_stat!(v) as f64 / 10.0_f64.powi(*scale);

--- a/crates/core/tests/command_restore.rs
+++ b/crates/core/tests/command_restore.rs
@@ -1,7 +1,7 @@
 use arrow::datatypes::Schema as ArrowSchema;
 use arrow_array::{Int32Array, RecordBatch};
 use arrow_schema::{DataType as ArrowDataType, Field};
-use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use chrono::DateTime;
 use deltalake_core::kernel::{DataType, PrimitiveType, StructField};
 use deltalake_core::protocol::SaveMode;
 use deltalake_core::storage::commit_uri_from_version;
@@ -128,8 +128,8 @@ async fn test_restore_by_datetime() -> Result<(), Box<dyn Error>> {
         .head(&commit_uri_from_version(version))
         .await?;
     let timestamp = meta.last_modified.timestamp_millis();
-    let naive = NaiveDateTime::from_timestamp_millis(timestamp).unwrap();
-    let datetime: DateTime<Utc> = Utc.from_utc_datetime(&naive);
+    let datetime = DateTime::from_timestamp_millis(timestamp).unwrap();
+
 
     let result = DeltaOps(table)
         .restore()
@@ -147,8 +147,8 @@ async fn test_restore_with_error_params() -> Result<(), Box<dyn Error>> {
     let table = context.table;
     let history = table.history(Some(10)).await?;
     let timestamp = history.get(1).unwrap().timestamp.unwrap();
-    let naive = NaiveDateTime::from_timestamp_millis(timestamp).unwrap();
-    let datetime: DateTime<Utc> = Utc.from_utc_datetime(&naive);
+    let datetime = DateTime::from_timestamp_millis(timestamp).unwrap();
+    
 
     // datetime and version both set
     let result = DeltaOps(table)

--- a/crates/core/tests/command_restore.rs
+++ b/crates/core/tests/command_restore.rs
@@ -130,7 +130,6 @@ async fn test_restore_by_datetime() -> Result<(), Box<dyn Error>> {
     let timestamp = meta.last_modified.timestamp_millis();
     let datetime = DateTime::from_timestamp_millis(timestamp).unwrap();
 
-
     let result = DeltaOps(table)
         .restore()
         .with_datetime_to_restore(datetime)
@@ -148,7 +147,6 @@ async fn test_restore_with_error_params() -> Result<(), Box<dyn Error>> {
     let history = table.history(Some(10)).await?;
     let timestamp = history.get(1).unwrap().timestamp.unwrap();
     let datetime = DateTime::from_timestamp_millis(timestamp).unwrap();
-    
 
     // datetime and version both set
     let result = DeltaOps(table)


### PR DESCRIPTION
# Description

I was having some dependency conflicts with the `chrono = "=0.4.34` dependency. This bumps chrono to `>0.4.34`, so it should be a bit more relaxed when resolving dependencies. 

# Documentation

<!---
Share links to useful documentation
--->
