### PR TITLE
fix: msrv in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
-rust-version = "1.72"
+rust-version = "1.75"
 keywords = ["deltalake", "delta", "datalake"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
# Description

Our min required rust version does not match the features we are using. Specifically, we are using `impl Trait` as a return type in a trait, which is only available since [`1.75`](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html).

https://github.com/delta-io/delta-rs/blob/8eb2b8b611ce4f8cdfd24d3ae5ff52332628188f/crates/core/src/delta_datafusion/mod.rs#L238-L241

# Related Issue(s)

This was raised in a discussion #2514.

# Documentation

<!---
Share links to useful documentation
--->
