### PR TITLE
chore: expose `files_by_partition` to public api

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -715,7 +715,7 @@ class DeltaTable:
         """
         Get the files for each partition
 
-        ""
+        """
         return self._table.files_by_partitions(partition_filters)
 
     def metadata(self) -> Metadata:

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -711,6 +711,13 @@ class DeltaTable:
         """
         return self._table.schema
 
+    def files_by_partitions(self, partition_filters:Option[FilterType]) -> List[str]:
+        """
+        Get the files for each partition
+
+        ""
+        return self._table.files_by_partitions(partition_filters)
+
     def metadata(self) -> Metadata:
         """
         Get the current metadata of the DeltaTable.

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -711,7 +711,7 @@ class DeltaTable:
         """
         return self._table.schema
 
-    def files_by_partitions(self, partition_filters:Option[FilterType]) -> List[str]:
+    def files_by_partitions(self, partition_filters:Optional[FilterType]) -> List[str]:
         """
         Get the files for each partition
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -711,7 +711,7 @@ class DeltaTable:
         """
         return self._table.schema
 
-    def files_by_partitions(self, partition_filters:Optional[FilterType]) -> List[str]:
+    def files_by_partitions(self, partition_filters: Optional[FilterType]) -> List[str]:
         """
         Get the files for each partition
 


### PR DESCRIPTION
# Description
This [documentation](https://delta-io.github.io/delta-rs/api/delta_table/#deltalake.DeltaTable.schema) describes the usage of `files_by_partition` but that API doesn't seem to be surfaced from the underlying rust implementation

- [ ] Add unit tests once confirmed this makes sense
