### PR TITLE
prepare the next :crab: release with fixed version ranges

### DIFF
--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-aws"
-version = "0.1.4"
+version = "0.2.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
+deltalake-core = { version = "0.19.0", path = "../core" }
 aws-smithy-runtime-api = { version="1.1.7" }
 aws-smithy-runtime = { version="1.1.7", optional = true}
 aws-credential-types = { version="1.1.7", features = ["hardcoded-credentials"]}

--- a/crates/azure/Cargo.toml
+++ b/crates/azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-azure"
-version = "0.1.4"
+version = "0.2.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
+deltalake-core = { version = "0.19.0", path = "../core" }
 lazy_static = "1"
 
 # workspace depenndecies

--- a/crates/catalog-glue/Cargo.toml
+++ b/crates/catalog-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-catalog-glue"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -15,9 +15,7 @@ rust-version.workspace = true
 async-trait = { workspace = true }
 aws-config = "1"
 aws-sdk-glue = "1"
-deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
-# This can depend on a lowest common denominator of core once that's released
-# deltalake_core = { version = "0.17.0" }
+deltalake-core = { version = "0.19.0", path = "../core" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -16,12 +16,12 @@ rust-version.workspace = true
 features = ["azure", "datafusion", "gcs", "hdfs", "json", "python", "s3", "unity-experimental"]
 
 [dependencies]
-deltalake-core = { version = "0.19.0", path = "../core" }
-deltalake-aws = { version = "0.1.4", path = "../aws", default-features = false, optional = true }
-deltalake-azure = { version = "0.1.4", path = "../azure", optional = true }
-deltalake-gcp = { version = "0.2.2", path = "../gcp", optional = true }
-deltalake-hdfs = { version = "0.2.0", path = "../hdfs", optional = true }
-deltalake-catalog-glue = { version = "0.2.0", path = "../catalog-glue", optional = true }
+deltalake-core = { version = "0.19.1", path = "../core" }
+deltalake-aws = { version = "0.2.0", path = "../aws", default-features = false, optional = true }
+deltalake-azure = { version = "0.2.0", path = "../azure", optional = true }
+deltalake-gcp = { version = "0.3.0", path = "../gcp", optional = true }
+deltalake-hdfs = { version = "0.3.0", path = "../hdfs", optional = true }
+deltalake-catalog-glue = { version = "0.3.0", path = "../catalog-glue", optional = true }
 
 [features]
 # All of these features are just reflected into the core crate until that

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-gcp"
-version = "0.2.3"
+version = "0.3.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
+deltalake-core = { version = "0.19.0", path = "../core" }
 lazy_static = "1"
 
 # workspace depenndecies

--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-hdfs"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core" }
+deltalake-core = { version = "0.19.0", path = "../core" }
 hdfs-native-object-store = "0.11"
 
 # workspace dependecies

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-mount"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = ">=0.17.0, <0.20.0", path = "../core", features = [
+deltalake-core = { version = "0.19.0", path = "../core", features = [
     "datafusion",
 ] }
 lazy_static = "1"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"


### PR DESCRIPTION
Until we release 1.0, every 0.x release is going to be treated as a "major" or incompatible change by Cargo

Fixes #2847
