### PR TITLE
fix(python): load_as_version with datetime object with no timezone specified

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -2,7 +2,7 @@ import json
 import operator
 import warnings
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from functools import reduce
 from pathlib import Path
@@ -607,6 +607,7 @@ class DeltaTable:
         """
         Load/time travel a DeltaTable to a specified version number, or a timestamp version of the table. If a
         string is passed then the argument should be an RFC 3339 and ISO 8601 date and time string format.
+        If a datetime object without a timezone is passed, the UTC timezone will be assumed.
 
         Args:
             version: the identifier of the version of the DeltaTable to load
@@ -620,7 +621,8 @@ class DeltaTable:
 
             **Use a datetime object**
             ```
-            dt.load_as_version(datetime(2023,1,1))
+            dt.load_as_version(datetime(2023, 1, 1))
+            dt.load_as_version(datetime(2023, 1, 1, tzinfo=timezone.utc))
             ```
 
             **Use a datetime in string format**
@@ -633,6 +635,8 @@ class DeltaTable:
         if isinstance(version, int):
             self._table.load_version(version)
         elif isinstance(version, datetime):
+            if version.tzinfo is None:
+                version = version.astimezone(timezone.utc)
             self._table.load_with_datetime(version.isoformat())
         elif isinstance(version, str):
             self._table.load_with_datetime(version)


### PR DESCRIPTION
# Description
Upon attempting to retrieve the version with a datetime object, the `load_as_version` method throws a `ValueError: Failed to parse datetime string: premature end of input`.

Datetime objects without a specified timezone will be treated as UTC datetimes.