### PR TITLE
chore: bump macOS runners, maybe resolve import error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11
+          - macos-14
           - windows-latest
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-14
+          - macos-11
           - windows-latest
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
# Description
Seems like many folks use Mac : ), so I hope this fixes the issue as the only info I could find was that compiling it on different OS could result in this

Related issue https://github.com/delta-io/delta-rs/issues/2577