### PR TITLE
chore: remove macos builders from pull request flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-11
           - windows-latest
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
These actions are dramatically slowing doiwn the PR feedback loop since runners are not being placed by GitHub it seems
