### PR TITLE
fix(rust, python): fixed differences in storage options between log and object stores

### DIFF
--- a/crates/aws/src/storage.rs
+++ b/crates/aws/src/storage.rs
@@ -516,7 +516,6 @@ pub(crate) fn str_option(map: &HashMap<String, String>, key: &str) -> Option<Str
     }
 
     if let Some(s) = map.get(&key.to_ascii_lowercase()) {
-        warn!("********** found lowercase **********: {} : {}", key, s);
         return Some(s.to_owned());
     }
 


### PR DESCRIPTION
The object store changes the keys used for creating the s3 options, while the log store does not. The difference between the two, and their usage together was causing some weird fallback behavior in the AWS SDK that invoked the IMDS service despite explicitly disabling it in multiple places. This fix handles the potentially different casing along with passing the options unmolested. It should stop any future, unwanted, IMDS behavior

# Description
The description of the main changes of your pull request

# Related Issue(s)
- closes #2460 
# Documentation

<!---
Share links to useful documentation
--->
