### PR TITLE
fix: properly handle the different flavors of storage options keys

### DIFF
--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-aws"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true


### PR DESCRIPTION
This change addresses some of the problems tacked onto #2893 but does not address the concern with ECS specifically. It does however improve the handling of `storage_options` since the improved credential provider code was introduced
