### PR TITLE
chore: pin `ruff` and `mypy` versions in the `lint` stage in the CI pipeline

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -15,30 +15,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.11
-
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Build and install deltalake
-        run: |
-          pip install virtualenv
-          virtualenv venv
-          source venv/bin/activate
-          make develop
+          python-version: "3.10"
 
       - name: Check Python
-        run: make check-python
+        run: |
+          pip install ruff==0.5.2 mypy==1.10.1 types-dataclasses typing-extensions
+          make check-python
+
+      - name: Install minimal stable with clippy and rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          override: true
 
       - name: Check Rust
         run: make check-rust

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -15,22 +15,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.10
 
-      - name: Check Python
-        run: |
-          pip install ruff black mypy types-dataclasses typing-extensions
-          make check-python
-
-      - name: Install minimal stable with clippy and rustfmt
+      - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
-          profile: default
           toolchain: stable
           override: true
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build and install deltalake
+        run: |
+          pip install virtualenv
+          virtualenv venv
+          source venv/bin/activate
+          make develop
+
+      - name: Check Python
+        run: make check-python
 
       - name: Check Rust
         run: make check-rust

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: 3.11
 
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,8 +28,6 @@ pandas = [
 ]
 devel = [
     "azure-storage-blob==12.20.0",
-    "mypy~=1.8.0",
-    "ruff~=0.5.2",
     "packaging>=20",
     "pytest",
     "pytest-mock",
@@ -39,7 +37,10 @@ devel = [
     "sphinx-rtd-theme",
     "toml",
     "wheel",
-    "pytest-benchmark"
+    "pytest-benchmark",
+    # keep ruff and mypy versions in sync with .github/workflows/python_build.yml
+    "mypy==1.10.1",
+    "ruff==0.5.2"
 ]
 pyspark = [
     "pyspark",


### PR DESCRIPTION
# Description

Currently, `ruff` and `mypy` have their latest versions installed in the CI pipeline, while locally they are fixed to a specific version. This can cause issues, see https://github.com/delta-io/delta-rs/issues/2678.

This PR proposes to fix them to their specific version in the pipeline. The alternative I could think of was installing the virtual environment with `make develop`, but that takes between 4 and 5 minutes, which might be considered a bit too long to wait on linting results.

This PR will have conflicts with https://github.com/delta-io/delta-rs/pull/2674, so I'll need to rebase one of these PR's once the other is merged.

# Related Issue(s)

- closes [#106](https://github.com/delta-io/delta-rs/issues/2678)

# Documentation

<!---
Share links to useful documentation
--->
