### PR TITLE
chore: increase subcrate versions 

### DIFF
--- a/crates/azure/Cargo.toml
+++ b/crates/azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-azure"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-gcp"
-version = "0.2.1"
+version = "0.2.2"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true


### PR DESCRIPTION
I already cut releases of these to crates.io since I forgot to push updates after we cleaned up the version declarations on deltalake-core a while back.


Fixes #2647