### PR TITLE
fix: enable parquet pushdown for DeltaScan via TableProvider impl for DeltaTable  (rebase)

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -391,14 +391,13 @@ impl DeltaScanConfigBuilder {
 
     /// Build a DeltaScanConfig and ensure no column name conflicts occur during downstream processing
     pub fn build(&self, snapshot: &DeltaTableState) -> DeltaResult<DeltaScanConfig> {
-        let input_schema = snapshot.input_schema()?;
-        let mut file_column_name = None;
-        let mut column_names: HashSet<&String> = HashSet::new();
-        for field in input_schema.fields.iter() {
-            column_names.insert(field.name());
-        }
+        let file_column_name = if self.include_file_column {
+            let input_schema = snapshot.input_schema()?;
+            let mut column_names: HashSet<&String> = HashSet::new();
+            for field in input_schema.fields.iter() {
+                column_names.insert(field.name());
+            }
 
-        if self.include_file_column {
             match &self.file_column_name {
                 Some(name) => {
                     if column_names.contains(name) {
@@ -408,7 +407,7 @@ impl DeltaScanConfigBuilder {
                         )));
                     }
 
-                    file_column_name = Some(name.to_owned())
+                    Some(name.to_owned())
                 }
                 None => {
                     let prefix = PATH_COLUMN;
@@ -420,10 +419,12 @@ impl DeltaScanConfigBuilder {
                         name = format!("{}_{}", prefix, idx);
                     }
 
-                    file_column_name = Some(name);
+                    Some(name)
                 }
             }
-        }
+        } else {
+            None
+        };
 
         Ok(DeltaScanConfig {
             file_column_name,
@@ -453,7 +454,7 @@ pub(crate) struct DeltaScanBuilder<'a> {
     projection: Option<&'a Vec<usize>>,
     limit: Option<usize>,
     files: Option<&'a [Add]>,
-    config: DeltaScanConfig,
+    config: Option<DeltaScanConfig>,
     schema: Option<SchemaRef>,
 }
 
@@ -471,7 +472,7 @@ impl<'a> DeltaScanBuilder<'a> {
             files: None,
             projection: None,
             limit: None,
-            config: DeltaScanConfig::default(),
+            config: None,
             schema: None,
         }
     }
@@ -497,7 +498,7 @@ impl<'a> DeltaScanBuilder<'a> {
     }
 
     pub fn with_scan_config(mut self, config: DeltaScanConfig) -> Self {
-        self.config = config;
+        self.config = Some(config);
         self
     }
 
@@ -508,7 +509,11 @@ impl<'a> DeltaScanBuilder<'a> {
     }
 
     pub async fn build(self) -> DeltaResult<DeltaScan> {
-        let config = self.config;
+        let config = match self.config {
+            Some(config) => config,
+            None => DeltaScanConfigBuilder::new().build(self.snapshot)?,
+        };
+
         let schema = match self.schema {
             Some(schema) => schema,
             None => {


### PR DESCRIPTION
# Description
The DeltaScanBuilder used by DeltaTable's TableProvider impl does not specify DeltaScanConfig. The builder uses Default for DeltaScanConfig and thus enable_parquet_pushdown is disabled.

This change makes it so DeltaScanConfig is an Option on the scan builder. If unset during build a default value will be created using the DeltaScanConfigBuilder rather than DeltaScanConfig::Default. The former has enable_parquet_pushdown defaulted to true. I considered changing the latter but it is used in a couple other places where I was not sure of the impact.

# Related Issue(s)

# Documentation

This is a rebase and closes the outstanding :boom: pull request from @alexwilcoxson-rel 

closes #2618