### PR TITLE
fix(python, rust): use from_name during column projection creation

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -60,7 +60,8 @@ use datafusion::physical_plan::{
 use datafusion_common::scalar::ScalarValue;
 use datafusion_common::tree_node::{TreeNode, TreeNodeVisitor, VisitRecursion};
 use datafusion_common::{
-    Column, DFSchema, DataFusionError, Result as DataFusionResult, ToDFSchema,
+    config::ConfigOptions, Column, DFSchema, DataFusionError, Result as DataFusionResult,
+    ToDFSchema,
 };
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::logical_plan::CreateExternalTable;
@@ -859,6 +860,23 @@ impl ExecutionPlan for DeltaScan {
 
     fn statistics(&self) -> DataFusionResult<Statistics> {
         self.parquet_scan.statistics()
+    }
+
+    fn repartitioned(
+        &self,
+        target_partitions: usize,
+        config: &ConfigOptions,
+    ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
+        if let Some(parquet_scan) = self.parquet_scan.repartitioned(target_partitions, config)? {
+            Ok(Some(Arc::new(DeltaScan {
+                table_uri: self.table_uri.clone(),
+                config: self.config.clone(),
+                parquet_scan,
+                logical_schema: self.logical_schema.clone(),
+            })))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1218,10 +1218,8 @@ async fn execute(
         .end()?;
 
         let name = "__delta_rs_c_".to_owned() + delta_field.name();
-        write_projection.push(
-            Expr::Column(Column::from_qualified_name_ignore_case(name.clone()))
-                .alias(delta_field.name()),
-        );
+        write_projection
+            .push(Expr::Column(Column::from_name(name.clone())).alias(delta_field.name()));
         new_columns.push((name, case));
     }
 


### PR DESCRIPTION
# Description
@Blajda I don't think `from_qualified_name_ignore_case` was needed here since the delta_fields don't have relation information, they are just the column names. 

`from_qualified_name_ignore_case` will try to parse `__delta_rs_c_y--1` and results into  `__delta_rs_c_y`, while `from_name `just keeps the column name as-is, which is preferred. 


# Related Issue(s)
- closes https://github.com/delta-io/delta-rs/issues/2438