### PR TITLE
fix: add raise_if_key_not_exists to CreateBuilder

### DIFF
--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -214,6 +214,7 @@ def create_deltalake(
     schema: pyarrow.Schema,
     partition_by: List[str],
     mode: str,
+    raise_if_key_not_exists: bool,
     name: Optional[str],
     description: Optional[str],
     configuration: Optional[Mapping[str, Optional[str]]],

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -457,6 +457,7 @@ class DeltaTable:
         configuration: Optional[Mapping[str, Optional[str]]] = None,
         storage_options: Optional[Dict[str, str]] = None,
         custom_metadata: Optional[Dict[str, str]] = None,
+        raise_if_key_not_exists: bool = True,
     ) -> "DeltaTable":
         """`CREATE` or `CREATE_OR_REPLACE` a delta table given a table_uri.
 
@@ -471,8 +472,9 @@ class DeltaTable:
             name: User-provided identifier for this table.
             description: User-provided description for this table.
             configuration:  A map containing configuration options for the metadata action.
-            storage_options: options passed to the object store crate.
-            custom_metadata: custom metadata that will be added to the transaction commit.
+            storage_options: Options passed to the object store crate.
+            custom_metadata: Custom metadata that will be added to the transaction commit.
+            raise_if_key_not_exists: Whether to raise an error if the configuration uses keys that are not Delta keys
 
         Returns:
             DeltaTable: created delta table
@@ -506,6 +508,7 @@ class DeltaTable:
             schema,
             partition_by or [],
             mode,
+            raise_if_key_not_exists,
             name,
             description,
             configuration,

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1650,6 +1650,7 @@ fn create_deltalake(
     schema: PyArrowType<ArrowSchema>,
     partition_by: Vec<String>,
     mode: String,
+    raise_if_key_not_exists: bool,
     name: Option<String>,
     description: Option<String>,
     configuration: Option<HashMap<String, Option<String>>>,
@@ -1669,6 +1670,7 @@ fn create_deltalake(
             .create()
             .with_columns(schema.fields().clone())
             .with_save_mode(mode)
+            .with_raise_if_not_exists(raise_if_key_not_exists)
             .with_partition_columns(partition_by);
 
         if let Some(name) = &name {


### PR DESCRIPTION
This PR adds a `raise_if_key_not_exists` flag to the `CreateBuilder` which we propagate (currently always `true`), such that users can choose not to fail if the configuration contains a key that is not a valid DeltaConfigKey. Also expose this in the Python binding.

Closes #2564.

@ion-elgreco 