### PR TITLE
docs: updating usage/managing-tables on optimizing tables

### DIFF
--- a/docs/usage/managing-tables.md
+++ b/docs/usage/managing-tables.md
@@ -26,4 +26,11 @@ Use `DeltaTable.vacuum` to perform the vacuum operation. Note that to prevent ac
 
 ## Optimizing tables
 
-Optimizing tables is not currently supported.
+Optimizing a table compacts small files into larger files to avoid the small file problem. This is especially important for tables that get small amounts of data appended to with high frequency. In addition to compacting small files, you can colocate similar data in the same files with Z Ordering, which allows for better file skipping and faster queries.
+
+A table `dt = DeltaTable(...)` has two methods for optimizing it:
+
+- `dt.optimize.compact()` for compacting small files,
+- `dt.optimize.z_order()` to compact and apply Z Ordering.
+
+See the section [Small file compaction](./optimize/small-file-compaction-with-optimize.md) for more information and a detailed example on `compact`, and the section [Z Order](./optimize/delta-lake-z-order.md) for more information on `z_order`.


### PR DESCRIPTION
# Description

Currently the docs section [usage/Managing a table](https://delta-io.github.io/delta-rs/usage/managing-tables/) states that
> Optimizing tables is not currently supported.

This PR adds a short explanation of optimize and links to the more detailed examples of the usage/Optimize sections.

# Related Issue(s)

Closes #2891

# Documentation

https://delta-io.github.io/delta-rs/usage/managing-tables/