### PR TITLE
feat(python): add sql() and show() convenience method to QueryBuilder

### DIFF
--- a/python/deltalake/query.py
+++ b/python/deltalake/query.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import warnings
 from typing import List
 
@@ -8,6 +9,8 @@ import pyarrow
 from deltalake._internal import PyQueryBuilder
 from deltalake.table import DeltaTable
 from deltalake.warnings import ExperimentalWarning
+
+logger = logging.getLogger(__name__)
 
 
 class QueryBuilder:
@@ -47,9 +50,9 @@ class QueryBuilder:
         )
         return self
 
-    def execute(self, sql: str) -> List[pyarrow.RecordBatch]:
+    def execute(self, sql: str) -> QueryResult:
         """
-        Execute the query and return a list of record batches
+        Prepares the sql query to be executed.
 
         For example:
 
@@ -59,6 +62,61 @@ class QueryBuilder:
         >>> dt = DeltaTable.create(table_uri=tmp, schema=pa.schema([pa.field('name', pa.string())]))
         >>> qb = QueryBuilder().register('test', dt)
         >>> results = qb.execute('SELECT * FROM test')
+        >>> assert isinstance(results, QueryResult)
+        """
+        return QueryResult(self._query_builder, sql)
+
+    def sql(self, sql: str) -> QueryResult:
+        """
+        Convenience method for `execute()` method.
+
+        For example:
+
+        >>> tmp = getfixture('tmp_path')
+        >>> import pyarrow as pa
+        >>> from deltalake import DeltaTable, QueryBuilder
+        >>> dt = DeltaTable.create(table_uri=tmp, schema=pa.schema([pa.field('name', pa.string())]))
+        >>> qb = QueryBuilder().register('test', dt)
+        >>> query = 'SELECT * FROM test'
+        >>> assert qb.execute(query).fetchall() == qb.sql(query).fetchall()
+        """
+        return self.execute(sql)
+
+
+class QueryResult:
+    def __init__(self, query_builder: PyQueryBuilder, sql: str):
+        self._query_builder = query_builder
+        self._sql_query = sql
+
+    def show(self) -> None:
+        """
+        Execute the query and prints the output in the console.
+
+        For example:
+
+        >>> tmp = getfixture('tmp_path')
+        >>> import pyarrow as pa
+        >>> from deltalake import DeltaTable, QueryBuilder
+        >>> dt = DeltaTable.create(table_uri=tmp, schema=pa.schema([pa.field('name', pa.string())]))
+        >>> qb = QueryBuilder().register('test', dt)
+        >>> results = qb.execute('SELECT * FROM test').show()
+        """
+        records = self.fetchall()
+        if len(records) > 0:
+            print(pyarrow.Table.from_batches(records))
+        else:
+            logger.info("The executed query contains no records.")
+
+    def fetchall(self) -> List[pyarrow.RecordBatch]:
+        """
+        Execute the query and return a list of record batches.
+
+        >>> tmp = getfixture('tmp_path')
+        >>> import pyarrow as pa
+        >>> from deltalake import DeltaTable, QueryBuilder
+        >>> dt = DeltaTable.create(table_uri=tmp, schema=pa.schema([pa.field('name', pa.string())]))
+        >>> qb = QueryBuilder().register('test', dt)
+        >>> results = qb.execute('SELECT * FROM test').fetchall()
         >>> assert results is not None
         """
-        return self._query_builder.execute(sql)
+        return self._query_builder.execute(self._sql_query)


### PR DESCRIPTION
# Description
Adds user friendly methods, namely sql() and show() to the QueryBuilder

# Related Issue(s)
- closes #3076

# Documentation

<!---
Share links to useful documentation
--->
