### PR TITLE
fix(python, rust): use input schema to get correct schema in cdf reads

### DIFF
--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -230,11 +230,11 @@ impl CdfLoadBuilder {
         );
 
         let partition_values = self.snapshot.metadata().partition_columns.clone();
-        let schema = self.snapshot.arrow_schema()?;
+        let schema = self.snapshot.input_schema()?;
         let schema_fields: Vec<Field> = self
             .snapshot
-            .arrow_schema()?
-            .all_fields()
+            .input_schema()?
+            .flattened_fields()
             .into_iter()
             .filter(|f| !partition_values.contains(f.name()))
             .cloned()


### PR DESCRIPTION
# Description
The arrow schema method wraps partition values, but these then incorrectly get read as Categorical/Dictionary values. Using the input schema fixes this.