### PR TITLE
feat(python, rust): `add feature` operation

### DIFF
--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-aws"
-version = "0.2.1"
+version = "0.3.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.19.1", path = "../core" }
+deltalake-core = { version = "0.20.0", path = "../core" }
 aws-smithy-runtime-api = { version="1.7" }
 aws-smithy-runtime = { version="1.7", optional = true}
 aws-credential-types = { version="1.2", features = ["hardcoded-credentials"]}

--- a/crates/azure/Cargo.toml
+++ b/crates/azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-azure"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.19.1", path = "../core" }
+deltalake-core = { version = "0.20.0", path = "../core" }
 lazy_static = "1"
 
 # workspace depenndecies

--- a/crates/catalog-glue/Cargo.toml
+++ b/crates/catalog-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-catalog-glue"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -15,7 +15,7 @@ rust-version.workspace = true
 async-trait = { workspace = true }
 aws-config = "1"
 aws-sdk-glue = "1"
-deltalake-core = { version = "0.19.1", path = "../core" }
+deltalake-core = { version = "0.20.0", path = "../core" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-core"
-version = "0.19.1"
+version = "0.20.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use super::schema::StructType;
 use crate::kernel::{error::Error, DeltaResult};
-use crate::DeltaConfigKey;
+use crate::TableProperty;
 
 /// Defines a file format used in table
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -240,10 +240,10 @@ impl Protocol {
         new_properties: &HashMap<String, String>,
         raise_if_not_exists: bool,
     ) -> DeltaResult<Protocol> {
-        let mut parsed_properties: HashMap<DeltaConfigKey, String> = HashMap::new();
+        let mut parsed_properties: HashMap<TableProperty, String> = HashMap::new();
 
         for (key, value) in new_properties {
-            if let Ok(parsed_key) = key.parse::<DeltaConfigKey>() {
+            if let Ok(parsed_key) = key.parse::<TableProperty>() {
                 parsed_properties.insert(parsed_key, value.to_string());
             } else if raise_if_not_exists {
                 return Err(Error::Generic(format!(
@@ -254,7 +254,7 @@ impl Protocol {
         }
 
         // Check and update delta.minReaderVersion
-        if let Some(min_reader_version) = parsed_properties.get(&DeltaConfigKey::MinReaderVersion) {
+        if let Some(min_reader_version) = parsed_properties.get(&TableProperty::MinReaderVersion) {
             let new_min_reader_version = min_reader_version.parse::<i32>();
             match new_min_reader_version {
                 Ok(version) => match version {
@@ -280,7 +280,7 @@ impl Protocol {
         }
 
         // Check and update delta.minWriterVersion
-        if let Some(min_writer_version) = parsed_properties.get(&DeltaConfigKey::MinWriterVersion) {
+        if let Some(min_writer_version) = parsed_properties.get(&TableProperty::MinWriterVersion) {
             let new_min_writer_version = min_writer_version.parse::<i32>();
             match new_min_writer_version {
                 Ok(version) => match version {
@@ -306,7 +306,7 @@ impl Protocol {
         }
 
         // Check enableChangeDataFeed and bump protocol or add writerFeature if writer versions is >=7
-        if let Some(enable_cdf) = parsed_properties.get(&DeltaConfigKey::EnableChangeDataFeed) {
+        if let Some(enable_cdf) = parsed_properties.get(&TableProperty::EnableChangeDataFeed) {
             let if_enable_cdf = enable_cdf.to_ascii_lowercase().parse::<bool>();
             match if_enable_cdf {
                 Ok(true) => {
@@ -335,7 +335,7 @@ impl Protocol {
             }
         }
 
-        if let Some(enable_dv) = parsed_properties.get(&DeltaConfigKey::EnableDeletionVectors) {
+        if let Some(enable_dv) = parsed_properties.get(&TableProperty::EnableDeletionVectors) {
             let if_enable_dv = enable_dv.to_ascii_lowercase().parse::<bool>();
             match if_enable_dv {
                 Ok(true) => {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -93,7 +93,7 @@ pub use self::errors::*;
 pub use self::schema::partitions::*;
 pub use self::schema::*;
 pub use self::table::builder::{DeltaTableBuilder, DeltaTableConfig, DeltaVersion};
-pub use self::table::config::DeltaConfigKey;
+pub use self::table::config::TableProperty;
 pub use self::table::DeltaTable;
 pub use object_store::{path::Path, Error as ObjectStoreError, ObjectMeta, ObjectStore};
 pub use operations::DeltaOps;

--- a/crates/core/src/operations/add_feature.rs
+++ b/crates/core/src/operations/add_feature.rs
@@ -1,0 +1,196 @@
+//! Enable table features
+
+use futures::future::BoxFuture;
+use itertools::Itertools;
+
+use super::transaction::{CommitBuilder, CommitProperties};
+use crate::kernel::{ReaderFeatures, TableFeatures, WriterFeatures};
+use crate::logstore::LogStoreRef;
+use crate::protocol::DeltaOperation;
+use crate::table::state::DeltaTableState;
+use crate::DeltaTable;
+use crate::{DeltaResult, DeltaTableError};
+
+/// Enable table features for a table
+pub struct AddTableFeatureBuilder {
+    /// A snapshot of the table's state
+    snapshot: DeltaTableState,
+    /// Name of the feature
+    name: Vec<TableFeatures>,
+    /// Allow protocol versions to be increased by setting features
+    allow_protocol_versions_increase: bool,
+    /// Delta object store for handling data files
+    log_store: LogStoreRef,
+    /// Additional information to add to the commit
+    commit_properties: CommitProperties,
+}
+
+impl super::Operation<()> for AddTableFeatureBuilder {}
+
+impl AddTableFeatureBuilder {
+    /// Create a new builder
+    pub fn new(log_store: LogStoreRef, snapshot: DeltaTableState) -> Self {
+        Self {
+            name: vec![],
+            allow_protocol_versions_increase: false,
+            snapshot,
+            log_store,
+            commit_properties: CommitProperties::default(),
+        }
+    }
+
+    /// Specify the features to be added
+    pub fn with_feature<S: Into<TableFeatures>>(mut self, name: S) -> Self {
+        self.name.push(name.into());
+        self
+    }
+
+    /// Specify the features to be added
+    pub fn with_features<S: Into<TableFeatures>>(mut self, name: Vec<S>) -> Self {
+        self.name
+            .extend(name.into_iter().map(Into::into).collect_vec());
+        self
+    }
+
+    /// Specify if you want to allow protocol version to be increased
+    pub fn with_allow_protocol_versions_increase(mut self, allow: bool) -> Self {
+        self.allow_protocol_versions_increase = allow;
+        self
+    }
+
+    /// Additional metadata to be added to commit info
+    pub fn with_commit_properties(mut self, commit_properties: CommitProperties) -> Self {
+        self.commit_properties = commit_properties;
+        self
+    }
+}
+
+impl std::future::IntoFuture for AddTableFeatureBuilder {
+    type Output = DeltaResult<DeltaTable>;
+
+    type IntoFuture = BoxFuture<'static, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let this = self;
+
+        Box::pin(async move {
+            let name = if this.name.is_empty() {
+                return Err(DeltaTableError::Generic("No features provided".to_string()));
+            } else {
+                this.name
+            };
+            let (reader_features, writer_features): (
+                Vec<Option<ReaderFeatures>>,
+                Vec<Option<WriterFeatures>>,
+            ) = name.iter().map(|v| v.to_reader_writer_features()).unzip();
+            let reader_features = reader_features.into_iter().flatten().collect_vec();
+            let writer_features = writer_features.into_iter().flatten().collect_vec();
+
+            let mut protocol = this.snapshot.protocol().clone();
+
+            if !this.allow_protocol_versions_increase {
+                if !reader_features.is_empty()
+                    && !writer_features.is_empty()
+                    && !(protocol.min_reader_version == 3 && protocol.min_writer_version == 7)
+                {
+                    return Err(DeltaTableError::Generic("Table feature enables reader and writer feature, but reader is not v3, and writer not v7. Set allow_protocol_versions_increase or increase versions explicitly through set_tbl_properties".to_string()));
+                } else if !reader_features.is_empty() && protocol.min_reader_version < 3 {
+                    return Err(DeltaTableError::Generic("Table feature enables reader feature, but min_reader is not v3. Set allow_protocol_versions_increase or increase version explicitly through set_tbl_properties".to_string()));
+                } else if !writer_features.is_empty() && protocol.min_writer_version < 7 {
+                    return Err(DeltaTableError::Generic("Table feature enables writer feature, but min_writer is not v7. Set allow_protocol_versions_increase or increase version explicitly through set_tbl_properties".to_string()));
+                }
+            }
+
+            protocol = protocol.with_reader_features(reader_features);
+            protocol = protocol.with_writer_features(writer_features);
+
+            let operation = DeltaOperation::AddFeature { name };
+
+            let actions = vec![protocol.into()];
+
+            let commit = CommitBuilder::from(this.commit_properties)
+                .with_actions(actions)
+                .build(Some(&this.snapshot), this.log_store.clone(), operation)
+                .await?;
+
+            Ok(DeltaTable::new_with_state(
+                this.log_store,
+                commit.snapshot(),
+            ))
+        })
+    }
+}
+
+#[cfg(feature = "datafusion")]
+#[cfg(test)]
+mod tests {
+    use delta_kernel::DeltaResult;
+
+    use crate::{
+        kernel::TableFeatures,
+        writer::test_utils::{create_bare_table, get_record_batch},
+        DeltaOps,
+    };
+
+    #[tokio::test]
+    async fn add_feature() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let write = DeltaOps(create_bare_table())
+            .write(vec![batch.clone()])
+            .await
+            .unwrap();
+        let table = DeltaOps(write);
+        let result = table
+            .add_feature()
+            .with_feature(TableFeatures::ChangeDataFeed)
+            .with_allow_protocol_versions_increase(true)
+            .await
+            .unwrap();
+
+        assert!(&result
+            .protocol()
+            .cloned()
+            .unwrap()
+            .writer_features
+            .unwrap_or_default()
+            .contains(&crate::kernel::WriterFeatures::ChangeDataFeed));
+
+        let result = DeltaOps(result)
+            .add_feature()
+            .with_feature(TableFeatures::DeletionVectors)
+            .with_allow_protocol_versions_increase(true)
+            .await
+            .unwrap();
+
+        let current_protocol = &result.protocol().cloned().unwrap();
+        assert!(&current_protocol
+            .writer_features
+            .clone()
+            .unwrap_or_default()
+            .contains(&crate::kernel::WriterFeatures::DeletionVectors));
+        assert!(&current_protocol
+            .reader_features
+            .clone()
+            .unwrap_or_default()
+            .contains(&crate::kernel::ReaderFeatures::DeletionVectors));
+        assert_eq!(result.version(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn add_feature_disallowed_increase() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let write = DeltaOps(create_bare_table())
+            .write(vec![batch.clone()])
+            .await
+            .unwrap();
+        let table = DeltaOps(write);
+        let result = table
+            .add_feature()
+            .with_feature(TableFeatures::ChangeDataFeed)
+            .await;
+
+        assert!(result.is_err());
+        Ok(())
+    }
+}

--- a/crates/core/src/operations/cdc.rs
+++ b/crates/core/src/operations/cdc.rs
@@ -88,7 +88,7 @@ mod tests {
     use crate::kernel::DataType as DeltaDataType;
     use crate::kernel::{Action, PrimitiveType, Protocol};
     use crate::operations::DeltaOps;
-    use crate::{DeltaConfigKey, DeltaTable};
+    use crate::{DeltaTable, TableProperty};
     use arrow::array::{ArrayRef, Int32Array, StructArray};
     use arrow::datatypes::{DataType, Field};
     use arrow_array::RecordBatch;
@@ -130,7 +130,7 @@ mod tests {
                 None,
             )
             .with_actions(actions)
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .expect("failed to make a version 4 table with EnableChangeDataFeed");
         table.load().await.expect("Failed to reload table");
@@ -185,7 +185,7 @@ mod tests {
                 None,
             )
             .with_actions(actions)
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .expect("failed to make a version 4 table with EnableChangeDataFeed");
         table.load().await.expect("Failed to reload table");

--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -23,7 +23,7 @@ use crate::{
     operations::create::CreateBuilder,
     protocol::SaveMode,
     table::builder::ensure_table_uri,
-    table::config::DeltaConfigKey,
+    table::config::TableProperty,
     writer::stats::stats_from_parquet_metadata,
     DeltaResult, DeltaTable, DeltaTableError, ObjectStoreError, NULL_PARTITION_VALUE_DATA_PATH,
 };
@@ -212,7 +212,7 @@ impl ConvertToDeltaBuilder {
     /// Specify a table property in the table configuration
     pub fn with_configuration_property(
         mut self,
-        key: DeltaConfigKey,
+        key: TableProperty,
         value: Option<impl Into<String>>,
     ) -> Self {
         self.configuration

--- a/crates/core/src/operations/create.rs
+++ b/crates/core/src/operations/create.rs
@@ -17,7 +17,7 @@ use crate::kernel::{
 use crate::logstore::{LogStore, LogStoreRef};
 use crate::protocol::{DeltaOperation, SaveMode};
 use crate::table::builder::ensure_table_uri;
-use crate::table::config::DeltaConfigKey;
+use crate::table::config::TableProperty;
 use crate::{DeltaTable, DeltaTableBuilder};
 
 #[derive(thiserror::Error, Debug)]
@@ -193,7 +193,7 @@ impl CreateBuilder {
     /// Specify a table property in the table configuration
     pub fn with_configuration_property(
         mut self,
-        key: DeltaConfigKey,
+        key: TableProperty,
         value: Option<impl Into<String>>,
     ) -> Self {
         self.configuration
@@ -213,7 +213,7 @@ impl CreateBuilder {
         self
     }
 
-    /// Specify whether to raise an error if the table properties in the configuration are not DeltaConfigKeys
+    /// Specify whether to raise an error if the table properties in the configuration are not TablePropertys
     pub fn with_raise_if_key_not_exists(mut self, raise_if_key_not_exists: bool) -> Self {
         self.raise_if_key_not_exists = raise_if_key_not_exists;
         self
@@ -393,7 +393,7 @@ impl std::future::IntoFuture for CreateBuilder {
 mod tests {
     use super::*;
     use crate::operations::DeltaOps;
-    use crate::table::config::DeltaConfigKey;
+    use crate::table::config::TableProperty;
     use crate::writer::test_utils::{get_delta_schema, get_record_batch};
     use tempfile::TempDir;
 
@@ -485,14 +485,14 @@ mod tests {
         let table = CreateBuilder::new()
             .with_location("memory://")
             .with_columns(schema.fields().cloned())
-            .with_configuration_property(DeltaConfigKey::AppendOnly, Some("true"))
+            .with_configuration_property(TableProperty::AppendOnly, Some("true"))
             .await
             .unwrap();
         let append = table
             .metadata()
             .unwrap()
             .configuration
-            .get(DeltaConfigKey::AppendOnly.as_ref())
+            .get(TableProperty::AppendOnly.as_ref())
             .unwrap()
             .as_ref()
             .unwrap()

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -432,8 +432,8 @@ mod tests {
     use crate::writer::test_utils::{
         get_arrow_schema, get_delta_schema, get_record_batch, setup_table_with_configuration,
     };
-    use crate::DeltaConfigKey;
     use crate::DeltaTable;
+    use crate::TableProperty;
     use arrow::array::Int32Array;
     use arrow::datatypes::{Field, Schema};
     use arrow::record_batch::RecordBatch;
@@ -465,7 +465,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_when_delta_table_is_append_only() {
-        let table = setup_table_with_configuration(DeltaConfigKey::AppendOnly, Some("true")).await;
+        let table = setup_table_with_configuration(TableProperty::AppendOnly, Some("true")).await;
         let batch = get_record_batch(None, false);
         // append some data
         let table = write_batch(table, batch).await;
@@ -909,7 +909,7 @@ mod tests {
                 true,
                 None,
             )
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
         assert_eq!(table.version(), 0);
@@ -987,7 +987,7 @@ mod tests {
                 None,
             )
             .with_partition_columns(vec!["year"])
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
         assert_eq!(table.version(), 0);

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -409,7 +409,7 @@ pub(crate) mod tests {
 
     use crate::test_utils::TestSchemas;
     use crate::writer::test_utils::TestResult;
-    use crate::{DeltaConfigKey, DeltaOps, DeltaTable};
+    use crate::{DeltaOps, DeltaTable, TableProperty};
 
     #[tokio::test]
     async fn test_load_local() -> TestResult {
@@ -603,7 +603,7 @@ pub(crate) mod tests {
             .create()
             .with_columns(delta_schema.fields().cloned())
             .with_partition_columns(["id"])
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
         assert_eq!(table.version(), 0);

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1386,8 +1386,8 @@ mod tests {
     use crate::writer::test_utils::get_arrow_schema;
     use crate::writer::test_utils::get_delta_schema;
     use crate::writer::test_utils::setup_table_with_configuration;
-    use crate::DeltaConfigKey;
     use crate::DeltaTable;
+    use crate::TableProperty;
     use arrow::datatypes::Schema as ArrowSchema;
     use arrow::record_batch::RecordBatch;
     use arrow_schema::DataType as ArrowDataType;
@@ -1426,7 +1426,7 @@ mod tests {
     #[tokio::test]
     async fn test_merge_when_delta_table_is_append_only() {
         let schema = get_arrow_schema(&None);
-        let table = setup_table_with_configuration(DeltaConfigKey::AppendOnly, Some("true")).await;
+        let table = setup_table_with_configuration(TableProperty::AppendOnly, Some("true")).await;
         // append some data
         let table = write_data(table, &schema).await;
         // merge
@@ -3107,7 +3107,7 @@ mod tests {
             .create()
             .with_columns(schema.fields().cloned())
             .with_actions(actions)
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
         assert_eq!(table.version(), 0);
@@ -3202,7 +3202,7 @@ mod tests {
             .create()
             .with_columns(schema.fields().cloned())
             .with_actions(actions)
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
         assert_eq!(table.version(), 0);

--- a/crates/core/src/operations/mod.rs
+++ b/crates/core/src/operations/mod.rs
@@ -8,6 +8,7 @@
 //! if the operation returns data as well.
 use std::collections::HashMap;
 
+use add_feature::AddTableFeatureBuilder;
 #[cfg(feature = "datafusion")]
 use arrow_array::RecordBatch;
 #[cfg(feature = "datafusion")]
@@ -31,6 +32,7 @@ use crate::table::builder::DeltaTableBuilder;
 use crate::DeltaTable;
 
 pub mod add_column;
+pub mod add_feature;
 pub mod cast;
 pub mod convert_to_delta;
 pub mod create;
@@ -218,6 +220,12 @@ impl DeltaOps {
     #[must_use]
     pub fn add_constraint(self) -> ConstraintBuilder {
         ConstraintBuilder::new(self.0.log_store, self.0.state.unwrap())
+    }
+
+    /// Enable a table feature for a table
+    #[must_use]
+    pub fn add_feature(self) -> AddTableFeatureBuilder {
+        AddTableFeatureBuilder::new(self.0.log_store, self.0.state.unwrap())
     }
 
     /// Drops constraints from a table

--- a/crates/core/src/operations/transaction/protocol.rs
+++ b/crates/core/src/operations/transaction/protocol.rs
@@ -272,7 +272,7 @@ mod tests {
     use crate::protocol::SaveMode;
     use crate::table::state::DeltaTableState;
     use crate::test_utils::{ActionFactory, TestSchemas};
-    use crate::DeltaConfigKey;
+    use crate::TableProperty;
 
     fn metadata_action(configuration: Option<HashMap<String, Option<String>>>) -> Metadata {
         ActionFactory::metadata(TestSchemas::simple(), None::<Vec<&str>>, configuration)
@@ -328,7 +328,7 @@ mod tests {
                     ..Default::default()
                 }),
                 metadata_action(Some(HashMap::from([(
-                    DeltaConfigKey::AppendOnly.as_ref().to_string(),
+                    TableProperty::AppendOnly.as_ref().to_string(),
                     Some(append.to_string()),
                 )])))
                 .into(),
@@ -630,7 +630,7 @@ mod tests {
                 )])),
             )
             .with_actions(actions)
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .expect("failed to make a version 4 table with EnableChangeDataFeed");
         let eager_5 = table

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -500,7 +500,7 @@ mod tests {
     use crate::writer::test_utils::{
         get_arrow_schema, get_delta_schema, get_record_batch, setup_table_with_configuration,
     };
-    use crate::{DeltaConfigKey, DeltaTable};
+    use crate::{DeltaTable, TableProperty};
     use arrow::array::{Int32Array, StringArray};
     use arrow::datatypes::Schema as ArrowSchema;
     use arrow::datatypes::{Field, Schema};
@@ -549,7 +549,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_when_delta_table_is_append_only() {
-        let table = setup_table_with_configuration(DeltaConfigKey::AppendOnly, Some("true")).await;
+        let table = setup_table_with_configuration(TableProperty::AppendOnly, Some("true")).await;
         let batch = get_record_batch(None, false);
         // Append
         let table = write_batch(table, batch).await;
@@ -1062,7 +1062,7 @@ mod tests {
                 None,
             )
             .with_actions(actions)
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
         assert_eq!(table.version(), 0);
@@ -1147,7 +1147,7 @@ mod tests {
             )
             .with_partition_columns(vec!["year"])
             .with_actions(actions)
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
         assert_eq!(table.version(), 0);

--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -1231,7 +1231,7 @@ mod tests {
         get_arrow_schema, get_delta_schema, get_delta_schema_with_nested_struct, get_record_batch,
         get_record_batch_with_nested_struct, setup_table_with_configuration,
     };
-    use crate::DeltaConfigKey;
+    use crate::TableProperty;
     use arrow_array::{Int32Array, StringArray, TimestampMicrosecondArray};
     use arrow_schema::{DataType, Field, Schema as ArrowSchema, TimeUnit};
     use datafusion::prelude::*;
@@ -1257,7 +1257,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_when_delta_table_is_append_only() {
-        let table = setup_table_with_configuration(DeltaConfigKey::AppendOnly, Some("true")).await;
+        let table = setup_table_with_configuration(TableProperty::AppendOnly, Some("true")).await;
         let batch = get_record_batch(None, false);
         // Append
         let table = write_batch(table, batch.clone()).await;
@@ -2068,7 +2068,7 @@ mod tests {
             .create()
             .with_columns(delta_schema.fields().cloned())
             .with_partition_columns(["id"])
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
         assert_eq!(table.version(), 0);
@@ -2141,7 +2141,7 @@ mod tests {
             .create()
             .with_columns(delta_schema.fields().cloned())
             .with_partition_columns(["id"])
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
         assert_eq!(table.version(), 0);
@@ -2217,7 +2217,7 @@ mod tests {
             .create()
             .with_columns(delta_schema.fields().cloned())
             .with_partition_columns(["id"])
-            .with_configuration_property(DeltaConfigKey::EnableChangeDataFeed, Some("true"))
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
         assert_eq!(table.version(), 0);

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -18,7 +18,7 @@ use serde_json::Value;
 use tracing::{debug, error};
 
 use crate::errors::{DeltaResult, DeltaTableError};
-use crate::kernel::{Add, CommitInfo, Metadata, Protocol, Remove, StructField};
+use crate::kernel::{Add, CommitInfo, Metadata, Protocol, Remove, StructField, TableFeatures};
 use crate::logstore::LogStore;
 use crate::table::CheckPoint;
 
@@ -364,6 +364,12 @@ pub enum DeltaOperation {
         expr: String,
     },
 
+    /// Add table features to a table
+    AddFeature {
+        /// Name of the feature
+        name: Vec<TableFeatures>,
+    },
+
     /// Drops constraints from a table
     DropConstraint {
         /// Constraints name
@@ -470,6 +476,7 @@ impl DeltaOperation {
             DeltaOperation::VacuumEnd { .. } => "VACUUM END",
             DeltaOperation::AddConstraint { .. } => "ADD CONSTRAINT",
             DeltaOperation::DropConstraint { .. } => "DROP CONSTRAINT",
+            DeltaOperation::AddFeature { .. } => "ADD FEATURE",
         }
     }
 
@@ -508,6 +515,7 @@ impl DeltaOperation {
             Self::Optimize { .. }
             | Self::SetTableProperties { .. }
             | Self::AddColumn { .. }
+            | Self::AddFeature { .. }
             | Self::VacuumStart { .. }
             | Self::VacuumEnd { .. }
             | Self::AddConstraint { .. }

--- a/crates/core/src/table/config.rs
+++ b/crates/core/src/table/config.rs
@@ -14,7 +14,7 @@ use crate::errors::DeltaTableError;
 /// <https://learn.microsoft.com/en-us/azure/databricks/delta/table-properties>
 #[derive(PartialEq, Eq, Hash)]
 #[non_exhaustive]
-pub enum DeltaConfigKey {
+pub enum TableProperty {
     /// true for this Delta table to be append-only. If append-only,
     /// existing records cannot be deleted, and existing values cannot be updated.
     AppendOnly,
@@ -116,7 +116,7 @@ pub enum DeltaConfigKey {
     CheckpointPolicy,
 }
 
-impl AsRef<str> for DeltaConfigKey {
+impl AsRef<str> for TableProperty {
     fn as_ref(&self) -> &str {
         match self {
             Self::AppendOnly => "delta.appendOnly",
@@ -146,7 +146,7 @@ impl AsRef<str> for DeltaConfigKey {
     }
 }
 
-impl FromStr for DeltaConfigKey {
+impl FromStr for TableProperty {
     type Err = DeltaTableError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -217,28 +217,28 @@ impl<'a> TableConfig<'a> {
     table_config!(
         (
             "true for this Delta table to be append-only",
-            DeltaConfigKey::AppendOnly,
+            TableProperty::AppendOnly,
             append_only,
             bool,
             false
         ),
         (
             "true for Delta Lake to write file statistics in checkpoints in JSON format for the stats column.",
-            DeltaConfigKey::CheckpointWriteStatsAsJson,
+            TableProperty::CheckpointWriteStatsAsJson,
             write_stats_as_json,
             bool,
             true
         ),
         (
             "true for Delta Lake to write file statistics to checkpoints in struct format",
-            DeltaConfigKey::CheckpointWriteStatsAsStruct,
+            TableProperty::CheckpointWriteStatsAsStruct,
             write_stats_as_struct,
             bool,
             false
         ),
         (
             "The target file size in bytes or higher units for file tuning",
-            DeltaConfigKey::TargetFileSize,
+            TableProperty::TargetFileSize,
             target_file_size,
             i64,
             // Databricks / spark defaults to 104857600 (bytes) or 100mb
@@ -246,14 +246,14 @@ impl<'a> TableConfig<'a> {
         ),
         (
             "true to enable change data feed.",
-            DeltaConfigKey::EnableChangeDataFeed,
+            TableProperty::EnableChangeDataFeed,
             enable_change_data_feed,
             bool,
             false
         ),
         (
             "true to enable deletion vectors and predictive I/O for updates.",
-            DeltaConfigKey::EnableDeletionVectors,
+            TableProperty::EnableDeletionVectors,
             enable_deletion_vectors,
             bool,
             // in databricks the default is dependent on the workspace settings and runtime version
@@ -262,21 +262,21 @@ impl<'a> TableConfig<'a> {
         ),
         (
             "The number of columns for Delta Lake to collect statistics about for data skipping.",
-            DeltaConfigKey::DataSkippingNumIndexedCols,
+            TableProperty::DataSkippingNumIndexedCols,
             num_indexed_cols,
             i32,
             32
         ),
         (
             "whether to cleanup expired logs",
-            DeltaConfigKey::EnableExpiredLogCleanup,
+            TableProperty::EnableExpiredLogCleanup,
             enable_expired_log_cleanup,
             bool,
             true
         ),
         (
             "Interval (number of commits) after which a new checkpoint should be created",
-            DeltaConfigKey::CheckpointInterval,
+            TableProperty::CheckpointInterval,
             checkpoint_interval,
             i32,
             100
@@ -297,7 +297,7 @@ impl<'a> TableConfig<'a> {
             static ref DEFAULT_DURATION: Duration = parse_interval("interval 1 weeks").unwrap();
         }
         self.0
-            .get(DeltaConfigKey::DeletedFileRetentionDuration.as_ref())
+            .get(TableProperty::DeletedFileRetentionDuration.as_ref())
             .and_then(|o| o.as_ref().and_then(|v| parse_interval(v).ok()))
             .unwrap_or_else(|| DEFAULT_DURATION.to_owned())
     }
@@ -313,7 +313,7 @@ impl<'a> TableConfig<'a> {
             static ref DEFAULT_DURATION: Duration = parse_interval("interval 30 days").unwrap();
         }
         self.0
-            .get(DeltaConfigKey::LogRetentionDuration.as_ref())
+            .get(TableProperty::LogRetentionDuration.as_ref())
             .and_then(|o| o.as_ref().and_then(|v| parse_interval(v).ok()))
             .unwrap_or_else(|| DEFAULT_DURATION.to_owned())
     }
@@ -323,7 +323,7 @@ impl<'a> TableConfig<'a> {
     /// Valid values are `Serializable` and `WriteSerializable`.
     pub fn isolation_level(&self) -> IsolationLevel {
         self.0
-            .get(DeltaConfigKey::IsolationLevel.as_ref())
+            .get(TableProperty::IsolationLevel.as_ref())
             .and_then(|o| o.as_ref().and_then(|v| v.parse().ok()))
             .unwrap_or_default()
     }
@@ -331,7 +331,7 @@ impl<'a> TableConfig<'a> {
     /// Policy applied during chepoint creation
     pub fn checkpoint_policy(&self) -> CheckpointPolicy {
         self.0
-            .get(DeltaConfigKey::CheckpointPolicy.as_ref())
+            .get(TableProperty::CheckpointPolicy.as_ref())
             .and_then(|o| o.as_ref().and_then(|v| v.parse().ok()))
             .unwrap_or_default()
     }
@@ -339,7 +339,7 @@ impl<'a> TableConfig<'a> {
     /// Return the column mapping mode according to delta.columnMapping.mode
     pub fn column_mapping_mode(&self) -> ColumnMappingMode {
         self.0
-            .get(DeltaConfigKey::ColumnMappingMode.as_ref())
+            .get(TableProperty::ColumnMappingMode.as_ref())
             .and_then(|o| o.as_ref().and_then(|v| v.parse().ok()))
             .unwrap_or_default()
     }
@@ -362,7 +362,7 @@ impl<'a> TableConfig<'a> {
     /// This property takes precedence over [num_indexed_cols](Self::num_indexed_cols).
     pub fn stats_columns(&self) -> Option<Vec<&str>> {
         self.0
-            .get(DeltaConfigKey::DataSkippingStatsColumns.as_ref())
+            .get(TableProperty::DataSkippingStatsColumns.as_ref())
             .and_then(|o| o.as_ref().map(|v| v.split(',').collect()))
     }
 }
@@ -536,7 +536,7 @@ mod tests {
         // change to 2 day
         let mut md = dummy_metadata();
         md.configuration.insert(
-            DeltaConfigKey::DeletedFileRetentionDuration
+            TableProperty::DeletedFileRetentionDuration
                 .as_ref()
                 .to_string(),
             Some("interval 2 day".to_string()),
@@ -567,7 +567,7 @@ mod tests {
         // change to false
         let mut md = dummy_metadata();
         md.configuration.insert(
-            DeltaConfigKey::EnableExpiredLogCleanup.as_ref().into(),
+            TableProperty::EnableExpiredLogCleanup.as_ref().into(),
             Some("false".to_string()),
         );
         let config = TableConfig(&md.configuration);

--- a/crates/core/src/writer/test_utils.rs
+++ b/crates/core/src/writer/test_utils.rs
@@ -10,7 +10,7 @@ use arrow_select::take::take;
 use crate::kernel::{DataType as DeltaDataType, Metadata, PrimitiveType, StructField, StructType};
 use crate::operations::create::CreateBuilder;
 use crate::operations::DeltaOps;
-use crate::{DeltaConfigKey, DeltaTable, DeltaTableBuilder};
+use crate::{DeltaTable, DeltaTableBuilder, TableProperty};
 
 pub type TestResult = Result<(), Box<dyn std::error::Error + 'static>>;
 
@@ -270,7 +270,7 @@ pub fn get_delta_schema_with_nested_struct() -> StructType {
 }
 
 pub async fn setup_table_with_configuration(
-    key: DeltaConfigKey,
+    key: TableProperty,
     value: Option<impl Into<String>>,
 ) -> DeltaTable {
     let table_schema = get_delta_schema();

--- a/crates/core/tests/checkpoint_writer.rs
+++ b/crates/core/tests/checkpoint_writer.rs
@@ -87,7 +87,7 @@ mod delete_expired_delta_log_in_checkpoint {
 
     use ::object_store::path::Path as ObjectStorePath;
     use chrono::Utc;
-    use deltalake_core::table::config::DeltaConfigKey;
+    use deltalake_core::table::config::TableProperty;
     use deltalake_core::*;
     use maplit::hashmap;
 
@@ -96,8 +96,8 @@ mod delete_expired_delta_log_in_checkpoint {
         let mut table = fs_common::create_table(
             "../test/tests/data/checkpoints_with_expired_logs/expired",
             Some(hashmap! {
-                DeltaConfigKey::LogRetentionDuration.as_ref().into() => Some("interval 10 minute".to_string()),
-                DeltaConfigKey::EnableExpiredLogCleanup.as_ref().into() => Some("true".to_string())
+                TableProperty::LogRetentionDuration.as_ref().into() => Some("interval 10 minute".to_string()),
+                TableProperty::EnableExpiredLogCleanup.as_ref().into() => Some("true".to_string())
             }),
         )
         .await;
@@ -160,8 +160,8 @@ mod delete_expired_delta_log_in_checkpoint {
         let mut table = fs_common::create_table(
             "../test/tests/data/checkpoints_with_expired_logs/not_delete_expired",
             Some(hashmap! {
-                DeltaConfigKey::LogRetentionDuration.as_ref().into() => Some("interval 1 second".to_string()),
-                DeltaConfigKey::EnableExpiredLogCleanup.as_ref().into() => Some("false".to_string())
+                TableProperty::LogRetentionDuration.as_ref().into() => Some("interval 1 second".to_string()),
+                TableProperty::EnableExpiredLogCleanup.as_ref().into() => Some("false".to_string())
             }),
         )
         .await;
@@ -208,7 +208,7 @@ mod checkpoints_with_tombstones {
     use ::object_store::path::Path as ObjectStorePath;
     use chrono::Utc;
     use deltalake_core::kernel::*;
-    use deltalake_core::table::config::DeltaConfigKey;
+    use deltalake_core::table::config::TableProperty;
     use deltalake_core::*;
     use maplit::hashmap;
     use parquet::file::reader::{FileReader, SerializedFileReader};
@@ -235,7 +235,7 @@ mod checkpoints_with_tombstones {
     #[ignore]
     async fn test_expired_tombstones() {
         let mut table = fs_common::create_table("../test/tests/data/checkpoints_tombstones/expired", Some(hashmap! {
-            DeltaConfigKey::DeletedFileRetentionDuration.as_ref().into() => Some("interval 1 minute".to_string())
+            TableProperty::DeletedFileRetentionDuration.as_ref().into() => Some("interval 1 minute".to_string())
         })).await;
 
         let a1 = fs_common::add(3 * 60 * 1000); // 3 mins ago,

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake"
-version = "0.19.1"
+version = "0.20.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -16,12 +16,12 @@ rust-version.workspace = true
 features = ["azure", "datafusion", "gcs", "hdfs", "json", "python", "s3", "unity-experimental"]
 
 [dependencies]
-deltalake-core = { version = "0.19.1", path = "../core" }
-deltalake-aws = { version = "0.2.0", path = "../aws", default-features = false, optional = true }
-deltalake-azure = { version = "0.2.0", path = "../azure", optional = true }
-deltalake-gcp = { version = "0.3.0", path = "../gcp", optional = true }
-deltalake-hdfs = { version = "0.3.0", path = "../hdfs", optional = true }
-deltalake-catalog-glue = { version = "0.3.0", path = "../catalog-glue", optional = true }
+deltalake-core = { version = "0.20.0", path = "../core" }
+deltalake-aws = { version = "0.3.0", path = "../aws", default-features = false, optional = true }
+deltalake-azure = { version = "0.3.0", path = "../azure", optional = true }
+deltalake-gcp = { version = "0.4.0", path = "../gcp", optional = true }
+deltalake-hdfs = { version = "0.4.0", path = "../hdfs", optional = true }
+deltalake-catalog-glue = { version = "0.4.0", path = "../catalog-glue", optional = true }
 
 [features]
 # All of these features are just reflected into the core crate until that

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-gcp"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.19.1", path = "../core" }
+deltalake-core = { version = "0.20.0", path = "../core" }
 lazy_static = "1"
 
 # workspace depenndecies

--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-hdfs"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.19.1", path = "../core" }
+deltalake-core = { version = "0.20.0", path = "../core" }
 hdfs-native-object-store = "0.11"
 
 # workspace dependecies

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-mount"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.19.1", path = "../core", features = [
+deltalake-core = { version = "0.20.0", path = "../core", features = [
     "datafusion",
 ] }
 lazy_static = "1"

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "deltalake-test"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 
 [dependencies]
 bytes = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["clock"] }
-deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
+deltalake-core = { version = "0.20.0", path = "../core" }
 dotenvy = "0"
 fs_extra = "1.3.0"
 futures = { version = "0.3" }

--- a/python/deltalake/__init__.py
+++ b/python/deltalake/__init__.py
@@ -1,3 +1,4 @@
+from ._internal import TableFeatures as TableFeatures
 from ._internal import __version__ as __version__
 from ._internal import rust_core_version as rust_core_version
 from .data_catalog import DataCatalog as DataCatalog

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any, Dict, List, Literal, Mapping, Optional, Tuple, Union
 
 import pyarrow
@@ -11,6 +12,34 @@ from deltalake.writer import (
 )
 
 __version__: str
+
+class TableFeatures(Enum):
+    # Mapping of one column to another
+    ColumnMapping = "ColumnMapping"
+    # Deletion vectors for merge, update, delete
+    DeletionVectors = "DeletionVectors"
+    # timestamps without timezone support
+    TimestampWithoutTimezone = "TimestampWithoutTimezone"
+    # version 2 of checkpointing
+    V2Checkpoint = "V2Checkpoint"
+    # Append Only Tables
+    AppendOnly = "AppendOnly"
+    # Table invariants
+    Invariants = "Invariants"
+    # Check constraints on columns
+    CheckConstraints = "CheckConstraints"
+    # CDF on a table
+    ChangeDataFeed = "ChangeDataFeed"
+    # Columns with generated values
+    GeneratedColumns = "GeneratedColumns"
+    # ID Columns
+    IdentityColumns = "IdentityColumns"
+    # Row tracking on tables
+    RowTracking = "RowTracking"
+    # domain specific metadata
+    DomainMetadata = "DomainMetadata"
+    # Iceberg compatibility support
+    IcebergCompatV1 = "IcebergCompatV1"
 
 class RawDeltaTableMetaData:
     id: int
@@ -91,6 +120,13 @@ class RawDeltaTable:
     def add_columns(
         self,
         fields: List[Field],
+        commit_properties: Optional[CommitProperties],
+        post_commithook_properties: Optional[PostCommitHookProperties],
+    ) -> None: ...
+    def add_feature(
+        self,
+        feature: List[TableFeatures],
+        allow_protocol_versions_increase: bool,
         commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
     ) -> None: ...

--- a/python/src/features.rs
+++ b/python/src/features.rs
@@ -1,0 +1,56 @@
+use deltalake::kernel::TableFeatures as KernelTableFeatures;
+use pyo3::pyclass;
+
+/// High level table features
+#[pyclass]
+#[derive(Clone)]
+pub enum TableFeatures {
+    /// Mapping of one column to another
+    ColumnMapping,
+    /// Deletion vectors for merge, update, delete
+    DeletionVectors,
+    /// timestamps without timezone support
+    TimestampWithoutTimezone,
+    /// version 2 of checkpointing
+    V2Checkpoint,
+    /// Append Only Tables
+    AppendOnly,
+    /// Table invariants
+    Invariants,
+    /// Check constraints on columns
+    CheckConstraints,
+    /// CDF on a table
+    ChangeDataFeed,
+    /// Columns with generated values
+    GeneratedColumns,
+    /// ID Columns
+    IdentityColumns,
+    /// Row tracking on tables
+    RowTracking,
+    /// domain specific metadata
+    DomainMetadata,
+    /// Iceberg compatibility support
+    IcebergCompatV1,
+}
+
+impl From<TableFeatures> for KernelTableFeatures {
+    fn from(value: TableFeatures) -> Self {
+        match value {
+            TableFeatures::ColumnMapping => KernelTableFeatures::ColumnMapping,
+            TableFeatures::DeletionVectors => KernelTableFeatures::DeletionVectors,
+            TableFeatures::TimestampWithoutTimezone => {
+                KernelTableFeatures::TimestampWithoutTimezone
+            }
+            TableFeatures::V2Checkpoint => KernelTableFeatures::V2Checkpoint,
+            TableFeatures::AppendOnly => KernelTableFeatures::AppendOnly,
+            TableFeatures::Invariants => KernelTableFeatures::Invariants,
+            TableFeatures::CheckConstraints => KernelTableFeatures::CheckConstraints,
+            TableFeatures::ChangeDataFeed => KernelTableFeatures::ChangeDataFeed,
+            TableFeatures::GeneratedColumns => KernelTableFeatures::GeneratedColumns,
+            TableFeatures::IdentityColumns => KernelTableFeatures::IdentityColumns,
+            TableFeatures::RowTracking => KernelTableFeatures::RowTracking,
+            TableFeatures::DomainMetadata => KernelTableFeatures::DomainMetadata,
+            TableFeatures::IcebergCompatV1 => KernelTableFeatures::IcebergCompatV1,
+        }
+    }
+}

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -229,6 +229,13 @@ def sample_table():
 
 
 @pytest.fixture()
+def existing_sample_table(tmp_path: pathlib.Path, sample_table: pa.Table):
+    path = str(tmp_path)
+    write_deltalake(path, sample_table)
+    return DeltaTable(path)
+
+
+@pytest.fixture()
 def sample_table_with_spaces_numbers():
     nrows = 5
     return pa.table(

--- a/python/tests/test_alter.py
+++ b/python/tests/test_alter.py
@@ -4,7 +4,7 @@ from typing import List
 import pyarrow as pa
 import pytest
 
-from deltalake import DeltaTable, write_deltalake
+from deltalake import DeltaTable, TableFeatures, write_deltalake
 from deltalake.exceptions import DeltaError, DeltaProtocolError
 from deltalake.schema import Field, PrimitiveType, StructType
 from deltalake.table import CommitProperties
@@ -375,3 +375,85 @@ def test_add_timestamp_ntz_column(tmp_path: pathlib.Path, sample_table: pa.Table
     assert new_protocol.min_writer_version == 7
     assert new_protocol.reader_features == ["timestampNtz"]
     assert new_protocol.writer_features == ["timestampNtz"]
+
+
+features = [
+    TableFeatures.ChangeDataFeed,
+    TableFeatures.DeletionVectors,
+    TableFeatures.ColumnMapping,
+    TableFeatures.TimestampWithoutTimezone,
+    TableFeatures.V2Checkpoint,
+    TableFeatures.AppendOnly,
+    TableFeatures.AppendOnly,
+    TableFeatures.Invariants,
+    TableFeatures.CheckConstraints,
+    TableFeatures.GeneratedColumns,
+    TableFeatures.IdentityColumns,
+    TableFeatures.RowTracking,
+    TableFeatures.DomainMetadata,
+    TableFeatures.IcebergCompatV1,
+]
+
+all_features = []
+all_features.extend(features)
+all_features.append(features)
+
+
+@pytest.mark.parametrize("feature", all_features)
+def test_add_feature_variations(existing_table: DeltaTable, feature):
+    """Existing table already has timestampNtz so it's already at v3,7"""
+    existing_table.alter.add_feature(
+        feature=feature,
+        allow_protocol_versions_increase=False,
+    )
+    last_action = existing_table.history(1)[0]
+    assert last_action["operation"] == "ADD FEATURE"
+    assert existing_table.version() == 1
+
+
+def test_add_features_disallowed_protocol_increase(existing_sample_table: DeltaTable):
+    with pytest.raises(
+        DeltaError,
+        match="Generic DeltaTable error: Table feature enables writer feature, but min_writer is not v7. Set allow_protocol_versions_increase or increase version explicitly through set_tbl_properties",
+    ):
+        existing_sample_table.alter.add_feature(
+            feature=TableFeatures.ChangeDataFeed,
+            allow_protocol_versions_increase=False,
+        )
+    with pytest.raises(
+        DeltaError,
+        match="Generic DeltaTable error: Table feature enables reader and writer feature, but reader is not v3, and writer not v7. Set allow_protocol_versions_increase or increase versions explicitly through set_tbl_properties",
+    ):
+        existing_sample_table.alter.add_feature(
+            feature=TableFeatures.DeletionVectors,
+            allow_protocol_versions_increase=False,
+        )
+
+
+def test_add_feautres(existing_sample_table: DeltaTable):
+    existing_sample_table.alter.add_feature(
+        feature=features,
+        allow_protocol_versions_increase=True,
+    )
+    protocol = existing_sample_table.protocol()
+
+    assert sorted(protocol.reader_features) == sorted(  # type: ignore
+        ["v2Checkpoint", "columnMapping", "deletionVectors", "timestampNtz"]
+    )
+    assert sorted(protocol.writer_features) == sorted(  # type: ignore
+        [
+            "appendOnly",
+            "changeDataFeed",
+            "checkConstraints",
+            "columnMapping",
+            "deletionVectors",
+            "domainMetadata",
+            "generatedColumns",
+            "icebergCompatV1",
+            "identityColumns",
+            "invariants",
+            "rowTracking",
+            "timestampNtz",
+            "v2Checkpoint",
+        ]
+    )  # type: ignore


### PR DESCRIPTION
# Description
Adds a new TableFeatures enum, that is a collection of all table features irrespective of reader/writer variant. Users simply select a feature they want, and we handle whether it needs to be added in readerFeatures or writerFeatures.

TableFeatures enum is exposed to python as well.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
