### PR TITLE
chore: Reduce compiler warnings by updating to use non deprecated DataFusion APIs

### DIFF
--- a/crates/catalog-unity/src/error.rs
+++ b/crates/catalog-unity/src/error.rs
@@ -10,7 +10,6 @@ pub enum UnityCatalogError {
     },
 
     /// A generic error qualified in the message
-
     #[error("{source}")]
     Retry {
         /// Error message
@@ -19,7 +18,6 @@ pub enum UnityCatalogError {
     },
 
     #[error("Request error: {source}")]
-
     /// Error from reqwest library
     RequestError {
         /// The underlying reqwest_middleware::Error
@@ -35,7 +33,6 @@ pub enum UnityCatalogError {
     },
 
     /// Error caused by invalid access token value
-
     #[error("Invalid Databricks personal access token")]
     InvalidAccessToken,
 }

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -1822,7 +1822,6 @@ mod tests {
     use crate::operations::write::SchemaMode;
     use crate::writer::test_utils::get_delta_schema;
     use arrow::array::StructArray;
-    use arrow::datatypes::DataType;
     use arrow::datatypes::{Field, Schema};
     use chrono::{TimeZone, Utc};
     use datafusion::assert_batches_sorted_eq;

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -1215,10 +1215,7 @@ pub(super) mod zorder {
         use url::Url;
 
         use ::datafusion::{
-            execution::{
-                memory_pool::FairSpillPool,
-                runtime_env::{RuntimeConfig, RuntimeEnv},
-            },
+            execution::{memory_pool::FairSpillPool, runtime_env::RuntimeEnvBuilder},
             prelude::{SessionConfig, SessionContext},
         };
         use arrow_schema::DataType;
@@ -1245,8 +1242,9 @@ pub(super) mod zorder {
                 let columns = columns.into();
 
                 let memory_pool = FairSpillPool::new(max_spill_size);
-                let config = RuntimeConfig::new().with_memory_pool(Arc::new(memory_pool));
-                let runtime = Arc::new(RuntimeEnv::try_new(config)?);
+                let runtime = RuntimeEnvBuilder::new()
+                    .with_memory_pool(Arc::new(memory_pool))
+                    .build_arc()?;
                 runtime.register_object_store(&Url::parse("delta-rs://").unwrap(), object_store);
 
                 let ctx = SessionContext::new_with_config_rt(SessionConfig::default(), runtime);

--- a/crates/sql/src/parser.rs
+++ b/crates/sql/src/parser.rs
@@ -5,7 +5,7 @@ use datafusion_sql::parser::{DFParser, Statement as DFStatement};
 use datafusion_sql::sqlparser::ast::{ObjectName, Value};
 use datafusion_sql::sqlparser::dialect::{keywords::Keyword, Dialect, GenericDialect};
 use datafusion_sql::sqlparser::parser::{Parser, ParserError};
-use datafusion_sql::sqlparser::tokenizer::{Token, TokenWithLocation, Tokenizer};
+use datafusion_sql::sqlparser::tokenizer::{Token, TokenWithSpan, Tokenizer};
 
 // Use `Parser::expected` instead, if possible
 macro_rules! parser_err {
@@ -129,7 +129,7 @@ impl<'a> DeltaParser<'a> {
     }
 
     /// Report an unexpected token
-    fn expected<T>(&self, expected: &str, found: TokenWithLocation) -> Result<T, ParserError> {
+    fn expected<T>(&self, expected: &str, found: TokenWithSpan) -> Result<T, ParserError> {
         parser_err!(format!("Expected {expected}, found: {found}"))
     }
 

--- a/crates/test/src/datafusion.rs
+++ b/crates/test/src/datafusion.rs
@@ -1,18 +1,10 @@
 use deltalake_core::datafusion::execution::context::SessionContext;
-use deltalake_core::datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use deltalake_core::datafusion::execution::session_state::SessionStateBuilder;
-use deltalake_core::datafusion::prelude::SessionConfig;
 use deltalake_core::delta_datafusion::DeltaTableFactory;
 use std::sync::Arc;
 
 pub fn context_with_delta_table_factory() -> SessionContext {
-    let cfg = RuntimeConfig::new();
-    let env = RuntimeEnv::try_new(cfg).unwrap();
-    let ses = SessionConfig::new();
-    let mut state = SessionStateBuilder::new()
-        .with_config(ses)
-        .with_runtime_env(Arc::new(env))
-        .build();
+    let mut state = SessionStateBuilder::new().build();
     state
         .table_factories_mut()
         .insert("DELTATABLE".to_string(), Arc::new(DeltaTableFactory {}));


### PR DESCRIPTION
- targets https://github.com/delta-io/delta-rs/pull/3073 from @rtyler 

This PR makes some small changes to reduce the build warnings by using non deprecated APIs