### PR TITLE
feat(python, rust): add `drop column` operation [BLOCKED]

### DIFF
--- a/crates/core/src/operations/drop_column.rs
+++ b/crates/core/src/operations/drop_column.rs
@@ -1,0 +1,88 @@
+//! Drop a column from the table
+
+use delta_kernel::schema::StructType;
+use futures::future::BoxFuture;
+use itertools::Itertools;
+
+use super::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
+
+use crate::kernel::StructField;
+use crate::logstore::LogStoreRef;
+use crate::protocol::DeltaOperation;
+use crate::table::state::DeltaTableState;
+use crate::{DeltaResult, DeltaTable, DeltaTableError};
+
+/// Add new columns and/or nested fields to a table
+pub struct DropColumnBuilder {
+    /// A snapshot of the table's state
+    snapshot: DeltaTableState,
+    /// Fields to drop from the schema
+    fields: Option<Vec<String>>,
+    /// Delta object store for handling data files
+    log_store: LogStoreRef,
+    /// Additional information to add to the commit
+    commit_properties: CommitProperties,
+}
+
+impl super::Operation<()> for DropColumnBuilder {}
+
+impl DropColumnBuilder {
+    /// Create a new builder
+    pub fn new(log_store: LogStoreRef, snapshot: DeltaTableState) -> Self {
+        Self {
+            snapshot,
+            log_store,
+            fields: None,
+            commit_properties: CommitProperties::default(),
+        }
+    }
+
+    /// Specify the fields to be added
+    pub fn with_fields(mut self, fields: impl IntoIterator<Item = String> + Clone) -> Self {
+        self.fields = Some(fields.into_iter().collect());
+        self
+    }
+    /// Additional metadata to be added to commit info
+    pub fn with_commit_properties(mut self, commit_properties: CommitProperties) -> Self {
+        self.commit_properties = commit_properties;
+        self
+    }
+}
+
+impl std::future::IntoFuture for DropColumnBuilder {
+    type Output = DeltaResult<DeltaTable>;
+
+    type IntoFuture = BoxFuture<'static, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let this = self;
+
+        Box::pin(async move {
+            let mut metadata = this.snapshot.metadata().clone();
+            let fields = match this.fields {
+                Some(v) => v,
+                None => return Err(DeltaTableError::Generic("No fields provided".to_string())),
+            };
+
+            let table_schema = this.snapshot.schema();
+
+            let new_table_schema = table_schema;
+
+            let operation = DeltaOperation::DropColumn { fields: fields };
+
+            metadata.schema_string = serde_json::to_string(&new_table_schema)?;
+
+            let actions = vec![metadata.into()];
+
+            let commit = CommitBuilder::from(this.commit_properties)
+                .with_actions(actions)
+                .build(Some(&this.snapshot), this.log_store.clone(), operation)
+                .await?;
+
+            Ok(DeltaTable::new_with_state(
+                this.log_store,
+                commit.snapshot(),
+            ))
+        })
+    }
+}

--- a/crates/core/src/operations/drop_column.rs
+++ b/crates/core/src/operations/drop_column.rs
@@ -145,7 +145,7 @@ impl std::future::IntoFuture for DropColumnBuilder {
                 )));
             }
 
-            let operation = DeltaOperation::DropColumn { fields: fields };
+            let operation = DeltaOperation::DropColumn { fields };
 
             metadata.schema_string = serde_json::to_string(&new_table_schema)?;
 

--- a/crates/core/src/operations/drop_column.rs
+++ b/crates/core/src/operations/drop_column.rs
@@ -119,7 +119,7 @@ impl std::future::IntoFuture for DropColumnBuilder {
                 .iter()
                 .map(|(key, value)| format!("{}.{}", key, value.join(".")))
                 .collect();
-            
+
             // Catch root fields that do not exist
             not_found.append(
                 &mut fields_map

--- a/crates/core/src/operations/drop_column.rs
+++ b/crates/core/src/operations/drop_column.rs
@@ -45,7 +45,7 @@ impl DropColumnBuilder {
         }
     }
 
-    /// Specify the fields to be added
+    /// Specify the fields to be removed
     pub fn with_fields(mut self, fields: impl IntoIterator<Item = String> + Clone) -> Self {
         self.fields = Some(fields.into_iter().collect());
         self

--- a/crates/core/src/operations/mod.rs
+++ b/crates/core/src/operations/mod.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 pub mod cast;
 pub mod convert_to_delta;
 pub mod create;
+pub mod drop_column;
 pub mod drop_constraints;
 pub mod filesystem_check;
 pub mod optimize;
@@ -35,6 +36,7 @@ use self::{
 pub use ::datafusion::physical_plan::common::collect as collect_sendable_stream;
 #[cfg(feature = "datafusion")]
 use arrow::record_batch::RecordBatch;
+use drop_column::DropColumnBuilder;
 use optimize::OptimizeBuilder;
 use restore::RestoreBuilder;
 use set_tbl_properties::SetTablePropertiesBuilder;
@@ -222,6 +224,11 @@ impl DeltaOps {
     #[must_use]
     pub fn drop_constraints(self) -> DropConstraintBuilder {
         DropConstraintBuilder::new(self.0.log_store, self.0.state.unwrap())
+    }
+
+    /// Add new columns
+    pub fn drop_columns(self) -> DropColumnBuilder {
+        DropColumnBuilder::new(self.0.log_store, self.0.state.unwrap())
     }
 
     /// Set table properties

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -377,6 +377,13 @@ pub enum DeltaOperation {
         name: String,
     },
 
+    /// Represents a Delta `Drop Column` operation.
+    /// Used to drop columns or fields in a struct
+    DropColumn {
+        /// Fields to be dropped from the schema
+        fields: Vec<String>,
+    },
+
     /// Merge data with a source data with the following predicate
     #[serde(rename_all = "camelCase")]
     Merge {
@@ -476,6 +483,7 @@ impl DeltaOperation {
             DeltaOperation::VacuumEnd { .. } => "VACUUM END",
             DeltaOperation::AddConstraint { .. } => "ADD CONSTRAINT",
             DeltaOperation::DropConstraint { .. } => "DROP CONSTRAINT",
+            DeltaOperation::DropColumn { .. } => "DROP COLUMN",
         }
     }
 
@@ -516,6 +524,7 @@ impl DeltaOperation {
             | Self::VacuumStart { .. }
             | Self::VacuumEnd { .. }
             | Self::AddConstraint { .. }
+            | Self::DropColumn { .. }
             | Self::DropConstraint { .. } => false,
             Self::Create { .. }
             | Self::FileSystemCheck {}

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -91,6 +91,12 @@ class RawDeltaTable:
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[Dict[str, Optional[bool]]],
     ) -> None: ...
+    def drop_columns(
+        self,
+        fields: List[str],
+        custom_metadata: Optional[Dict[str, str]],
+        post_commithook_properties: Optional[Dict[str, Optional[bool]]],
+    ) -> None: ...
     def set_table_properties(
         self,
         properties: Dict[str, str],

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -94,6 +94,7 @@ class RawDeltaTable:
     def drop_columns(
         self,
         fields: List[str],
+        raise_if_not_exists: bool,
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[Dict[str, Optional[bool]]],
     ) -> None: ...

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1871,6 +1871,7 @@ class TableAlterer:
     def drop_columns(
         self,
         fields: Union[str, List[str]],
+        raise_if_not_exists: bool = True,
         custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
     ) -> None:
@@ -1896,6 +1897,7 @@ class TableAlterer:
 
         self.table._table.drop_columns(
             fields,
+            raise_if_not_exists,
             custom_metadata,
             post_commithook_properties.__dict__ if post_commithook_properties else None,
         )

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1868,6 +1868,38 @@ class TableAlterer:
             post_commithook_properties.__dict__ if post_commithook_properties else None,
         )
 
+    def drop_columns(
+        self,
+        fields: Union[str, List[str]],
+        custom_metadata: Optional[Dict[str, str]] = None,
+        post_commithook_properties: Optional[PostCommitHookProperties] = None,
+    ) -> None:
+        """Drop columns and/or update the fields of a stuct column
+        Args:
+            fields: fields to drop from table schema
+            custom_metadata: custom metadata that will be added to the transaction commit.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
+        Example:
+            ```python
+            from deltalake import DeltaTable
+            dt = DeltaTable("test_table")
+            dt.alter.drop_columns(
+                [
+                    "foo",
+                    "bar.baz"
+                ]
+            )
+            ```
+        """
+        if isinstance(fields, str):
+            fields = [fields]
+
+        self.table._table.drop_columns(
+            fields,
+            custom_metadata,
+            post_commithook_properties.__dict__ if post_commithook_properties else None,
+        )
+
     def set_table_properties(
         self,
         properties: Dict[str, str],

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -631,11 +631,12 @@ impl RawDeltaTable {
         Ok(())
     }
 
-    #[pyo3(signature = (fields, custom_metadata=None, post_commithook_properties=None))]
+    #[pyo3(signature = (fields, raise_if_not_exists, custom_metadata=None, post_commithook_properties=None))]
     pub fn drop_columns(
         &mut self,
         py: Python,
         fields: Vec<String>,
+        raise_if_not_exists: bool,
         custom_metadata: Option<HashMap<String, String>>,
         post_commithook_properties: Option<HashMap<String, Option<bool>>>,
     ) -> PyResult<()> {
@@ -644,7 +645,9 @@ impl RawDeltaTable {
                 self._table.log_store(),
                 self._table.snapshot().map_err(PythonError::from)?.clone(),
             );
-            cmd = cmd.with_fields(fields);
+            cmd = cmd
+                .with_fields(fields)
+                .with_raise_if_not_exists(raise_if_not_exists);
 
             if let Some(commit_properties) =
                 maybe_create_commit_properties(custom_metadata, post_commithook_properties)


### PR DESCRIPTION
# Description
Adds a drop column operation, can be used to drop root fields and nested fields in a struct.
