### PR TITLE
fix: re-enable optional old casting behavior in merge

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1000,13 +1000,18 @@ class DeltaTable:
                 commit_properties, custom_metadata
             )
 
-        if large_dtypes:
+        if large_dtypes is not None:
             warnings.warn(
                 "large_dtypes is deprecated",
                 category=DeprecationWarning,
                 stacklevel=2,
             )
-        conversion_mode = ArrowSchemaConversionMode.PASSTHROUGH
+            if large_dtypes:
+                conversion_mode = ArrowSchemaConversionMode.LARGE
+            else:
+                conversion_mode = ArrowSchemaConversionMode.NORMAL
+        else:
+            conversion_mode = ArrowSchemaConversionMode.PASSTHROUGH
 
         from .schema import (
             convert_pyarrow_dataset,


### PR DESCRIPTION
# Description
The description of the main changes of your pull request

# Related Issue(s)
https://github.com/delta-io/delta-rs/issues/2851


@ericvandever, this doesn't fix the coercion but allows you to still use large_dtypes=False to downcast so that you can still run most of your queries
