### PR TITLE
fix: schema adapter doesn't map partial batches correctly

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -2280,7 +2280,10 @@ mod tests {
         let ctx = SessionContext::new_with_config(cfg);
         ctx.register_table("test", Arc::new(provider)).unwrap();
 
-        let df = ctx.sql("select col_1, col_2 from test WHERE col_1 = 'A'").await.unwrap();
+        let df = ctx
+            .sql("select col_1, col_2 from test WHERE col_1 = 'A'")
+            .await
+            .unwrap();
         let actual = df.collect().await.unwrap();
         let expected = vec![
             "+-------+-------+",

--- a/crates/core/src/delta_datafusion/schema_adapter.rs
+++ b/crates/core/src/delta_datafusion/schema_adapter.rs
@@ -62,7 +62,19 @@ impl SchemaMapper for SchemaMapping {
     }
 
     fn map_partial_batch(&self, batch: RecordBatch) -> datafusion_common::Result<RecordBatch> {
-        let record_batch = cast_record_batch(&batch, self.table_schema.clone(), false, true)?;
+        let partial_table_schema = Arc::new(Schema::new(
+            batch
+                .schema()
+                .fields()
+                .iter()
+                .filter_map(|batch_field| {
+                    self.table_schema.field_with_name(batch_field.name()).ok()
+                })
+                .cloned()
+                .collect::<Vec<_>>(),
+        ));
+
+        let record_batch = cast_record_batch(&batch, partial_table_schema, false, true)?;
         Ok(record_batch)
     }
 }


### PR DESCRIPTION
# Description
When pushdown_filters on DataFusion SessionConfig is enabled for Parquet, map_partial_batch on the schema adapter is called with a batch that is evaluating the RowFilter created by pushdown_filters. The batch only contains the column(s) in the predicate for the RowFilter. If table_schema contains not null column then the cast will fail.

Example error:
```
thread 'delta_datafusion::tests::delta_scan_supports_pushdown' panicked at crates/core/src/delta_datafusion/mod.rs:2284:41:
called `Result::unwrap()` on an `Err` value: ArrowError(ExternalError(External(SchemaError("Could not find column col_2"))), None)
```

This change only uses from table_schema the columns that exist in the batch.

See https://docs.rs/datafusion/latest/datafusion/datasource/schema_adapter/trait.SchemaMapper.html#tymethod.map_partial_batch

# Related Issue(s)

# Documentation
