### PR TITLE
fix(python, rust): cdc in writer not creating inserts

### DIFF
--- a/crates/core/src/delta_datafusion/cdf/scan_utils.rs
+++ b/crates/core/src/delta_datafusion/cdf/scan_utils.rs
@@ -18,9 +18,9 @@ pub fn map_action_to_scalar<F: FileAction>(
     action: &F,
     part: &str,
     schema: SchemaRef,
-) -> ScalarValue {
-    action
-        .partition_values()
+) -> DeltaResult<ScalarValue> {
+    Ok(action
+        .partition_values()?
         .get(part)
         .map(|val| {
             schema
@@ -36,7 +36,7 @@ pub fn map_action_to_scalar<F: FileAction>(
                 })
                 .unwrap_or(ScalarValue::Null)
         })
-        .unwrap_or(ScalarValue::Null)
+        .unwrap_or(ScalarValue::Null))
 }
 
 pub fn create_spec_partition_values<F: FileAction>(
@@ -67,7 +67,7 @@ pub fn create_partition_values<F: FileAction>(
             let partition_values = table_partition_cols
                 .iter()
                 .map(|part| map_action_to_scalar(&action, part, schema.clone()))
-                .collect::<Vec<ScalarValue>>();
+                .collect::<DeltaResult<Vec<ScalarValue>>>()?;
 
             let mut new_part_values = spec_partition_values.clone();
             new_part_values.extend(partition_values);
@@ -75,7 +75,7 @@ pub fn create_partition_values<F: FileAction>(
             let part = PartitionedFile {
                 object_meta: ObjectMeta {
                     location: Path::parse(action.path().as_str())?,
-                    size: action.size(),
+                    size: action.size()?,
                     e_tag: None,
                     last_modified: chrono::Utc.timestamp_nanos(0),
                     version: None,

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1247,7 +1247,7 @@ impl RawDeltaTable {
 
         Ok(actions
             .iter()
-            .map(|action| (action.path(), action.size() as i64))
+            .map(|action| (action.path(), action.size))
             .collect::<HashMap<String, i64>>())
     }
     /// Run the delete command on the delta table: delete records following a predicate and return the delete metrics.


### PR DESCRIPTION
# Description
Improved logic
- If it's partition scan, we don't write CDC actions and data. CDF reader will use remove actions in this case now to know what's deleted or not
- When the predicate doesn't hit a partition, we also write CDC data for the inserts

# Related Issue(s)
- closes https://github.com/delta-io/delta-rs/issues/2750
