### PR TITLE
fix(python, rust): use url encoder when encoding partition values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ tracing = { version = "0.1", features = ["log"] }
 regex = { version = "1" }
 thiserror = { version = "1" }
 url = { version = "2" }
+urlencoding = "2.1.3"
 uuid = { version = "1" }
 
 # runtime / async

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -57,6 +57,7 @@ regex = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 url = { workspace = true }
+urlencoding = { workspace = true}
 
 # runtime
 async-trait = { workspace = true }

--- a/crates/core/src/kernel/scalars.rs
+++ b/crates/core/src/kernel/scalars.rs
@@ -1,7 +1,5 @@
 //! Auxiliary methods for dealing with kernel scalars
 //!
-use std::cmp::Ordering;
-
 use arrow_array::Array;
 use arrow_schema::TimeUnit;
 use chrono::{DateTime, TimeZone, Utc};
@@ -10,6 +8,8 @@ use delta_kernel::{
     schema::StructField,
 };
 use object_store::path::Path;
+use std::cmp::Ordering;
+use urlencoding::encode;
 
 use crate::NULL_PARTITION_VALUE_DATA_PATH;
 
@@ -76,7 +76,7 @@ impl ScalarExt for Scalar {
         if self.is_null() {
             return NULL_PARTITION_VALUE_DATA_PATH.to_string();
         }
-        Path::from(self.serialize()).to_string()
+        encode(Path::from(self.serialize()).as_ref()).to_string()
     }
 
     /// Create a [`Scalar`] form a row in an arrow array.


### PR DESCRIPTION
# Description
First parse in path and then encode, otherwise Path::from does double encoding if you do it reversed.

# Related Issue(s)
- closes https://github.com/delta-io/delta-rs/issues/2634