### PR TITLE
fix: convert last checkpoint json keys to camelCase

### DIFF
--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -627,4 +627,21 @@ mod tests {
             .unwrap();
         (dt, tmp_dir)
     }
+
+    #[test]
+    fn checkpoint_should_serialize_in_camel_case() {
+        let checkpoint = CheckPoint {
+            version: 1,
+            size: 1,
+            parts: None,
+            size_in_bytes: Some(1),
+            num_of_add_files: Some(1),
+        };
+
+        let checkpoint_json_serialized =
+            serde_json::to_string(&checkpoint).expect("could not serialize to json");
+
+        assert!(checkpoint_json_serialized.contains("sizeInBytes"));
+        assert!(checkpoint_json_serialized.contains("numOfAddFiles"));
+    }
 }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -30,6 +30,7 @@ pub mod state_arrow;
 
 /// Metadata for a checkpoint file
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
 pub struct CheckPoint {
     /// Delta table version
     pub(crate) version: i64, // 20 digits decimals


### PR DESCRIPTION
## Description

While storing `_last_checkpoint` delta-rs does not convert json keys to camel case, but protocol mentions they should be in camelCase, fix exactly that :)

## Related Issue(s)

Fixes https://github.com/delta-incubator/delta-kernel-rs/issues/326

## Documentation

Issue description is nicely documented :)

## Output screenshots:

Tested with local crate copy and created a table

![Screenshot 2024-09-19 at 3 55 14 PM](https://github.com/user-attachments/assets/02c03996-6289-4e99-b7da-6834b0511276)

