### PR TITLE
fix: `ListingSchemaProvider` not forwarding custom `storage_options`

### DIFF
--- a/crates/azure/Cargo.toml
+++ b/crates/azure/Cargo.toml
@@ -12,7 +12,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.21.0", path = "../core" }
+deltalake-core = { version = "0.21.0", path = "../core", features = [
+    "datafusion",
+] }
 lazy_static = "1"
 
 # workspace depenndecies
@@ -20,7 +22,7 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
-object_store = { workspace = true, features = ["azure"]}
+object_store = { workspace = true, features = ["azure"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 regex = { workspace = true }

--- a/crates/core/src/data_catalog/storage/mod.rs
+++ b/crates/core/src/data_catalog/storage/mod.rs
@@ -47,9 +47,9 @@ impl ListingSchemaProvider {
         storage_options: Option<HashMap<String, String>>,
     ) -> DeltaResult<Self> {
         let uri = ensure_table_uri(root_uri)?;
-        let storage_options = storage_options.unwrap_or_default().into();
+        let storage_options: StorageOptions = storage_options.unwrap_or_default().into();
         // We already parsed the url, so unwrapping is safe.
-        let store = store_for(&uri)?;
+        let store = store_for(&uri, &storage_options)?;
         Ok(Self {
             authority: uri.to_string(),
             store,

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -395,10 +395,10 @@ pub fn factories() -> FactoryRegistry {
 }
 
 /// Simpler access pattern for the [FactoryRegistry] to get a single store
-pub fn store_for(url: &Url) -> DeltaResult<ObjectStoreRef> {
+pub fn store_for(url: &Url, storage_options: &StorageOptions) -> DeltaResult<ObjectStoreRef> {
     let scheme = Url::parse(&format!("{}://", url.scheme())).unwrap();
     if let Some(factory) = factories().get(&scheme) {
-        let (store, _prefix) = factory.parse_url_opts(url, &StorageOptions::default())?;
+        let (store, _prefix) = factory.parse_url_opts(url, storage_options)?;
         Ok(store)
     } else {
         Err(DeltaTableError::InvalidTableLocation(url.clone().into()))

--- a/crates/core/tests/fs_common/mod.rs
+++ b/crates/core/tests/fs_common/mod.rs
@@ -5,7 +5,7 @@ use deltalake_core::kernel::{
 use deltalake_core::operations::create::CreateBuilder;
 use deltalake_core::operations::transaction::CommitBuilder;
 use deltalake_core::protocol::{DeltaOperation, SaveMode};
-use deltalake_core::storage::{GetResult, ObjectStoreResult};
+use deltalake_core::storage::{GetResult, ObjectStoreResult, StorageOptions};
 use deltalake_core::DeltaTable;
 use object_store::path::Path as StorePath;
 use object_store::{
@@ -152,7 +152,7 @@ impl SlowStore {
         _options: impl Into<deltalake_core::storage::StorageOptions> + Clone,
     ) -> deltalake_core::DeltaResult<Self> {
         Ok(Self {
-            inner: deltalake_core::storage::store_for(&location)?,
+            inner: deltalake_core::storage::store_for(&location, &StorageOptions::default())?,
         })
     }
 }


### PR DESCRIPTION
# Description
The `ListingTableProvider` used to gather `delta tables` from an `object_store` did not pass the `storage_options` (connection details) to the `object_store` library. Therefore, it was not possible to establish a connection. This PR fixes that specific issue

# Related Issue(s)
None

# Documentation
None