### PR TITLE
docs: fix the verify table existence example in usage docs

### DIFF
--- a/docs/usage/loading-table.md
+++ b/docs/usage/loading-table.md
@@ -131,7 +131,7 @@ wish to load:
 >>> dt = DeltaTable("../rust/tests/data/simple_table", version=2)
 ```
 
-Once you\'ve loaded a table, you can also change versions using either a
+Once you've loaded a table, you can also change versions using either a
 version number or datetime string:
 
 ```python

--- a/docs/usage/loading-table.md
+++ b/docs/usage/loading-table.md
@@ -81,7 +81,7 @@ storage_options = {
     "AWS_SECRET_ACCESS_KEY": "THE_AWS_SECRET_ACCESS_KEY",
     ...
 }
-DeltaTable.is_deltatable(bucket_table_path)
+DeltaTable.is_deltatable(bucket_table_path, storage_options)
 # True
 ```
 


### PR DESCRIPTION
# Description
Added the `storage_options` parameter to the `is_deltatable()` method in Usage's "Verify Table Existence" section.

# Related Issue(s)
<!---
For example:

- closes #106
--->
closes #3002 
# Documentation

<!---
Share links to useful documentation
--->
