### PR TITLE
chore: add test coverage command to `Makefile`

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -77,6 +77,11 @@ unit-test: ## Run unit test
 	$(info --- Run Python unit-test ---)
 	python -m pytest --doctest-modules 
 
+.PHONY: test-cov
+test-cov: ## Create coverage report
+	$(info --- Run Python unit-test ---)
+	python -m pytest --doctest-modules --cov --cov-config=pyproject.toml --cov-report=term --cov-report=html
+
 .PHONY: test-pyspark
 test-pyspark:
 	python -m pytest -m 'pyspark and integration'

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -94,7 +94,7 @@ ignore = ["E501"]
 known-first-party = ["deltalake"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=deltalake -v -m 'not integration and not benchmark'"
+addopts = "-v -m 'not integration and not benchmark'"
 testpaths = [
     "tests",
     "deltalake",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -106,3 +106,7 @@ markers = [
     "pandas: marks tests that require pandas",
     "pyspark: marks tests that require pyspark",
 ]
+
+[tool.coverage.run]
+branch = true
+source = ["deltalake"]


### PR DESCRIPTION
# Description

This PR proposes to add a `make test-cov` command to the `Makefile` to make it easier for contributors to check test coverage.

Output currently looks as follows:

```
[...]
tests/test_writerproperties.py::test_write_with_writerproperties PASSED    

---------- coverage: platform darwin, python 3.11.2-final-0 ----------
Name                        Stmts   Miss Branch BrPart  Cover
-------------------------------------------------------------
deltalake/__init__.py          11      0      0      0   100%
deltalake/_util.py             16      1     12      1    93%
deltalake/data_catalog.py       6      0      0      0   100%
deltalake/exceptions.py         5      0      0      0   100%
deltalake/fs.py                44     11      2      0    76%
deltalake/schema.py            60      0     22      0   100%
deltalake/table.py            431     42    174     23    89%
deltalake/writer.py           267     98    175     14    58%
-------------------------------------------------------------
TOTAL                         840    152    385     38    78%
Coverage HTML written to dir htmlcov
```

Also removed `--cov=deltalake` from the `pytest` ini commands, because I think that is better moved to `[tool.coverage.run]`.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
