### PR TITLE
fix(rust): remove flush after writing every batch

### DIFF
--- a/crates/core/src/operations/writer.rs
+++ b/crates/core/src/operations/writer.rs
@@ -386,7 +386,7 @@ impl PartitionWriter {
                 self.flush_arrow_writer().await?;
             }
         }
-        self.arrow_writer.flush()?;
+
         Ok(())
     }
 


### PR DESCRIPTION
# Description

Reverts https://github.com/delta-io/delta-rs/pull/2318 by removing `flush` after writing each batch since it was causing smaller than expected row groups to be written during compaction.

# Related Issue(s)
- closes #2386 
