### PR TITLE
fix(rust): do not delete the temp commit file when write_commit_entry returns error

### DIFF
--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -568,10 +568,6 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                         };
                     }
                     Err(err) => {
-                        this.log_store
-                            .object_store()
-                            .delete_with_retries(tmp_commit, 15)
-                            .await?;
                         return Err(err.into());
                     }
                 }


### PR DESCRIPTION
# Description

Do not delete the temp commit file when `write_commit_entry` returns an error.

This fixes a rare bug when using DynamoDB as the locking provider. Consider the following events:
1. `S3DynamoDbLogStore.write_commit_entry` succeeds at creating a DynamoDB entry, but fails during `repair_entry`
2. The error handling deletes the `tmp_commit` file
3. The next time `repair_entry` is called on this entry, it will lead to `ObjectStoreError::NotFound` since the temp commit file was deleted
4. We infer the temp commit json was already moved, so we update the DynamoDB entry as complete

This results in a complete DynamoDB log entry, even though the corresponding transaction log does not exist in `_delta_log`.
