### PR TITLE
fix(python): empty dataset fix for "pyarrow" engine

### DIFF
--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -85,7 +85,9 @@ def _cast_schema_to_recordbatchreader(
 ) -> Generator[pa.RecordBatch, None, None]:
     """Creates recordbatch generator."""
     for batch in reader:
-        yield pa.Table.from_batches([batch]).cast(schema).to_batches()[0]
+        batchs = pa.Table.from_batches([batch]).cast(schema).to_batches()
+        if len(batchs) > 0:
+            yield batchs[0]
 
 
 def convert_pyarrow_recordbatchreader(

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1838,3 +1838,9 @@ def test_roundtrip_cdc_evolution(tmp_path: pathlib.Path):
     print(os.listdir(tmp_path))
     # This is kind of a weak test to verify that CDFs were written
     assert os.path.isdir(os.path.join(tmp_path, "_change_data"))
+
+
+def test_empty_dataset_write(tmp_path: pathlib.Path, sample_data: pa.Table):
+    empty_arrow_table = sample_data.schema.empty_table()
+    empty_dataset = dataset(empty_arrow_table)
+    write_deltalake(tmp_path, empty_dataset, mode="append")


### PR DESCRIPTION
# Description
part of #2686  fix writing empty arrow dataset with pyarrow engine 

# Related Issue(s)
<!---
For example:

- closes #106
--->
part of #2686 

# Documentation

<!---
Share links to useful documentation
--->
