### PR TITLE
feat: improve merge performance by using predicate non-partition columns min/max for prefiltering

### DIFF
--- a/crates/core/tests/command_merge.rs
+++ b/crates/core/tests/command_merge.rs
@@ -138,7 +138,30 @@ async fn merge(
 
 #[tokio::test]
 async fn test_merge_concurrent_conflict() {
-    // No partition key or filter predicate -> Commit conflict
+    // Overlapping id ranges -> Commit conflict
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let table_uri = tmp_dir.path().to_str().to_owned().unwrap();
+
+    let table_ref1 = create_table(&table_uri.to_string(), Some(vec!["event_date"])).await;
+    let table_ref2 = open_table(table_uri).await.unwrap();
+    let (df1, _df2) = create_test_data();
+
+    let expr = col("target.id").eq(col("source.id"));
+    let (_table_ref1, _metrics) = merge(table_ref1, df1.clone(), expr.clone()).await.unwrap();
+    let result = merge(table_ref2, df1, expr).await;
+
+    assert!(matches!(
+        result.as_ref().unwrap_err(),
+        DeltaTableError::Transaction { .. }
+    ));
+    if let DeltaTableError::Transaction { source } = result.unwrap_err() {
+        assert!(matches!(source, TransactionError::CommitConflict(_)));
+    }
+}
+
+#[tokio::test]
+async fn test_merge_different_range() {
+    // No overlapping id ranges -> No conflict
     let tmp_dir = tempfile::tempdir().unwrap();
     let table_uri = tmp_dir.path().to_str().to_owned().unwrap();
 
@@ -150,13 +173,7 @@ async fn test_merge_concurrent_conflict() {
     let (_table_ref1, _metrics) = merge(table_ref1, df1, expr.clone()).await.unwrap();
     let result = merge(table_ref2, df2, expr).await;
 
-    assert!(matches!(
-        result.as_ref().unwrap_err(),
-        DeltaTableError::Transaction { .. }
-    ));
-    if let DeltaTableError::Transaction { source } = result.unwrap_err() {
-        assert!(matches!(source, TransactionError::CommitConflict(_)));
-    }
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
@@ -175,9 +192,7 @@ async fn test_merge_concurrent_different_partition() {
     let (_table_ref1, _metrics) = merge(table_ref1, df1, expr.clone()).await.unwrap();
     let result = merge(table_ref2, df2, expr).await;
 
-    // TODO: Currently it throws a Version mismatch error, but the merge commit was successfully
-    // This bug needs to be fixed, see pull request #2280
-    assert!(result.as_ref().is_ok());
+    assert!(result.is_ok());
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description
This pr improves the merging performance by adding min/max filters to the early filter.
The number of files scanned from the target file table is reduced by using the table statistics. 
I have extended the early filter for this purpose. This filter is responsible for pre-filtering the target table. 
Previously, the early filter only consisted of partition columns by filtering for all unique values from the source. Now the non-partition columns are also used by aggregating the min/max values from the source and adding a between expression to the early filter. 

It is also automatically part of the conflict detection based on the predicate.

I added a property `extended_early_filter` to make this advanced filtering optional. I don't know if this is important, and maybe we can replace the bool with an enum. What do you think about this?  


## Example:
Merge into table t with partition date

Predicate: source.date = target.date and source.timestamp = target.timestamp and source.id = target.id and frob > 42

Early filter before: `date = '2024-‚05-14' and frob > 42`
Early filter now: `date = '2024-05-14' and timestamp BETWEEN '…15:00' AND '…15:05' and id BETWEEN 'A' AND 'B' and frob > 42`
