### PR TITLE
fix: num rows statistics

### DIFF
--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -509,7 +509,9 @@ mod datafusion {
         fn collect_count(&self, name: &str) -> Precision<usize> {
             let num_records = extract_and_cast_opt::<Int64Array>(self.stats, name);
             if let Some(num_records) = num_records {
-                if let Some(null_count_mulls) = num_records.nulls() {
+                if num_records.len() == 0 {
+                    Precision::Exact(0)
+                } else if let Some(null_count_mulls) = num_records.nulls() {
                     if null_count_mulls.null_count() > 0 {
                         Precision::Absent
                     } else {


### PR DESCRIPTION
# Description
This pr is to get correct `num_rows` statistics for optimizing `select count(*) from xxx` case. 

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
