### PR TITLE
chore: prepare the next notable release of 0.19.0

### DIFF
--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-aws"
-version = "0.1.2"
+version = "0.1.4"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core" }
+deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
 aws-smithy-runtime-api = { version="1.1.7" }
 aws-smithy-runtime = { version="1.1.7", optional = true}
 aws-credential-types = { version="1.1.7", features = ["hardcoded-credentials"]}

--- a/crates/azure/Cargo.toml
+++ b/crates/azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-azure"
-version = "0.1.3"
+version = "0.1.4"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core" }
+deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
 lazy_static = "1"
 
 # workspace depenndecies

--- a/crates/catalog-glue/Cargo.toml
+++ b/crates/catalog-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-catalog-glue"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -15,7 +15,7 @@ rust-version.workspace = true
 async-trait = { workspace = true }
 aws-config = "1"
 aws-sdk-glue = "1"
-deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core" }
+deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
 # This can depend on a lowest common denominator of core once that's released
 # deltalake_core = { version = "0.17.0" }
 thiserror = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-core"
-version = "0.18.3"
+version = "0.19.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake"
-version = "0.18.3"
+version = "0.19.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -16,12 +16,12 @@ rust-version.workspace = true
 features = ["azure", "datafusion", "gcs", "hdfs", "json", "python", "s3", "unity-experimental"]
 
 [dependencies]
-deltalake-core = { version = "~0.18.0", path = "../core" }
-deltalake-aws = { version = "0.1.1", path = "../aws", default-features = false, optional = true }
-deltalake-azure = { version = "0.1.1", path = "../azure", optional = true }
-deltalake-gcp = { version = "0.2.1", path = "../gcp", optional = true }
-deltalake-hdfs = { version = "0.1.0", path = "../hdfs", optional = true }
-deltalake-catalog-glue = { version = "0.1.0", path = "../catalog-glue", optional = true }
+deltalake-core = { version = "0.19.0", path = "../core" }
+deltalake-aws = { version = "0.1.4", path = "../aws", default-features = false, optional = true }
+deltalake-azure = { version = "0.1.4", path = "../azure", optional = true }
+deltalake-gcp = { version = "0.2.2", path = "../gcp", optional = true }
+deltalake-hdfs = { version = "0.2.0", path = "../hdfs", optional = true }
+deltalake-catalog-glue = { version = "0.2.0", path = "../catalog-glue", optional = true }
 
 [features]
 # All of these features are just reflected into the core crate until that

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-gcp"
-version = "0.2.2"
+version = "0.2.3"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core" }
+deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
 lazy_static = "1"
 
 # workspace depenndecies

--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-hdfs"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core" }
+deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
 hdfs-native-object-store = "0.11"
 
 # workspace dependecies

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-mount"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core", features = [
+deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core", features = [
     "datafusion",
 ] }
 lazy_static = "1"

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "deltalake-test"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 
 [dependencies]
 bytes = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["clock"] }
-deltalake-core = { version = ">=0.17.0, <0.19.0", path = "../core" }
+deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
 dotenvy = "0"
 fs_extra = "1.3.0"
 futures = { version = "0.3" }

--- a/dev/publish.sh
+++ b/dev/publish.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -xe
+
+for crate in "mount" "catalog-glue" "hdfs" "azure" "aws" "gcp" "core" "deltalake"; do
+        echo ">> Dry-run publishing ${crate}"
+        (cd crates/${crate} && \
+                cargo publish \
+                        --allow-dirty \
+                        --dry-run)
+done;


### PR DESCRIPTION
To the best of my knowledge and testing ( :laughing: ) the version ranges on subcrates should be fine since we did not incorporate any major API changes since the 0.18.x line.

This also includes a little script to help me release these things in the right order :tada:
