### PR TITLE
test(python): fix optimize call in benchmark

### DIFF
--- a/python/tests/test_benchmark.py
+++ b/python/tests/test_benchmark.py
@@ -95,7 +95,7 @@ def test_benchmark_optimize(benchmark, sample_table, tmp_path, max_tasks):
         return (dt,), dict(max_concurrent_tasks=max_tasks)
 
     def func(dt, max_concurrent_tasks):
-        return dt.optimize(
+        return dt.optimize.compact(
             max_concurrent_tasks=max_concurrent_tasks, target_size=1024 * 1024 * 1024
         )
 


### PR DESCRIPTION
# Description
Benchmark was still using the old optimize syntax which got removed a couple commits ago :)
