### PR TITLE
fix: consistently use raise_if_key_not_exists in CreateBuilder

### DIFF
--- a/crates/core/src/operations/create.rs
+++ b/crates/core/src/operations/create.rs
@@ -199,7 +199,7 @@ impl CreateBuilder {
     }
 
     /// Specify whether to raise an error if the table properties in the configuration are not DeltaConfigKeys
-    pub fn with_raise_if_not_exists(mut self, raise_if_key_not_exists: bool) -> Self {
+    pub fn with_raise_if_key_not_exists(mut self, raise_if_key_not_exists: bool) -> Self {
         self.raise_if_key_not_exists = raise_if_key_not_exists;
         self
     }
@@ -598,7 +598,7 @@ mod tests {
         let table = CreateBuilder::new()
             .with_location("memory://")
             .with_columns(schema.fields().clone())
-            .with_raise_if_not_exists(false)
+            .with_raise_if_key_not_exists(false)
             .with_configuration(config)
             .await;
         assert!(table.is_ok());

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1670,7 +1670,7 @@ fn create_deltalake(
             .create()
             .with_columns(schema.fields().clone())
             .with_save_mode(mode)
-            .with_raise_if_not_exists(raise_if_key_not_exists)
+            .with_raise_if_key_not_exists(raise_if_key_not_exists)
             .with_partition_columns(partition_by);
 
         if let Some(name) = &name {


### PR DESCRIPTION
I forgot to change the name of the builder method!

Follow up from #2565.