### PR TITLE
fix: jsonwriter should checkpoint by default

### DIFF
--- a/crates/core/src/writer/mod.rs
+++ b/crates/core/src/writer/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::errors::DeltaTableError;
 use crate::kernel::{Action, Add};
-use crate::operations::transaction::CommitBuilder;
+use crate::operations::transaction::{CommitBuilder, CommitProperties};
 use crate::protocol::{ColumnCountStat, DeltaOperation, SaveMode};
 use crate::DeltaTable;
 
@@ -174,7 +174,7 @@ pub(crate) async fn flush_and_commit(
         predicate: None,
     };
 
-    let version = CommitBuilder::default()
+    let version = CommitBuilder::from(CommitProperties::default())
         .with_actions(adds)
         .build(Some(snapshot), table.log_store.clone(), operation)
         .await?


### PR DESCRIPTION
# Description
This is a fix aimed to enable jsonwriter to checkpoint in accordance with delta.checkpointInterval.  It changes the default commitbuilder to set a post_commit_hook so that checkpointing will be done by default. Potentially we could also expose CommitProperties as an argument to flush_and_commit, but that would require a change to the function signature and would be a breaking change.

# Related Issue(s)

- closes #2992 

