### PR TITLE
chore: remove some `file_actions` call sites

### DIFF
--- a/crates/core/src/operations/filesystem_check.rs
+++ b/crates/core/src/operations/filesystem_check.rs
@@ -100,7 +100,7 @@ impl FileSystemCheckBuilder {
 
     async fn create_fsck_plan(&self) -> DeltaResult<FileSystemCheckPlan> {
         let mut files_relative: HashMap<String, Add> =
-            HashMap::with_capacity(self.snapshot.file_actions()?.len());
+            HashMap::with_capacity(self.snapshot.files_count());
         let log_store = self.log_store.clone();
 
         for active in self.snapshot.file_actions_iter()? {

--- a/crates/core/src/operations/transaction/state.rs
+++ b/crates/core/src/operations/transaction/state.rs
@@ -256,7 +256,7 @@ mod tests {
     use datafusion_expr::{col, lit};
 
     use super::*;
-    use crate::delta_datafusion::{DataFusionFileMixins, DataFusionMixins};
+    use crate::delta_datafusion::{files_matching_predicate, DataFusionMixins};
     use crate::kernel::Action;
     use crate::test_utils::{ActionFactory, TestSchemas};
 
@@ -318,9 +318,7 @@ mod tests {
         )));
 
         let state = DeltaTableState::from_actions(actions).unwrap();
-        let files = state
-            .snapshot
-            .files_matching_predicate(&[])
+        let files = files_matching_predicate(&state.snapshot, &[])
             .unwrap()
             .collect::<Vec<_>>();
         assert_eq!(files.len(), 3);
@@ -329,9 +327,7 @@ mod tests {
             .gt(lit::<i32>(10))
             .or(col("value").lt_eq(lit::<i32>(0)));
 
-        let files = state
-            .snapshot
-            .files_matching_predicate(&[predictate])
+        let files = files_matching_predicate(&state.snapshot, &[predictate])
             .unwrap()
             .collect::<Vec<_>>();
         assert_eq!(files.len(), 2);

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -59,7 +59,7 @@ enum CheckpointError {
         source: ArrowError,
     },
 
-    #[error("missing rewquired action type in snapshot: {0}")]
+    #[error("missing required action type in snapshot: {0}")]
     MissingActionType(String),
 }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1238,16 +1238,13 @@ impl RawDeltaTable {
     }
 
     pub fn get_add_file_sizes(&self) -> PyResult<HashMap<String, i64>> {
-        let actions = self
+        Ok(self
             ._table
             .snapshot()
             .map_err(PythonError::from)?
-            .file_actions()
-            .map_err(PythonError::from)?;
-
-        Ok(actions
-            .iter()
-            .map(|action| (action.path(), action.size))
+            .eager_snapshot()
+            .files()
+            .map(|f| (f.path().to_string(), f.size()))
             .collect::<HashMap<String, i64>>())
     }
     /// Run the delete command on the delta table: delete records following a predicate and return the delete metrics.


### PR DESCRIPTION
# Description

The `file_actions` method on our various state representations is quite inefficient, since it does some often unnecessary work converting out internal arrow state to the `Add` action representation. This PR removes some of the easy to remove call sites and does some drive by cleanup on the way.

All this is in preparation for some bigger work refactoring our checkpoint writing and generally fully embracing the arrow state.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
