### PR TITLE
test: reintroduce azurite SAS integration tests

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,6 +27,7 @@ pandas = [
     "pandas"
 ]
 devel = [
+    "azure-storage-blob==12.20.0",
     "mypy~=1.8.0",
     "ruff~=0.3.0",
     "packaging>=20",

--- a/python/tests/test_fs.py
+++ b/python/tests/test_fs.py
@@ -207,18 +207,8 @@ def test_roundtrip_azure_direct(azurite_creds, sample_data: pa.Table):
 @pytest.mark.azure
 @pytest.mark.integration
 @pytest.mark.timeout(timeout=60, method="thread")
-@pytest.mark.skip("since object store 0.9.1 sas tokens aren't working with azurite.")
 def test_roundtrip_azure_sas(azurite_sas_creds, sample_data: pa.Table):
     table_path = "az://deltars/roundtrip3"
-    import os
-
-    for key in [
-        "AZURE_USE_EMULATOR",
-        "AZURE_STORAGE_ALLOW_HTTP",
-        "AZURE_STORAGE_CONNECTION_STRING",
-    ]:
-        if key in os.environ:
-            del os.environ[key]
     write_deltalake(table_path, sample_data, storage_options=azurite_sas_creds)
     dt = DeltaTable(table_path, storage_options=azurite_sas_creds)
     table = dt.to_pyarrow_table()
@@ -229,7 +219,6 @@ def test_roundtrip_azure_sas(azurite_sas_creds, sample_data: pa.Table):
 @pytest.mark.azure
 @pytest.mark.integration
 @pytest.mark.timeout(timeout=60, method="thread")
-@pytest.mark.skip("since object store 0.9.1 sas tokens aren't working with azurite.")
 def test_roundtrip_azure_decoded_sas(azurite_sas_creds, sample_data: pa.Table):
     table_path = "az://deltars/roundtrip4"
     azurite_sas_creds["SAS_TOKEN"] = urllib.parse.unquote(


### PR DESCRIPTION
# Description
Reintroduce integration tests using Azurite and SAS tokens.

These tests were skipped believing that the mistake was due to the upgrade of version in `object-store>=0.9.1". Actually, what `object-store` started doing from that version on, is really using the SAS token for the first time. For more details, see:
- https://github.com/apache/arrow-rs/issues/5475#issuecomment-2084748858

I changed the command to create the SAS token using the `azure-storage-blob` library (adding it to the dev deps), rather than the azure CLI, and removed the pytest markers to skip the tests.

@ion-elgreco pinging you as promised, sorry if this took more time than expected!