### PR TITLE
fix: return error when checkpoints and metadata get out of sync

### DIFF
--- a/crates/core/src/kernel/snapshot/log_segment.rs
+++ b/crates/core/src/kernel/snapshot/log_segment.rs
@@ -453,10 +453,16 @@ async fn list_log_files_with_checkpoint(
         })
         .collect_vec();
 
-    // TODO raise a proper error
-    assert_eq!(checkpoint_files.len(), cp.parts.unwrap_or(1) as usize);
-
-    Ok((commit_files, checkpoint_files))
+    if checkpoint_files.len() != cp.parts.unwrap_or(1) as usize {
+        let msg = format!(
+            "Number of checkpoint files '{}' is not equal to number of checkpoint metadata parts '{:?}'",
+            checkpoint_files.len(),
+            cp.parts
+        );
+        Err(DeltaTableError::MetadataError(msg))
+    } else {
+        Ok((commit_files, checkpoint_files))
+    }
 }
 
 /// List relevant log files.


### PR DESCRIPTION
# Description
When a table is corrupted and `_last_checkpoint` file points to a 
version that has been deleted, `list_log_files_with_checkpoint` 
function panics. With this change `list_log_files_with_checkpoint` 
function returns an error allowing callers react to such issues.

# Related Issue(s)
- https://github.com/delta-io/delta-rs/issues/2290