### PR TITLE
feat: public method to get partitions for DeltaTable (#2671)

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -514,25 +514,19 @@ class DeltaTable:
     def partitions(
         self,
         partition_filters: Optional[List[Tuple[str, str, Any]]] = None,
-        as_tuple_list: bool = False,
-    ) -> List[Dict[str, str]] | List[Tuple[str]]:
+    ) -> List[Dict[str, str]]:
         """
         Returns the partitions as a list of dicts. Example: `[{'month': '1', 'year': '2020', 'day': '1'}, ...]`
 
         Args:
             partition_filters: The partition filters that will be used for getting the matched partitions, defaults to `None` (no filtering).
-            as_tuple_list: If `True`, returns the partitions as a list of tuples. Example: `[(("day", "5"), ("month", "4"), ("year", "2021")), ...]`
         """
 
-        partitions: List[Any] = []
+        partitions: List[Dict[str, str]] = []
         for partition in self._table.get_active_partitions(partition_filters):
             if not partition:
                 continue
-            if as_tuple_list:
-                sorted_partition = sorted(partition, key=lambda x: x[0])
-                partitions.append(tuple(sorted_partition))
-            else:
-                partitions.append({k: v for (k, v) in partition})
+            partitions.append({k: v for (k, v) in partition})
         return partitions
 
     def files(

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -511,6 +511,30 @@ class DeltaTable:
         """
         return self._table.version()
 
+    def partitions(
+        self,
+        partition_filters: Optional[List[Tuple[str, str, Any]]] = None,
+        as_tuple_list: bool = False,
+    ) -> List[Dict[str, str]] | List[Tuple[str]]:
+        """
+        Returns the partitions as a list of dicts. Example: `[{'month': '1', 'year': '2020', 'day': '1'}, ...]`
+
+        Args:
+            partition_filters: The partition filters that will be used for getting the matched partitions, defaults to `None` (no filtering).
+            as_tuple_list: If `True`, returns the partitions as a list of tuples. Example: `[(("day", "5"), ("month", "4"), ("year", "2021")), ...]`
+        """
+
+        partitions: List[Any] = []
+        for partition in self._table.get_active_partitions(partition_filters):
+            if not partition:
+                continue
+            if as_tuple_list:
+                sorted_partition = sorted(tuple(partition), key=lambda x: x[0])
+                partitions.append(tuple(sorted_partition))
+            else:
+                partitions.append({k: v for (k, v) in partition})
+        return partitions
+
     def files(
         self, partition_filters: Optional[List[Tuple[str, str, Any]]] = None
     ) -> List[str]:

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -529,7 +529,7 @@ class DeltaTable:
             if not partition:
                 continue
             if as_tuple_list:
-                sorted_partition = sorted(tuple(partition), key=lambda x: x[0])
+                sorted_partition = sorted(partition, key=lambda x: x[0])
                 partitions.append(tuple(sorted_partition))
             else:
                 partitions.append({k: v for (k, v) in partition})

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from datetime import date, datetime, timezone
 from pathlib import Path
 from random import random
@@ -869,6 +870,35 @@ def test_partitions_filtering_partitioned_table():
     assert len(expected) == len(actual)
     for partition in expected:
         partition in actual
+
+
+def test_partitions_date_partitioned_table():
+    table_path = tempfile.gettempdir() + "/date_partition_table"
+    date_partitions = [
+        date(2024, 8, 1),
+        date(2024, 8, 2),
+        date(2024, 8, 3),
+        date(2024, 8, 4),
+    ]
+    sample_data = pa.table(
+        {
+            "date_field": pa.array(date_partitions, pa.date32()),
+            "numeric_data": pa.array([1, 2, 3, 4], pa.int64()),
+        }
+    )
+    write_deltalake(
+        table_path, sample_data, mode="overwrite", partition_by=["date_field"]
+    )
+
+    delta_table = DeltaTable(table_path)
+    expected = [
+        {"date_field": "2024-08-01"},
+        {"date_field": "2024-08-02"},
+        {"date_field": "2024-08-03"},
+        {"date_field": "2024-08-04"},
+    ]
+    actual = sorted(delta_table.partitions(), key=lambda x: x["date_field"])
+    assert expected == actual
 
 
 def test_partitions_special_partitioned_table():

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -855,33 +855,17 @@ def test_partitions_partitioned_table():
         assert partition in actual
 
 
-def test_partitions_tuples_partitioned_table():
-    table_path = "../crates/test/tests/data/delta-0.8.0-partitioned"
-    dt = DeltaTable(table_path)
-    expected = [
-        (("day", "5"), ("month", "2"), ("year", "2020")),
-        (("day", "1"), ("month", "1"), ("year", "2020")),
-        (("day", "5"), ("month", "4"), ("year", "2021")),
-        (("day", "3"), ("month", "2"), ("year", "2020")),
-        (("day", "20"), ("month", "12"), ("year", "2021")),
-        (("day", "4"), ("month", "12"), ("year", "2021")),
-    ]
-    actual = dt.partitions(as_tuple_list=True)
-    assert len(expected) == len(actual)
-    for partition in expected:
-        partition in actual
-
-
 def test_partitions_filtering_partitioned_table():
     table_path = "../crates/test/tests/data/delta-0.8.0-partitioned"
     dt = DeltaTable(table_path)
     expected = [
-        (("day", "5"), ("month", "4"), ("year", "2021")),
-        (("day", "20"), ("month", "12"), ("year", "2021")),
-        (("day", "4"), ("month", "12"), ("year", "2021")),
+        {"day": "5", "month": "4", "year": "2021"},
+        {"day": "20", "month": "12", "year": "2021"},
+        {"day": "4", "month": "12", "year": "2021"},
     ]
+
     partition_filters = [("year", ">=", "2021")]
-    actual = dt.partitions(partition_filters=partition_filters, as_tuple_list=True)
+    actual = dt.partitions(partition_filters=partition_filters)
     assert len(expected) == len(actual)
     for partition in expected:
         partition in actual
@@ -891,18 +875,10 @@ def test_partitions_special_partitioned_table():
     table_path = "../crates/test/tests/data/delta-0.8.0-special-partition"
     dt = DeltaTable(table_path)
 
-    # Partitions as list of dicts (default).
-    expected_dict = [{"x": "A/A"}, {"x": "B B"}]
-    actual_dict = dt.partitions()
-    for partition in expected_dict:
-        partition in actual_dict
-
-    # Partitions as list of tuples.
-    expected_tuple = [[("x", "B B")], [("x", "A/A")]]
-    actual_tuple = dt.partitions(as_tuple_list=True)
-    assert len(expected_tuple) == len(actual_tuple)
-    for partition in expected_tuple:
-        partition in actual_tuple
+    expected = [{"x": "A/A"}, {"x": "B B"}]
+    actual = dt.partitions()
+    for partition in expected:
+        partition in actual
 
 
 def test_partitions_unpartitioned_table():


### PR DESCRIPTION
# Description
This adds a public method `partitions()` to the `DeltaTable` class to get properly formatted partitions (list of dicts) for the table. Also provides an option to return partitions as a list of tuples, and proxies the partition filters to rust `get_active_partitions()`.

This also adds supporting tests for this feature.

# Related Issue(s)
<!---
For example:

- closes #106
--->

- closes #2671

# Documentation

<!---
Share links to useful documentation
--->
Documentation included in method's docstring.