### PR TITLE
chore: bump ruff to 0.5.2

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -53,7 +53,7 @@ format: ## Format the code
 	$(info --- Rust format ---)
 	cargo fmt
 	$(info --- Python format ---)
-	ruff . --fix
+	ruff check . --fix
 	ruff format .
 
 .PHONY: check-rust

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,7 +29,7 @@ pandas = [
 devel = [
     "azure-storage-blob==12.20.0",
     "mypy~=1.8.0",
-    "ruff~=0.3.0",
+    "ruff~=0.5.2",
     "packaging>=20",
     "pytest",
     "pytest-mock",
@@ -76,7 +76,7 @@ strict_equality = true
 include = '\.pyi?$'
 exclude = "venv"
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
     # pycodestyle error
     "E",
@@ -87,7 +87,7 @@ select = [
 ]
 ignore = ["E501"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["deltalake"]
 
 [tool.pytest.ini_options]

--- a/python/tests/test_file_system_handler.py
+++ b/python/tests/test_file_system_handler.py
@@ -34,7 +34,7 @@ def test_file_info(file_systems, table_data):
     info = store.get_file_info(file_path)
     arrow_info = arrow_fs.get_file_info(file_path)
 
-    assert type(info) == type(arrow_info)
+    assert type(info) is type(arrow_info)
     assert info.path == arrow_info.path
     assert info.type == arrow_info.type
     assert info.size == arrow_info.size


### PR DESCRIPTION
# Description

This PR bumps `ruff` to the [latest version](https://github.com/astral-sh/ruff/releases). After the update, running `make format` returns:

```
--- Rust format ---
--- Python format ---
cargo fmt
ruff check . --fix
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'isort' -> 'lint.isort'
tests/test_file_system_handler.py:37:12: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
   |
35 |     arrow_info = arrow_fs.get_file_info(file_path)
36 | 
37 |     assert type(info) == type(arrow_info)
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E721
38 |     assert info.path == arrow_info.path
39 |     assert info.type == arrow_info.type
   |

Found 1 error.
make: *** [format] Error 1
```

So this PR also updates the configuration in `pyproject.toml` and fixes the newly identified violation.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
