### PR TITLE
feat(python, rust): cleanup expired logs post-commit hook

### DIFF
--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -364,7 +364,7 @@ impl CommitProperties {
         self
     }
 
-    /// Configure the property to clean up expired transactions
+    /// Specify if it should clean up the logs when the logRetentionDuration interval is met
     pub fn with_cleanup_expired_logs(mut self, cleanup_expired_logs: Option<bool>) -> Self {
         self.cleanup_expired_logs = cleanup_expired_logs;
         self

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -655,7 +655,8 @@ impl<'a> PostCommit<'a> {
                 cleanup_expired_logs_for(
                     self.version,
                     self.log_store.as_ref(),
-                    state.table_config().log_retention_duration().as_millis() as i64,
+                    Utc::now().timestamp_millis()
+                        - state.table_config().log_retention_duration().as_millis() as i64,
                 )
                 .await?;
             }

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -83,7 +83,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 use self::conflict_checker::{CommitConflictError, TransactionInfo, WinningCommitSummary};
-use crate::checkpoints::create_checkpoint_for;
+use crate::checkpoints::{cleanup_expired_logs_for, create_checkpoint_for};
 use crate::errors::DeltaTableError;
 use crate::kernel::{
     Action, CommitInfo, EagerSnapshot, Metadata, Protocol, ReaderFeatures, Transaction,
@@ -309,6 +309,8 @@ impl CommitData {
 /// Properties for post commit hook.
 pub struct PostCommitHookProperties {
     create_checkpoint: bool,
+    /// Override the EnableExpiredLogCleanUp setting, if None config setting is used
+    cleanup_expired_logs: Option<bool>,
 }
 
 #[derive(Clone, Debug)]
@@ -319,6 +321,7 @@ pub struct CommitProperties {
     pub(crate) app_transaction: Vec<Transaction>,
     max_retries: usize,
     create_checkpoint: bool,
+    cleanup_expired_logs: Option<bool>,
 }
 
 impl Default for CommitProperties {
@@ -328,6 +331,7 @@ impl Default for CommitProperties {
             app_transaction: Vec::new(),
             max_retries: DEFAULT_RETRIES,
             create_checkpoint: true,
+            cleanup_expired_logs: None,
         }
     }
 }
@@ -359,6 +363,12 @@ impl CommitProperties {
         self.app_transaction = txn;
         self
     }
+
+    /// Configure the property to clean up expired transactions
+    pub fn with_cleanup_expired_logs(mut self, cleanup_expired_logs: Option<bool>) -> Self {
+        self.cleanup_expired_logs = cleanup_expired_logs;
+        self
+    }
 }
 
 impl From<CommitProperties> for CommitBuilder {
@@ -368,6 +378,7 @@ impl From<CommitProperties> for CommitBuilder {
             app_metadata: value.app_metadata,
             post_commit_hook: Some(PostCommitHookProperties {
                 create_checkpoint: value.create_checkpoint,
+                cleanup_expired_logs: value.cleanup_expired_logs,
             }),
             app_transaction: value.app_transaction,
             ..Default::default()
@@ -527,6 +538,7 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                     version: 0,
                     data: this.data,
                     create_checkpoint: false,
+                    cleanup_expired_logs: None,
                     log_store: this.log_store,
                     table_data: this.table_data,
                 });
@@ -547,6 +559,10 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                             create_checkpoint: this
                                 .post_commit
                                 .map(|v| v.create_checkpoint)
+                                .unwrap_or_default(),
+                            cleanup_expired_logs: this
+                                .post_commit
+                                .map(|v| v.cleanup_expired_logs)
                                 .unwrap_or_default(),
                             log_store: this.log_store,
                             table_data: this.table_data,
@@ -603,6 +619,7 @@ pub struct PostCommit<'a> {
     /// The data that was comitted to the log store
     pub data: CommitData,
     create_checkpoint: bool,
+    cleanup_expired_logs: Option<bool>,
     log_store: LogStoreRef,
     table_data: Option<&'a dyn TableReference>,
 }
@@ -627,6 +644,20 @@ impl<'a> PostCommit<'a> {
             if self.create_checkpoint {
                 self.create_checkpoint(&state, &self.log_store, self.version)
                     .await?;
+            }
+            let cleanup_logs = if let Some(cleanup_logs) = self.cleanup_expired_logs {
+                cleanup_logs
+            } else {
+                state.table_config().enable_expired_log_cleanup()
+            };
+
+            if cleanup_logs {
+                cleanup_expired_logs_for(
+                    self.version,
+                    self.log_store.as_ref(),
+                    state.table_config().log_retention_duration().as_millis() as i64,
+                )
+                .await?;
             }
             Ok(state)
         } else {

--- a/python/deltalake/__init__.py
+++ b/python/deltalake/__init__.py
@@ -6,6 +6,7 @@ from .schema import Field as Field
 from .schema import Schema as Schema
 from .table import DeltaTable as DeltaTable
 from .table import Metadata as Metadata
+from .table import PostCommitHookProperties as PostCommitHookProperties
 from .table import WriterProperties as WriterProperties
 from .writer import convert_to_deltalake as convert_to_deltalake
 from .writer import write_deltalake as write_deltalake

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -54,6 +54,7 @@ class RawDeltaTable:
         retention_hours: Optional[int],
         enforce_retention_duration: bool,
         custom_metadata: Optional[Dict[str, str]],
+        post_commithook_properties: Optional[Dict[str, Optional[bool]]],
     ) -> List[str]: ...
     def compact_optimize(
         self,
@@ -63,6 +64,7 @@ class RawDeltaTable:
         min_commit_interval: Optional[int],
         writer_properties: Optional[Dict[str, Optional[str]]],
         custom_metadata: Optional[Dict[str, str]],
+        post_commithook_properties: Optional[Dict[str, Optional[bool]]],
     ) -> str: ...
     def z_order_optimize(
         self,
@@ -74,17 +76,20 @@ class RawDeltaTable:
         min_commit_interval: Optional[int],
         writer_properties: Optional[Dict[str, Optional[str]]],
         custom_metadata: Optional[Dict[str, str]],
+        post_commithook_properties: Optional[Dict[str, Optional[bool]]],
     ) -> str: ...
     def add_constraints(
         self,
         constraints: Dict[str, str],
         custom_metadata: Optional[Dict[str, str]],
+        post_commithook_properties: Optional[Dict[str, Optional[bool]]],
     ) -> None: ...
     def drop_constraints(
         self,
         name: str,
         raise_if_not_exists: bool,
         custom_metadata: Optional[Dict[str, str]],
+        post_commithook_properties: Optional[Dict[str, Optional[bool]]],
     ) -> None: ...
     def set_table_properties(
         self,
@@ -111,9 +116,13 @@ class RawDeltaTable:
         predicate: Optional[str],
         writer_properties: Optional[Dict[str, Optional[str]]],
         custom_metadata: Optional[Dict[str, str]],
+        post_commithook_properties: Optional[Dict[str, Optional[bool]]],
     ) -> str: ...
     def repair(
-        self, dry_run: bool, custom_metadata: Optional[Dict[str, str]]
+        self,
+        dry_run: bool,
+        custom_metadata: Optional[Dict[str, str]],
+        post_commithook_properties: Optional[Dict[str, Optional[bool]]],
     ) -> str: ...
     def update(
         self,
@@ -122,6 +131,7 @@ class RawDeltaTable:
         writer_properties: Optional[Dict[str, Optional[str]]],
         safe_cast: bool,
         custom_metadata: Optional[Dict[str, str]],
+        post_commithook_properties: Optional[Dict[str, Optional[bool]]],
     ) -> str: ...
     def merge_execute(
         self,
@@ -131,6 +141,7 @@ class RawDeltaTable:
         target_alias: Optional[str],
         writer_properties: Optional[Dict[str, Optional[str]]],
         custom_metadata: Optional[Dict[str, str]],
+        post_commithook_properties: Optional[Dict[str, Optional[bool]]],
         safe_cast: bool,
         matched_update_updates: Optional[List[Dict[str, str]]],
         matched_update_predicate: Optional[List[Optional[str]]],
@@ -154,6 +165,7 @@ class RawDeltaTable:
         schema: pyarrow.Schema,
         partitions_filters: Optional[FilterType],
         custom_metadata: Optional[Dict[str, str]],
+        post_commithook_properties: Optional[Dict[str, Optional[bool]]],
     ) -> None: ...
     def cleanup_metadata(self) -> None: ...
     def check_can_write_timestamp_ntz(self, schema: pyarrow.Schema) -> None: ...
@@ -193,6 +205,7 @@ def write_to_deltalake(
     storage_options: Optional[Dict[str, str]],
     writer_properties: Optional[Dict[str, Optional[str]]],
     custom_metadata: Optional[Dict[str, str]],
+    post_commithook_properties: Optional[Dict[str, Optional[bool]]],
 ) -> None: ...
 def convert_to_deltalake(
     uri: str,

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -701,6 +701,7 @@ class DeltaTable:
             dry_run: when activated, list only the files, delete otherwise
             enforce_retention_duration: when disabled, accepts retention hours smaller than the value from `delta.deletedFileRetentionDuration`.
             custom_metadata: custom metadata that will be added to the transaction commit.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
         Returns:
             the list of files no longer referenced by the Delta Table and are older than the retention threshold.
         """
@@ -738,6 +739,7 @@ class DeltaTable:
             writer_properties: Pass writer properties to the Rust parquet writer.
             error_on_type_mismatch: specify if update will return error if data types are mismatching :default = True
             custom_metadata: custom metadata that will be added to the transaction commit.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
         Returns:
             the metrics from update
 
@@ -875,6 +877,7 @@ class DeltaTable:
             writer_properties: Pass writer properties to the Rust parquet writer
             large_dtypes: If True, the data schema is kept in large_dtypes.
             custom_metadata: custom metadata that will be added to the transaction commit.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
 
         Returns:
             TableMerger: TableMerger Object
@@ -923,6 +926,7 @@ class DeltaTable:
             safe_cast=not error_on_type_mismatch,
             writer_properties=writer_properties,
             custom_metadata=custom_metadata,
+            post_commithook_properties=post_commithook_properties,
         )
 
     def restore(
@@ -1189,6 +1193,7 @@ class DeltaTable:
         predicate: Optional[str] = None,
         writer_properties: Optional[WriterProperties] = None,
         custom_metadata: Optional[Dict[str, str]] = None,
+        post_commithook_properties: Optional[PostCommitHookProperties] = None,
     ) -> Dict[str, Any]:
         """Delete records from a Delta Table that statisfy a predicate.
 
@@ -1201,6 +1206,7 @@ class DeltaTable:
             predicate: a SQL where clause. If not passed, will delete all rows.
             writer_properties: Pass writer properties to the Rust parquet writer.
             custom_metadata: custom metadata that will be added to the transaction commit.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
 
         Returns:
             the metrics from delete.
@@ -1209,11 +1215,15 @@ class DeltaTable:
             predicate,
             writer_properties._to_dict() if writer_properties else None,
             custom_metadata,
+            post_commithook_properties.__dict__ if post_commithook_properties else None,
         )
         return json.loads(metrics)
 
     def repair(
-        self, dry_run: bool = False, custom_metadata: Optional[Dict[str, str]] = None
+        self,
+        dry_run: bool = False,
+        custom_metadata: Optional[Dict[str, str]] = None,
+        post_commithook_properties: Optional[PostCommitHookProperties] = None,
     ) -> Dict[str, Any]:
         """Repair the Delta Table by auditing active files that do not exist in the underlying
         filesystem and removes them. This can be useful when there are accidental deletions or corrupted files.
@@ -1225,6 +1235,8 @@ class DeltaTable:
         Args:
             dry_run: when activated, list only the files, otherwise add remove actions to transaction log. Defaults to False.
             custom_metadata: custom metadata that will be added to the transaction commit.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
+
         Returns:
             The metrics from repair (FSCK) action.
 
@@ -1239,7 +1251,11 @@ class DeltaTable:
             {'dry_run': False, 'files_removed': ['6-0d084325-6885-4847-b008-82c1cf30674c-0.parquet', 5-4fba1d3e-3e20-4de1-933d-a8e13ac59f53-0.parquet']}
             ```
         """
-        metrics = self._table.repair(dry_run, custom_metadata)
+        metrics = self._table.repair(
+            dry_run,
+            custom_metadata,
+            post_commithook_properties.__dict__ if post_commithook_properties else None,
+        )
         return json.loads(metrics)
 
 
@@ -1781,6 +1797,8 @@ class TableAlterer:
         Args:
             constraints: mapping of constraint name to SQL-expression to evaluate on write
             custom_metadata: custom metadata that will be added to the transaction commit.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
+
         Example:
             ```python
             from deltalake import DeltaTable
@@ -1822,6 +1840,8 @@ class TableAlterer:
             name: constraint name which to drop.
             raise_if_not_exists: set if should raise if not exists.
             custom_metadata: custom metadata that will be added to the transaction commit.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
+
         Example:
             ```python
             from deltalake import DeltaTable
@@ -1924,6 +1944,7 @@ class TableOptimizer:
                                     want a commit per partition.
             writer_properties: Pass writer properties to the Rust parquet writer.
             custom_metadata: custom metadata that will be added to the transaction commit.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
 
         Returns:
             the metrics from optimize
@@ -1991,6 +2012,7 @@ class TableOptimizer:
                                     want a commit per partition.
             writer_properties: Pass writer properties to the Rust parquet writer.
             custom_metadata: custom metadata that will be added to the transaction commit.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
 
         Returns:
             the metrics from optimize

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -273,6 +273,7 @@ def write_deltalake(
             see up to 4x performance improvements over pyarrow.
         writer_properties: Pass writer properties to the Rust parquet writer.
         custom_metadata: Custom metadata to add to the commitInfo.
+        post_commithook_properties: properties for the post commit hook. If None, default values are used.
     """
     table, table_uri = try_get_table_and_table_uri(table_or_uri, storage_options)
     if table is not None:

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -51,6 +51,7 @@ from .table import (
     NOT_SUPPORTED_PYARROW_WRITER_VERSIONS,
     SUPPORTED_WRITER_FEATURES,
     DeltaTable,
+    PostCommitHookProperties,
     WriterProperties,
 )
 
@@ -121,6 +122,7 @@ def write_deltalake(
     large_dtypes: bool = ...,
     engine: Literal["pyarrow"] = ...,
     custom_metadata: Optional[Dict[str, str]] = ...,
+    post_commithook_properties: Optional[PostCommitHookProperties] = ...,
 ) -> None: ...
 
 
@@ -149,6 +151,7 @@ def write_deltalake(
     engine: Literal["rust"],
     writer_properties: WriterProperties = ...,
     custom_metadata: Optional[Dict[str, str]] = ...,
+    post_commithook_properties: Optional[PostCommitHookProperties] = ...,
 ) -> None: ...
 
 
@@ -178,6 +181,7 @@ def write_deltalake(
     engine: Literal["rust"],
     writer_properties: WriterProperties = ...,
     custom_metadata: Optional[Dict[str, str]] = ...,
+    post_commithook_properties: Optional[PostCommitHookProperties] = ...,
 ) -> None: ...
 
 
@@ -213,6 +217,7 @@ def write_deltalake(
     engine: Literal["pyarrow", "rust"] = "pyarrow",
     writer_properties: Optional[WriterProperties] = None,
     custom_metadata: Optional[Dict[str, str]] = None,
+    post_commithook_properties: Optional[PostCommitHookProperties] = None,
 ) -> None:
     """Write to a Delta Lake table
 
@@ -304,6 +309,9 @@ def write_deltalake(
                 writer_properties._to_dict() if writer_properties else None
             ),
             custom_metadata=custom_metadata,
+            post_commithook_properties=post_commithook_properties.__dict__
+            if post_commithook_properties
+            else None,
         )
         if table:
             table.update_incremental()
@@ -533,6 +541,9 @@ def write_deltalake(
                 schema,
                 partition_filters,
                 custom_metadata,
+                post_commithook_properties=post_commithook_properties.__dict__
+                if post_commithook_properties
+                else None,
             )
             table.update_incremental()
     else:

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -415,6 +415,7 @@ impl RawDeltaTable {
     }
 
     /// Run the optimize command on the Delta Table: merge small files into a large file by bin-packing.
+    #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
         partition_filters = None,
         target_size = None,

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -340,23 +340,22 @@ impl RawDeltaTable {
                 cmd = cmd.with_retention_period(Duration::hours(retention_period as i64));
             }
 
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
-            let mut commit_properties = CommitProperties::default();
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                commit_properties = commit_properties.with_metadata(json_metadata);
-            };
+            if custom_metadata.is_some() || post_commithook_properties.is_some() {
+                let mut commit_properties = CommitProperties::default();
+                if let Some(metadata) = custom_metadata {
+                    let json_metadata: Map<String, Value> =
+                        metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
+                    commit_properties = commit_properties.with_metadata(json_metadata);
+                };
 
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
-            }
-            cmd = cmd.with_commit_properties(commit_properties);
-        };
-        let (table, metrics) = rt()
-            .block_on(cmd.into_future())
-            .map_err(PythonError::from)?;
+                if let Some(post_commit_hook_props) = post_commithook_properties {
+                    commit_properties =
+                        set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                }
+                cmd = cmd.with_commit_properties(commit_properties);
+            };
+            rt().block_on(cmd.into_future()).map_err(PythonError::from)
+        })?;
         self._table.state = table.state;
         Ok(metrics.files_deleted)
     }
@@ -394,48 +393,23 @@ impl RawDeltaTable {
                 cmd = cmd.with_predicate(update_predicate);
             }
 
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
-            let mut commit_properties = CommitProperties::default();
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                commit_properties = commit_properties.with_metadata(json_metadata);
-            };
+            if custom_metadata.is_some() || post_commithook_properties.is_some() {
+                let mut commit_properties = CommitProperties::default();
+                if let Some(metadata) = custom_metadata {
+                    let json_metadata: Map<String, Value> =
+                        metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
+                    commit_properties = commit_properties.with_metadata(json_metadata);
+                };
 
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                if let Some(post_commit_hook_props) = post_commithook_properties {
+                    commit_properties =
+                        set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                }
+                cmd = cmd.with_commit_properties(commit_properties);
             }
-            cmd = cmd.with_commit_properties(commit_properties);
-        }
 
-        for (col_name, expression) in updates {
-            cmd = cmd.with_update(col_name.clone(), expression.clone());
-        }
-
-        if let Some(update_predicate) = predicate {
-            cmd = cmd.with_predicate(update_predicate);
-        }
-
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
-            let mut commit_properties = CommitProperties::default();
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                commit_properties = commit_properties.with_metadata(json_metadata);
-            };
-
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
-            }
-            cmd = cmd.with_commit_properties(commit_properties);
-        }
-
-        let (table, metrics) = rt()
-            .block_on(cmd.into_future())
-            .map_err(PythonError::from)?;
->>>>>>> 29bfea1c (add clean up logs hook, expose PostCommitHookProps to python)
+            rt().block_on(cmd.into_future()).map_err(PythonError::from)
+        })?;
         self._table.state = table.state;
         Ok(serde_json::to_string(&metrics).unwrap())
     }
@@ -482,48 +456,28 @@ impl RawDeltaTable {
                 );
             }
 
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
-            let mut commit_properties = CommitProperties::default();
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                commit_properties = commit_properties.with_metadata(json_metadata);
-            };
+            if custom_metadata.is_some() || post_commithook_properties.is_some() {
+                let mut commit_properties = CommitProperties::default();
+                if let Some(metadata) = custom_metadata {
+                    let json_metadata: Map<String, Value> =
+                        metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
+                    commit_properties = commit_properties.with_metadata(json_metadata);
+                };
 
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                if let Some(post_commit_hook_props) = post_commithook_properties {
+                    commit_properties =
+                        set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                }
+                cmd = cmd.with_commit_properties(commit_properties);
             }
-            cmd = cmd.with_commit_properties(commit_properties);
-        }
 
             let converted_filters =
                 convert_partition_filters(partition_filters.unwrap_or_default())
                     .map_err(PythonError::from)?;
             cmd = cmd.with_filters(&converted_filters);
 
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
-            let mut commit_properties = CommitProperties::default();
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                commit_properties = commit_properties.with_metadata(json_metadata);
-            };
-
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
-            }
-            cmd = cmd.with_commit_properties(commit_properties);
-        }
-
-        let converted_filters = convert_partition_filters(partition_filters.unwrap_or_default())
-            .map_err(PythonError::from)?;
-        cmd = cmd.with_filters(&converted_filters);
-
-        let (table, metrics) = rt()
-            .block_on(cmd.into_future())
-            .map_err(PythonError::from)?;
+            rt().block_on(cmd.into_future()).map_err(PythonError::from)
+        })?;
         self._table.state = table.state;
         Ok(serde_json::to_string(&metrics).unwrap())
     }
@@ -572,48 +526,29 @@ impl RawDeltaTable {
                     set_writer_properties(writer_props).map_err(PythonError::from)?,
                 );
             }
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
-            let mut commit_properties = CommitProperties::default();
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                commit_properties = commit_properties.with_metadata(json_metadata);
-            };
 
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
+            if custom_metadata.is_some() || post_commithook_properties.is_some() {
+                let mut commit_properties = CommitProperties::default();
+                if let Some(metadata) = custom_metadata {
+                    let json_metadata: Map<String, Value> =
+                        metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
+                    commit_properties = commit_properties.with_metadata(json_metadata);
+                };
+
+                if let Some(post_commit_hook_props) = post_commithook_properties {
+                    commit_properties =
+                        set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                }
+                cmd = cmd.with_commit_properties(commit_properties);
             }
-            cmd = cmd.with_commit_properties(commit_properties);
-        }
 
             let converted_filters =
                 convert_partition_filters(partition_filters.unwrap_or_default())
                     .map_err(PythonError::from)?;
             cmd = cmd.with_filters(&converted_filters);
 
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
-            let mut commit_properties = CommitProperties::default();
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                commit_properties = commit_properties.with_metadata(json_metadata);
-            };
-
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
-            }
-            cmd = cmd.with_commit_properties(commit_properties);
-        }
-
-        let converted_filters = convert_partition_filters(partition_filters.unwrap_or_default())
-            .map_err(PythonError::from)?;
-        cmd = cmd.with_filters(&converted_filters);
-
-        let (table, metrics) = rt()
-            .block_on(cmd.into_future())
-            .map_err(PythonError::from)?;
+            rt().block_on(cmd.into_future()).map_err(PythonError::from)
+        })?;
         self._table.state = table.state;
         Ok(serde_json::to_string(&metrics).unwrap())
     }
@@ -636,39 +571,23 @@ impl RawDeltaTable {
                 cmd = cmd.with_constraint(col_name.clone(), expression.clone());
             }
 
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
-            let mut commit_properties = CommitProperties::default();
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                commit_properties = commit_properties.with_metadata(json_metadata);
-            };
+            if custom_metadata.is_some() || post_commithook_properties.is_some() {
+                let mut commit_properties = CommitProperties::default();
+                if let Some(metadata) = custom_metadata {
+                    let json_metadata: Map<String, Value> =
+                        metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
+                    commit_properties = commit_properties.with_metadata(json_metadata);
+                };
 
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                if let Some(post_commit_hook_props) = post_commithook_properties {
+                    commit_properties =
+                        set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                }
+                cmd = cmd.with_commit_properties(commit_properties);
             }
-            cmd = cmd.with_commit_properties(commit_properties);
-        }
 
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
-            let mut commit_properties = CommitProperties::default();
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                commit_properties = commit_properties.with_metadata(json_metadata);
-            };
-
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
-            }
-            cmd = cmd.with_commit_properties(commit_properties);
-        }
-
-        let table = rt()
-            .block_on(cmd.into_future())
-            .map_err(PythonError::from)?;
+            rt().block_on(cmd.into_future()).map_err(PythonError::from)
+        })?;
         self._table.state = table.state;
         Ok(())
     }
@@ -690,26 +609,20 @@ impl RawDeltaTable {
             .with_constraint(name)
             .with_raise_if_not_exists(raise_if_not_exists);
 
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
-            let mut commit_properties = CommitProperties::default();
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                commit_properties = commit_properties.with_metadata(json_metadata);
-            };
+            if custom_metadata.is_some() || post_commithook_properties.is_some() {
+                let mut commit_properties = CommitProperties::default();
+                if let Some(metadata) = custom_metadata {
+                    let json_metadata: Map<String, Value> =
+                        metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
+                    commit_properties = commit_properties.with_metadata(json_metadata);
+                };
 
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                if let Some(post_commit_hook_props) = post_commithook_properties {
+                    commit_properties =
+                        set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                }
+                cmd = cmd.with_commit_properties(commit_properties);
             }
-            cmd = cmd.with_commit_properties(commit_properties);
-        }
-
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
-            }
-            cmd = cmd.with_commit_properties(commit_properties);
 
             rt().block_on(cmd.into_future()).map_err(PythonError::from)
         })?;
@@ -826,7 +739,7 @@ impl RawDeltaTable {
         not_matched_by_source_delete_predicate: Option<Vec<String>>,
         not_matched_by_source_delete_all: Option<bool>,
     ) -> PyResult<String> {
-        py.allow_threads(|| {
+        let (table, metrics) = py.allow_threads(|| {
             let ctx = SessionContext::new();
             let schema = source.0.schema();
             let batches = vec![source.0.map(|batch| batch.unwrap()).collect::<Vec<_>>()];
@@ -981,12 +894,10 @@ impl RawDeltaTable {
                 }
             }
 
-            let (table, metrics) = rt()
-                .block_on(cmd.into_future())
-                .map_err(PythonError::from)?;
-            self._table.state = table.state;
-            Ok(serde_json::to_string(&metrics).unwrap())
-        })
+            rt().block_on(cmd.into_future()).map_err(PythonError::from)
+        })?;
+        self._table.state = table.state;
+        Ok(serde_json::to_string(&metrics).unwrap())
     }
 
     // Run the restore command on the Delta Table: restore table to a given version or datetime
@@ -1267,37 +1178,29 @@ impl RawDeltaTable {
                 predicate: None,
             };
 
-        let mut commit_properties = CommitProperties::default();
-        if let Some(metadata) = custom_metadata {
-            let json_metadata: Map<String, Value> =
-                metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-            commit_properties = commit_properties.with_metadata(json_metadata);
-        };
+            let mut commit_properties = CommitProperties::default();
+            if let Some(metadata) = custom_metadata {
+                let json_metadata: Map<String, Value> =
+                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
+                commit_properties = commit_properties.with_metadata(json_metadata);
+            };
 
-        let mut commit_properties = CommitProperties::default();
-        if let Some(metadata) = custom_metadata {
-            let json_metadata: Map<String, Value> =
-                metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-            commit_properties = commit_properties.with_metadata(json_metadata);
-        };
+            if let Some(post_commit_hook_props) = post_commithook_properties {
+                commit_properties =
+                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
+            }
 
-        if let Some(post_commit_hook_props) = post_commithook_properties {
-            commit_properties =
-                set_post_commithook_properties(commit_properties, post_commit_hook_props)
-        }
-
-        rt().block_on(
-            CommitBuilder::from(commit_properties)
-                .with_actions(actions)
-                .build(
-                    Some(self._table.snapshot().map_err(PythonError::from)?),
-                    self._table.log_store(),
-                    operation,
-                )
-                .map_err(|err| PythonError::from(DeltaTableError::from(err)))?
-                .into_future(),
-        )
-        .map_err(PythonError::from)?;
+            rt().block_on(
+                CommitBuilder::from(commit_properties)
+                    .with_actions(actions)
+                    .build(
+                        Some(self._table.snapshot().map_err(PythonError::from)?),
+                        self._table.log_store(),
+                        operation,
+                    )
+                    .into_future(),
+            )
+            .map_err(PythonError::from)?;
 
             Ok(())
         })
@@ -1362,28 +1265,20 @@ impl RawDeltaTable {
                 cmd = cmd.with_predicate(predicate);
             }
 
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
-            let mut commit_properties = CommitProperties::default();
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                commit_properties = commit_properties.with_metadata(json_metadata);
-            };
+            if custom_metadata.is_some() || post_commithook_properties.is_some() {
+                let mut commit_properties = CommitProperties::default();
+                if let Some(metadata) = custom_metadata {
+                    let json_metadata: Map<String, Value> =
+                        metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
+                    commit_properties = commit_properties.with_metadata(json_metadata);
+                };
 
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                if let Some(post_commit_hook_props) = post_commithook_properties {
+                    commit_properties =
+                        set_post_commithook_properties(commit_properties, post_commit_hook_props)
+                }
+                cmd = cmd.with_commit_properties(commit_properties);
             }
-            cmd = cmd.with_commit_properties(commit_properties);
-        }
-
-            if let Some(metadata) = custom_metadata {
-                let json_metadata: Map<String, Value> =
-                    metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                cmd = cmd.with_commit_properties(
-                    CommitProperties::default().with_metadata(json_metadata),
-                );
-            };
 
             rt().block_on(cmd.into_future()).map_err(PythonError::from)
         })?;
@@ -1405,7 +1300,7 @@ impl RawDeltaTable {
         .with_properties(properties)
         .with_raise_if_not_exists(raise_if_not_exists);
 
-        if custom_metadata.is_some() || post_commithook_properties.is_some() {
+        if custom_metadata.is_some() {
             let mut commit_properties = CommitProperties::default();
             if let Some(metadata) = custom_metadata {
                 let json_metadata: Map<String, Value> =
@@ -1413,10 +1308,6 @@ impl RawDeltaTable {
                 commit_properties = commit_properties.with_metadata(json_metadata);
             };
 
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                commit_properties =
-                    set_post_commithook_properties(commit_properties, post_commit_hook_props)
-            }
             cmd = cmd.with_commit_properties(commit_properties);
         }
 

--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -141,6 +141,7 @@ def test_cleanup_metadata_log_cleanup_hook_disabled(
         sample_data,
         mode="append",
         engine=engine,
+        post_commithook_properties=PostCommitHookProperties(cleanup_expired_logs=False),
     )
 
     tmp_table_path = tmp_path / "path" / "to" / "table"

--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -100,14 +100,15 @@ def test_cleanup_metadata(tmp_path: pathlib.Path, sample_data: pa.Table):
     assert second_failed_log_path.exists()
 
 
+@pytest.mark.parametrize("engine", ["pyarrow", "rust"])
 def test_cleanup_metadata_log_cleanup_hook(
-    tmp_path: pathlib.Path, sample_data: pa.Table
+    tmp_path: pathlib.Path, sample_data: pa.Table, engine
 ):
     delta_table = setup_cleanup_metadata(tmp_path, sample_data)
     delta_table.create_checkpoint()
 
     sample_data = sample_data.drop(["binary"])
-    write_deltalake(delta_table, sample_data, mode="append", engine="rust")
+    write_deltalake(delta_table, sample_data, mode="append", engine=engine)
 
     tmp_table_path = tmp_path / "path" / "to" / "table"
     first_failed_log_path = (
@@ -127,8 +128,9 @@ def test_cleanup_metadata_log_cleanup_hook(
     assert second_failed_log_path.exists()
 
 
+@pytest.mark.parametrize("engine", ["pyarrow", "rust"])
 def test_cleanup_metadata_log_cleanup_hook_disabled(
-    tmp_path: pathlib.Path, sample_data: pa.Table
+    tmp_path: pathlib.Path, sample_data: pa.Table, engine
 ):
     delta_table = setup_cleanup_metadata(tmp_path, sample_data)
     delta_table.create_checkpoint()
@@ -138,7 +140,7 @@ def test_cleanup_metadata_log_cleanup_hook_disabled(
         delta_table,
         sample_data,
         mode="append",
-        engine="rust",
+        engine=engine,
         post_commithook_properties=PostCommitHookProperties(cleanup_expired_logs=False),
     )
 

--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -141,7 +141,6 @@ def test_cleanup_metadata_log_cleanup_hook_disabled(
         sample_data,
         mode="append",
         engine=engine,
-        post_commithook_properties=PostCommitHookProperties(cleanup_expired_logs=False),
     )
 
     tmp_table_path = tmp_path / "path" / "to" / "table"


### PR DESCRIPTION
# Description
This adds the cleanup expired logs post-commit hook. Tables by default have `delta.enableExpiredLogCleanup = true`, and` delta.logRetentionDuration = interval 30 days`. So moving forward those logs will be automatically cleaned up.

If users set `delta.enableExpiredLogCleanup = false` during table creation, the log clean up will never be executed in the post-commit. When cleanup_expired_logs in the post-commit hook properties is passed, then that take precedence over the table config. 

Additionally to most operations you can now pass in Python the PostCommitHookProperties to control the post commit hook, only really needed for advanced use cases, where you want to disable creating checkpoints across the board or override the log clean up.

@Blajda this is a follow up PR of the hooks, will look into creating an auto_vacuum_hook afterwards