### PR TITLE
fix(python, rust): use new schema for stats parsing instead of old

### DIFF
--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1626,3 +1626,22 @@ def test_write_timestamp_ntz_on_table_with_features_not_enabled(tmp_path: pathli
         write_deltalake(
             tmp_path, data, mode="overwrite", engine="pyarrow", schema_mode="overwrite"
         )
+
+
+@pytest.mark.parametrize("engine", ["pyarrow", "rust"])
+def test_parse_stats_with_new_schema(tmp_path, engine):
+    sample_data = pa.table(
+        {
+            "val": pa.array([1, 1], pa.int8()),
+        }
+    )
+    write_deltalake(tmp_path, sample_data)
+
+    sample_data = pa.table(
+        {
+            "val": pa.array([1000000000000, 1000000000000], pa.int64()),
+        }
+    )
+    write_deltalake(
+        tmp_path, sample_data, mode="overwrite", schema_mode="overwrite", engine=engine
+    )


### PR DESCRIPTION
# Description
In some edge cases where we schema evolve, it would parse the stats with the old schema result in these kind of errors:
`Exception: Json error: whilst decoding field 'minValues': whilst decoding field 'foo': failed to parse 1000000000000 as Int8`

```python
import polars as pl
from deltalake import write_deltalake

pl.DataFrame({
    "foo": [1]
}, schema={"foo": pl.Int8}).write_delta("TEST_TABLE_BUG")


write_deltalake("TEST_TABLE_BUG", data = pl.DataFrame({
    "foo": [1000000000000]
}, schema={"foo": pl.Int64}).to_arrow(), mode='overwrite', overwrite_schema=True,engine='rust')
```

Instead of taking the old schema, I added an optional schema to be passed in the logMapper