### PR TITLE
feat: allow multiple Python threads to work with a single DeltaTable instance

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.23.1"
+version = "0.23.2"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"
@@ -33,6 +33,7 @@ env_logger = "0"
 lazy_static = "1"
 regex = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 # runtime
 futures = { workspace = true }

--- a/python/src/filesystem.rs
+++ b/python/src/filesystem.rs
@@ -71,11 +71,11 @@ impl DeltaFileSystemHandler {
         options: Option<HashMap<String, String>>,
         known_sizes: Option<HashMap<String, i64>>,
     ) -> PyResult<Self> {
-        let storage = table._table.object_store();
+        let storage = table.object_store()?;
         Ok(Self {
             inner: storage,
             config: FsConfig {
-                root_url: table._table.table_uri(),
+                root_url: table.with_table(|t| Ok(t.table_uri()))?,
                 options: options.unwrap_or_default(),
             },
             known_sizes,

--- a/python/src/query.rs
+++ b/python/src/query.rs
@@ -35,15 +35,15 @@ impl PyQueryBuilder {
     /// Once called, the provided `delta_table` will be referencable in SQL queries so long as
     /// another table of the same name is not registered over it.
     pub fn register(&self, table_name: &str, delta_table: &RawDeltaTable) -> PyResult<()> {
-        let snapshot = delta_table._table.snapshot().map_err(PythonError::from)?;
-        let log_store = delta_table._table.log_store();
+        let snapshot = delta_table.cloned_state()?;
+        let log_store = delta_table.log_store()?;
 
         let scan_config = DeltaScanConfigBuilder::default()
-            .build(snapshot)
+            .build(&snapshot)
             .map_err(PythonError::from)?;
 
         let provider = Arc::new(
-            DeltaTableProvider::try_new(snapshot.clone(), log_store, scan_config)
+            DeltaTableProvider::try_new(snapshot, log_store, scan_config)
                 .map_err(PythonError::from)?,
         );
 

--- a/python/tests/test_threaded.py
+++ b/python/tests/test_threaded.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+#
+# This filue contains all the tests of the deltalake python package in a
+# multithreaded environment
+
+import pathlib
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pyarrow as pa
+import pytest
+
+from deltalake import DeltaTable, write_deltalake
+from deltalake.exceptions import CommitFailedError
+
+
+def test_concurrency(existing_table: DeltaTable, sample_data: pa.Table):
+    exception = None
+
+    def comp():
+        nonlocal exception
+        dt = DeltaTable(existing_table.table_uri)
+        for _ in range(5):
+            # We should always be able to get a consistent table state
+            data = DeltaTable(dt.table_uri).to_pyarrow_table()
+            # If two overwrites delete the same file and then add their own
+            # concurrently, then this will fail.
+            assert data.num_rows == sample_data.num_rows
+            try:
+                write_deltalake(dt.table_uri, sample_data, mode="overwrite")
+            except Exception as e:
+                exception = e
+
+    n_threads = 2
+    threads = [threading.Thread(target=comp) for _ in range(n_threads)]
+
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert isinstance(exception, CommitFailedError)
+    assert (
+        "a concurrent transaction deleted the same data your transaction deletes"
+        in str(exception)
+    )
+
+
+@pytest.mark.polars
+def test_multithreaded_write(sample_data: pa.Table, tmp_path: pathlib.Path):
+    import polars as pl
+
+    table = pl.DataFrame({"a": [1, 2, 3]}).to_arrow()
+    write_deltalake(tmp_path, table, mode="overwrite")
+
+    dt = DeltaTable(tmp_path)
+
+    with ThreadPoolExecutor() as exe:
+        list(exe.map(lambda _: write_deltalake(dt, table, mode="append"), range(5)))


### PR DESCRIPTION
This change introduces an internal Mutex inside of RawDeltaTable which allows the PyO3 bindings to share the Python object between threads at the Python layer.

PyO3 will raise a `RuntimeError: Already borrowed` for any function call which takes a mutable reference to `self`. Introducing the internal Mutex ensures that all function signatures can operate with just self-references safely.

The Rust-level Mutex is a simple passthrough for most operations which do not need to modify the underlying state. The critical sections which typically need to acquire and mutate with a lock are after I/O bound operations are completed as far as I can tell, so I don't anticipate deadlock or performance issues.

There is still some cleanup of errors that needs to happen to make the code here more ergonomic when blending DeltaError with PoisonError from the lock, as such right now there's a lot of ugly error mapping.

Fixes #2958
