### PR TITLE
fix: column parsing to include nested columns and enclosing char

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -94,13 +94,13 @@ tracing = { workspace = true }
 rand = "0.8"
 z85 = "3.0.5"
 maplit = "1"
+sqlparser = { version = "0.49" }
 
 # Unity
 reqwest = { version = "0.11.18", default-features = false, features = [
     "rustls-tls",
     "json",
 ], optional = true }
-sqlparser = { version = "0.49", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
@@ -130,7 +130,6 @@ datafusion = [
     "datafusion-sql",
     "datafusion-functions",
     "datafusion-functions-aggregate",
-    "sqlparser",
 ]
 datafusion-ext = ["datafusion"]
 json = ["parquet/json"]


### PR DESCRIPTION
# Description
Added column parsing to include nested columns and `` enclosing to adopt 0.18.x

# Addressing issue
#2572  
https://github.com/delta-io/delta/blob/4b102d34a2ce881b2a851b4c6cfbf2ab3ab5534f/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala#L549-L561

# Changes:
## Added:
_extract_enclosed_string_ - is a utility function to remove enclosing characters from a string.
_get_stats_field_ - is a function to retrieve a field from a schema, handling nested field names and removing enclosing backticks.