### PR TITLE
fix(rust): writer missing invariants feature

### DIFF
--- a/crates/core/src/operations/transaction/protocol.rs
+++ b/crates/core/src/operations/transaction/protocol.rs
@@ -212,10 +212,10 @@ pub static INSTANCE: Lazy<ProtocolChecker> = Lazy::new(|| {
 
     let mut writer_features = HashSet::new();
     writer_features.insert(WriterFeatures::AppendOnly);
+    writer_features.insert(WriterFeatures::Invariants);
     writer_features.insert(WriterFeatures::TimestampWithoutTimezone);
     #[cfg(feature = "datafusion")]
     {
-        writer_features.insert(WriterFeatures::Invariants);
         writer_features.insert(WriterFeatures::CheckConstraints);
     }
     // writer_features.insert(WriterFeatures::ChangeDataFeed);


### PR DESCRIPTION
# Description

The default version of Writer is `2`, but the global `ProtocolChecker` is missing the `invariants` feature, which causes `ProtocolChecker::can_write_to` to return an `UnsupportedWriterFeatures` error. The error prevents me from passing `false` to the `nullable` field of `StructField::new` without the use of the `datafunction` feature.

```
Error: Transaction failed: Unsupported writer features required: [Invariants]

Caused by:
    Unsupported writer features required: [Invariants]
```

# Related Issue(s)
<!---
For example:

- closes #106
--->

- Resolved #2204 
- Resolved #2292.

# Documentation

<!---
Share links to useful documentation
--->

https://github.com/delta-io/delta-rs/blob/d49d95ba4bf576254122b8491c4d73c5f65b16b0/crates/core/src/operations/transaction/protocol.rs#L68-L70

https://github.com/delta-io/delta-rs/blob/d49d95ba4bf576254122b8491c4d73c5f65b16b0/README.md?plain=1#L159-L164