### PR TITLE
docs: fix typo

### DIFF
--- a/docs/usage/optimize/delta-lake-z-order.md
+++ b/docs/usage/optimize/delta-lake-z-order.md
@@ -12,5 +12,5 @@ Here's how to Z Order a Delta table:
 
 ```python
 dt = DeltaTable("tmp")
-dt.optimize.z_order([country])
+dt.optimize.z_order(["country"])
 ```


### PR DESCRIPTION
Docs small correction to z_order columns argument.

# Description
`country` should be a string in the `TableOptimizer.z_order`'s `columns` argument.

# Related Issue(s)
N/A

