### PR TITLE
chore: set max_retries in CommitProperties

### DIFF
--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -346,6 +346,15 @@ impl CommitProperties {
         self
     }
 
+    /// Specify maximum number of times to retry the transaction before failing to commit
+    pub fn with_max_retries(
+        mut self,
+        max_retries: usize,
+    ) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
     /// Specify if it should create a checkpoint when the commit interval condition is met
     pub fn with_create_checkpoint(mut self, create_checkpoint: bool) -> Self {
         self.create_checkpoint = create_checkpoint;

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -347,10 +347,7 @@ impl CommitProperties {
     }
 
     /// Specify maximum number of times to retry the transaction before failing to commit
-    pub fn with_max_retries(
-        mut self,
-        max_retries: usize,
-    ) -> Self {
+    pub fn with_max_retries(mut self, max_retries: usize) -> Self {
         self.max_retries = max_retries;
         self
     }

--- a/python/deltalake/__init__.py
+++ b/python/deltalake/__init__.py
@@ -10,6 +10,7 @@ from .table import (
 from .table import (
     ColumnProperties as ColumnProperties,
 )
+from .table import CommitProperties as CommitProperties
 from .table import DeltaTable as DeltaTable
 from .table import Metadata as Metadata
 from .table import PostCommitHookProperties as PostCommitHookProperties

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -3,7 +3,12 @@ from typing import Any, Dict, List, Literal, Mapping, Optional, Tuple, Union
 import pyarrow
 import pyarrow.fs as fs
 
-from deltalake.writer import AddAction, PostCommitHookProperties, WriterProperties
+from deltalake.writer import (
+    AddAction,
+    CommitProperties,
+    PostCommitHookProperties,
+    WriterProperties,
+)
 
 __version__: str
 
@@ -57,9 +62,8 @@ class RawDeltaTable:
         dry_run: bool,
         retention_hours: Optional[int],
         enforce_retention_duration: bool,
-        custom_metadata: Optional[Dict[str, str]],
+        commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
-        max_commit_retries: Optional[int],
     ) -> List[str]: ...
     def compact_optimize(
         self,
@@ -68,9 +72,8 @@ class RawDeltaTable:
         max_concurrent_tasks: Optional[int],
         min_commit_interval: Optional[int],
         writer_properties: Optional[WriterProperties],
-        custom_metadata: Optional[Dict[str, str]],
+        commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
-        max_commit_retries: Optional[int],
     ) -> str: ...
     def z_order_optimize(
         self,
@@ -81,46 +84,40 @@ class RawDeltaTable:
         max_spill_size: Optional[int],
         min_commit_interval: Optional[int],
         writer_properties: Optional[WriterProperties],
-        custom_metadata: Optional[Dict[str, str]],
+        commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
-        max_commit_retries: Optional[int],
     ) -> str: ...
     def add_columns(
         self,
         fields: List[Field],
-        custom_metadata: Optional[Dict[str, str]],
+        commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
-        max_commit_retries: Optional[int],
     ) -> None: ...
     def add_constraints(
         self,
         constraints: Dict[str, str],
-        custom_metadata: Optional[Dict[str, str]],
+        commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
-        max_commit_retries: Optional[int],
     ) -> None: ...
     def drop_constraints(
         self,
         name: str,
         raise_if_not_exists: bool,
-        custom_metadata: Optional[Dict[str, str]],
+        commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
-        max_commit_retries: Optional[int],
     ) -> None: ...
     def set_table_properties(
         self,
         properties: Dict[str, str],
         raise_if_not_exists: bool,
-        custom_metadata: Optional[Dict[str, str]],
-        max_commit_retries: Optional[int],
+        commit_properties: Optional[CommitProperties],
     ) -> None: ...
     def restore(
         self,
         target: Optional[Any],
         ignore_missing_files: bool,
         protocol_downgrade_allowed: bool,
-        custom_metadata: Optional[Dict[str, str]],
-        max_commit_retries: Optional[int],
+        commit_properties: Optional[CommitProperties],
     ) -> str: ...
     def history(self, limit: Optional[int]) -> List[str]: ...
     def update_incremental(self) -> None: ...
@@ -133,16 +130,14 @@ class RawDeltaTable:
         self,
         predicate: Optional[str],
         writer_properties: Optional[WriterProperties],
-        custom_metadata: Optional[Dict[str, str]],
+        commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
-        max_commit_retries: Optional[int],
     ) -> str: ...
     def repair(
         self,
         dry_run: bool,
-        custom_metadata: Optional[Dict[str, str]],
+        commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
-        max_commit_retries: Optional[int],
     ) -> str: ...
     def update(
         self,
@@ -150,9 +145,8 @@ class RawDeltaTable:
         predicate: Optional[str],
         writer_properties: Optional[WriterProperties],
         safe_cast: bool,
-        custom_metadata: Optional[Dict[str, str]],
+        commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
-        max_commit_retries: Optional[int],
     ) -> str: ...
     def create_merge_builder(
         self,
@@ -161,10 +155,9 @@ class RawDeltaTable:
         source_alias: Optional[str],
         target_alias: Optional[str],
         writer_properties: Optional[WriterProperties],
-        custom_metadata: Optional[Dict[str, str]],
+        commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
         safe_cast: bool,
-        max_commit_retries: Optional[int],
     ) -> PyMergeBuilder: ...
     def merge_execute(self, merge_builder: PyMergeBuilder) -> str: ...
     def get_active_partitions(
@@ -177,9 +170,8 @@ class RawDeltaTable:
         partition_by: List[str],
         schema: pyarrow.Schema,
         partitions_filters: Optional[FilterType],
-        custom_metadata: Optional[Dict[str, str]],
+        commit_properties: Optional[CommitProperties],
         post_commithook_properties: Optional[PostCommitHookProperties],
-        max_commit_retries: Optional[int],
     ) -> None: ...
     def cleanup_metadata(self) -> None: ...
     def check_can_write_timestamp_ntz(self, schema: pyarrow.Schema) -> None: ...
@@ -219,9 +211,8 @@ def write_to_deltalake(
     configuration: Optional[Mapping[str, Optional[str]]],
     storage_options: Optional[Dict[str, str]],
     writer_properties: Optional[WriterProperties],
-    custom_metadata: Optional[Dict[str, str]],
+    commit_properties: Optional[CommitProperties],
     post_commithook_properties: Optional[PostCommitHookProperties],
-    max_commit_retries: Optional[int],
 ) -> None: ...
 def convert_to_deltalake(
     uri: str,

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -59,6 +59,7 @@ class RawDeltaTable:
         enforce_retention_duration: bool,
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[PostCommitHookProperties],
+        max_commit_retries: Optional[int],
     ) -> List[str]: ...
     def compact_optimize(
         self,
@@ -69,6 +70,7 @@ class RawDeltaTable:
         writer_properties: Optional[WriterProperties],
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[PostCommitHookProperties],
+        max_commit_retries: Optional[int],
     ) -> str: ...
     def z_order_optimize(
         self,
@@ -81,18 +83,21 @@ class RawDeltaTable:
         writer_properties: Optional[WriterProperties],
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[PostCommitHookProperties],
+        max_commit_retries: Optional[int],
     ) -> str: ...
     def add_columns(
         self,
         fields: List[Field],
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[PostCommitHookProperties],
+        max_commit_retries: Optional[int],
     ) -> None: ...
     def add_constraints(
         self,
         constraints: Dict[str, str],
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[PostCommitHookProperties],
+        max_commit_retries: Optional[int],
     ) -> None: ...
     def drop_constraints(
         self,
@@ -100,12 +105,14 @@ class RawDeltaTable:
         raise_if_not_exists: bool,
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[PostCommitHookProperties],
+        max_commit_retries: Optional[int],
     ) -> None: ...
     def set_table_properties(
         self,
         properties: Dict[str, str],
         raise_if_not_exists: bool,
         custom_metadata: Optional[Dict[str, str]],
+        max_commit_retries: Optional[int],
     ) -> None: ...
     def restore(
         self,
@@ -113,6 +120,7 @@ class RawDeltaTable:
         ignore_missing_files: bool,
         protocol_downgrade_allowed: bool,
         custom_metadata: Optional[Dict[str, str]],
+        max_commit_retries: Optional[int],
     ) -> str: ...
     def history(self, limit: Optional[int]) -> List[str]: ...
     def update_incremental(self) -> None: ...
@@ -127,12 +135,14 @@ class RawDeltaTable:
         writer_properties: Optional[WriterProperties],
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[PostCommitHookProperties],
+        max_commit_retries: Optional[int],
     ) -> str: ...
     def repair(
         self,
         dry_run: bool,
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[PostCommitHookProperties],
+        max_commit_retries: Optional[int],
     ) -> str: ...
     def update(
         self,
@@ -142,6 +152,7 @@ class RawDeltaTable:
         safe_cast: bool,
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[PostCommitHookProperties],
+        max_commit_retries: Optional[int],
     ) -> str: ...
     def create_merge_builder(
         self,
@@ -153,6 +164,7 @@ class RawDeltaTable:
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[PostCommitHookProperties],
         safe_cast: bool,
+        max_commit_retries: Optional[int],
     ) -> PyMergeBuilder: ...
     def merge_execute(self, merge_builder: PyMergeBuilder) -> str: ...
     def get_active_partitions(
@@ -167,6 +179,7 @@ class RawDeltaTable:
         partitions_filters: Optional[FilterType],
         custom_metadata: Optional[Dict[str, str]],
         post_commithook_properties: Optional[PostCommitHookProperties],
+        max_commit_retries: Optional[int],
     ) -> None: ...
     def cleanup_metadata(self) -> None: ...
     def check_can_write_timestamp_ntz(self, schema: pyarrow.Schema) -> None: ...
@@ -208,6 +221,7 @@ def write_to_deltalake(
     writer_properties: Optional[WriterProperties],
     custom_metadata: Optional[Dict[str, str]],
     post_commithook_properties: Optional[PostCommitHookProperties],
+    max_commit_retries: Optional[int],
 ) -> None: ...
 def convert_to_deltalake(
     uri: str,

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -744,6 +744,7 @@ class DeltaTable:
         enforce_retention_duration: bool = True,
         custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> List[str]:
         """
         Run the Vacuum command on the Delta Table: list and delete files no longer referenced by the Delta table and are older than the retention threshold.
@@ -754,6 +755,7 @@ class DeltaTable:
             enforce_retention_duration: when disabled, accepts retention hours smaller than the value from `delta.deletedFileRetentionDuration`.
             custom_metadata: custom metadata that will be added to the transaction commit.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            max_commit_retries: maximum number of times to retry the transaction commit.
         Returns:
             the list of files no longer referenced by the Delta Table and are older than the retention threshold.
         """
@@ -767,6 +769,7 @@ class DeltaTable:
             enforce_retention_duration,
             custom_metadata,
             post_commithook_properties,
+            max_commit_retries,
         )
 
     def update(
@@ -780,6 +783,7 @@ class DeltaTable:
         error_on_type_mismatch: bool = True,
         custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> Dict[str, Any]:
         """`UPDATE` records in the Delta Table that matches an optional predicate. Either updates or new_values needs
         to be passed for it to execute.
@@ -792,6 +796,7 @@ class DeltaTable:
             error_on_type_mismatch: specify if update will return error if data types are mismatching :default = True
             custom_metadata: custom metadata that will be added to the transaction commit.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            max_commit_retries: maximum number of times to retry the transaction commit.
         Returns:
             the metrics from update
 
@@ -871,6 +876,7 @@ class DeltaTable:
             safe_cast=not error_on_type_mismatch,
             custom_metadata=custom_metadata,
             post_commithook_properties=post_commithook_properties,
+            max_commit_retries=max_commit_retries,
         )
         return json.loads(metrics)
 
@@ -913,6 +919,7 @@ class DeltaTable:
         large_dtypes: Optional[bool] = None,
         custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> "TableMerger":
         """Pass the source data which you want to merge on the target delta table, providing a
         predicate in SQL query like format. You can also specify on what to do when the underlying data types do not
@@ -929,6 +936,7 @@ class DeltaTable:
             arrow_schema_conversion_mode: Large converts all types of data schema into Large Arrow types, passthrough keeps string/binary/list types untouched
             custom_metadata: custom metadata that will be added to the transaction commit.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            max_commit_retries: maximum number of times to retry the transaction commit.
 
         Returns:
             TableMerger: TableMerger Object
@@ -978,6 +986,7 @@ class DeltaTable:
             writer_properties=writer_properties,
             custom_metadata=custom_metadata,
             post_commithook_properties=post_commithook_properties,
+            max_commit_retries=max_commit_retries,
         )
         return TableMerger(py_merge_builder, self._table)
 
@@ -988,6 +997,7 @@ class DeltaTable:
         ignore_missing_files: bool = False,
         protocol_downgrade_allowed: bool = False,
         custom_metadata: Optional[Dict[str, str]] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Run the Restore command on the Delta Table: restore table to a given version or datetime.
@@ -997,6 +1007,7 @@ class DeltaTable:
             ignore_missing_files: whether the operation carry on when some data files missing.
             protocol_downgrade_allowed: whether the operation when protocol version upgraded.
             custom_metadata: custom metadata that will be added to the transaction commit.
+            max_commit_retries: maximum number of times to retry the transaction commit.
 
         Returns:
             the metrics from restore.
@@ -1007,6 +1018,7 @@ class DeltaTable:
                 ignore_missing_files=ignore_missing_files,
                 protocol_downgrade_allowed=protocol_downgrade_allowed,
                 custom_metadata=custom_metadata,
+                max_commit_retries=max_commit_retries,
             )
         else:
             metrics = self._table.restore(
@@ -1014,6 +1026,7 @@ class DeltaTable:
                 ignore_missing_files=ignore_missing_files,
                 protocol_downgrade_allowed=protocol_downgrade_allowed,
                 custom_metadata=custom_metadata,
+                max_commit_retries=max_commit_retries,
             )
         return json.loads(metrics)
 
@@ -1242,6 +1255,7 @@ class DeltaTable:
         writer_properties: Optional[WriterProperties] = None,
         custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Delete records from a Delta Table that statisfy a predicate.
 
@@ -1255,12 +1269,13 @@ class DeltaTable:
             writer_properties: Pass writer properties to the Rust parquet writer.
             custom_metadata: custom metadata that will be added to the transaction commit.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            max_commit_retries: maximum number of times to retry the transaction commit.
 
         Returns:
             the metrics from delete.
         """
         metrics = self._table.delete(
-            predicate, writer_properties, custom_metadata, post_commithook_properties
+            predicate, writer_properties, custom_metadata, post_commithook_properties, max_commit_retries
         )
         return json.loads(metrics)
 
@@ -1269,6 +1284,7 @@ class DeltaTable:
         dry_run: bool = False,
         custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Repair the Delta Table by auditing active files that do not exist in the underlying
         filesystem and removes them. This can be useful when there are accidental deletions or corrupted files.
@@ -1281,6 +1297,7 @@ class DeltaTable:
             dry_run: when activated, list only the files, otherwise add remove actions to transaction log. Defaults to False.
             custom_metadata: custom metadata that will be added to the transaction commit.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            max_commit_retries: maximum number of times to retry the transaction commit.
 
         Returns:
             The metrics from repair (FSCK) action.
@@ -1297,7 +1314,7 @@ class DeltaTable:
             ```
         """
         metrics = self._table.repair(
-            dry_run, custom_metadata, post_commithook_properties
+            dry_run, custom_metadata, post_commithook_properties, max_commit_retries
         )
         return json.loads(metrics)
 
@@ -1689,6 +1706,7 @@ class TableAlterer:
         fields: Union[DeltaField, List[DeltaField]],
         custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> None:
         """Add new columns and/or update the fields of a stuctcolumn
 
@@ -1696,6 +1714,7 @@ class TableAlterer:
             fields: fields to merge into schema
             custom_metadata: custom metadata that will be added to the transaction commit.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            max_commit_retries: maximum number of times to retry the transaction commit.
 
         Example:
             ```python
@@ -1715,7 +1734,7 @@ class TableAlterer:
             fields = [fields]
 
         self.table._table.add_columns(
-            fields, custom_metadata, post_commithook_properties
+            fields, custom_metadata, post_commithook_properties, max_commit_retries
         )
 
     def add_constraint(
@@ -1723,6 +1742,7 @@ class TableAlterer:
         constraints: Dict[str, str],
         custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> None:
         """
         Add constraints to the table. Limited to `single constraint` at once.
@@ -1731,6 +1751,7 @@ class TableAlterer:
             constraints: mapping of constraint name to SQL-expression to evaluate on write
             custom_metadata: custom metadata that will be added to the transaction commit.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            max_commit_retries: maximum number of times to retry the transaction commit.
 
         Example:
             ```python
@@ -1754,7 +1775,7 @@ class TableAlterer:
             )
 
         self.table._table.add_constraints(
-            constraints, custom_metadata, post_commithook_properties
+            constraints, custom_metadata, post_commithook_properties, max_commit_retries
         )
 
     def drop_constraint(
@@ -1763,6 +1784,7 @@ class TableAlterer:
         raise_if_not_exists: bool = True,
         custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> None:
         """
         Drop constraints from a table. Limited to `single constraint` at once.
@@ -1772,6 +1794,7 @@ class TableAlterer:
             raise_if_not_exists: set if should raise if not exists.
             custom_metadata: custom metadata that will be added to the transaction commit.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            max_commit_retries: maximum number of times to retry the transaction commit.
 
         Example:
             ```python
@@ -1793,7 +1816,7 @@ class TableAlterer:
             ```
         """
         self.table._table.drop_constraints(
-            name, raise_if_not_exists, custom_metadata, post_commithook_properties
+            name, raise_if_not_exists, custom_metadata, post_commithook_properties, max_commit_retries,
         )
 
     def set_table_properties(
@@ -1801,6 +1824,7 @@ class TableAlterer:
         properties: Dict[str, str],
         raise_if_not_exists: bool = True,
         custom_metadata: Optional[Dict[str, str]] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> None:
         """
         Set properties from the table.
@@ -1809,6 +1833,7 @@ class TableAlterer:
             properties: properties which set
             raise_if_not_exists: set if should raise if not exists.
             custom_metadata: custom metadata that will be added to the transaction commit.
+            max_commit_retries: maximum number of times to retry the transaction commit.
 
         Example:
             ```python
@@ -1826,7 +1851,7 @@ class TableAlterer:
             ```
         """
         self.table._table.set_table_properties(
-            properties, raise_if_not_exists, custom_metadata
+            properties, raise_if_not_exists, custom_metadata, max_commit_retries
         )
 
 
@@ -1845,6 +1870,7 @@ class TableOptimizer:
         writer_properties: Optional[WriterProperties] = None,
         custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Compacts small files to reduce the total number of files in the table.
@@ -1869,6 +1895,7 @@ class TableOptimizer:
             writer_properties: Pass writer properties to the Rust parquet writer.
             custom_metadata: custom metadata that will be added to the transaction commit.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            max_commit_retries: maximum number of times to retry the transaction commit.
 
         Returns:
             the metrics from optimize
@@ -1900,6 +1927,7 @@ class TableOptimizer:
             writer_properties,
             custom_metadata,
             post_commithook_properties,
+            max_commit_retries,
         )
         self.table.update_incremental()
         return json.loads(metrics)
@@ -1915,6 +1943,7 @@ class TableOptimizer:
         writer_properties: Optional[WriterProperties] = None,
         custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        max_commit_retries: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Reorders the data using a Z-order curve to improve data skipping.
@@ -1937,6 +1966,7 @@ class TableOptimizer:
             writer_properties: Pass writer properties to the Rust parquet writer.
             custom_metadata: custom metadata that will be added to the transaction commit.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            max_commit_retries: maximum number of times to retry the transaction commit.
 
         Returns:
             the metrics from optimize
@@ -1970,6 +2000,7 @@ class TableOptimizer:
             writer_properties,
             custom_metadata,
             post_commithook_properties,
+            max_commit_retries,
         )
         self.table.update_incremental()
         return json.loads(metrics)

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -761,8 +761,9 @@ class DeltaTable:
         retention_hours: Optional[int] = None,
         dry_run: bool = True,
         enforce_retention_duration: bool = True,
-        commit_properties: Optional[CommitProperties] = None,
+        custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        commit_properties: Optional[CommitProperties] = None,
     ) -> List[str]:
         """
         Run the Vacuum command on the Delta Table: list and delete files no longer referenced by the Delta table and are older than the retention threshold.
@@ -771,11 +772,19 @@ class DeltaTable:
             retention_hours: the retention threshold in hours, if none then the value from `delta.deletedFileRetentionDuration` is used or default of 1 week otherwise.
             dry_run: when activated, list only the files, delete otherwise
             enforce_retention_duration: when disabled, accepts retention hours smaller than the value from `delta.deletedFileRetentionDuration`.
-            commit_properties: properties of the transaction commit. If None, default values are used.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            commit_properties: properties of the transaction commit. If None, default values are used.
         Returns:
             the list of files no longer referenced by the Delta Table and are older than the retention threshold.
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         if retention_hours:
             if retention_hours < 0:
                 raise ValueError("The retention periods should be positive.")
@@ -784,7 +793,7 @@ class DeltaTable:
             dry_run,
             retention_hours,
             enforce_retention_duration,
-            commit_properties.custom_metadata if commit_properties else None,
+            commit_properties.custom_metadata if commit_properties else custom_metadata,
             post_commithook_properties,
             commit_properties.max_commit_retries if commit_properties else None,
         )
@@ -798,8 +807,9 @@ class DeltaTable:
         predicate: Optional[str] = None,
         writer_properties: Optional[WriterProperties] = None,
         error_on_type_mismatch: bool = True,
-        commit_properties: Optional[CommitProperties] = None,
+        custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        commit_properties: Optional[CommitProperties] = None,
     ) -> Dict[str, Any]:
         """`UPDATE` records in the Delta Table that matches an optional predicate. Either updates or new_values needs
         to be passed for it to execute.
@@ -810,8 +820,9 @@ class DeltaTable:
             predicate: a logical expression.
             writer_properties: Pass writer properties to the Rust parquet writer.
             error_on_type_mismatch: specify if update will return error if data types are mismatching :default = True
-            commit_properties: properties of the transaction commit. If None, default values are used.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            commit_properties: properties of the transaction commit. If None, default values are used.
         Returns:
             the metrics from update
 
@@ -853,6 +864,13 @@ class DeltaTable:
             {'num_added_files': 1, 'num_removed_files': 1, 'num_updated_rows': 1, 'num_copied_rows': 2, 'execution_time_ms': ..., 'scan_time_ms': ...}
             ```
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         if updates is None and new_values is not None:
             updates = {}
             for key, value in new_values.items():
@@ -891,7 +909,7 @@ class DeltaTable:
             safe_cast=not error_on_type_mismatch,
             custom_metadata=commit_properties.custom_metadata
             if commit_properties
-            else None,
+            else custom_metadata,
             post_commithook_properties=post_commithook_properties,
             max_commit_retries=commit_properties.max_commit_retries
             if commit_properties
@@ -936,8 +954,9 @@ class DeltaTable:
         error_on_type_mismatch: bool = True,
         writer_properties: Optional[WriterProperties] = None,
         large_dtypes: Optional[bool] = None,
-        commit_properties: Optional[CommitProperties] = None,
+        custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        commit_properties: Optional[CommitProperties] = None,
     ) -> "TableMerger":
         """Pass the source data which you want to merge on the target delta table, providing a
         predicate in SQL query like format. You can also specify on what to do when the underlying data types do not
@@ -952,13 +971,20 @@ class DeltaTable:
             writer_properties: Pass writer properties to the Rust parquet writer
             large_dtypes: Deprecated, will be removed in 1.0
             arrow_schema_conversion_mode: Large converts all types of data schema into Large Arrow types, passthrough keeps string/binary/list types untouched
-            custom_metadata: properties for the commit. If None, default values are used.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
-
+            commit_properties: properties for the commit. If None, default values are used.
 
         Returns:
             TableMerger: TableMerger Object
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         if large_dtypes:
             warnings.warn(
                 "large_dtypes is deprecated",
@@ -1004,7 +1030,7 @@ class DeltaTable:
             writer_properties=writer_properties,
             custom_metadata=commit_properties.custom_metadata
             if commit_properties
-            else None,
+            else custom_metadata,
             post_commithook_properties=post_commithook_properties,
             max_commit_retries=commit_properties.max_commit_retries
             if commit_properties
@@ -1018,6 +1044,7 @@ class DeltaTable:
         *,
         ignore_missing_files: bool = False,
         protocol_downgrade_allowed: bool = False,
+        custom_metadata: Optional[Dict[str, str]] = None,
         commit_properties: Optional[CommitProperties] = None,
     ) -> Dict[str, Any]:
         """
@@ -1027,11 +1054,19 @@ class DeltaTable:
             target: the expected version will restore, which represented by int, date str or datetime.
             ignore_missing_files: whether the operation carry on when some data files missing.
             protocol_downgrade_allowed: whether the operation when protocol version upgraded.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             commit_properties: properties of the transaction commit. If None, default values are used.
 
         Returns:
             the metrics from restore.
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         if isinstance(target, datetime):
             metrics = self._table.restore(
                 target.isoformat(),
@@ -1039,7 +1074,7 @@ class DeltaTable:
                 protocol_downgrade_allowed=protocol_downgrade_allowed,
                 custom_metadata=commit_properties.custom_metadata
                 if commit_properties
-                else None,
+                else custom_metadata,
                 max_commit_retries=commit_properties.max_commit_retries
                 if commit_properties
                 else None,
@@ -1051,7 +1086,7 @@ class DeltaTable:
                 protocol_downgrade_allowed=protocol_downgrade_allowed,
                 custom_metadata=commit_properties.custom_metadata
                 if commit_properties
-                else None,
+                else custom_metadata,
                 max_commit_retries=commit_properties.max_commit_retries
                 if commit_properties
                 else None,
@@ -1281,8 +1316,9 @@ class DeltaTable:
         self,
         predicate: Optional[str] = None,
         writer_properties: Optional[WriterProperties] = None,
-        commit_properties: Optional[CommitProperties] = None,
+        custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        commit_properties: Optional[CommitProperties] = None,
     ) -> Dict[str, Any]:
         """Delete records from a Delta Table that statisfy a predicate.
 
@@ -1294,16 +1330,24 @@ class DeltaTable:
         Args:
             predicate: a SQL where clause. If not passed, will delete all rows.
             writer_properties: Pass writer properties to the Rust parquet writer.
-            commit_properties: properties of the transaction commit. If None, default values are used.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            commit_properties: properties of the transaction commit. If None, default values are used.
 
         Returns:
             the metrics from delete.
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         metrics = self._table.delete(
             predicate,
             writer_properties,
-            commit_properties.custom_metadata if commit_properties else None,
+            commit_properties.custom_metadata if commit_properties else custom_metadata,
             post_commithook_properties,
             commit_properties.max_commit_retries if commit_properties else None,
         )
@@ -1312,8 +1356,9 @@ class DeltaTable:
     def repair(
         self,
         dry_run: bool = False,
-        commit_properties: Optional[CommitProperties] = None,
+        custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        commit_properties: Optional[CommitProperties] = None,
     ) -> Dict[str, Any]:
         """Repair the Delta Table by auditing active files that do not exist in the underlying
         filesystem and removes them. This can be useful when there are accidental deletions or corrupted files.
@@ -1324,8 +1369,9 @@ class DeltaTable:
 
         Args:
             dry_run: when activated, list only the files, otherwise add remove actions to transaction log. Defaults to False.
-            commit_properties: properties of the transaction commit. If None, default values are used.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            commit_properties: properties of the transaction commit. If None, default values are used.
 
         Returns:
             The metrics from repair (FSCK) action.
@@ -1341,9 +1387,16 @@ class DeltaTable:
             {'dry_run': False, 'files_removed': ['6-0d084325-6885-4847-b008-82c1cf30674c-0.parquet', 5-4fba1d3e-3e20-4de1-933d-a8e13ac59f53-0.parquet']}
             ```
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         metrics = self._table.repair(
             dry_run,
-            commit_properties.custom_metadata if commit_properties else None,
+            commit_properties.custom_metadata if commit_properties else custom_metadata,
             post_commithook_properties,
             commit_properties.max_commit_retries if commit_properties else None,
         )
@@ -1735,15 +1788,17 @@ class TableAlterer:
     def add_columns(
         self,
         fields: Union[DeltaField, List[DeltaField]],
-        commit_properties: Optional[CommitProperties] = None,
+        custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        commit_properties: Optional[CommitProperties] = None,
     ) -> None:
         """Add new columns and/or update the fields of a stuctcolumn
 
         Args:
             fields: fields to merge into schema
-            commit_properties: properties of the transaction commit. If None, default values are used.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            commit_properties: properties of the transaction commit. If None, default values are used.
 
         Example:
             ```python
@@ -1759,12 +1814,19 @@ class TableAlterer:
             )
             ```
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         if isinstance(fields, DeltaField):
             fields = [fields]
 
         self.table._table.add_columns(
             fields,
-            commit_properties.custom_metadata if commit_properties else None,
+            commit_properties.custom_metadata if commit_properties else custom_metadata,
             post_commithook_properties,
             commit_properties.max_commit_retries if commit_properties else None,
         )
@@ -1772,16 +1834,18 @@ class TableAlterer:
     def add_constraint(
         self,
         constraints: Dict[str, str],
-        commit_properties: Optional[CommitProperties] = None,
+        custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        commit_properties: Optional[CommitProperties] = None,
     ) -> None:
         """
         Add constraints to the table. Limited to `single constraint` at once.
 
         Args:
             constraints: mapping of constraint name to SQL-expression to evaluate on write
-            commit_properties: properties of the transaction commit. If None, default values are used.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            commit_properties: properties of the transaction commit. If None, default values are used.
 
         Example:
             ```python
@@ -1798,6 +1862,13 @@ class TableAlterer:
             {'delta.constraints.value_gt_5': 'value > 5'}
             ```
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         if len(constraints.keys()) > 1:
             raise ValueError(
                 """add_constraints is limited to a single constraint addition at once for now. 
@@ -1806,7 +1877,7 @@ class TableAlterer:
 
         self.table._table.add_constraints(
             constraints,
-            commit_properties.custom_metadata if commit_properties else None,
+            commit_properties.custom_metadata if commit_properties else custom_metadata,
             post_commithook_properties,
             commit_properties.max_commit_retries if commit_properties else None,
         )
@@ -1815,8 +1886,9 @@ class TableAlterer:
         self,
         name: str,
         raise_if_not_exists: bool = True,
-        commit_properties: Optional[CommitProperties] = None,
+        custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        commit_properties: Optional[CommitProperties] = None,
     ) -> None:
         """
         Drop constraints from a table. Limited to `single constraint` at once.
@@ -1824,8 +1896,9 @@ class TableAlterer:
         Args:
             name: constraint name which to drop.
             raise_if_not_exists: set if should raise if not exists.
-            commit_properties: properties of the transaction commit. If None, default values are used.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            commit_properties: properties of the transaction commit. If None, default values are used.
 
         Example:
             ```python
@@ -1846,10 +1919,17 @@ class TableAlterer:
             {}
             ```
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         self.table._table.drop_constraints(
             name,
             raise_if_not_exists,
-            commit_properties.custom_metadata if commit_properties else None,
+            commit_properties.custom_metadata if commit_properties else custom_metadata,
             post_commithook_properties,
             commit_properties.max_commit_retries if commit_properties else None,
         )
@@ -1858,6 +1938,7 @@ class TableAlterer:
         self,
         properties: Dict[str, str],
         raise_if_not_exists: bool = True,
+        custom_metadata: Optional[Dict[str, str]] = None,
         commit_properties: Optional[CommitProperties] = None,
     ) -> None:
         """
@@ -1866,6 +1947,7 @@ class TableAlterer:
         Args:
             properties: properties which set
             raise_if_not_exists: set if should raise if not exists.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             commit_properties: properties of the transaction commit. If None, default values are used.
 
         Example:
@@ -1883,10 +1965,17 @@ class TableAlterer:
             dt.alter.set_table_properties({"delta.enableChangeDataFeed": "true"})
             ```
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         self.table._table.set_table_properties(
             properties,
             raise_if_not_exists,
-            commit_properties.custom_metadata if commit_properties else None,
+            commit_properties.custom_metadata if commit_properties else custom_metadata,
             commit_properties.max_commit_retries if commit_properties else None,
         )
 
@@ -1904,8 +1993,9 @@ class TableOptimizer:
         max_concurrent_tasks: Optional[int] = None,
         min_commit_interval: Optional[Union[int, timedelta]] = None,
         writer_properties: Optional[WriterProperties] = None,
-        commit_properties: Optional[CommitProperties] = None,
+        custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        commit_properties: Optional[CommitProperties] = None,
     ) -> Dict[str, Any]:
         """
         Compacts small files to reduce the total number of files in the table.
@@ -1928,8 +2018,9 @@ class TableOptimizer:
                                     created. Interval is useful for long running executions. Set to 0 or timedelta(0), if you
                                     want a commit per partition.
             writer_properties: Pass writer properties to the Rust parquet writer.
-            commit_properties: properties of the transaction commit. If None, default values are used.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            commit_properties: properties of the transaction commit. If None, default values are used.
 
         Returns:
             the metrics from optimize
@@ -1950,6 +2041,13 @@ class TableOptimizer:
             {'numFilesAdded': 1, 'numFilesRemoved': 2, 'filesAdded': ..., 'filesRemoved': ..., 'partitionsOptimized': 1, 'numBatches': 2, 'totalConsideredFiles': 2, 'totalFilesSkipped': 0, 'preserveInsertionOrder': True}
             ```
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         if isinstance(min_commit_interval, timedelta):
             min_commit_interval = int(min_commit_interval.total_seconds())
 
@@ -1959,7 +2057,7 @@ class TableOptimizer:
             max_concurrent_tasks,
             min_commit_interval,
             writer_properties,
-            commit_properties.custom_metadata if commit_properties else None,
+            commit_properties.custom_metadata if commit_properties else custom_metadata,
             post_commithook_properties,
             commit_properties.max_commit_retries if commit_properties else None,
         )
@@ -1975,8 +2073,9 @@ class TableOptimizer:
         max_spill_size: int = 20 * 1024 * 1024 * 1024,
         min_commit_interval: Optional[Union[int, timedelta]] = None,
         writer_properties: Optional[WriterProperties] = None,
-        commit_properties: Optional[CommitProperties] = None,
+        custom_metadata: Optional[Dict[str, str]] = None,
         post_commithook_properties: Optional[PostCommitHookProperties] = None,
+        commit_properties: Optional[CommitProperties] = None,
     ) -> Dict[str, Any]:
         """
         Reorders the data using a Z-order curve to improve data skipping.
@@ -1997,8 +2096,9 @@ class TableOptimizer:
                                     created. Interval is useful for long running executions. Set to 0 or timedelta(0), if you
                                     want a commit per partition.
             writer_properties: Pass writer properties to the Rust parquet writer.
-            commit_properties: properties of the transaction commit. If None, default values are used.
+            custom_metadata: Deprecated and will be removed in future versions. Use commit_properties instead.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            commit_properties: properties of the transaction commit. If None, default values are used.
 
         Returns:
             the metrics from optimize
@@ -2019,6 +2119,13 @@ class TableOptimizer:
             {'numFilesAdded': 1, 'numFilesRemoved': 2, 'filesAdded': ..., 'filesRemoved': ..., 'partitionsOptimized': 0, 'numBatches': 1, 'totalConsideredFiles': 2, 'totalFilesSkipped': 0, 'preserveInsertionOrder': True}
             ```
         """
+        if custom_metadata:
+            warnings.warn(
+                "custom_metadata is deprecated, please use commit_properties instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         if isinstance(min_commit_interval, timedelta):
             min_commit_interval = int(min_commit_interval.total_seconds())
 
@@ -2030,7 +2137,7 @@ class TableOptimizer:
             max_spill_size,
             min_commit_interval,
             writer_properties,
-            commit_properties.custom_metadata if commit_properties else None,
+            commit_properties.custom_metadata if commit_properties else custom_metadata,
             post_commithook_properties,
             commit_properties.max_commit_retries if commit_properties else None,
         )

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -56,6 +56,7 @@ from .table import (
     DeltaTable,
     PostCommitHookProperties,
     WriterProperties,
+    _commit_properties_from_custom_metadata,
 )
 
 try:
@@ -290,6 +291,9 @@ def write_deltalake(
             category=DeprecationWarning,
             stacklevel=2,
         )
+        commit_properties = _commit_properties_from_custom_metadata(
+            commit_properties, custom_metadata
+        )
 
     table, table_uri = try_get_table_and_table_uri(table_or_uri, storage_options)
     if table is not None:
@@ -330,13 +334,8 @@ def write_deltalake(
             configuration=configuration,
             storage_options=storage_options,
             writer_properties=writer_properties,
-            custom_metadata=commit_properties.custom_metadata
-            if commit_properties
-            else custom_metadata,
+            commit_properties=commit_properties,
             post_commithook_properties=post_commithook_properties,
-            max_commit_retries=commit_properties.max_commit_retries
-            if commit_properties
-            else None,
         )
         if table:
             table.update_incremental()
@@ -570,13 +569,8 @@ def write_deltalake(
                 partition_by or [],
                 schema,
                 partition_filters,
-                custom_metadata=commit_properties.custom_metadata
-                if commit_properties
-                else custom_metadata,
+                commit_properties=commit_properties,
                 post_commithook_properties=post_commithook_properties,
-                max_commit_retries=commit_properties.max_commit_retries
-                if commit_properties
-                else None,
             )
             table.update_incremental()
     else:

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -124,6 +124,7 @@ def write_deltalake(
     engine: Literal["pyarrow"] = ...,
     custom_metadata: Optional[Dict[str, str]] = ...,
     post_commithook_properties: Optional[PostCommitHookProperties] = ...,
+    max_commit_retries: Optional[int] = ...,
 ) -> None: ...
 
 
@@ -153,6 +154,7 @@ def write_deltalake(
     writer_properties: WriterProperties = ...,
     custom_metadata: Optional[Dict[str, str]] = ...,
     post_commithook_properties: Optional[PostCommitHookProperties] = ...,
+    max_commit_retries: Optional[int] = ...,
 ) -> None: ...
 
 
@@ -184,6 +186,7 @@ def write_deltalake(
     writer_properties: WriterProperties = ...,
     custom_metadata: Optional[Dict[str, str]] = ...,
     post_commithook_properties: Optional[PostCommitHookProperties] = ...,
+    max_commit_retries: Optional[int] = ...,
 ) -> None: ...
 
 
@@ -221,6 +224,7 @@ def write_deltalake(
     writer_properties: Optional[WriterProperties] = None,
     custom_metadata: Optional[Dict[str, str]] = None,
     post_commithook_properties: Optional[PostCommitHookProperties] = None,
+    max_commit_retries: Optional[int] = None,
 ) -> None:
     """Write to a Delta Lake table
 
@@ -277,6 +281,7 @@ def write_deltalake(
         writer_properties: Pass writer properties to the Rust parquet writer.
         custom_metadata: Custom metadata to add to the commitInfo.
         post_commithook_properties: properties for the post commit hook. If None, default values are used.
+        max_commit_retries: maximum number of times to retry the transaction commit.
     """
     table, table_uri = try_get_table_and_table_uri(table_or_uri, storage_options)
     if table is not None:
@@ -319,6 +324,7 @@ def write_deltalake(
             writer_properties=writer_properties,
             custom_metadata=custom_metadata,
             post_commithook_properties=post_commithook_properties,
+            max_commit_retries=max_commit_retries,
         )
         if table:
             table.update_incremental()
@@ -552,6 +558,7 @@ def write_deltalake(
                 partition_filters,
                 custom_metadata,
                 post_commithook_properties=post_commithook_properties,
+                max_commit_retries=max_commit_retries,
             )
             table.update_incremental()
     else:

--- a/python/src/merge.rs
+++ b/python/src/merge.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use crate::error::PythonError;
 use crate::utils::rt;
 use crate::{
-    maybe_create_commit_properties, set_writer_properties, PyPostCommitHookProperties,
-    PyWriterProperties,
+    maybe_create_commit_properties, set_writer_properties, PyCommitProperties,
+    PyPostCommitHookProperties, PyWriterProperties,
 };
 
 #[pyclass(module = "deltalake._internal")]
@@ -43,8 +43,7 @@ impl PyMergeBuilder {
         safe_cast: bool,
         writer_properties: Option<PyWriterProperties>,
         post_commithook_properties: Option<PyPostCommitHookProperties>,
-        custom_metadata: Option<HashMap<String, String>>,
-        max_commit_retries: Option<usize>,
+        commit_properties: Option<PyCommitProperties>,
     ) -> DeltaResult<Self> {
         let ctx = SessionContext::new();
         let schema = source.schema();
@@ -68,11 +67,9 @@ impl PyMergeBuilder {
             cmd = cmd.with_writer_properties(set_writer_properties(writer_props)?);
         }
 
-        if let Some(commit_properties) = maybe_create_commit_properties(
-            custom_metadata,
-            max_commit_retries,
-            post_commithook_properties,
-        ) {
+        if let Some(commit_properties) =
+            maybe_create_commit_properties(commit_properties, post_commithook_properties)
+        {
             cmd = cmd.with_commit_properties(commit_properties);
         }
         Ok(Self {

--- a/python/src/merge.rs
+++ b/python/src/merge.rs
@@ -44,6 +44,7 @@ impl PyMergeBuilder {
         writer_properties: Option<PyWriterProperties>,
         post_commithook_properties: Option<PyPostCommitHookProperties>,
         custom_metadata: Option<HashMap<String, String>>,
+        max_commit_retries: Option<usize>,
     ) -> DeltaResult<Self> {
         let ctx = SessionContext::new();
         let schema = source.schema();
@@ -67,9 +68,11 @@ impl PyMergeBuilder {
             cmd = cmd.with_writer_properties(set_writer_properties(writer_props)?);
         }
 
-        if let Some(commit_properties) =
-            maybe_create_commit_properties(custom_metadata, post_commithook_properties)
-        {
+        if let Some(commit_properties) = maybe_create_commit_properties(
+            custom_metadata,
+            max_commit_retries,
+            post_commithook_properties,
+        ) {
             cmd = cmd.with_commit_properties(commit_properties);
         }
         Ok(Self {

--- a/python/tests/test_alter.py
+++ b/python/tests/test_alter.py
@@ -7,6 +7,7 @@ import pytest
 from deltalake import DeltaTable, write_deltalake
 from deltalake.exceptions import DeltaError, DeltaProtocolError
 from deltalake.schema import Field, PrimitiveType, StructType
+from deltalake.table import CommitProperties
 
 
 def test_add_constraint(tmp_path: pathlib.Path, sample_table: pa.Table):
@@ -58,8 +59,9 @@ def test_add_constraint_roundtrip_metadata(
 
     dt = DeltaTable(tmp_path)
 
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
     dt.alter.add_constraint(
-        {"check_price2": "price >= 0"}, custom_metadata={"userName": "John Doe"}
+        {"check_price2": "price >= 0"}, commit_properties=commit_properties
     )
 
     assert dt.history(1)[0]["userName"] == "John Doe"
@@ -112,7 +114,8 @@ def test_drop_constraint_roundtrip_metadata(
     dt = DeltaTable(tmp_path)
 
     dt.alter.add_constraint({"check_price2": "price >= 0"})
-    dt.alter.drop_constraint("check_price2", custom_metadata={"userName": "John Doe"})
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
+    dt.alter.drop_constraint("check_price2", commit_properties=commit_properties)
 
     assert dt.history(1)[0]["userName"] == "John Doe"
 

--- a/python/tests/test_delete.py
+++ b/python/tests/test_delete.py
@@ -4,14 +4,15 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 
-from deltalake.table import DeltaTable
+from deltalake.table import CommitProperties, DeltaTable
 from deltalake.writer import write_deltalake
 
 
 def test_delete_no_predicates(existing_table: DeltaTable):
     old_version = existing_table.version()
 
-    existing_table.delete(custom_metadata={"userName": "John Doe"})
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
+    existing_table.delete(commit_properties=commit_properties)
 
     last_action = existing_table.history(1)[0]
     assert last_action["operation"] == "DELETE"

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -4,6 +4,7 @@ import pyarrow as pa
 import pytest
 
 from deltalake import DeltaTable, write_deltalake
+from deltalake.table import CommitProperties
 
 
 def test_merge_when_matched_delete_wo_predicate(
@@ -20,12 +21,13 @@ def test_merge_when_matched_delete_wo_predicate(
         }
     )
 
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
     dt.merge(
         source=source_table,
         predicate="t.id = s.id",
         source_alias="s",
         target_alias="t",
-        custom_metadata={"userName": "John Doe"},
+        commit_properties=commit_properties,
     ).when_matched_delete().execute()
 
     nrows = 4

--- a/python/tests/test_optimize.py
+++ b/python/tests/test_optimize.py
@@ -5,6 +5,7 @@ import pyarrow as pa
 import pytest
 
 from deltalake import DeltaTable, write_deltalake
+from deltalake.table import CommitProperties
 
 
 @pytest.mark.parametrize("engine", ["pyarrow", "rust"])
@@ -39,7 +40,8 @@ def test_optimize_run_table(
     old_data = dt.to_pyarrow_table()
     old_version = dt.version()
 
-    dt.optimize.compact(custom_metadata={"userName": "John Doe"})
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
+    dt.optimize.compact(commit_properties=commit_properties)
 
     new_data = dt.to_pyarrow_table()
     last_action = dt.history(1)[0]
@@ -70,9 +72,8 @@ def test_z_order_optimize(
     dt = DeltaTable(tmp_path)
     old_version = dt.version()
 
-    dt.optimize.z_order(
-        ["date32", "timestamp"], custom_metadata={"userName": "John Doe"}
-    )
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
+    dt.optimize.z_order(["date32", "timestamp"], commit_properties=commit_properties)
     last_action = dt.history(1)[0]
     assert last_action["operation"] == "OPTIMIZE"
     assert last_action["userName"] == "John Doe"

--- a/python/tests/test_repair.py
+++ b/python/tests/test_repair.py
@@ -1,6 +1,7 @@
 import os
 
 from deltalake import DeltaTable, write_deltalake
+from deltalake.table import CommitProperties
 
 
 def test_repair_with_dry_run(tmp_path, sample_data):
@@ -23,7 +24,8 @@ def test_repair_wo_dry_run(tmp_path, sample_data):
     dt = DeltaTable(tmp_path)
     os.remove(dt.file_uris()[0])
 
-    metrics = dt.repair(dry_run=False, custom_metadata={"userName": "John Doe"})
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
+    metrics = dt.repair(dry_run=False, commit_properties=commit_properties)
     last_action = dt.history(1)[0]
 
     assert len(metrics["files_removed"]) == 1

--- a/python/tests/test_restore.py
+++ b/python/tests/test_restore.py
@@ -5,6 +5,7 @@ import pyarrow as pa
 import pytest
 
 from deltalake import DeltaTable, write_deltalake
+from deltalake.table import CommitProperties
 
 
 @pytest.mark.parametrize("use_relative", [True, False])
@@ -24,7 +25,8 @@ def test_restore_with_version(
 
     dt = DeltaTable(table_path)
     old_version = dt.version()
-    dt.restore(1, custom_metadata={"userName": "John Doe"})
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
+    dt.restore(1, commit_properties=commit_properties)
     last_action = dt.history(1)[0]
     assert last_action["operation"] == "RESTORE"
     assert last_action["userName"] == "John Doe"

--- a/python/tests/test_update.py
+++ b/python/tests/test_update.py
@@ -4,6 +4,7 @@ import pyarrow as pa
 import pytest
 
 from deltalake import DeltaTable, write_deltalake
+from deltalake.table import CommitProperties
 
 
 @pytest.fixture()
@@ -38,10 +39,11 @@ def test_update_with_predicate(tmp_path: pathlib.Path, sample_table: pa.Table):
         }
     )
 
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
     dt.update(
         updates={"deleted": "True"},
         predicate="price > 3",
-        custom_metadata={"userName": "John Doe"},
+        commit_properties=commit_properties,
     )
 
     result = dt.to_pyarrow_table()

--- a/python/tests/test_vacuum.py
+++ b/python/tests/test_vacuum.py
@@ -5,6 +5,7 @@ import pyarrow as pa
 import pytest
 
 from deltalake import DeltaTable, write_deltalake
+from deltalake.table import CommitProperties
 
 
 def test_vacuum_dry_run_simple_table():
@@ -72,11 +73,12 @@ def test_vacuum_transaction_log(tmp_path: pathlib.Path, sample_data: pa.Table):
 
     dt = DeltaTable(tmp_path)
 
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
     dt.vacuum(
         retention_hours=0,
         dry_run=False,
         enforce_retention_duration=False,
-        custom_metadata={"userName": "John Doe"},
+        commit_properties=commit_properties,
     )
 
     dt = DeltaTable(tmp_path)


### PR DESCRIPTION
# Description
Adds a `with_max_retries` in `CommitProperties`. Allow for clients to control the maximum number of times a commit will be retried before failing.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
