### PR TITLE
chore: attempt to ignore all dependabot checks for arrow and datafusion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,4 @@ updates:
     ignore:
       # arrow and datafusion are bumped manually
       - dependency-name: "arrow*"
-        update-types: ["version-update:semver-major"]
       - dependency-name: "datafusion*"
-        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
The major update-type still means we're getting pinged with some frequency