### PR TITLE
chore: enable `RUF` ruleset for `ruff`

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -49,7 +49,7 @@ from deltalake.fs import DeltaStorageHandler
 from deltalake.schema import Schema as DeltaSchema
 
 try:
-    import pandas as pd  # noqa: F811
+    import pandas as pd
 except ModuleNotFoundError:
     _has_pandas = False
 else:

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -60,7 +60,7 @@ from .table import (
 )
 
 try:
-    import pandas as pd  # noqa: F811
+    import pandas as pd
 except ModuleNotFoundError:
     _has_pandas = False
 else:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -84,7 +84,7 @@ select = [
     "F",
     # isort
     "I",
-    # ruff
+    # ruff-specific rules
     "RUF"
 ]
 ignore = ["E501"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -83,7 +83,9 @@ select = [
     # pyflakes
     "F",
     # isort
-    "I"
+    "I",
+    # ruff
+    "RUF"
 ]
 ignore = ["E501"]
 

--- a/python/tests/pyspark_integration/test_write_to_pyspark.py
+++ b/python/tests/pyspark_integration/test_write_to_pyspark.py
@@ -106,7 +106,7 @@ def test_checks_min_writer_version(tmp_path: pathlib.Path):
     )
 
     # Add a constraint upgrades the minWriterProtocol
-    spark.sql(f"ALTER TABLE delta.`{str(tmp_path)}` ADD CONSTRAINT x CHECK (c1 > 2)")
+    spark.sql(f"ALTER TABLE delta.`{tmp_path!s}` ADD CONSTRAINT x CHECK (c1 > 2)")
 
     with pytest.raises(
         DeltaProtocolError, match="This table's min_writer_version is 3, but"


### PR DESCRIPTION
# Description
This PR proposes to enable the [`RUF`](https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf) ruleset.

```
ruff check .
```

returned:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'isort' -> 'lint.isort'
deltalake/table.py:52:26: RUF100 [*] Unused `noqa` directive (unused: `F811`)
deltalake/writer.py:63:26: RUF100 [*] Unused `noqa` directive (unused: `F811`)
tests/pyspark_integration/test_write_to_pyspark.py:109:37: RUF010 [*] Use explicit conversion flag
Found 3 errors.
[*] 3 fixable with the `--fix` option.
```

So these were simply fixed with `ruff check . --fix`. https://github.com/delta-io/delta-rs/pull/2673 handles the fixing of the outdated config.
