### PR TITLE
fix: expression with dates to string conversation

### DIFF
--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -505,7 +505,7 @@ impl<'a> fmt::Display for ScalarValueFormat<'a> {
             ScalarValue::Date32(e) => match e {
                 Some(e) => write!(
                     f,
-                    "{}",
+                    "'{}'::date",
                     NaiveDate::from_num_days_from_ce_opt(EPOCH_DAYS_FROM_CE + (*e)).ok_or(Error)?
                 )?,
                 None => write!(f, "NULL")?,
@@ -871,6 +871,18 @@ mod test {
                                 lit(ScalarValue::Utf8(Some("2010-01-01T00:00:00.000000".into()))),
                                 lit(ScalarValue::Utf8(Some("Timestamp(Microsecond, Some(\"UTC\"))".into())))
                             ]
+                        }
+                    )
+                )),
+            },
+            ParseTest {
+                expr: col("_date").eq(lit(ScalarValue::Date32(Some(18262)))),
+                expected: "_date = '2020-01-01'::date".to_string(),
+                override_expected_expr: Some(col("_date").eq(
+                    Expr::Cast(
+                        Cast {
+                            expr: Box::from(lit("2020-01-01")),
+                            data_type: arrow_schema::DataType::Date32
                         }
                     )
                 )),

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -805,7 +805,7 @@ def test_merge_date_partitioned_2344(tmp_path: pathlib.Path):
 
     assert last_action["operation"] == "MERGE"
     assert result == data
-    assert last_action["operationParameters"].get("predicate") == "2022-02-01 = date"
+    assert last_action["operationParameters"].get("predicate") == "'2022-02-01'::date = date"
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -805,7 +805,10 @@ def test_merge_date_partitioned_2344(tmp_path: pathlib.Path):
 
     assert last_action["operation"] == "MERGE"
     assert result == data
-    assert last_action["operationParameters"].get("predicate") == "'2022-02-01'::date = date"
+    assert (
+        last_action["operationParameters"].get("predicate")
+        == "'2022-02-01'::date = date"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description
In the expr to str conversation was an issue for dates.

Before this expr `lit(ScalarValue::Date32(Some(18262)))` was converted to `_date = 2020-01-01`. If you want to parse this string again as an expr it will result into `...BinaryExpr(**BinaryExpr { left: BinaryExpr(BinaryExpr { left: Literal(Int64(2020)), op: Minus, right: Literal(Int64(1)) })...` which is not correct.

Now `lit(ScalarValue::Date32(Some(18262)))` will be converted to `_date = '2020-01-01'::date`, which will be parsed a as date again. 

# Related Issue(s)
- closes #2980
- closes https://github.com/delta-io/delta-rs/issues/2462

