### PR TITLE
fix: update deltalake crate examples for crate layout and TimestampNtz

### DIFF
--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -54,4 +54,3 @@ required-features = ["datafusion"]
 
 [[example]]
 name = "recordbatch-writer"
-required-features = ["arrow"]

--- a/crates/deltalake/examples/basic_operations.rs
+++ b/crates/deltalake/examples/basic_operations.rs
@@ -27,7 +27,7 @@ fn get_table_columns() -> Vec<StructField> {
         ),
         StructField::new(
             String::from("timestamp"),
-            DataType::Primitive(PrimitiveType::Timestamp),
+            DataType::Primitive(PrimitiveType::TimestampNtz),
             true,
         ),
     ]

--- a/crates/deltalake/examples/load_table.rs
+++ b/crates/deltalake/examples/load_table.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<(), deltalake::errors::DeltaTableError> {
     let ops = if let Ok(table_uri) = std::env::var("TABLE_URI") {
         DeltaOps::try_from_uri(table_uri).await?
     } else {
-        DeltaOps::try_from_uri("./rust/tests/data/delta-0.8.0").await?
+        DeltaOps::try_from_uri("../test/tests/data/delta-0.8.0").await?
     };
 
     let (_table, stream) = ops.load().await?;

--- a/crates/deltalake/examples/read_delta_table.rs
+++ b/crates/deltalake/examples/read_delta_table.rs
@@ -1,6 +1,6 @@
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), deltalake::errors::DeltaTableError> {
-    let table_path = "./tests/data/delta-0.8.0";
+    let table_path = "../test/tests/data/delta-0.8.0";
     let table = deltalake::open_table(table_path).await?;
     println!("{table}");
     Ok(())

--- a/crates/deltalake/examples/recordbatch-writer.rs
+++ b/crates/deltalake/examples/recordbatch-writer.rs
@@ -88,7 +88,7 @@ impl WeatherRecord {
         vec![
             StructField::new(
                 "timestamp".to_string(),
-                DataType::Primitive(PrimitiveType::Timestamp),
+                DataType::Primitive(PrimitiveType::TimestampNtz),
                 true,
             ),
             StructField::new(
@@ -98,12 +98,12 @@ impl WeatherRecord {
             ),
             StructField::new(
                 "lat".to_string(),
-                DataType::Primitive(PrimitiveType::Float),
+                DataType::Primitive(PrimitiveType::Double),
                 true,
             ),
             StructField::new(
                 "long".to_string(),
-                DataType::Primitive(PrimitiveType::Float),
+                DataType::Primitive(PrimitiveType::Double),
                 true,
             ),
         ]


### PR DESCRIPTION
The data types and delta table paths in the examples were no longer correct.

There is no "arrow" feature anymore.

# Description
The description of the main changes of your pull request

# Related Issue(s)

- closes #2552.

