### PR TITLE
fix(rust): implement abort commit for S3DynamoDBLogStore

### DIFF
--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-aws"
-version = "0.1.1"
+version = "0.1.2"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/aws/src/logstore.rs
+++ b/crates/aws/src/logstore.rs
@@ -239,6 +239,36 @@ impl LogStore for S3DynamoDbLogStore {
         Ok(())
     }
 
+    /// Tries to abort an entry by first deleting the commit log entry, then deleting the temp commit file
+    async fn abort_commit_entry(
+        &self,
+        version: i64,
+        tmp_commit: &Path,
+    ) -> Result<(), TransactionError> {
+        self.lock_client
+            .delete_commit_entry(version, &self.table_path)
+            .await
+            .map_err(|err| match err {
+                LockClientError::ProvisionedThroughputExceeded => todo!(
+                    "deltalake-aws does not yet handle DynamoDB provisioned throughput errors"
+                ),
+                LockClientError::VersionAlreadyCompleted { version, .. } => {
+                    error!("Trying to abort a completed commit");
+                    TransactionError::LogStoreError {
+                        msg: format!("trying to abort a completed log entry: {}", version),
+                        source: Box::new(err),
+                    }
+                }
+                err => TransactionError::LogStoreError {
+                    msg: "dynamodb client failed to delete log entry".to_owned(),
+                    source: Box::new(err),
+                },
+            })?;
+
+        abort_commit_entry(&self.storage, version, tmp_commit).await?;
+        Ok(())
+    }
+
     async fn get_latest_version(&self, current_version: i64) -> DeltaResult<i64> {
         debug!("Retrieving latest version of {self:?} at v{current_version}");
         let entry = self

--- a/crates/aws/src/storage.rs
+++ b/crates/aws/src/storage.rs
@@ -85,7 +85,7 @@ impl ObjectStoreFactory for S3ObjectStoreFactory {
             .0
             .contains_key(AmazonS3ConfigKey::CopyIfNotExists.as_ref())
         {
-            Ok((Arc::from(store), prefix))
+            Ok((store, prefix))
         } else {
             let s3_options = S3StorageOptions::from_map(&options.0)?;
 

--- a/crates/core/src/logstore/default_logstore.rs
+++ b/crates/core/src/logstore/default_logstore.rs
@@ -50,6 +50,14 @@ impl LogStore for DefaultLogStore {
         super::write_commit_entry(self.storage.as_ref(), version, tmp_commit).await
     }
 
+    async fn abort_commit_entry(
+        &self,
+        version: i64,
+        tmp_commit: &Path,
+    ) -> Result<(), TransactionError> {
+        super::abort_commit_entry(self.storage.as_ref(), version, tmp_commit).await
+    }
+
     async fn get_latest_version(&self, current_version: i64) -> DeltaResult<i64> {
         super::get_latest_version(self, current_version).await
     }

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     kernel::Action,
     operations::transaction::TransactionError,
     protocol::{get_last_checkpoint, ProtocolError},
-    storage::{commit_uri_from_version, ObjectStoreRef, StorageOptions},
+    storage::{commit_uri_from_version, ObjectStoreRef, StorageOptions, retry_ext::ObjectStoreRetryExt},
     DeltaTableError,
 };
 use bytes::Bytes;
@@ -178,6 +178,13 @@ pub trait LogStore: Sync + Send {
     /// This operation can be retried with a higher version in case the write
     /// fails with [`TransactionError::VersionAlreadyExists`].
     async fn write_commit_entry(
+        &self,
+        version: i64,
+        tmp_commit: &Path,
+    ) -> Result<(), TransactionError>;
+
+    /// Abort the commit entry for the given version.
+    async fn abort_commit_entry(
         &self,
         version: i64,
         tmp_commit: &Path,
@@ -446,6 +453,16 @@ pub async fn write_commit_entry(
                 _ => TransactionError::from(err),
             }
         })?;
+    Ok(())
+}
+
+/// Default implementation for aborting a commit entry
+pub async fn abort_commit_entry(
+    storage: &dyn ObjectStore,
+    _version: i64,
+    tmp_commit: &Path,
+) -> Result<(), TransactionError> {
+    storage.delete_with_retries(tmp_commit, 15).await?;
     Ok(())
 }
 

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -18,7 +18,9 @@ use crate::{
     kernel::Action,
     operations::transaction::TransactionError,
     protocol::{get_last_checkpoint, ProtocolError},
-    storage::{commit_uri_from_version, ObjectStoreRef, StorageOptions, retry_ext::ObjectStoreRetryExt},
+    storage::{
+        commit_uri_from_version, retry_ext::ObjectStoreRetryExt, ObjectStoreRef, StorageOptions,
+    },
     DeltaTableError,
 };
 use bytes::Bytes;

--- a/crates/core/src/operations/restore.rs
+++ b/crates/core/src/operations/restore.rs
@@ -279,7 +279,7 @@ async fn execute(
             return Err(err.into());
         }
         Err(err) => {
-            log_store.object_store().delete(commit).await?;
+            log_store.abort_commit_entry(commit_version, commit).await?;
             return Err(err.into());
         }
     }

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -552,13 +552,17 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                                 attempt_number += 1;
                             }
                             Err(err) => {
-                                this.log_store.abort_commit_entry(version, tmp_commit).await?;
+                                this.log_store
+                                    .abort_commit_entry(version, tmp_commit)
+                                    .await?;
                                 return Err(TransactionError::CommitConflict(err).into());
                             }
                         };
                     }
                     Err(err) => {
-                        this.log_store.abort_commit_entry(version, tmp_commit).await?;
+                        this.log_store
+                            .abort_commit_entry(version, tmp_commit)
+                            .await?;
                         return Err(err.into());
                     }
                 }

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -90,7 +90,6 @@ use crate::kernel::{
 };
 use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
-use crate::storage::ObjectStoreRetryExt;
 use crate::table::config::TableConfig;
 use crate::table::state::DeltaTableState;
 use crate::{crate_version, DeltaResult};
@@ -553,19 +552,13 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                                 attempt_number += 1;
                             }
                             Err(err) => {
-                                this.log_store
-                                    .object_store()
-                                    .delete_with_retries(tmp_commit, 15)
-                                    .await?;
+                                this.log_store.abort_commit_entry(version, tmp_commit).await?;
                                 return Err(TransactionError::CommitConflict(err).into());
                             }
                         };
                     }
                     Err(err) => {
-                        this.log_store
-                            .object_store()
-                            .delete_with_retries(tmp_commit, 15)
-                            .await?;
+                        this.log_store.abort_commit_entry(version, tmp_commit).await?;
                         return Err(err.into());
                     }
                 }

--- a/crates/core/src/storage/retry_ext.rs
+++ b/crates/core/src/storage/retry_ext.rs
@@ -79,4 +79,4 @@ pub trait ObjectStoreRetryExt: ObjectStore {
     }
 }
 
-impl<T: ObjectStore> ObjectStoreRetryExt for T {}
+impl<T: ObjectStore + ?Sized> ObjectStoreRetryExt for T {}


### PR DESCRIPTION
# Description

This PR ensures when using `S3DynamoDBLogStore`, temp commit files are only deleted when the DynamoDB log entry is deleted.

Add `abort_commit_entry(version, tmp_commit)` to `LogStore`
- By default, this just deletes the `tmp_commit` file
- For `S3DynamoDBLogStore`, it first deletes the DynamoDB entry. Then, it only deletes `tmp_commit` if the entry is deleted successfully

## Context

This fixes a rare bug when using DynamoDB as the locking provider. Consider the following events:
1. `S3DynamoDbLogStore.write_commit_entry` succeeds at creating a DynamoDB entry, but fails during `repair_entry`
2. The error handling deletes the `tmp_commit` file
3. The next time `repair_entry` is called on this entry, it will lead to `ObjectStoreError::NotFound` since the temp commit file was deleted
4. We infer the temp commit json was already moved, so we update the DynamoDB entry as complete

This results in a complete DynamoDB log entry, even though the corresponding transaction log does not exist in `_delta_log`.

# Related Issue(s)

- #2446 



