### PR TITLE
feat: add support for `pyarrow.ExtensionType`

### DIFF
--- a/python/deltalake/schema.py
+++ b/python/deltalake/schema.py
@@ -95,6 +95,8 @@ def _convert_pa_schema_to_delta(
                 return pa.timestamp("us", "UTC")
         elif type(dtype) is pa.FixedSizeBinaryType:
             return pa.binary()
+        elif isinstance(dtype, pa.ExtensionType):
+            return dtype.storage_type
         try:
             return dtype_map[dtype]
         except KeyError:

--- a/python/stubs/pyarrow/__init__.pyi
+++ b/python/stubs/pyarrow/__init__.pyi
@@ -14,6 +14,7 @@ FixedSizeListType: Any
 LargeListViewType: Any
 ListViewType: Any
 FixedSizeBinaryType: Any
+ExtensionType: Any
 schema: Any
 map_: Any
 list_: Any


### PR DESCRIPTION
# Description
The description of the main changes of your pull request

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->

The current code lacks support for pyarrow's [`ExtensionType`](https://arrow.apache.org/docs/python/generated/pyarrow.ExtensionType.html) when writing to Delta Lake, which is used by many libraries in the pyarrow ecosystem. This PR aims to improve the Delta Lake Python bindings to enhance support for these third-party ecosystems.

For example, the following code tests that data can be correctly written after adding this PR per https://github.com/Eventual-Inc/Daft/pull/2827#issuecomment-2346463669:

```py
import daft

df_dogs = daft.from_pydict(
    {
        "urls": [
            "https://live.staticflickr.com/65535/53671838774_03ba68d203_o.jpg",
            "https://live.staticflickr.com/65535/53671700073_2c9441422e_o.jpg",
            "https://live.staticflickr.com/65535/53670606332_1ea5f2ce68_o.jpg",
            "https://live.staticflickr.com/65535/53671838039_b97411a441_o.jpg",
            "https://live.staticflickr.com/65535/53671698613_0230f8af3c_o.jpg",
        ],
        "full_name": [
            "Ernesto Evergreen",
            "James Jale",
            "Wolfgang Winter",
            "Shandra Shamas",
            "Zaya Zaphora",
        ],
        "dog_name": ["Ernie", "Jackie", "Wolfie", "Shaggie", "Zadie"],
    }
)
df_dogs = df_dogs.with_column(
    "image_bytes", df_dogs["urls"].url.download(on_error="null")
).with_column("image", daft.col("image_bytes").image.decode())
df_dogs.write_deltalake("path/to/file")
```