### PR TITLE
fix: remove deprecated overwrite_schema configuration which has incorrect behavior

### DIFF
--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.17.0", path = "../core" }
+deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core" }
 aws-smithy-runtime-api = { version="1.1.7" }
 aws-smithy-runtime = { version="1.1.7", optional = true}
 aws-credential-types = { version="1.1.7", features = ["hardcoded-credentials"]}

--- a/crates/azure/Cargo.toml
+++ b/crates/azure/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.17.0", path = "../core" }
+deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core" }
 lazy_static = "1"
 
 # workspace depenndecies

--- a/crates/catalog-glue/Cargo.toml
+++ b/crates/catalog-glue/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 async-trait = { workspace = true }
 aws-config = "1"
 aws-sdk-glue = "1"
-deltalake-core = { version = "0.17.0", path = "../core" }
+deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core" }
 # This can depend on a lowest common denominator of core once that's released
 # deltalake_core = { version = "0.17.0" }
 thiserror = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-core"
-version = "0.17.3"
+version = "0.18.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake"
-version = "0.17.3"
+version = "0.18.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -17,7 +17,7 @@ rust-version.workspace = true
 features = ["azure", "datafusion", "gcs", "hdfs", "json", "python", "s3", "unity-experimental"]
 
 [dependencies]
-deltalake-core = { version = "0.17.3", path = "../core" }
+deltalake-core = { version = "~0.18.0", path = "../core" }
 deltalake-aws = { version = "0.1.1", path = "../aws", default-features = false, optional = true }
 deltalake-azure = { version = "0.1.1", path = "../azure", optional = true }
 deltalake-gcp = { version = "0.2.1", path = "../gcp", optional = true }

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.17.0", path = "../core" }
+deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core" }
 lazy_static = "1"
 
 # workspace depenndecies

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.17.0", path = "../core", features = [
+deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core", features = [
     "datafusion",
 ] }
 lazy_static = "1"

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 bytes = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["clock"] }
-deltalake-core = { version = "0.17.0", path = "../core" }
+deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core" }
 dotenvy = "0"
 fs_extra = "1.3.0"
 futures = { version = "0.3" }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.17.5"
+version = "0.18.0"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -31,8 +31,6 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-import warnings
-
 import pyarrow as pa
 import pyarrow.dataset as ds
 import pyarrow.fs as pa_fs
@@ -106,7 +104,6 @@ def write_deltalake(
     name: Optional[str] = ...,
     description: Optional[str] = ...,
     configuration: Optional[Mapping[str, Optional[str]]] = ...,
-    overwrite_schema: bool = ...,
     schema_mode: Optional[Literal["overwrite"]] = ...,
     storage_options: Optional[Dict[str, str]] = ...,
     partition_filters: Optional[List[Tuple[str, str, Any]]] = ...,
@@ -134,7 +131,6 @@ def write_deltalake(
     name: Optional[str] = ...,
     description: Optional[str] = ...,
     configuration: Optional[Mapping[str, Optional[str]]] = ...,
-    overwrite_schema: bool = ...,
     schema_mode: Optional[Literal["merge", "overwrite"]] = ...,
     storage_options: Optional[Dict[str, str]] = ...,
     large_dtypes: bool = ...,
@@ -162,7 +158,6 @@ def write_deltalake(
     name: Optional[str] = ...,
     description: Optional[str] = ...,
     configuration: Optional[Mapping[str, Optional[str]]] = ...,
-    overwrite_schema: bool = ...,
     schema_mode: Optional[Literal["merge", "overwrite"]] = ...,
     storage_options: Optional[Dict[str, str]] = ...,
     predicate: Optional[str] = ...,
@@ -196,7 +191,6 @@ def write_deltalake(
     name: Optional[str] = None,
     description: Optional[str] = None,
     configuration: Optional[Mapping[str, Optional[str]]] = None,
-    overwrite_schema: bool = False,
     schema_mode: Optional[Literal["merge", "overwrite"]] = None,
     storage_options: Optional[Dict[str, str]] = None,
     partition_filters: Optional[List[Tuple[str, str, Any]]] = None,
@@ -251,7 +245,6 @@ def write_deltalake(
         name: User-provided identifier for this table.
         description: User-provided description for this table.
         configuration: A map containing configuration options for the metadata action.
-        overwrite_schema: Deprecated, use schema_mode instead.
         schema_mode: If set to "overwrite", allows replacing the schema of the table. Set to "merge" to merge with existing schema.
         storage_options: options passed to the native delta filesystem.
         predicate: When using `Overwrite` mode, replace data that matches a predicate. Only used in rust engine.
@@ -269,14 +262,6 @@ def write_deltalake(
         table.update_incremental()
 
     __enforce_append_only(table=table, configuration=configuration, mode=mode)
-    if overwrite_schema:
-        schema_mode = "overwrite"
-
-        warnings.warn(
-            "overwrite_schema is deprecated, use schema_mode instead. ",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
     if isinstance(partition_by, str):
         partition_by = [partition_by]
 


### PR DESCRIPTION
Uses of mode='append' and overwrite_schema=True lead to inconsistent behavior between Rust and PyArrow engines for write_deltalake. In the PyArrow case the parameter is quietly omitted so users may experience unexpected behavior since schemas will not actually be overridden.

Users of this parameter set most likely want schema_mode='merge' which would allow for schema evolution on appends to a Delta Table

Fixes #2553