### PR TITLE
fix: remove println from regular_rename func

### DIFF
--- a/crates/mount/src/file.rs
+++ b/crates/mount/src/file.rs
@@ -272,8 +272,6 @@ async fn regular_rename(from: &str, to: &str) -> Result<(), LocalFileSystemError
     let from_path = String::from(from);
     let to_path = String::from(to);
 
-    println!("rr {from_path} -> {to_path}");
-
     tokio::task::spawn_blocking(move || {
         if std::fs::metadata(&to_path).is_ok() {
             Err(LocalFileSystemError::AlreadyExists {


### PR DESCRIPTION
# Description
Remove a println that looks to be unnecessary.


Closes #3070


