### PR TITLE
feat: support userMetadata in CommitInfo

### DIFF
--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -736,6 +736,10 @@ pub struct CommitInfo {
     /// Additional provenance information for the commit
     #[serde(flatten, default)]
     pub info: HashMap<String, serde_json::Value>,
+
+    /// User defined metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_metadata: Option<String>,
 }
 
 /// The domain metadata action contains a configuration (string) for a named metadata domain


### PR DESCRIPTION
# Description

Add support for reading `userMetadata` from `CommitInfo`. This field is set by Spark when certain writer or session options are set (please see https://docs.databricks.com/en/delta/custom-metadata.html or https://github.com/delta-io/delta/blob/573a57f62918d0cb8937ca8c9b4047f8d696cc9c/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala#L80-L84).