### PR TITLE
feat(python): handle PyCapsule interface objects in write_deltalake

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -77,7 +77,9 @@ class ArrowStreamExportable(Protocol):
     https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html
     """
 
-    def __arrow_c_stream__(self, requested_schema: Optional[object] = None) -> object: ...
+    def __arrow_c_stream__(
+        self, requested_schema: Optional[object] = None
+    ) -> object: ...
 
 
 @dataclass

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -77,7 +77,7 @@ class ArrowStreamExportable(Protocol):
     https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html
     """
 
-    def __arrow_c_stream__(self, requested_schema: object | None = None) -> object: ...
+    def __arrow_c_stream__(self, requested_schema: Optional[object] = None) -> object: ...
 
 
 @dataclass


### PR DESCRIPTION
# Description

Adds support for the [Arrow PyCapsule interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html). 

Since pyarrow is already a required dependency, this takes the minimal route of converting pycapsule interface objects into pyarrow objects. This requires pyarrow 15 or higher for the stream conversion (https://github.com/apache/arrow/issues/39217).

This doesn't modify the existing hard-coded support for pyarrow and pandas

# Related Issue(s)

- closes https://github.com/delta-io/delta-rs/issues/2376

# Documentation
