### PR TITLE
fix(rust): handle 429 from GCS

### DIFF
--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -550,11 +550,9 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                         );
                         match conflict_checker.check_conflicts() {
                             Ok(_) => {
-                                println!("Attempt {} failed: Version {} already exists", attempt_number, version);
                                 attempt_number += 1;
                             }
                             Err(err) => {
-                                panic!();
                                 this.log_store
                                     .object_store()
                                     .delete_with_retries(tmp_commit, 15)
@@ -572,6 +570,7 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                     }
                 }
             }
+
             Err(TransactionError::MaxCommitAttempts(this.max_retries as i32).into())
         })
     }

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -550,6 +550,7 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                         );
                         match conflict_checker.check_conflicts() {
                             Ok(_) => {
+                                println!("Attempt {} failed: Version {} already exists", attempt_number, version);
                                 attempt_number += 1;
                             }
                             Err(err) => {

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -550,7 +550,6 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                         );
                         match conflict_checker.check_conflicts() {
                             Ok(_) => {
-                                println!("Attempt {} failed: Version {} already exists", attempt_number, version);
                                 attempt_number += 1;
                             }
                             Err(err) => {

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -550,9 +550,11 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                         );
                         match conflict_checker.check_conflicts() {
                             Ok(_) => {
+                                println!("Attempt {} failed: Version {} already exists", attempt_number, version);
                                 attempt_number += 1;
                             }
                             Err(err) => {
+                                panic!();
                                 this.log_store
                                     .object_store()
                                     .delete_with_retries(tmp_commit, 15)
@@ -570,7 +572,6 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                     }
                 }
             }
-
             Err(TransactionError::MaxCommitAttempts(this.max_retries as i32).into())
         })
     }

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -20,7 +20,7 @@ features = ["azure", "datafusion", "gcs", "hdfs", "json", "mount", "python", "s3
 deltalake-core = { version = "0.17.1", path = "../core" }
 deltalake-aws = { version = "0.1.0", path = "../aws", default-features = false, optional = true }
 deltalake-azure = { version = "0.1.0", path = "../azure", optional = true }
-deltalake-gcp = { version = "0.1.0", path = "../gcp", optional = true }
+deltalake-gcp = { version = "0.2", path = "../gcp", optional = true }
 deltalake-catalog-glue = { version = "0.1.0", path = "../catalog-glue", optional = true }
 deltalake-mount = { version = "0.1.0", path = "../mount", optional = true }
 

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 regex = { workspace = true }
 url = { workspace = true }
+reqwest = "0.12.4"
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-gcp"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -25,7 +25,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 regex = { workspace = true }
 url = { workspace = true }
-reqwest = "0.12.4"
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/crates/gcp/src/lib.rs
+++ b/crates/gcp/src/lib.rs
@@ -13,6 +13,7 @@ use url::Url;
 
 mod config;
 pub mod error;
+mod storage;
 
 trait GcpOptions {
     fn as_gcp_options(&self) -> HashMap<GoogleConfigKey, String>;
@@ -43,6 +44,7 @@ impl ObjectStoreFactory for GcpFactory {
     ) -> DeltaResult<(ObjectStoreRef, Path)> {
         let config = config::GcpConfigHelper::try_new(options.as_gcp_options())?.build()?;
         let (store, prefix) = parse_url_opts(url, config)?;
+        let store = crate::storage::GcsStorageBackend::try_new(Arc::new(store))?;
         Ok((url_prefix_handler(store, prefix.clone())?, prefix))
     }
 }

--- a/crates/gcp/src/storage.rs
+++ b/crates/gcp/src/storage.rs
@@ -8,7 +8,8 @@ use std::ops::Range;
 use tokio::io::AsyncWrite;
 
 use deltalake_core::storage::object_store::{
-    Result as ObjectStoreResult, PutOptions, GetOptions, ListResult, MultipartId, ObjectMeta, PutResult, GetResult, ObjectStore
+    GetOptions, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, PutOptions, PutResult,
+    Result as ObjectStoreResult,
 };
 
 pub(crate) struct GcsStorageBackend {
@@ -105,18 +106,17 @@ impl ObjectStore for GcsStorageBackend {
                         // Source would be a reqwest error which we don't have access to so the easiest thing to do is check
                         // for "429" in the error message
                         if format!("{:?}", source).contains("429") {
-                            Err(
-                                object_store::Error::AlreadyExists { path: to.to_string(), source }
-                            )
+                            Err(object_store::Error::AlreadyExists {
+                                path: to.to_string(),
+                                source,
+                            })
                         } else {
-                            Err(
-                                object_store::Error::Generic { store, source }
-                            )
+                            Err(object_store::Error::Generic { store, source })
                         }
                     }
-                    _ => Err(e)
+                    _ => Err(e),
                 }
-            },
+            }
         }
     }
 

--- a/crates/gcp/src/storage.rs
+++ b/crates/gcp/src/storage.rs
@@ -1,0 +1,137 @@
+//! AWS S3 storage backend.
+
+use bytes::Bytes;
+use deltalake_core::storage::ObjectStoreRef;
+use deltalake_core::Path;
+use futures::stream::BoxStream;
+use std::ops::Range;
+use tokio::io::AsyncWrite;
+
+use deltalake_core::storage::object_store::{
+    Result as ObjectStoreResult, PutOptions, GetOptions, ListResult, MultipartId, ObjectMeta, PutResult, GetResult, ObjectStore
+};
+
+pub(crate) struct GcsStorageBackend {
+    inner: ObjectStoreRef,
+}
+
+impl GcsStorageBackend {
+    pub fn try_new(storage: ObjectStoreRef) -> ObjectStoreResult<Self> {
+        Ok(Self { inner: storage })
+    }
+}
+
+impl std::fmt::Debug for GcsStorageBackend {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(fmt, "GcsStorageBackend")
+    }
+}
+
+impl std::fmt::Display for GcsStorageBackend {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(fmt, "GcsStorageBackend")
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for GcsStorageBackend {
+    async fn put(&self, location: &Path, bytes: Bytes) -> ObjectStoreResult<PutResult> {
+        self.inner.put(location, bytes).await
+    }
+
+    async fn put_opts(
+        &self,
+        location: &Path,
+        bytes: Bytes,
+        options: PutOptions,
+    ) -> ObjectStoreResult<PutResult> {
+        self.inner.put_opts(location, bytes, options).await
+    }
+
+    async fn get(&self, location: &Path) -> ObjectStoreResult<GetResult> {
+        self.inner.get(location).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> ObjectStoreResult<GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<usize>) -> ObjectStoreResult<Bytes> {
+        self.inner.get_range(location, range).await
+    }
+
+    async fn head(&self, location: &Path) -> ObjectStoreResult<ObjectMeta> {
+        self.inner.head(location).await
+    }
+
+    async fn delete(&self, location: &Path) -> ObjectStoreResult<()> {
+        self.inner.delete(location).await
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, ObjectStoreResult<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'_, ObjectStoreResult<ObjectMeta>> {
+        self.inner.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> ObjectStoreResult<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+        let res = self.inner.rename_if_not_exists(from, to).await;
+        match res {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                match e {
+                    object_store::Error::Generic { store, source } => {
+                        // If this is a 429 (rate limit) error it means more than 1 mutation operation per second
+                        // Was attempted on this same key
+                        // That means we're experiencing concurrency conflicts, so return a transaction error
+                        // Source would be a reqwest error which we don't have access to so the easiest thing to do is check
+                        // for "429" in the error message
+                        if format!("{:?}", source).contains("429") {
+                            Err(
+                                object_store::Error::AlreadyExists { path: to.to_string(), source }
+                            )
+                        } else {
+                            Err(
+                                object_store::Error::Generic { store, source }
+                            )
+                        }
+                    }
+                    _ => Err(e)
+                }
+            },
+        }
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> ObjectStoreResult<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
+        self.inner.put_multipart(location).await
+    }
+
+    async fn abort_multipart(
+        &self,
+        location: &Path,
+        multipart_id: &MultipartId,
+    ) -> ObjectStoreResult<()> {
+        self.inner.abort_multipart(location, multipart_id).await
+    }
+}

--- a/crates/gcp/src/storage.rs
+++ b/crates/gcp/src/storage.rs
@@ -1,4 +1,4 @@
-//! AWS S3 storage backend.
+//! GCP GCS storage backend.
 
 use bytes::Bytes;
 use deltalake_core::storage::ObjectStoreRef;


### PR DESCRIPTION
Fixes #2451 

This is probably not the best implementation but it at least let me test the outcome.

Here's my test script:

```python
import os
from uuid import uuid4

os.environ['RUST_LOG'] = 'INFO'

from time import time
from concurrent.futures import ProcessPoolExecutor

import polars as pl
from deltalake import DeltaTable, write_deltalake

def worker(uri: str, df: pl.DataFrame) -> None:
    table = DeltaTable(uri, log_buffer_size=1024 * 1024)
    table.update_incremental()

    print('writing in a loop')
    while True:
        try:
            start = time()
            write_deltalake(table, df.to_arrow(), engine='rust', mode='append')
            print('Time taken:', time() - start)
        except Exception as e:
            print('Python error:', e)
            continue

if __name__ == '__main__':    
    df = pl.DataFrame({
        'a': [1, 2, 3],
        'b': [4, 5, 6],
    })

    uri = f'gs://bucket-00d0331/test/delta/{uuid4()}'

    print('initializing delta table')
    write_deltalake(uri, df.to_arrow(), engine='rust', mode='append')

    with ProcessPoolExecutor(32) as executor:
        futures = [
            executor.submit(worker, uri, df)
            for _ in range(32)
        ]
        for future in futures:
            future.result()
```

With this change I now get:

```
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Python error: Generic DeltaTable error: Version mismatch
Time taken: 1.4619898796081543
Attempt 1 failed: Version 1 already exists
Attempt 2 failed: Version 2 already exists
Attempt 1 failed: Version 1 already exists
Attempt 2 failed: Version 2 already exists
Python error: Generic DeltaTable error: Version mismatch
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 2 failed: Version 2 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 3 failed: Version 3 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 3 failed: Version 3 already exists
Attempt 1 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 1 failed: Version 1 already exists
Attempt 2 failed: Version 2 already exists
Attempt 1 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 1 failed: Version 1 already exists
Attempt 1 failed: Version 1 already exists
Attempt 2 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 1 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 1 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 1 failed: Version 1 already exists
Python error: Generic DeltaTable error: Version mismatch
Attempt 2 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 1 failed: Version 2 already exists
Attempt 3 failed: Version 3 already exists
Attempt 1 failed: Version 2 already exists
Attempt 1 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 3 failed: Version 3 already exists
Attempt 4 failed: Version 4 already exists
Attempt 3 failed: Version 3 already exists
Attempt 3 failed: Version 3 already exists
Attempt 2 failed: Version 3 already exists
Attempt 3 failed: Version 3 already exists
Attempt 3 failed: Version 3 already exists
Attempt 2 failed: Version 3 already exists
Attempt 3 failed: Version 3 already exists
Attempt 2 failed: Version 3 already exists
Attempt 2 failed: Version 2 already exists
Attempt 2 failed: Version 2 already exists
Attempt 1 failed: Version 2 already exists
Attempt 3 failed: Version 3 already exists
Attempt 3 failed: Version 3 already exists
Attempt 3 failed: Version 3 already exists
Attempt 2 failed: Version 3 already exists
Attempt 2 failed: Version 2 already exists
Attempt 3 failed: Version 3 already exists
Python error: Generic DeltaTable error: Version mismatch
```


So this is an improvement but the behavior is still problematic: I'm not sure that it's updating to try the next version every time a commit fails. I also don't know if updating to the next version is even the right thing to do, maybe it should be refreshing the table state before retrying in case it's gotten far out of sync (e.g. because writing the data took a long time). Buy maybe these are crate wide or protocol wide issues not related to the particularities of GCS.