### PR TITLE
chore: add a reproduction case for merge failures with struct<string>

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -825,7 +825,7 @@ class DeltaTable:
         target_alias: Optional[str] = None,
         error_on_type_mismatch: bool = True,
         writer_properties: Optional[WriterProperties] = None,
-        large_dtypes: bool = True,
+        large_dtypes: bool = False,
         custom_metadata: Optional[Dict[str, str]] = None,
     ) -> "TableMerger":
         """Pass the source data which you want to merge on the target delta table, providing a

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -970,17 +970,18 @@ def test_struct_casting(tmp_path: pathlib.Path):
     assert not df.empty
 
     schema = pa.Table.from_pandas(df=df).schema
-
     dt = DeltaTable.create(tmp_path, schema, name="test")
     metadata = dt.metadata()
     assert metadata.name == "test"
 
     result = (
         dt.merge(
-            source=df_merge, predicate="t.id = s.id", source_alias="s", target_alias="t"
+            source=df_merge,
+            predicate="t.id = s.id",
+            source_alias="s",
+            target_alias="t",
         )
         .when_matched_update_all()
-        .when_not_matched_insert_all()
         .execute()
     )
     assert result is not None

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -940,3 +940,47 @@ def test_merge_field_special_characters_delete_2438(tmp_path: pathlib.Path):
     expected = pa.table({"x": [1], "y--1": [4]})
 
     assert dt.to_pyarrow_table() == expected
+
+
+@pytest.mark.pandas
+def test_struct_casting(tmp_path: pathlib.Path):
+    import pandas as pd
+
+    cols = ["id", "name", "address", "scores"]
+    data = [
+        (
+            2,
+            "Marry Doe",
+            {"street": "123 Main St", "city": "Anytown", "state": "CA"},
+            [0, 0, 0],
+        )
+    ]
+    df = pd.DataFrame(data, columns=cols)
+    df_merge = pd.DataFrame(
+        [
+            (
+                2,
+                "Merged",
+                {"street": "1 Front", "city": "San Francisco", "state": "CA"},
+                [7, 0, 7],
+            )
+        ],
+        columns=cols,
+    )
+    assert not df.empty
+
+    schema = pa.Table.from_pandas(df=df).schema
+
+    dt = DeltaTable.create(tmp_path, schema, name="test")
+    metadata = dt.metadata()
+    assert metadata.name == "test"
+
+    result = (
+        dt.merge(
+            source=df_merge, predicate="t.id = s.id", source_alias="s", target_alias="t"
+        )
+        .when_matched_update_all()
+        .when_not_matched_insert_all()
+        .execute()
+    )
+    assert result is not None


### PR DESCRIPTION
```
E       _internal.DeltaError: Generic DeltaTable error: type_coercion
E       caused by
E       Error during planning: Failed to coerce then ([Struct([Field { name: "city", data_type: LargeUtf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "state", data_type: LargeUtf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "street", data_type: LargeUtf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }]), Struct([Field { name: "city", data_type: LargeUtf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "state", data_type: LargeUtf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "street", data_type: LargeUtf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }]), Struct([Field { name: "city", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "state", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "street", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }]), Struct([Field { name: "city", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "state", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "street", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }]), Struct([Field { name: "city", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "state", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "street", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }])]) and else (None) to common types in CASE WHEN expression
```