### PR TITLE
feat: fail fast on forked process

### DIFF
--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -15,9 +15,10 @@ pub fn rt() -> &'static Runtime {
         Some(pid) if pid == &std::process::id() => {} // Reuse the static runtime.
         Some(pid) => {
             panic!(
-                "Forked process detected - current PID is {} but the tokio runtime was by {}. The tokio runtime 
-                does not support forked processes https://github.com/tokio-rs/tokio/issues/4301. If you are seeing this 
-                message while using Python multithreading make sure to use the `spawn` or `forkserver` mode.", 
+                "Forked process detected - current PID is {} but the tokio runtime was created by {}. The tokio \
+                runtime does not support forked processes https://github.com/tokio-rs/tokio/issues/4301. If you are \
+                seeing this message while using Python multithreading make sure to use the `spawn` or `forkserver` \
+                mode.", 
                 pid, std::process::id()
             );
         }

--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -10,6 +10,22 @@ use tokio::runtime::Runtime;
 #[inline]
 pub fn rt() -> &'static Runtime {
     static TOKIO_RT: OnceLock<Runtime> = OnceLock::new();
+    static PID: OnceLock<u32> = OnceLock::new();
+    match PID.get() {
+        Some(pid) if pid == &std::process::id() => {} // Reuse the static runtime.
+        Some(pid) => {
+            panic!(
+                "Forked process detected - current PID is {} but the tokio runtime was by {}. The tokio runtime 
+                does not support forked processes https://github.com/tokio-rs/tokio/issues/4301. If you are seeing this 
+                message while using Python multithreading make sure to use the `spawn` or `forkserver` mode.", 
+                pid, std::process::id()
+            );
+        }
+        None => {
+            PID.set(std::process::id())
+                .expect("Failed to record PID for tokio runtime.");
+        }
+    }
     TOKIO_RT.get_or_init(|| Runtime::new().expect("Failed to create a tokio runtime."))
 }
 


### PR DESCRIPTION
# Description
The tokio runtime does not support forked processes, so fail fast if we detect this scenario

- Avoids difficult to debug deadlocks
- Using the deltalake python bindings with `multiprocessing` can easily run into this problem because the default `multiprocessing` start method is `fork` on linux systems

# Related Issue(s)
- closes #2744

# Documentation

<!---
Share links to useful documentation
--->
