### PR TITLE
Docs: concurrent writes permission missing

### DIFF
--- a/docs/usage/writing/writing-to-s3-with-locking-provider.md
+++ b/docs/usage/writing/writing-to-s3-with-locking-provider.md
@@ -95,6 +95,7 @@ In DynamoDB, you need those permissions:
 - dynamodb:Query
 - dynamodb:PutItem
 - dynamodb:UpdateItem
+- dynamodb:DeleteItem
 
 ### Enabling concurrent writes for alternative clients
 


### PR DESCRIPTION
There was a missing permission in the list of DynamoDB list of permissions for concurrent writes.

# Description
The description of the main changes of your pull request

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

https://delta-io.github.io/delta-rs/usage/writing/writing-to-s3-with-locking-provider/
<!---
Share links to useful documentation
--->
