### PR TITLE
feat: concurrent commit changes to `PartitionWriter`

### DIFF
--- a/crates/core/src/operations/writer.rs
+++ b/crates/core/src/operations/writer.rs
@@ -419,6 +419,7 @@ impl PartitionWriter {
         Ok(())
     }
 
+    /// Retrieves the list of [Add] actions associated with the files written.
     pub async fn drain_files_written(&self) -> Vec<Add> {
         self.files_written.write().await.drain(..).collect()
     }


### PR DESCRIPTION
# Description
Added `drain_files_written()` to `PartitionWriter` to drain the not yet committed changes.

# Related Issue(s)
None

# Documentation
None
