### PR TITLE
docs: fix broken link in docs

### DIFF
--- a/docs/usage/loading-table.md
+++ b/docs/usage/loading-table.md
@@ -143,4 +143,4 @@ version number or datetime string:
 
     Previous table versions may not exist if they have been vacuumed, in
     which case an exception will be thrown. See [Vacuuming
-    tables](#vacuuming-tables) for more information.
+    tables](managing-tables.md#vacuuming-tables) for more information.


### PR DESCRIPTION
Vacuuming tables section has moved.

Offending page: https://delta-io.github.io/delta-rs/usage/loading-table/#time-travel
Target page: https://delta-io.github.io/delta-rs/usage/managing-tables/#vacuuming-tables