### PR TITLE
chore: remove references to black from the project

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: psf/black@stable
-        with:
-          src: docs/src/python
+      - run: |
+          cd docs
+          make check
 
   build-deploy:
     needs:

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Check Python
         run: |
-          pip install ruff black mypy types-dataclasses typing-extensions
+          pip install ruff mypy types-dataclasses typing-extensions
           make check-python
 
       - name: Install minimal stable with clippy and rustfmt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+.DEFAULT_GOAL := help
+
+.PHONY: install-ruff
+install-ruff: ## install ruff
+	$(info --- Installing ruff ---)
+	pip install ruff==0.5.2
+
+.PHONY: format
+format: install-ruff ## format code with ruff
+	$(info --- format Python code in docs ---)
+	ruff format .
+
+.PHONY: check
+check: install-ruff ## check if code is formatted with ruff
+	$(info --- format Python code in docs ---)
+	ruff format --check .
+
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -72,10 +72,6 @@ warn_return_any = false
 implicit_reexport = true
 strict_equality = true
 
-[tool.black]
-include = '\.pyi?$'
-exclude = "venv"
-
 [tool.ruff.lint]
 select = [
     # pycodestyle error


### PR DESCRIPTION
# Description

There are a few mentions of `black` in the project, but they seem inconsistent;

- In `.github/workflows/docs.yml`, we use black to validate the formatting of Python code in the docs. However, there is no set-up or instructions to format code locally. Of course this is not a big issue; fixing the formatting is trivial when this gives an error by installing `black`.
  ```yaml
  - uses: psf/black@stable
    with:
      src: docs/src/python
  ``` 
- In `.github/workflows/python_build.yml` `black` seems to be installed but unused.
- There is some configuration for `black` in `python/pyproject.toml`, even though the formatter for the project is `ruff`.

This PR aims to solve these inconsistencies:

- Remove the references to `black` listed above.
- Use `ruff` as a formatter for the `docs` to be consistent with the `python` directory.
- Add a small `Makefile` to the `docs` directory, with a `format` and a `check` command. 

## Considered alternative

I also considered adding the `make` commands to `python/Makefile`, similar to the `build-docs` command:
  ```make
  .PHONY: format-docs-py
  format-docs-py: ## Format python files in the docs directory
	  $(info --- format Python code in docs ---)
	  (cd ../docs; ruff format .)
  
  .PHONY: check-docs-py
  check-docs-py: ## Check if python files in the docs directory are formatted
	  $(info --- check Python code in docs ---)
	  (cd ../docs; ruff format --check .)
  ```

However, this solution has the disadvantage that we need to either install the complete virtual environment in the `docs.yml` workflow, or hardcode the version of `ruff` there, e.g.

```
  lint:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - run: |
          cd python
          # Should be the same as in python/pyproject.toml
          pip install ruff==0.5.2 
          make check-docs-py
```
