### PR TITLE
docs: fix documentation about max_spill_size

### DIFF
--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -203,9 +203,9 @@ pub struct OptimizeBuilder<'a> {
     commit_properties: CommitProperties,
     /// Whether to preserve insertion order within files (default false)
     preserve_insertion_order: bool,
-    /// Max number of concurrent tasks (default is number of cpus)
+    /// Maximum number of concurrent tasks (default is number of cpus)
     max_concurrent_tasks: usize,
-    /// Maximum number of bytes that are allowed to spill to disk
+    /// Maximum number of bytes allowed in memory before spilling to disk
     max_spill_size: usize,
     /// Optimize type
     optimize_type: OptimizeType,

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1928,7 +1928,7 @@ class TableOptimizer:
             max_concurrent_tasks: the maximum number of concurrent tasks to use for
                                     file compaction. Defaults to number of CPUs. More concurrent tasks can make compaction
                                     faster, but will also use more memory.
-            max_spill_size: the maximum number of bytes to spill to disk. Defaults to 20GB.
+            max_spill_size: the maximum number of bytes allowed in memory before spilling to disk. Defaults to 20GB.
             min_commit_interval: minimum interval in seconds or as timedeltas before a new commit is
                                     created. Interval is useful for long running executions. Set to 0 or timedelta(0), if you
                                     want a commit per partition.


### PR DESCRIPTION
# Description
`max_spill_size` had misleading documentation that seemed to indicate the limit on disk.
However, the value was a limit on memory to avoid out-of-memory and to spill to disk on such case.

This issue was raised in https://github.com/delta-io/delta-rs/issues/2205

# Related Issue(s)
- closes #2205 

# Documentation

<!---
Share links to useful documentation
--->
