### PR TITLE
fix: cdc merge union schema order

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"


### PR DESCRIPTION
# Description
DataFusion doesn't have unionByName or a relaxed concat, so the before and after schema needs to be in the same order. The before though was getting expressions in different order. So just doing a simple select_columns afterwards to take the after schema order (which has the write projection order)

# Related Issue(s)
- closes https://github.com/delta-io/delta-rs/issues/2908
- closes https://github.com/delta-io/delta-rs/issues/2832