### PR TITLE
fix: jsonwriter and recordbatchwriter to respect stats skipping

### DIFF
--- a/crates/core/src/table/config.rs
+++ b/crates/core/src/table/config.rs
@@ -207,6 +207,7 @@ macro_rules! table_config {
 }
 
 /// Well known delta table configuration
+#[derive(Debug)]
 pub struct TableConfig<'a>(pub(crate) &'a HashMap<String, Option<String>>);
 
 /// Default num index cols

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -44,6 +44,8 @@ pub struct RecordBatchWriter {
     should_evolve: bool,
     partition_columns: Vec<String>,
     arrow_writers: HashMap<String, PartitionWriter>,
+    num_indexed_cols: i32,
+    stats_columns: Option<Vec<String>>,
 }
 
 impl std::fmt::Debug for RecordBatchWriter {
@@ -60,25 +62,39 @@ impl RecordBatchWriter {
         partition_columns: Option<Vec<String>>,
         storage_options: Option<HashMap<String, String>>,
     ) -> Result<Self, DeltaTableError> {
-        let storage = DeltaTableBuilder::from_uri(table_uri)
+        let delta_table = DeltaTableBuilder::from_uri(table_uri)
             .with_storage_options(storage_options.unwrap_or_default())
-            .build_storage()?
-            .object_store();
-
+            .build()?;
         // Initialize writer properties for the underlying arrow writer
         let writer_properties = WriterProperties::builder()
             // NOTE: Consider extracting config for writer properties and setting more than just compression
             .set_compression(Compression::SNAPPY)
             .build();
 
+        // if metadata fails to load, use an empty hashmap and default values for num_indexed_cols and stats_columns
+        let configuration: HashMap<String, Option<String>> = delta_table.metadata().map_or_else(
+            |_| HashMap::new(),
+            |metadata| metadata.configuration.clone(),
+        );
+
         Ok(Self {
-            storage,
+            storage: delta_table.object_store(),
             arrow_schema_ref: schema.clone(),
             original_schema_ref: schema,
             writer_properties,
             partition_columns: partition_columns.unwrap_or_default(),
             should_evolve: false,
             arrow_writers: HashMap::new(),
+            num_indexed_cols: configuration
+                .get("delta.dataSkippingNumIndexedCols")
+                .and_then(|v| v.clone().map(|v| v.parse::<i32>().unwrap()))
+                .unwrap_or(DEFAULT_NUM_INDEX_COLS),
+            stats_columns: configuration
+                .get("delta.dataSkippingStatsColumns")
+                .and_then(|v| {
+                    v.as_ref()
+                        .map(|v| v.split(',').map(|s| s.to_string()).collect())
+                }),
         })
     }
 
@@ -96,6 +112,8 @@ impl RecordBatchWriter {
             // NOTE: Consider extracting config for writer properties and setting more than just compression
             .set_compression(Compression::SNAPPY)
             .build();
+        let configuration: HashMap<String, Option<String>> =
+            table.metadata()?.configuration.clone();
 
         Ok(Self {
             storage: table.object_store(),
@@ -105,6 +123,16 @@ impl RecordBatchWriter {
             partition_columns,
             should_evolve: false,
             arrow_writers: HashMap::new(),
+            num_indexed_cols: configuration
+                .get("delta.dataSkippingNumIndexedCols")
+                .and_then(|v| v.clone().map(|v| v.parse::<i32>().unwrap()))
+                .unwrap_or(DEFAULT_NUM_INDEX_COLS),
+            stats_columns: configuration
+                .get("delta.dataSkippingStatsColumns")
+                .and_then(|v| {
+                    v.as_ref()
+                        .map(|v| v.split(',').map(|s| s.to_string()).collect())
+                }),
         })
     }
 
@@ -233,8 +261,8 @@ impl DeltaWriter<RecordBatch> for RecordBatchWriter {
                 path.to_string(),
                 file_size,
                 &metadata,
-                DEFAULT_NUM_INDEX_COLS,
-                &None,
+                self.num_indexed_cols,
+                &self.stats_columns,
             )?);
         }
         Ok(actions)
@@ -984,5 +1012,101 @@ mod tests {
                 result
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_write_data_skipping_stats_columns() {
+        let batch = get_record_batch(None, false);
+        let partition_cols: &[String] = &vec![];
+        let table_schema: StructType = get_delta_schema();
+        let table_dir = tempfile::tempdir().unwrap();
+        let table_path = table_dir.path();
+        let config: HashMap<String, Option<String>> = vec![(
+            "delta.dataSkippingStatsColumns".to_string(),
+            Some("id,value".to_string()),
+        )]
+        .into_iter()
+        .collect();
+
+        let mut table = CreateBuilder::new()
+            .with_location(table_path.to_str().unwrap())
+            .with_table_name("test-table")
+            .with_comment("A table for running tests")
+            .with_columns(table_schema.fields().cloned())
+            .with_configuration(config)
+            .with_partition_columns(partition_cols)
+            .await
+            .unwrap();
+
+        let mut writer = RecordBatchWriter::for_table(&table).unwrap();
+        let partitions = writer.divide_by_partition_values(&batch).unwrap();
+
+        assert_eq!(partitions.len(), 1);
+        assert_eq!(partitions[0].record_batch, batch);
+        writer.write(batch).await.unwrap();
+        writer.flush_and_commit(&mut table).await.unwrap();
+        assert_eq!(table.version(), 1);
+        let add_actions = table.state.unwrap().file_actions().unwrap();
+        assert_eq!(add_actions.len(), 1);
+        let expected_stats ="{\"numRecords\":11,\"minValues\":{\"value\":1,\"id\":\"A\"},\"maxValues\":{\"id\":\"B\",\"value\":11},\"nullCount\":{\"id\":0,\"value\":0}}";
+        assert_eq!(
+            expected_stats.parse::<serde_json::Value>().unwrap(),
+            add_actions
+                .into_iter()
+                .nth(0)
+                .unwrap()
+                .stats
+                .unwrap()
+                .parse::<serde_json::Value>()
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_write_data_skipping_num_indexed_colsn() {
+        let batch = get_record_batch(None, false);
+        let partition_cols: &[String] = &vec![];
+        let table_schema: StructType = get_delta_schema();
+        let table_dir = tempfile::tempdir().unwrap();
+        let table_path = table_dir.path();
+        let config: HashMap<String, Option<String>> = vec![(
+            "delta.dataSkippingNumIndexedCols".to_string(),
+            Some("1".to_string()),
+        )]
+        .into_iter()
+        .collect();
+
+        let mut table = CreateBuilder::new()
+            .with_location(table_path.to_str().unwrap())
+            .with_table_name("test-table")
+            .with_comment("A table for running tests")
+            .with_columns(table_schema.fields().cloned())
+            .with_configuration(config)
+            .with_partition_columns(partition_cols)
+            .await
+            .unwrap();
+
+        let mut writer = RecordBatchWriter::for_table(&table).unwrap();
+        let partitions = writer.divide_by_partition_values(&batch).unwrap();
+
+        assert_eq!(partitions.len(), 1);
+        assert_eq!(partitions[0].record_batch, batch);
+        writer.write(batch).await.unwrap();
+        writer.flush_and_commit(&mut table).await.unwrap();
+        assert_eq!(table.version(), 1);
+        let add_actions = table.state.unwrap().file_actions().unwrap();
+        assert_eq!(add_actions.len(), 1);
+        let expected_stats = "{\"numRecords\":11,\"minValues\":{\"id\":\"A\"},\"maxValues\":{\"id\":\"B\"},\"nullCount\":{\"id\":0}}";
+        assert_eq!(
+            expected_stats.parse::<serde_json::Value>().unwrap(),
+            add_actions
+                .into_iter()
+                .nth(0)
+                .unwrap()
+                .stats
+                .unwrap()
+                .parse::<serde_json::Value>()
+                .unwrap()
+        );
     }
 }

--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -26,7 +26,7 @@ pub fn create_add(
     size: i64,
     file_metadata: &FileMetaData,
     num_indexed_cols: i32,
-    stats_columns: &Option<Vec<String>>,
+    stats_columns: &Option<Vec<impl AsRef<str>>>,
 ) -> Result<Add, DeltaTableError> {
     let stats = stats_from_file_metadata(
         partition_values,
@@ -99,7 +99,7 @@ fn stats_from_file_metadata(
     partition_values: &IndexMap<String, Scalar>,
     file_metadata: &FileMetaData,
     num_indexed_cols: i32,
-    stats_columns: &Option<Vec<String>>,
+    stats_columns: &Option<Vec<impl AsRef<str>>>,
 ) -> Result<Stats, DeltaWriterError> {
     let type_ptr = parquet::schema::types::from_thrift(file_metadata.schema.as_slice());
     let schema_descriptor = type_ptr.map(|type_| Arc::new(SchemaDescriptor::new(type_)))?;
@@ -126,7 +126,7 @@ fn stats_from_metadata(
     row_group_metadata: Vec<RowGroupMetaData>,
     num_rows: i64,
     num_indexed_cols: i32,
-    stats_columns: &Option<Vec<String>>,
+    stats_columns: &Option<Vec<impl AsRef<str>>>,
 ) -> Result<Stats, DeltaWriterError> {
     let mut min_values: HashMap<String, ColumnValueStat> = HashMap::new();
     let mut max_values: HashMap<String, ColumnValueStat> = HashMap::new();
@@ -138,7 +138,7 @@ fn stats_from_metadata(
             .into_iter()
             .map(|v| {
                 match sqlparser::parser::Parser::new(&dialect)
-                    .try_with_sql(v)
+                    .try_with_sql(v.as_ref())
                     .map_err(|e| DeltaTableError::generic(e.to_string()))?
                     .parse_multipart_identifier()
                 {

--- a/crates/core/src/writer/test_utils.rs
+++ b/crates/core/src/writer/test_utils.rs
@@ -291,7 +291,7 @@ pub fn create_bare_table() -> DeltaTable {
 }
 
 pub async fn create_initialized_table(partition_cols: &[String]) -> DeltaTable {
-    let table_schema = get_delta_schema();
+    let table_schema: StructType = get_delta_schema();
     let table_dir = tempfile::tempdir().unwrap();
     let table_path = table_dir.path();
 


### PR DESCRIPTION
# Description

This is an update to JsonWriter and RecordBatchWriter to allow them to write commit log stats information in accordance with delta.dataSkippingNumIndexedCols and
delta.dataSkippingStatsColumns if present on the table.  If these fields are unset, then the default behavior of collecting stats for the first 32 columns is preserved

# Related Issue(s)
- closes [#2982](https://github.com/delta-io/delta-rs/issues/2982)

# Tests

Tested by running all unit tests with `cargo test` as well as followed the instructions in CONTRIBUTING.md