### PR TITLE
chore: create a new minor version with the MSRV upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: '1.80'
+          toolchain: '1.81'
           override: true
 
       - name: Format
@@ -42,7 +42,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: '1.80'
+          toolchain: '1.81'
           override: true
 
       - name: build and lint with clippy
@@ -79,7 +79,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: '1.80'
+          toolchain: '1.81'
           override: true
 
       - name: Run tests
@@ -114,7 +114,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: '1.80'
+          toolchain: '1.81'
           override: true
 
       # Install Java and Hadoop for HDFS integration tests

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: '1.80'
+          toolchain: '1.81'
           override: true
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Qingping Hou <dave2008713@gmail.com>"]
-rust-version = "1.80"
+rust-version = "1.81"
 keywords = ["deltalake", "delta", "datalake"]
 readme = "README.md"
 edition = "2021"

--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-aws"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.22.0", path = "../core" }
+deltalake-core = { version = "0.23.0", path = "../core" }
 aws-smithy-runtime-api = { version="1.7" }
 aws-smithy-runtime = { version="1.7", optional = true}
 aws-credential-types = { version="1.2", features = ["hardcoded-credentials"]}

--- a/crates/azure/Cargo.toml
+++ b/crates/azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-azure"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.22.0", path = "../core", features = [
+deltalake-core = { version = "0.23.0", path = "../core", features = [
     "datafusion",
 ] }
 lazy_static = "1"

--- a/crates/catalog-glue/Cargo.toml
+++ b/crates/catalog-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-catalog-glue"
-version = "0.6.0"
+version = "0.7.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -15,7 +15,7 @@ rust-version.workspace = true
 async-trait = { workspace = true }
 aws-config = "1"
 aws-sdk-glue = "1"
-deltalake-core = { version = "0.22.0", path = "../core" }
+deltalake-core = { version = "0.23.0", path = "../core" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/catalog-unity/Cargo.toml
+++ b/crates/catalog-unity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-catalog-unity"
-version = "0.6.0"
+version = "0.7.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -17,7 +17,7 @@ tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-deltalake-core = { version = "0.22", path = "../core" }
+deltalake-core = { version = "0.23", path = "../core" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "http2"] }
 reqwest-retry = "0.7"
 reqwest-middleware = "0.4.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-core"
-version = "0.22.4"
+version = "0.23.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake"
-version = "0.22.4"
+version = "0.23.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -16,13 +16,13 @@ rust-version.workspace = true
 features = ["azure", "datafusion", "gcs", "hdfs", "json", "python", "s3", "unity-experimental"]
 
 [dependencies]
-deltalake-core = { version = "0.22.2", path = "../core" }
-deltalake-aws = { version = "0.5.0", path = "../aws", default-features = false, optional = true }
-deltalake-azure = { version = "0.5.0", path = "../azure", optional = true }
-deltalake-gcp = { version = "0.6.0", path = "../gcp", optional = true }
-deltalake-hdfs = { version = "0.6.0", path = "../hdfs", optional = true }
-deltalake-catalog-glue = { version = "0.6.0", path = "../catalog-glue", optional = true }
-deltalake-catalog-unity = { version = "0.6.0", path = "../catalog-unity", optional = true }
+deltalake-core = { version = "0.23.0", path = "../core" }
+deltalake-aws = { version = "0.6.0", path = "../aws", default-features = false, optional = true }
+deltalake-azure = { version = "0.6.0", path = "../azure", optional = true }
+deltalake-gcp = { version = "0.7.0", path = "../gcp", optional = true }
+deltalake-hdfs = { version = "0.7.0", path = "../hdfs", optional = true }
+deltalake-catalog-glue = { version = "0.7.0", path = "../catalog-glue", optional = true }
+deltalake-catalog-unity = { version = "0.7.0", path = "../catalog-unity", optional = true }
 
 [features]
 # All of these features are just reflected into the core crate until that

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-gcp"
-version = "0.6.0"
+version = "0.7.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.22.0", path = "../core" }
+deltalake-core = { version = "0.23.0", path = "../core" }
 lazy_static = "1"
 
 # workspace depenndecies

--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-hdfs"
-version = "0.6.0"
+version = "0.7.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.22.0", path = "../core" }
+deltalake-core = { version = "0.23.0", path = "../core" }
 hdfs-native-object-store = "0.12"
 
 # workspace dependecies

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-mount"
-version = "0.6.0"
+version = "0.7.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.22.0", path = "../core", features = [
+deltalake-core = { version = "0.23.0", path = "../core", features = [
     "datafusion",
 ] }
 lazy_static = "1"

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "deltalake-test"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 publish = false
 
 [dependencies]
 bytes = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["clock"] }
-deltalake-core = { version = "0.22.0", path = "../core" }
+deltalake-core = { version = "0.23.0", path = "../core" }
 dotenvy = "0"
 fs_extra = "1.3.0"
 futures = { version = "0.3" }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.22.4"
+version = "0.23.0"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"


### PR DESCRIPTION
a number of our transitive dependencies have forced the upgrade in patch versions of the Minimum Supported Rust Version (MSRV) and broke builds from crates.io and `main` on Rust 1.80. :unamused:

This change upgrades us to 1.81 but bumps to 0.23 in the process.
