### PR TITLE
fix: double-encode paths during zorder optimize when they contain special characters

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -76,9 +76,7 @@ use url::Url;
 use crate::delta_datafusion::expr::parse_predicate_expression;
 use crate::delta_datafusion::schema_adapter::DeltaSchemaAdapterFactory;
 use crate::errors::{DeltaResult, DeltaTableError};
-use crate::kernel::{
-    Add, DataCheck, EagerSnapshot, Invariant, LogicalFile, Snapshot, StructTypeExt,
-};
+use crate::kernel::{Add, DataCheck, EagerSnapshot, Invariant, Snapshot, StructTypeExt};
 use crate::logstore::LogStoreRef;
 use crate::table::builder::ensure_table_uri;
 use crate::table::state::DeltaTableState;

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -3099,7 +3099,6 @@ mod tests {
         use crate::kernel::Protocol;
         use crate::operations::merge::Action;
 
-        let _ = pretty_env_logger::try_init();
         let schema = get_delta_schema();
 
         let actions = vec![Action::Protocol(Protocol::new(1, 4))];
@@ -3194,7 +3193,6 @@ mod tests {
         use crate::kernel::Protocol;
         use crate::operations::merge::Action;
 
-        let _ = pretty_env_logger::try_init();
         let schema = get_delta_schema();
 
         let actions = vec![Action::Protocol(Protocol::new(1, 4))];

--- a/python/tests/test_optimize.py
+++ b/python/tests/test_optimize.py
@@ -4,6 +4,13 @@ from datetime import timedelta
 import pyarrow as pa
 import pytest
 
+try:
+    import pandas as pd
+except ModuleNotFoundError:
+    _has_pandas = False
+else:
+    _has_pandas = True
+
 from deltalake import DeltaTable, write_deltalake
 from deltalake.table import CommitProperties
 
@@ -132,3 +139,31 @@ def test_optimize_schema_evolved_table(
     assert dt.to_pyarrow_table().sort_by([("foo", "ascending")]) == data.sort_by(
         [("foo", "ascending")]
     )
+
+
+@pytest.mark.pandas
+def test_zorder_with_space_partition(tmp_path: pathlib.Path):
+    df = pd.DataFrame(
+        {
+            "user": ["James", "Anna", "Sara", "Martin"],
+            "country": ["United States", "Canada", "Costa Rica", "South Africa"],
+            "age": [34, 23, 45, 26],
+        }
+    )
+
+    write_deltalake(
+        table_or_uri=tmp_path,
+        data=df,
+        mode="overwrite",
+        partition_by=["country"],
+    )
+
+    test_table = DeltaTable(tmp_path)
+
+    # retrieve by partition works fine
+    partitioned_df = test_table.to_pandas(
+        partitions=[("country", "=", "United States")],
+    )
+    print(partitioned_df)
+
+    test_table.optimize.z_order(columns=["user"])


### PR DESCRIPTION
The real fix should be likely done in Datafusion, allowing [ListingTableUrl] to be directly created rather than needing to parse the &str passed  through


Fixes #2834 