### PR TITLE
fix: change arrow map root name to follow with parquet root name

### DIFF
--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -11,7 +11,7 @@ use lazy_static::lazy_static;
 pub(crate) mod extract;
 pub(crate) mod json;
 
-const MAP_ROOT_DEFAULT: &str = "entries";
+const MAP_ROOT_DEFAULT: &str = "key_value";
 const MAP_KEY_DEFAULT: &str = "key";
 const MAP_VALUE_DEFAULT: &str = "value";
 const LIST_ROOT_DEFAULT: &str = "item";


### PR DESCRIPTION
# Description
Change root field name for map to key_value

# Related Issue(s)
https://github.com/delta-io/delta-rs/pull/2182

# Documentation

https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps
