### PR TITLE
fix: panics when creating delta tables in threads

### DIFF
--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -11,21 +11,16 @@ use tokio::runtime::Runtime;
 pub fn rt() -> &'static Runtime {
     static TOKIO_RT: OnceLock<Runtime> = OnceLock::new();
     static PID: OnceLock<u32> = OnceLock::new();
-    match PID.get() {
-        Some(pid) if pid == &std::process::id() => {} // Reuse the static runtime.
-        Some(pid) => {
-            panic!(
-                "Forked process detected - current PID is {} but the tokio runtime was created by {}. The tokio \
-                runtime does not support forked processes https://github.com/tokio-rs/tokio/issues/4301. If you are \
-                seeing this message while using Python multithreading make sure to use the `spawn` or `forkserver` \
-                mode.", 
-                pid, std::process::id()
-            );
-        }
-        None => {
-            PID.set(std::process::id())
-                .expect("Failed to record PID for tokio runtime.");
-        }
+    let pid = std::process::id();
+    let runtime_pid = *PID.get_or_init(|| pid);
+    if pid != runtime_pid {
+        panic!(
+            "Forked process detected - current PID is {} but the tokio runtime was created by {}. The tokio \
+            runtime does not support forked processes https://github.com/tokio-rs/tokio/issues/4301. If you are \
+            seeing this message while using Python multithreading make sure to use the `spawn` or `forkserver` \
+            mode.", 
+            pid, runtime_pid
+        );
     }
     TOKIO_RT.get_or_init(|| Runtime::new().expect("Failed to create a tokio runtime."))
 }


### PR DESCRIPTION
# Description

Loading in delta tables from multiple threads is causing panics. Reproducible example:

```python
from multiprocessing.pool import ThreadPool
from deltalake import DeltaTable

def make_dt(x):
    return DeltaTable('/path/to/some/local/table')

pool = ThreadPool(processes=16)
list(pool.map(make_dt, range(16)))
```
causes
```
pyo3_runtime.PanicException: Failed to record PID for tokio runtime.: 71866
```

This race condition is caused by multiple threads trying to acquire and set the `PID`. Multiple threads could succeed at the `PID.get()` call at time before any threads set the `PID`, but only one thread can successfully call `PID.set`, causing the remaining threads to panic.

This fixes by using `get_or_init` for setting `PID`, and only panics if the returned `runtime_pid` is different from the current `pid`.

# Related Issue(s)

- closes https://github.com/delta-io/delta-rs/issues/2905
