### PR TITLE
feat(rust,python): cast each parquet file to delta schema

### DIFF
--- a/crates/core/src/delta_datafusion/find_files/mod.rs
+++ b/crates/core/src/delta_datafusion/find_files/mod.rs
@@ -148,7 +148,7 @@ async fn scan_table_by_files(
     // Add path column
     used_columns.push(logical_schema.index_of(scan_config.file_column_name.as_ref().unwrap())?);
 
-    let scan = DeltaScanBuilder::new(&snapshot, log_store, &state)
+    let scan = DeltaScanBuilder::new(&snapshot, log_store)
         .with_filter(Some(expression.clone()))
         .with_projection(Some(&used_columns))
         .with_scan_config(scan_config)

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -507,11 +507,7 @@ impl<'a> DeltaScanBuilder<'a> {
         let config = self.config;
         let schema = match self.schema {
             Some(schema) => schema,
-            None => {
-                self.snapshot
-                    .physical_arrow_schema(self.log_store.object_store())
-                    .await?
-            }
+            None => self.snapshot.arrow_schema()?,
         };
         let logical_schema = df_logical_schema(self.snapshot, &config)?;
 

--- a/crates/core/src/delta_datafusion/schema_adapter.rs
+++ b/crates/core/src/delta_datafusion/schema_adapter.rs
@@ -1,0 +1,68 @@
+use crate::operations::cast::cast_record_batch;
+use arrow_array::RecordBatch;
+use arrow_schema::{Schema, SchemaRef};
+use datafusion::datasource::schema_adapter::{SchemaAdapter, SchemaAdapterFactory, SchemaMapper};
+use std::fmt::Debug;
+use std::sync::Arc;
+
+/// A Schema Adapter Factory which provides casting record batches from parquet to meet
+/// delta lake conventions.
+#[derive(Debug)]
+pub(crate) struct DeltaSchemaAdapterFactory {}
+
+impl SchemaAdapterFactory for DeltaSchemaAdapterFactory {
+    fn create(&self, schema: SchemaRef) -> Box<dyn SchemaAdapter> {
+        Box::new(DeltaSchemaAdapter {
+            table_schema: schema,
+        })
+    }
+}
+
+pub(crate) struct DeltaSchemaAdapter {
+    /// Schema for the table
+    table_schema: SchemaRef,
+}
+
+impl SchemaAdapter for DeltaSchemaAdapter {
+    fn map_column_index(&self, index: usize, file_schema: &Schema) -> Option<usize> {
+        let field = self.table_schema.field(index);
+        Some(file_schema.fields.find(field.name())?.0)
+    }
+
+    fn map_schema(
+        &self,
+        file_schema: &Schema,
+    ) -> datafusion_common::Result<(Arc<dyn SchemaMapper>, Vec<usize>)> {
+        let mut projection = Vec::with_capacity(file_schema.fields().len());
+
+        for (file_idx, file_field) in file_schema.fields.iter().enumerate() {
+            if self.table_schema.fields().find(file_field.name()).is_some() {
+                projection.push(file_idx);
+            }
+        }
+
+        Ok((
+            Arc::new(SchemaMapping {
+                table_schema: self.table_schema.clone(),
+            }),
+            projection,
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SchemaMapping {
+    table_schema: SchemaRef,
+}
+
+impl SchemaMapper for SchemaMapping {
+    fn map_batch(&self, batch: RecordBatch) -> datafusion_common::Result<RecordBatch> {
+        let record_batch = cast_record_batch(&batch, self.table_schema.clone(), false, true)?;
+        Ok(record_batch)
+    }
+
+    fn map_partial_batch(&self, batch: RecordBatch) -> datafusion_common::Result<RecordBatch> {
+        let record_batch = cast_record_batch(&batch, self.table_schema.clone(), false, true)?;
+        Ok(record_batch)
+    }
+}

--- a/crates/core/src/operations/constraints.rs
+++ b/crates/core/src/operations/constraints.rs
@@ -114,7 +114,7 @@ impl std::future::IntoFuture for ConstraintBuilder {
                 session.state()
             });
 
-            let scan = DeltaScanBuilder::new(&this.snapshot, this.log_store.clone(), &state)
+            let scan = DeltaScanBuilder::new(&this.snapshot, this.log_store.clone())
                 .build()
                 .await?;
 

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -139,7 +139,7 @@ async fn excute_non_empty_expr(
 
     let table_partition_cols = snapshot.metadata().partition_columns.clone();
 
-    let scan = DeltaScanBuilder::new(snapshot, log_store.clone(), state)
+    let scan = DeltaScanBuilder::new(snapshot, log_store.clone())
         .with_files(rewrite)
         .build()
         .await?;

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -236,7 +236,7 @@ async fn execute(
 
     // For each rewrite evaluate the predicate and then modify each expression
     // to either compute the new value or obtain the old one then write these batches
-    let scan = DeltaScanBuilder::new(&snapshot, log_store.clone(), &state)
+    let scan = DeltaScanBuilder::new(&snapshot, log_store.clone())
         .with_files(&candidates.candidates)
         .build()
         .await?;

--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -511,7 +511,7 @@ async fn execute_non_empty_expr(
     let input_schema = snapshot.input_schema()?;
     let input_dfschema: DFSchema = input_schema.clone().as_ref().clone().try_into()?;
 
-    let scan = DeltaScanBuilder::new(snapshot, log_store.clone(), &state)
+    let scan = DeltaScanBuilder::new(snapshot, log_store.clone())
         .with_files(rewrite)
         .build()
         .await?;

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -900,13 +900,14 @@ mod local {
 
         let batches = ctx.sql("SELECT * FROM demo").await?.collect().await?;
 
+        // Without defining a schema of the select the default for a timestamp is ms UTC
         let expected = vec![
-            "+-------------------------------+---------------------+------------+",
-            "| BIG_DATE                      | NORMAL_DATE         | SOME_VALUE |",
-            "+-------------------------------+---------------------+------------+",
-            "| 1816-03-28T05:56:08.066277376 | 2022-02-01T00:00:00 | 2          |",
-            "| 1816-03-29T05:56:08.066277376 | 2022-01-01T00:00:00 | 1          |",
-            "+-------------------------------+---------------------+------------+",
+            "+-----------------------------+----------------------+------------+",
+            "| BIG_DATE                    | NORMAL_DATE          | SOME_VALUE |",
+            "+-----------------------------+----------------------+------------+",
+            "| 1816-03-28T05:56:08.066278Z | 2022-02-01T00:00:00Z | 2          |",
+            "| 1816-03-29T05:56:08.066278Z | 2022-01-01T00:00:00Z | 1          |",
+            "+-----------------------------+----------------------+------------+",
         ];
 
         assert_batches_sorted_eq!(&expected, &batches);
@@ -1113,7 +1114,7 @@ mod local {
             .unwrap();
         let batch = batches.pop().unwrap();
 
-        let expected_schema = Schema::new(vec![Field::new("id", ArrowDataType::Int32, true)]);
+        let expected_schema = Schema::new(vec![Field::new("id", ArrowDataType::Int64, false)]);
         assert_eq!(batch.schema().as_ref(), &expected_schema);
         Ok(())
     }


### PR DESCRIPTION
# Description

By casting the read record batch to the delta schema datafusion can read tables where the underlying parquet files can be cast to the desired schema. Fixes:

- Errors querying data where some of the parquet files may not have columns that were added later because of schema migration.  This includes nested columns for structs that are in Maps, Lists, or children of other structs
- maps and lists written with different different element names
- timestamps of different units.
- Any other cast supported by arrow-cast.

This can be done now since data-fusion exposes a SchemaAdapter which can be overwritten.

We should note that this makes all times being read by delta-rs as having microsecond precision to match the Delta protocol.

# Related Issue(s)
- This makes solving #2478 and #2341 just a matter of adding code to delta-rs cast.


