### PR TITLE
fix: workaround for Add actions being read slightly differently out of parquet files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ debug = "line-tables-only"
 
 [workspace.dependencies]
 delta_kernel = { version = "0.4.1", features = ["sync-engine"] }
-# delta_kernel = { path = "../delta-kernel-rs/kernel", version = "0.3.0" }
+#delta_kernel = { path = "../delta-kernel-rs/kernel", features = ["sync-engine"]  }
 
 # arrow
 arrow = { version = "53" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-core"
-version = "0.22.0"
+version = "0.22.1"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/core/src/kernel/models/fields.rs
+++ b/crates/core/src/kernel/models/fields.rs
@@ -258,11 +258,11 @@ fn deletion_vector_field() -> StructField {
     StructField::new(
         "deletionVector",
         DataType::Struct(Box::new(StructType::new(vec![
-            StructField::new("storageType", DataType::STRING, true),
-            StructField::new("pathOrInlineDv", DataType::STRING, true),
+            StructField::new("storageType", DataType::STRING, false),
+            StructField::new("pathOrInlineDv", DataType::STRING, false),
             StructField::new("offset", DataType::INTEGER, true),
-            StructField::new("sizeInBytes", DataType::INTEGER, true),
-            StructField::new("cardinality", DataType::LONG, true),
+            StructField::new("sizeInBytes", DataType::INTEGER, false),
+            StructField::new("cardinality", DataType::LONG, false),
         ]))),
         true,
     )

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake"
-version = "0.22.0"
+version = "0.22.1"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"

--- a/python/tests/test_checkpoint.py
+++ b/python/tests/test_checkpoint.py
@@ -468,3 +468,33 @@ def test_checkpoint_with_nullable_false(tmp_path: pathlib.Path):
     assert checkpoint_path.exists()
 
     assert DeltaTable(str(tmp_table_path)).to_pyarrow_table() == data
+
+
+@pytest.mark.pandas
+def test_checkpoint_with_multiple_writes(tmp_path: pathlib.Path):
+    import pandas as pd
+
+    write_deltalake(
+        tmp_path,
+        pd.DataFrame(
+            {
+                "a": ["a"],
+                "b": [3],
+            }
+        ),
+    )
+    DeltaTable(tmp_path).create_checkpoint()
+
+    dt = DeltaTable(tmp_path)
+    print(dt.to_pandas())
+
+    write_deltalake(
+        tmp_path,
+        pd.DataFrame(
+            {
+                "a": ["a"],
+                "b": [100],
+            }
+        ),
+        mode="overwrite",
+    )


### PR DESCRIPTION
This  workaround fixes #3030 but I'm not quite happy about how. I believe there is likely an upstream issue in arrow that I have not been able to reproduce where the nullable struct (deletionVector) which has non-nullable members (e.g. storageType) that are being read as empty strings rather than `null`.

This issue started to appear with the v0.22 release which included an upgrade to datafusion 43 and arrow 53. I believe the latter is causing the issue here since it affects non-datafusion code paths.

This workaround at least allows us to move forward and release a v0.22.1 while continuing to hunt down the issue.