### PR TITLE
chore: pin the Rust baseline version to 1.80

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: stable
+          toolchain: 1.80
           override: true
 
       - name: Format
@@ -36,7 +36,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: stable
+          toolchain: 1.80
           override: true
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -67,7 +67,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: stable
+          toolchain: 1.80
           override: true
 
       - name: build and lint with clippy
@@ -104,7 +104,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: "stable"
+          toolchain: 1.80
           override: true
 
       - name: Run tests
@@ -138,7 +138,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: stable
+          toolchain: 1.80
           override: true
 
       # Install Java and Hadoop for HDFS integration tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: 1.80
+          toolchain: '1.80'
           override: true
 
       - name: Format
@@ -36,7 +36,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: 1.80
+          toolchain: '1.80'
           override: true
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -67,7 +67,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: 1.80
+          toolchain: '1.80'
           override: true
 
       - name: build and lint with clippy
@@ -104,7 +104,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: 1.80
+          toolchain: '1.80'
           override: true
 
       - name: Run tests
@@ -138,7 +138,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: 1.80
+          toolchain: '1.80'
           override: true
 
       # Install Java and Hadoop for HDFS integration tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
-rust-version = "1.75"
+rust-version = "1.80"
 keywords = ["deltalake", "delta", "datalake"]
 readme = "README.md"
 edition = "2021"


### PR DESCRIPTION
See #2837
