### PR TITLE
docs: fix docstring of set_table_properties

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1903,7 +1903,7 @@ class TableAlterer:
         custom_metadata: Optional[Dict[str, str]] = None,
     ) -> None:
         """
-        Unset properties from the table.
+        Set properties from the table.
 
         Args:
             properties: properties which set

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1904,11 +1904,26 @@ class TableAlterer:
     ) -> None:
         """
         Unset properties from the table.
+
         Args:
             properties: properties which set
             raise_if_not_exists: set if should raise if not exists.
             custom_metadata: custom metadata that will be added to the transaction commit.
+
         Example:
+            ```python
+            from deltalake import write_deltalake, DeltaTable
+            import pandas as pd
+            df = pd.DataFrame(
+                {"id": ["1", "2", "3"],
+                "deleted": [False, False, False],
+                "price": [10., 15., 20.]
+                })
+            write_deltalake("tmp", df)
+
+            dt = DeltaTable("tmp")
+            dt.alter.set_table_properties({"delta.enableChangeDataFeed": "true"})
+            ```
         """
         self.table._table.set_table_properties(
             properties, raise_if_not_exists, custom_metadata


### PR DESCRIPTION
# Description
The docstring wasn't rendering properly, see https://delta-io.github.io/delta-rs/api/delta_table/delta_table_alterer/#deltalake.table.TableAlterer.set_table_properties, so I _think_ I fixed the syntax (I haven't tested it locally, does the CI build the docs?) and I also added an example (mostly taken from another docstring + https://github.com/delta-io/delta-rs/blob/fcd62ab10be9545eab296f03ae0e4324fc4be6cb/python/tests/test_alter.py#L184-L189)

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
