### PR TITLE
chore: pin to pre-release DataFusion to test upgrade to 44

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,17 @@ async-trait = { version = "0.1" }
 futures = { version = "0.3" }
 tokio = { version = "1" }
 num_cpus = { version = "1" }
+
+# temporary datafusion patches
+[patch.crates-io]
+datafusion = { git = "https://github.com/apache/datafusion.git", rev = "a50ed3488f77743a192d9e8dd9c99f00df659ef1" }
+datafusion-common = { git = "https://github.com/apache/datafusion.git", rev = "a50ed3488f77743a192d9e8dd9c99f00df659ef1" }
+datafusion-execution = { git = "https://github.com/apache/datafusion.git", rev = "a50ed3488f77743a192d9e8dd9c99f00df659ef1" }
+datafusion-expr = { git = "https://github.com/apache/datafusion.git", rev = "a50ed3488f77743a192d9e8dd9c99f00df659ef1" }
+datafusion-ffi = { git = "https://github.com/apache/datafusion.git", rev = "a50ed3488f77743a192d9e8dd9c99f00df659ef1" }
+datafusion-functions = { git = "https://github.com/apache/datafusion.git", rev = "a50ed3488f77743a192d9e8dd9c99f00df659ef1" }
+datafusion-functions-aggregate = { git = "https://github.com/apache/datafusion.git", rev = "a50ed3488f77743a192d9e8dd9c99f00df659ef1" }
+datafusion-physical-expr = { git = "https://github.com/apache/datafusion.git", rev = "a50ed3488f77743a192d9e8dd9c99f00df659ef1" }
+datafusion-physical-plan = { git = "https://github.com/apache/datafusion.git", rev = "a50ed3488f77743a192d9e8dd9c99f00df659ef1" }
+datafusion-proto = { git = "https://github.com/apache/datafusion.git", rev = "a50ed3488f77743a192d9e8dd9c99f00df659ef1" }
+datafusion-sql = { git = "https://github.com/apache/datafusion.git", rev = "a50ed3488f77743a192d9e8dd9c99f00df659ef1" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -96,7 +96,7 @@ tracing = { workspace = true }
 rand = "0.8"
 z85 = "3.0.5"
 maplit = "1"
-sqlparser = { version = "0.52.0" }
+sqlparser = { version = "0.53.0" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/sql/src/parser.rs
+++ b/crates/sql/src/parser.rs
@@ -224,9 +224,9 @@ impl<'a> DeltaParser<'a> {
 
 #[cfg(test)]
 mod tests {
-    use datafusion_sql::sqlparser::ast::Ident;
-
     use super::*;
+    use datafusion_sql::sqlparser::ast::Ident;
+    use datafusion_sql::sqlparser::tokenizer::Span;
 
     fn expect_parse_ok(sql: &str, expected: Statement) -> Result<(), ParserError> {
         let statements = DeltaParser::parse_sql(sql)?;
@@ -245,6 +245,7 @@ mod tests {
             table: ObjectName(vec![Ident {
                 value: "data_table".to_string(),
                 quote_style: None,
+                span: Span::empty(),
             }]),
             retention_hours: None,
             dry_run: false,
@@ -255,6 +256,7 @@ mod tests {
             table: ObjectName(vec![Ident {
                 value: "data_table".to_string(),
                 quote_style: None,
+                span: Span::empty(),
             }]),
             retention_hours: Some(10),
             dry_run: false,
@@ -265,6 +267,7 @@ mod tests {
             table: ObjectName(vec![Ident {
                 value: "data_table".to_string(),
                 quote_style: None,
+                span: Span::empty(),
             }]),
             retention_hours: Some(10),
             dry_run: true,
@@ -275,6 +278,7 @@ mod tests {
             table: ObjectName(vec![Ident {
                 value: "data_table".to_string(),
                 quote_style: None,
+                span: Span::empty(),
             }]),
             retention_hours: None,
             dry_run: true,


### PR DESCRIPTION
# Description
This PR is designed to help test DataFusion 44 with delta-rs *before* we release DataFusion

- It targets https://github.com/delta-io/delta-rs/pull/3073 from @rtyler 

It temporarily pins DataFusion to the latest version on main so we can test / verify the tests run

# Related Issue(s)
- https://github.com/delta-io/delta-rs/pull/3073
- https://github.com/apache/datafusion/issues/13834

# Documentation

<!---
Share links to useful documentation
--->
