### PR TITLE
fix(rust, python): fix writing empty structs when creating checkpoint

### DIFF
--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -250,13 +250,15 @@ pub(crate) fn delta_log_schema_for_table(
             .iter()
             .for_each(|f| max_min_schema_for_fields(&mut max_min_vec, f));
 
-        stats_parsed_fields.extend(["minValues", "maxValues"].into_iter().map(|name| {
-            ArrowField::new(
-                name,
-                ArrowDataType::Struct(max_min_vec.clone().into()),
-                true,
-            )
-        }));
+        if max_min_vec.len() > 0 {
+            stats_parsed_fields.extend(["minValues", "maxValues"].into_iter().map(|name| {
+                ArrowField::new(
+                    name,
+                    ArrowDataType::Struct(max_min_vec.clone().into()),
+                    true,
+                )
+            }));
+        }
 
         let mut null_count_vec = Vec::new();
         non_partition_fields

--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -249,6 +249,29 @@ def test_checkpoint_partition_timestamp_2380(
     assert checkpoint_path.exists()
 
 
+def test_checkpoint_with_binary_column(tmp_path: pathlib.Path):
+    data = pa.table(
+        {
+            "intColumn": pa.array([1]),
+            "binaryColumn": pa.array([b"a"]),
+        }
+    )
+
+    write_deltalake(
+        str(tmp_path),
+        data,
+        partition_by=["intColumn"],
+        mode="append",
+    )
+
+    dt = DeltaTable(tmp_path)
+    dt.create_checkpoint()
+
+    dt = DeltaTable(tmp_path)
+
+    assert dt.to_pyarrow_table().equals(data)
+
+
 def test_checkpoint_post_commit_config(tmp_path: pathlib.Path, sample_data: pa.Table):
     """Checks whether checkpoints are properly written based on commit_interval"""
     tmp_table_path = tmp_path / "path" / "to" / "table"


### PR DESCRIPTION
# Description
avoid adding maxvalue and minvalue when there is no value in max_min_vec 


# Related Issue(s)

closes #2622 
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
