### PR TITLE
fix: improve errors on field cast failures

### DIFF
--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -273,7 +273,8 @@ def test_write_type_castable_types(existing_table: DeltaTable):
         engine="rust",
     )
     with pytest.raises(
-        Exception, match="Cast error: Cannot cast string 'hello' to value of Int8 type"
+        Exception,
+        match="Cast error: Failed to cast int8 from Int8 to Utf8: Cannot cast string 'hello' to value of Int8 type",
     ):
         write_deltalake(
             existing_table,
@@ -284,7 +285,8 @@ def test_write_type_castable_types(existing_table: DeltaTable):
         )
 
     with pytest.raises(
-        Exception, match="Cast error: Can't cast value 1000 to type Int8"
+        Exception,
+        match="Cast error: Failed to cast int8 from Int8 to Int64: Can't cast value 1000 to type Int8",
     ):
         write_deltalake(
             existing_table,


### PR DESCRIPTION
# Description
Adds information on the field, to-type and from-type when casting fails.

We could consider using our own error type for the casting errors to allow unrolling errors to get the full path to a field. Currently we only give the last part of the path.

When looking at `cast_field` I noticed that we might be missing a match on `(DataType::List(_), DataType::LargeList(_))`. Casting List to LargeList can currently cause some tricky behaviour. I had a record batch with a List type, and tried reading it with a LargeList schema. For some choices of schemas it failed with an error message, for other schemas is did not fail, but read the columns in the wrong order.