### PR TITLE
chore: refactor `write_deltalake` in `writer.py`

### DIFF
--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -623,7 +623,7 @@ def _convert_data_and_schema(
     ],
     schema: Optional[Union[pa.Schema, DeltaSchema]],
     large_dtypes: bool,
-) -> tuple[pa.RecordBatchReader, pa.Schema]:
+) -> Tuple[pa.RecordBatchReader, pa.Schema]:
     if isinstance(data, RecordBatchReader):
         data = convert_pyarrow_recordbatchreader(data, large_dtypes)
     elif isinstance(data, pa.RecordBatch):


### PR DESCRIPTION
# Description

Te body of the `write_deltalake` function is quite long, and thus a bit difficult to read and understand. This PR proposes to reduce the complexity of the `write_deltalake` function a little bit, by extracting some logic to a separate function, and moving some function definitions to outside of the body.

I guess this is a bit opinionated, so if you think this does not add value, feel free to close the PR.