### PR TITLE
fix(python): pass ending_timestamp correctly

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -697,7 +697,7 @@ impl RawDeltaTable {
             let ending_ts = DateTime::<Utc>::from_str(&et)
                 .map_err(|pe| PyValueError::new_err(pe.to_string()))?
                 .to_utc();
-            cdf_read = cdf_read.with_starting_timestamp(ending_ts);
+            cdf_read = cdf_read.with_ending_timestamp(ending_ts);
         }
 
         if let Some(columns) = columns {


### PR DESCRIPTION
# Description
Ending_timestamp was passed to starting_timestamp instead of ending_timestamp

cc@hntd187 
# Related Issue(s)
- closes https://github.com/delta-io/delta-rs/issues/3023