### PR TITLE
chore: tidying up builds without datafusion feature and clippy

### DIFF
--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -1,7 +1,7 @@
 //! Command for converting a Parquet table to a Delta table in place
 // https://github.com/delta-io/delta/blob/1d5dd774111395b0c4dc1a69c94abc169b1c83b6/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
 
-use crate::operations::write::get_num_idx_cols_and_stats_columns;
+use crate::operations::get_num_idx_cols_and_stats_columns;
 use crate::{
     kernel::{Add, DataType, Schema, StructField},
     logstore::{LogStore, LogStoreRef},

--- a/crates/core/src/operations/transaction/conflict_checker.rs
+++ b/crates/core/src/operations/transaction/conflict_checker.rs
@@ -194,7 +194,7 @@ impl<'a> TransactionInfo<'a> {
     #[cfg(not(feature = "datafusion"))]
     /// Files read by the transaction
     pub fn read_files(&self) -> Result<impl Iterator<Item = Add> + '_, CommitConflictError> {
-        Ok(self.read_snapshot.file_actions().unwrap().into_iter())
+        Ok(self.read_snapshot.file_actions().unwrap())
     }
 
     /// Whether the whole table was read during the transaction
@@ -310,13 +310,6 @@ impl WinningCommitSummary {
             self.added_files()
         }
     }
-
-    // pub fn only_add_files(&self) -> bool {
-    //     !self
-    //         .actions
-    //         .iter()
-    //         .any(|action| matches!(action, Action::remove(_)))
-    // }
 
     pub fn is_blind_append(&self) -> Option<bool> {
         self.commit_info

--- a/crates/core/src/operations/transaction/protocol.rs
+++ b/crates/core/src/operations/transaction/protocol.rs
@@ -80,8 +80,8 @@ impl ProtocolChecker {
     }
 
     /// checks if table contains timestamp_ntz in any field including nested fields.
-    pub fn contains_timestampntz(&self, fields: &Vec<StructField>) -> bool {
-        fn check_vec_fields(fields: &Vec<StructField>) -> bool {
+    pub fn contains_timestampntz(&self, fields: &[StructField]) -> bool {
+        fn check_vec_fields(fields: &[StructField]) -> bool {
             fields.iter().any(|f| _check_type(f.data_type()))
         }
 

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -520,7 +520,7 @@ mod tests {
         use crate::DeltaOps;
 
         let table = crate::writer::test_utils::create_bare_table();
-        let partition_cols = vec!["modified".to_string()];
+        let partition_cols = ["modified".to_string()];
         let delta_schema = r#"
         {"type" : "struct",
         "fields" : [

--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -133,7 +133,7 @@ fn stats_from_metadata(
     let idx_to_iterate = if let Some(stats_cols) = stats_columns {
         schema_descriptor
             .columns()
-            .into_iter()
+            .iter()
             .enumerate()
             .filter_map(|(index, col)| {
                 if stats_cols.contains(&col.name().to_string()) {

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1732,12 +1732,10 @@ fn get_num_idx_cols_and_stats_columns(
         .map_err(PythonError::from)?
         .map(|snapshot| snapshot.table_config());
 
-    Ok(
-        deltalake::operations::write::get_num_idx_cols_and_stats_columns(
-            config,
-            configuration.unwrap_or_default(),
-        ),
-    )
+    Ok(deltalake::operations::get_num_idx_cols_and_stats_columns(
+        config,
+        configuration.unwrap_or_default(),
+    ))
 }
 
 #[pyclass(name = "DeltaDataChecker", module = "deltalake._internal")]


### PR DESCRIPTION
The recent convert_to_delta changes imported a symbol from a module that is only compiled in with the datafusion feature, oops!
