### PR TITLE
docs: fix bullets on hdfs docs

### DIFF
--- a/docs/integrations/object-storage/hdfs.md
+++ b/docs/integrations/object-storage/hdfs.md
@@ -3,12 +3,14 @@ HDFS support is provided via the [hdfs-native-object-store](https://github.com/d
 
 ## Supported Configurations
 By default, the client looks for existing Hadoop configs in following manner:
+
 - If the `HADOOP_CONF_DIR` environment variable is defined, load configs from `$HADOOP_CONF_DIR/core-site.xml` and `$HADOOP_CONF_DIR/hdfs-site.xml`
 - Otherwise, if the `HADOOP_HOME` environment variable is set, load configs from `$HADOOP_HOME/etc/hadoop/core-site.xml` and `$HADOOP_HOME/etc/hadoop/hdfs-site.xml`
 
 Additionally, you can pass Hadoop configs as `storage_options` and these will take precedence over the above configs.
 
 Currently the supported client configuration parameters are:
+
 - `dfs.ha.namenodes.*` - name service support
 - `dfs.namenode.rpc-address.*` - name service support
 - `fs.viewfs.mounttable.*.link.*` - ViewFS links


### PR DESCRIPTION
# Description
Fix formatting of the HDFS docs for the bullets. They're currently collapsed into a paragraph instead of actually listed as bullets

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
![image](https://github.com/delta-io/delta-rs/assets/3536454/4618a7ab-1134-4254-aed1-235fc038deaf)
