### PR TITLE
fix: enable feature flags to which deltalake-core build tokio with enable_io

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -66,8 +66,10 @@ futures = { workspace = true }
 num_cpus = { workspace = true }
 tokio = { workspace = true, features = [
     "macros",
+    "process",
     "rt",
     "rt-multi-thread",
+    "signal",
     "sync",
     "fs",
     "parking_lot",


### PR DESCRIPTION
`cargo build` just in core was broken previously. When building at the root of the project this did not fail because some combination of feature flags for tokio were being used during that `cargo` run
