### PR TITLE
fix: pin the build-dependencies for Python to a slightly older vendored openssl

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -55,3 +55,6 @@ features = ["azure", "gcs", "python", "datafusion", "unity-experimental", "hdfs"
 default = ["rustls"]
 native-tls = ["deltalake/s3-native-tls", "deltalake/glue"]
 rustls = ["deltalake/s3", "deltalake/glue"]
+
+[build-dependencies]
+openssl-src = "=300.3.1"


### PR DESCRIPTION
This is the patch that was used to resolve the release errors of python-v0.19.2 for the Linux manywheels

Upstream reference openssl/openssl#25367

Fixes #2848
