### PR TITLE
feat: lakefs integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,3 +139,40 @@ jobs:
       - name: Run tests with native-tls
         run: |
           cargo test --no-default-features --features integration_test,s3-native-tls,datafusion
+
+  integration_test_lakefs:
+    name: Integration Tests (LakeFS v1.48)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 0
+      # Disable full debug symbol generation to speed up CI build and keep memory down
+      # <https://doc.rust-lang.org/cargo/reference/profiles.html>
+      RUSTFLAGS: "-C debuginfo=line-tables-only"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      RUST_BACKTRACE: "1"
+      RUST_LOG: debug
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install minimal stable with clippy and rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: '1.81'
+          override: true
+
+      - name: Download Lakectl
+        run: |
+          wget -q https://github.com/treeverse/lakeFS/releases/download/1.48.1/lakeFS_1.48.1_Linux_x86_64.tar.gz
+          tar -xf lakeFS_1.48.1_Linux_x86_64.tar.gz -C $GITHUB_WORKSPACE
+          echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
+
+      - name: Start emulated services
+        run: docker compose -f docker-compose-lakefs.yml up -d
+
+      - name: Run tests with rustls (default)
+        run: |
+          cargo test --features integration_test_lakefs,lakefs,datafusion
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Download Lakectl
         run: |
-          wget -q https://github.com/treeverse/lakeFS/releases/download/1.48.1/lakeFS_1.48.1_Linux_x86_64.tar.gz
+          wget -q https://github.com/treeverse/lakeFS/releases/download/v1.48.1/lakeFS_1.48.1_Linux_x86_64.tar.gz
           tar -xf lakeFS_1.48.1_Linux_x86_64.tar.gz -C $GITHUB_WORKSPACE
           echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,7 +26,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - uses: Swatinem/rust-cache@v2
       - name: Generate code coverage
-        run: cargo llvm-cov --features ${DEFAULT_FEATURES} --workspace --codecov --output-path codecov.json -- --skip read_table_version_hdfs
+        run: cargo llvm-cov --features ${DEFAULT_FEATURES} --workspace --codecov --output-path codecov.json -- --skip read_table_version_hdfs --skip test_read_tables_lakefs
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -77,13 +77,38 @@ jobs:
         run: make setup-dat
 
       - name: Run tests
-        run: uv run pytest -m '((s3 or azure) and integration) or not integration and not benchmark' --doctest-modules
+        run: uv run --no-sync pytest -m '((s3 or azure) and integration) or not integration and not benchmark' --doctest-modules
 
       - name: Test without pandas
         run: |
           uv pip uninstall pandas
-          uv run pytest -m "not pandas and not integration and not benchmark"
+          uv run --no-sync pytest -m "not pandas and not integration and not benchmark"
           uv pip install pandas
+  
+  test-lakefs:
+    name: Python Build (Python 3.10 LakeFS Integration tests)
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-C debuginfo=1"
+      CARGO_INCREMENTAL: 0
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+
+      - name: Start emulated services
+        run: docker compose -f ../docker-compose-lakefs.yml up -d
+
+      - name: Build and install deltalake
+        run: make develop
+
+      - name: Download Data Acceptance Tests (DAT) files
+        run: make setup-dat
+
+      - name: Run tests
+        run: uv run --no-sync pytest -m '(lakefs and integration)' --doctest-modules
 
   test-pyspark:
     name: PySpark Integration Tests
@@ -108,6 +133,7 @@ jobs:
 
       - name: Run tests
         run: make test-pyspark
+
 
   multi-python-running:
     name: Running with Python ${{ matrix.python-version }}

--- a/crates/aws/src/storage.rs
+++ b/crates/aws/src/storage.rs
@@ -830,7 +830,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_is_aws() {
+        clear_env_of_aws_keys();
         let options = StorageOptions::default();
         assert!(is_aws(&options));
 

--- a/crates/aws/tests/repair_s3_rename_test.rs
+++ b/crates/aws/tests/repair_s3_rename_test.rs
@@ -120,7 +120,7 @@ fn create_s3_backend(
         .with_allow_http(true)
         .build_storage()
         .unwrap()
-        .object_store();
+        .object_store(None);
 
     let delayed_store = DelayedObjectStore {
         inner: store,

--- a/crates/azure/tests/integration.rs
+++ b/crates/azure/tests/integration.rs
@@ -75,7 +75,7 @@ async fn read_write_test_onelake(context: &IntegrationContext, path: &Path) -> T
     let delta_store = DeltaTableBuilder::from_uri(&context.root_uri())
         .with_allow_http(true)
         .build_storage()?
-        .object_store();
+        .object_store(None);
 
     let expected = Bytes::from_static(b"test world from delta-rs on friday");
 

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -282,7 +282,7 @@ impl DeltaTableState {
 pub(crate) fn register_store(store: LogStoreRef, env: Arc<RuntimeEnv>) {
     let object_store_url = store.object_store_url();
     let url: &Url = object_store_url.as_ref();
-    env.register_object_store(url, store.object_store());
+    env.register_object_store(url, store.object_store(None));
 }
 
 /// The logical schema for a Deltatable is different from the protocol level schema since partition
@@ -2708,7 +2708,7 @@ mod tests {
             .unwrap();
 
         let (object_store, mut operations) =
-            RecordingObjectStore::new(table.log_store().object_store());
+            RecordingObjectStore::new(table.log_store().object_store(None));
         let log_store =
             DefaultLogStore::new(Arc::new(object_store), table.log_store().config().clone());
         let provider = DeltaTableProvider::try_new(

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -149,7 +149,7 @@ impl Snapshot {
         }
 
         let (protocol, metadata) = log_segment
-            .read_metadata(log_store.object_store().clone(), &self.config)
+            .read_metadata(log_store.object_store(None).clone(), &self.config)
             .await?;
         if let Some(protocol) = protocol {
             self.protocol = protocol;
@@ -454,7 +454,7 @@ impl EagerSnapshot {
                 StructType::new(schema_actions.iter().map(|a| a.schema_field().clone()));
             new_slice
                 .checkpoint_stream(
-                    log_store.object_store(),
+                    log_store.object_store(None),
                     &read_schema,
                     &self.snapshot.config,
                 )
@@ -464,7 +464,7 @@ impl EagerSnapshot {
         schema_actions.insert(ActionType::Remove);
         let read_schema = StructType::new(schema_actions.iter().map(|a| a.schema_field().clone()));
         let log_stream = new_slice.commit_stream(
-            log_store.object_store().clone(),
+            log_store.object_store(None).clone(),
             &read_schema,
             &self.snapshot.config,
         )?;
@@ -847,7 +847,7 @@ mod tests {
         let store = context
             .table_builder(TestTables::Simple)
             .build_storage()?
-            .object_store();
+            .object_store(None);
 
         let snapshot =
             Snapshot::try_new(&Path::default(), store.clone(), Default::default(), None).await?;
@@ -895,7 +895,7 @@ mod tests {
         let store = context
             .table_builder(TestTables::Checkpoints)
             .build_storage()?
-            .object_store();
+            .object_store(None);
 
         for version in 0..=12 {
             let snapshot = Snapshot::try_new(
@@ -920,7 +920,7 @@ mod tests {
         let store = context
             .table_builder(TestTables::Simple)
             .build_storage()?
-            .object_store();
+            .object_store(None);
 
         let snapshot =
             EagerSnapshot::try_new(&Path::default(), store.clone(), Default::default(), None)
@@ -937,7 +937,7 @@ mod tests {
         let store = context
             .table_builder(TestTables::Checkpoints)
             .build_storage()?
-            .object_store();
+            .object_store(None);
 
         for version in 0..=12 {
             let snapshot = EagerSnapshot::try_new(
@@ -962,7 +962,7 @@ mod tests {
         let store = context
             .table_builder(TestTables::Simple)
             .build_storage()?
-            .object_store();
+            .object_store(None);
 
         let mut snapshot =
             EagerSnapshot::try_new(&Path::default(), store.clone(), Default::default(), None)

--- a/crates/core/src/kernel/snapshot/replay.rs
+++ b/crates/core/src/kernel/snapshot/replay.rs
@@ -627,7 +627,7 @@ pub(super) mod tests {
         let store = context
             .table_builder(TestTables::SimpleWithCheckpoint)
             .build_storage()?
-            .object_store();
+            .object_store(None);
 
         let segment = LogSegment::try_new(&Path::default(), Some(9), store.as_ref()).await?;
         let mut scanner = LogReplayScanner::new();
@@ -649,7 +649,7 @@ pub(super) mod tests {
         let store = context
             .table_builder(TestTables::Simple)
             .build_storage()?
-            .object_store();
+            .object_store(None);
         let segment = LogSegment::try_new(&Path::default(), None, store.as_ref()).await?;
         let batches = segment
             .commit_stream(store.clone(), &log_schema, &Default::default())?

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -15,6 +15,7 @@ use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 use url::Url;
+use uuid::Uuid;
 
 use crate::kernel::log_segment::PathExt;
 use crate::kernel::Action;
@@ -212,6 +213,7 @@ pub trait LogStore: Sync + Send {
         &self,
         version: i64,
         commit_or_bytes: CommitOrBytes,
+        operation_id: Uuid,
     ) -> Result<(), TransactionError>;
 
     /// Abort the commit entry for the given version.
@@ -219,6 +221,7 @@ pub trait LogStore: Sync + Send {
         &self,
         version: i64,
         commit_or_bytes: CommitOrBytes,
+        operation_id: Uuid,
     ) -> Result<(), TransactionError>;
 
     /// Find latest version currently stored in the delta log.
@@ -240,8 +243,8 @@ pub trait LogStore: Sync + Send {
         Ok(PeekCommit::New(next_version, actions.unwrap()))
     }
 
-    /// Get underlying object store.
-    fn object_store(&self) -> Arc<dyn ObjectStore>;
+    /// Get object store, can pass operation_id for object stores linked to an operation
+    fn object_store(&self, operation_id: Option<Uuid>) -> Arc<dyn ObjectStore>;
 
     /// [Path] to Delta log
     fn to_uri(&self, location: &Path) -> String {
@@ -262,7 +265,7 @@ pub trait LogStore: Sync + Send {
     /// Check if the location is a delta table location
     async fn is_delta_table_location(&self) -> DeltaResult<bool> {
         // TODO We should really be using HEAD here, but this fails in windows tests
-        let object_store = self.object_store();
+        let object_store = self.object_store(None);
         let mut stream = object_store.list(Some(self.log_path()));
         if let Some(res) = stream.next().await {
             match res {
@@ -446,7 +449,7 @@ pub async fn get_latest_version(
         let mut max_version: i64 = version_start;
         let prefix = Some(log_store.log_path());
         let offset_path = commit_uri_from_version(max_version);
-        let object_store = log_store.object_store();
+        let object_store = log_store.object_store(None);
         let mut files = object_store.list_with_offset(prefix, &offset_path);
 
         while let Some(obj_meta) = files.next().await {
@@ -491,7 +494,7 @@ pub async fn get_earliest_version(
         let mut min_version: i64 = version_start;
         let prefix = Some(log_store.log_path());
         let offset_path = commit_uri_from_version(version_start);
-        let object_store = log_store.object_store();
+        let object_store = log_store.object_store(None);
 
         // Manually filter until we can provide direction in https://github.com/apache/arrow-rs/issues/6274
         let mut files = object_store
@@ -602,7 +605,7 @@ mod tests {
         // delta table (it shouldn't be).
         let payload = PutPayload::from_static(b"test-drivin");
         let _put = store
-            .object_store()
+            .object_store(None)
             .put_opts(
                 &Path::from("_delta_log/_commit_failed.tmp"),
                 payload,
@@ -631,7 +634,7 @@ mod tests {
         // Save a commit to the transaction log
         let payload = PutPayload::from_static(b"test");
         let _put = store
-            .object_store()
+            .object_store(None)
             .put_opts(
                 &Path::from("_delta_log/0.json"),
                 payload,
@@ -661,7 +664,7 @@ mod tests {
         // Save a "checkpoint" file to the transaction log directory
         let payload = PutPayload::from_static(b"test");
         let _put = store
-            .object_store()
+            .object_store(None)
             .put_opts(
                 &Path::from("_delta_log/0.checkpoint.parquet"),
                 payload,

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -6,6 +6,7 @@ use std::{cmp::max, collections::HashMap, sync::Arc};
 
 use bytes::Bytes;
 use dashmap::DashMap;
+use delta_kernel::AsAny;
 use futures::{StreamExt, TryStreamExt};
 use lazy_static::lazy_static;
 use object_store::{path::Path, Error as ObjectStoreError, ObjectStore};
@@ -193,7 +194,7 @@ pub struct LogStoreConfig {
 ///   `get_latest_version` must return a version >= `v`, i.e. the underlying file system entry must
 ///   become visible immediately.
 #[async_trait::async_trait]
-pub trait LogStore: Sync + Send {
+pub trait LogStore: Send + Sync + AsAny {
     /// Return the name of this LogStore implementation
     fn name(&self) -> String;
 

--- a/crates/core/src/operations/constraints.rs
+++ b/crates/core/src/operations/constraints.rs
@@ -24,6 +24,7 @@ use crate::{DeltaResult, DeltaTable, DeltaTableError};
 
 use super::datafusion_utils::into_expr;
 use super::transaction::{CommitBuilder, CommitProperties};
+use super::{CustomExecuteHandler, Operation};
 
 /// Build a constraint to add to a table
 pub struct ConstraintBuilder {
@@ -39,9 +40,17 @@ pub struct ConstraintBuilder {
     state: Option<SessionState>,
     /// Additional information to add to the commit
     commit_properties: CommitProperties,
+    custom_execute_handler: Option<Arc<dyn CustomExecuteHandler>>,
 }
 
-impl super::Operation<()> for ConstraintBuilder {}
+impl super::Operation<()> for ConstraintBuilder {
+    fn log_store(&self) -> &LogStoreRef {
+        &self.log_store
+    }
+    fn get_custom_execute_handler(&self) -> Option<Arc<dyn CustomExecuteHandler>> {
+        self.custom_execute_handler.clone()
+    }
+}
 
 impl ConstraintBuilder {
     /// Create a new builder
@@ -53,6 +62,7 @@ impl ConstraintBuilder {
             log_store,
             state: None,
             commit_properties: CommitProperties::default(),
+            custom_execute_handler: None,
         }
     }
 
@@ -78,6 +88,12 @@ impl ConstraintBuilder {
         self.commit_properties = commit_properties;
         self
     }
+
+    /// Set a custom execute handler, for pre and post execution
+    pub fn with_custom_execute_handler(mut self, handler: Arc<dyn CustomExecuteHandler>) -> Self {
+        self.custom_execute_handler = Some(handler);
+        self
+    }
 }
 
 impl std::future::IntoFuture for ConstraintBuilder {
@@ -94,6 +110,8 @@ impl std::future::IntoFuture for ConstraintBuilder {
                     "ADD CONSTRAINTS".into(),
                 ));
             }
+            let operation_id = this.get_operation_id();
+            this.pre_execute(operation_id).await?;
 
             let name = match this.name {
                 Some(v) => v,
@@ -201,8 +219,14 @@ impl std::future::IntoFuture for ConstraintBuilder {
 
             let commit = CommitBuilder::from(this.commit_properties)
                 .with_actions(actions)
+                .with_operation_id(operation_id)
+                .with_post_commit_hook_handler(this.custom_execute_handler.clone())
                 .build(Some(&this.snapshot), this.log_store.clone(), operation)
                 .await?;
+
+            if let Some(handler) = this.custom_execute_handler {
+                handler.post_execute(&this.log_store, operation_id).await?;
+            }
 
             Ok(DeltaTable::new_with_state(
                 this.log_store,

--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -255,7 +255,7 @@ impl ConvertToDeltaBuilder {
         );
 
         // Get all the parquet files in the location
-        let object_store = log_store.object_store();
+        let object_store = self.log_store().object_store(None);
         let mut files = Vec::new();
         object_store
             .list(None)

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -33,6 +33,7 @@ use datafusion_physical_plan::ExecutionPlan;
 use futures::future::BoxFuture;
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
 
 use parquet::file::properties::WriterProperties;
 use serde::Serialize;
@@ -40,6 +41,7 @@ use serde::Serialize;
 use super::cdc::should_write_cdc;
 use super::datafusion_utils::Expression;
 use super::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
+use super::Operation;
 use crate::delta_datafusion::expr::fmt_expr_to_sql;
 use crate::delta_datafusion::logical::MetricObserver;
 use crate::delta_datafusion::physical::{find_metric_node, get_metric, MetricObserverExec};
@@ -52,6 +54,7 @@ use crate::errors::DeltaResult;
 use crate::kernel::{Action, Add, Remove};
 use crate::logstore::LogStoreRef;
 use crate::operations::write::{write_execution_plan, write_execution_plan_cdc, WriterStatsConfig};
+use crate::operations::CustomExecuteHandler;
 use crate::protocol::DeltaOperation;
 use crate::table::state::DeltaTableState;
 use crate::{DeltaTable, DeltaTableError};
@@ -74,6 +77,7 @@ pub struct DeleteBuilder {
     writer_properties: Option<WriterProperties>,
     /// Commit properties and configuration
     commit_properties: CommitProperties,
+    custom_execute_handler: Option<Arc<dyn CustomExecuteHandler>>,
 }
 
 #[derive(Default, Debug, Serialize)]
@@ -95,7 +99,14 @@ pub struct DeleteMetrics {
     pub rewrite_time_ms: u64,
 }
 
-impl super::Operation<()> for DeleteBuilder {}
+impl super::Operation<()> for DeleteBuilder {
+    fn log_store(&self) -> &LogStoreRef {
+        &self.log_store
+    }
+    fn get_custom_execute_handler(&self) -> Option<Arc<dyn CustomExecuteHandler>> {
+        self.custom_execute_handler.clone()
+    }
+}
 
 impl DeleteBuilder {
     /// Create a new [`DeleteBuilder`]
@@ -107,6 +118,7 @@ impl DeleteBuilder {
             state: None,
             commit_properties: CommitProperties::default(),
             writer_properties: None,
+            custom_execute_handler: None,
         }
     }
 
@@ -131,6 +143,12 @@ impl DeleteBuilder {
     /// Writer properties passed to parquet writer for when files are rewritten
     pub fn with_writer_properties(mut self, writer_properties: WriterProperties) -> Self {
         self.writer_properties = Some(writer_properties);
+        self
+    }
+
+    /// Set a custom execute handler, for pre and post execution
+    pub fn with_custom_execute_handler(mut self, handler: Arc<dyn CustomExecuteHandler>) -> Self {
+        self.custom_execute_handler = Some(handler);
         self
     }
 }
@@ -175,6 +193,7 @@ async fn excute_non_empty_expr(
     metrics: &mut DeleteMetrics,
     writer_properties: Option<WriterProperties>,
     partition_scan: bool,
+    operation_id: Uuid,
 ) -> DeltaResult<Vec<Action>> {
     // For each identified file perform a parquet scan + filter + limit (1) + count.
     // If returned count is not zero then append the file to be rewritten and removed from the log. Otherwise do nothing to the file.
@@ -234,7 +253,7 @@ async fn excute_non_empty_expr(
             state.clone(),
             filter.clone(),
             table_partition_cols.clone(),
-            log_store.object_store(),
+            log_store.object_store(Some(operation_id)),
             Some(snapshot.table_config().target_file_size() as usize),
             None,
             writer_properties.clone(),
@@ -271,7 +290,7 @@ async fn excute_non_empty_expr(
             state.clone(),
             cdc_filter,
             table_partition_cols.clone(),
-            log_store.object_store(),
+            log_store.object_store(Some(operation_id)),
             Some(snapshot.table_config().target_file_size() as usize),
             None,
             writer_properties,
@@ -285,6 +304,7 @@ async fn excute_non_empty_expr(
     Ok(actions)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn execute(
     predicate: Option<Expr>,
     log_store: LogStoreRef,
@@ -292,6 +312,8 @@ async fn execute(
     state: SessionState,
     writer_properties: Option<WriterProperties>,
     mut commit_properties: CommitProperties,
+    operation_id: Uuid,
+    handle: Option<&Arc<dyn CustomExecuteHandler>>,
 ) -> DeltaResult<(DeltaTableState, DeleteMetrics)> {
     if !&snapshot.load_config().require_files {
         return Err(DeltaTableError::NotInitializedWithFiles("DELETE".into()));
@@ -317,6 +339,7 @@ async fn execute(
             &mut metrics,
             writer_properties,
             candidates.partition_scan,
+            operation_id,
         )
         .await?;
         metrics.rewrite_time_ms = Instant::now().duration_since(write_start).as_millis() as u64;
@@ -367,8 +390,14 @@ async fn execute(
 
     let commit = CommitBuilder::from(commit_properties)
         .with_actions(actions)
-        .build(Some(&snapshot), log_store, operation)
+        .with_operation_id(operation_id)
+        .with_post_commit_hook_handler(handle.cloned())
+        .build(Some(&snapshot), log_store.clone(), operation)
         .await?;
+
+    if let Some(handler) = handle {
+        handler.post_execute(&log_store, operation_id).await?;
+    }
     Ok((commit.snapshot(), metrics))
 }
 
@@ -382,6 +411,9 @@ impl std::future::IntoFuture for DeleteBuilder {
         Box::pin(async move {
             PROTOCOL.check_append_only(&this.snapshot.snapshot)?;
             PROTOCOL.can_write_to(&this.snapshot.snapshot)?;
+
+            let operation_id = this.get_operation_id();
+            this.pre_execute(operation_id).await?;
 
             let state = this.state.unwrap_or_else(|| {
                 let session: SessionContext = DeltaSessionContext::default().into();
@@ -409,6 +441,8 @@ impl std::future::IntoFuture for DeleteBuilder {
                 state,
                 this.writer_properties,
                 this.commit_properties,
+                operation_id,
+                this.custom_execute_handler.as_ref(),
             )
             .await?;
 

--- a/crates/core/src/operations/filesystem_check.rs
+++ b/crates/core/src/operations/filesystem_check.rs
@@ -113,7 +113,7 @@ impl FileSystemCheckBuilder {
             }
         }
 
-        let object_store = log_store.object_store();
+        let object_store = log_store.object_store(None);
         let mut files = object_store.list(None);
         while let Some(result) = files.next().await {
             let file = result?;

--- a/crates/core/src/operations/load.rs
+++ b/crates/core/src/operations/load.rs
@@ -7,6 +7,7 @@ use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use futures::future::BoxFuture;
 
 use super::transaction::PROTOCOL;
+use super::CustomExecuteHandler;
 use crate::delta_datafusion::DataFusionMixins;
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::logstore::LogStoreRef;
@@ -23,7 +24,14 @@ pub struct LoadBuilder {
     columns: Option<Vec<String>>,
 }
 
-impl super::Operation<()> for LoadBuilder {}
+impl super::Operation<()> for LoadBuilder {
+    fn log_store(&self) -> &LogStoreRef {
+        &self.log_store
+    }
+    fn get_custom_execute_handler(&self) -> Option<Arc<dyn CustomExecuteHandler>> {
+        unimplemented!("Not required in loadBuilder for now.")
+    }
+}
 
 impl LoadBuilder {
     /// Create a new [`LoadBuilder`]

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -59,11 +59,13 @@ use itertools::Itertools;
 use parquet::file::properties::WriterProperties;
 use serde::Serialize;
 use tracing::log::*;
+use uuid::Uuid;
 
 use self::barrier::{MergeBarrier, MergeBarrierExec};
 
 use super::datafusion_utils::{into_expr, maybe_into_expr, Expression};
 use super::transaction::{CommitProperties, PROTOCOL};
+use super::{CustomExecuteHandler, Operation};
 use crate::delta_datafusion::expr::{fmt_expr_to_sql, parse_predicate_expression};
 use crate::delta_datafusion::logical::MetricObserver;
 use crate::delta_datafusion::physical::{find_metric_node, get_metric, MetricObserverExec};
@@ -135,9 +137,17 @@ pub struct MergeBuilder {
     /// safe_cast determines how data types that do not match the underlying table are handled
     /// By default an error is returned
     safe_cast: bool,
+    custom_execute_handler: Option<Arc<dyn CustomExecuteHandler>>,
 }
 
-impl super::Operation<()> for MergeBuilder {}
+impl super::Operation<()> for MergeBuilder {
+    fn log_store(&self) -> &LogStoreRef {
+        &self.log_store
+    }
+    fn get_custom_execute_handler(&self) -> Option<Arc<dyn CustomExecuteHandler>> {
+        self.custom_execute_handler.clone()
+    }
+}
 
 impl MergeBuilder {
     /// Create a new [`MergeBuilder`]
@@ -162,6 +172,7 @@ impl MergeBuilder {
             not_match_operations: Vec::new(),
             not_match_source_operations: Vec::new(),
             safe_cast: false,
+            custom_execute_handler: None,
         }
     }
 
@@ -379,6 +390,12 @@ impl MergeBuilder {
     /// Test123     ->      null
     pub fn with_safe_cast(mut self, safe_cast: bool) -> Self {
         self.safe_cast = safe_cast;
+        self
+    }
+
+    /// Set a custom execute handler, for pre and post execution
+    pub fn with_custom_execute_handler(mut self, handler: Arc<dyn CustomExecuteHandler>) -> Self {
+        self.custom_execute_handler = Some(handler);
         self
     }
 }
@@ -689,11 +706,9 @@ async fn execute(
     match_operations: Vec<MergeOperationConfig>,
     not_match_target_operations: Vec<MergeOperationConfig>,
     not_match_source_operations: Vec<MergeOperationConfig>,
+    operation_id: Uuid,
+    handle: Option<&Arc<dyn CustomExecuteHandler>>,
 ) -> DeltaResult<(DeltaTableState, MergeMetrics)> {
-    if !snapshot.load_config().require_files {
-        return Err(DeltaTableError::NotInitializedWithFiles("MERGE".into()));
-    }
-
     let mut metrics = MergeMetrics::default();
     let exec_start = Instant::now();
     // Determining whether we should write change data once so that computation of change data can
@@ -1215,7 +1230,7 @@ async fn execute(
         state.clone(),
         write,
         table_partition_cols.clone(),
-        log_store.object_store(),
+        log_store.object_store(Some(operation_id)),
         Some(snapshot.table_config().target_file_size() as usize),
         None,
         writer_properties.clone(),
@@ -1239,7 +1254,7 @@ async fn execute(
                 state.clone(),
                 df.create_physical_plan().await?,
                 table_partition_cols.clone(),
-                log_store.object_store(),
+                log_store.object_store(Some(operation_id)),
                 Some(snapshot.table_config().target_file_size() as usize),
                 None,
                 writer_properties,
@@ -1320,6 +1335,8 @@ async fn execute(
 
     let commit = CommitBuilder::from(commit_properties)
         .with_actions(actions)
+        .with_operation_id(operation_id)
+        .with_post_commit_hook_handler(handle.cloned())
         .build(Some(&snapshot), log_store.clone(), operation)
         .await?;
     Ok((commit.snapshot(), metrics))
@@ -1351,6 +1368,13 @@ impl std::future::IntoFuture for MergeBuilder {
         Box::pin(async move {
             PROTOCOL.can_write_to(&this.snapshot.snapshot)?;
 
+            if !this.snapshot.load_config().require_files {
+                return Err(DeltaTableError::NotInitializedWithFiles("MERGE".into()));
+            }
+
+            let operation_id = this.get_operation_id();
+            this.pre_execute(operation_id).await?;
+
             let state = this.state.unwrap_or_else(|| {
                 let config: SessionConfig = DeltaSessionConfig::default().into();
                 let session = SessionContext::new_with_config(config);
@@ -1375,8 +1399,14 @@ impl std::future::IntoFuture for MergeBuilder {
                 this.match_operations,
                 this.not_match_operations,
                 this.not_match_source_operations,
+                operation_id,
+                this.custom_execute_handler.as_ref(),
             )
             .await?;
+
+            if let Some(handler) = this.custom_execute_handler {
+                handler.post_execute(&this.log_store, operation_id).await?;
+            }
 
             Ok((
                 DeltaTable::new_with_state(this.log_store, snapshot),

--- a/crates/core/src/operations/restore.rs
+++ b/crates/core/src/operations/restore.rs
@@ -210,7 +210,7 @@ async fn execute(
         .collect();
 
     if !ignore_missing_files {
-        check_files_available(log_store.object_store().as_ref(), &files_to_add).await?;
+        check_files_available(log_store.object_store(None).as_ref(), &files_to_add).await?;
     }
 
     let metrics = RestoreMetrics {

--- a/crates/core/src/operations/transaction/application.rs
+++ b/crates/core/src/operations/transaction/application.rs
@@ -70,7 +70,7 @@ mod tests {
         assert_eq!(app_txns2.get("my-app").map(|t| t.version), Some(3));
 
         // Create a checkpoint and then load
-        checkpoints::create_checkpoint(&table).await.unwrap();
+        checkpoints::create_checkpoint(&table, None).await.unwrap();
         let table3 = DeltaTableBuilder::from_uri(tmp_path.to_str().unwrap())
             .load()
             .await

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -74,6 +74,7 @@
 //!       └───────────────────────────────┘           
 //!</pre>
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use chrono::Utc;
@@ -83,6 +84,7 @@ use object_store::path::Path;
 use object_store::Error as ObjectStoreError;
 use serde_json::Value;
 use tracing::*;
+use uuid::Uuid;
 
 use self::conflict_checker::{TransactionInfo, WinningCommitSummary};
 use crate::checkpoints::{cleanup_expired_logs_for, create_checkpoint_for};
@@ -100,6 +102,8 @@ use crate::{crate_version, DeltaResult};
 
 pub use self::conflict_checker::CommitConflictError;
 pub use self::protocol::INSTANCE as PROTOCOL;
+
+use super::CustomExecuteHandler;
 
 #[cfg(test)]
 pub(crate) mod application;
@@ -401,6 +405,8 @@ pub struct CommitBuilder {
     app_transaction: Vec<Transaction>,
     max_retries: usize,
     post_commit_hook: Option<PostCommitHookProperties>,
+    post_commit_hook_handler: Option<Arc<dyn CustomExecuteHandler>>,
+    operation_id: Uuid,
 }
 
 impl Default for CommitBuilder {
@@ -411,6 +417,8 @@ impl Default for CommitBuilder {
             app_transaction: Vec::new(),
             max_retries: DEFAULT_RETRIES,
             post_commit_hook: None,
+            post_commit_hook_handler: None,
+            operation_id: Uuid::new_v4(),
         }
     }
 }
@@ -440,6 +448,21 @@ impl<'a> CommitBuilder {
         self
     }
 
+    /// Propogate operation id to log store
+    pub fn with_operation_id(mut self, operation_id: Uuid) -> Self {
+        self.operation_id = operation_id;
+        self
+    }
+
+    /// Set a custom execute handler, for pre and post execution
+    pub fn with_post_commit_hook_handler(
+        mut self,
+        handler: Option<Arc<dyn CustomExecuteHandler>>,
+    ) -> Self {
+        self.post_commit_hook_handler = handler;
+        self
+    }
+
     /// Prepare a Commit operation using the configured builder
     pub fn build(
         self,
@@ -459,6 +482,8 @@ impl<'a> CommitBuilder {
             max_retries: self.max_retries,
             data,
             post_commit_hook: self.post_commit_hook,
+            post_commit_hook_handler: self.post_commit_hook_handler,
+            operation_id: self.operation_id,
         }
     }
 }
@@ -470,6 +495,8 @@ pub struct PreCommit<'a> {
     data: CommitData,
     max_retries: usize,
     post_commit_hook: Option<PostCommitHookProperties>,
+    post_commit_hook_handler: Option<Arc<dyn CustomExecuteHandler>>,
+    operation_id: Uuid,
 }
 
 impl<'a> std::future::IntoFuture for PreCommit<'a> {
@@ -504,12 +531,18 @@ impl<'a> PreCommit<'a> {
             }
             let log_entry = this.data.get_bytes()?;
 
-            // With the DefaultLogStore, we just pass the bytes around, since we use conditionalPuts
+            // With the DefaultLogStore & LakeFSLogstore, we just pass the bytes around, since we use conditionalPuts
             // Other stores will use tmp_commits
-            let commit_or_bytes = if this.log_store.name() == "DefaultLogStore" {
+            let commit_or_bytes = if ["LakeFSLogStore", "DefaultLogStore"]
+                .contains(&this.log_store.name().as_str())
+            {
                 CommitOrBytes::LogBytes(log_entry)
             } else {
-                write_tmp_commit(log_entry, this.log_store.object_store()).await?
+                write_tmp_commit(
+                    log_entry,
+                    this.log_store.object_store(Some(this.operation_id)),
+                )
+                .await?
             };
 
             Ok(PreparedCommit {
@@ -519,6 +552,8 @@ impl<'a> PreCommit<'a> {
                 max_retries: this.max_retries,
                 data: this.data,
                 post_commit: this.post_commit_hook,
+                post_commit_hook_handler: this.post_commit_hook_handler,
+                operation_id: this.operation_id,
             })
         })
     }
@@ -532,6 +567,8 @@ pub struct PreparedCommit<'a> {
     table_data: Option<&'a dyn TableReference>,
     max_retries: usize,
     post_commit: Option<PostCommitHookProperties>,
+    post_commit_hook_handler: Option<Arc<dyn CustomExecuteHandler>>,
+    operation_id: Uuid,
 }
 
 impl PreparedCommit<'_> {
@@ -553,7 +590,7 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
 
             if this.table_data.is_none() {
                 this.log_store
-                    .write_commit_entry(0, commit_or_bytes.clone())
+                    .write_commit_entry(0, commit_or_bytes.clone(), this.operation_id)
                     .await?;
                 return Ok(PostCommit {
                     version: 0,
@@ -562,6 +599,7 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                     cleanup_expired_logs: None,
                     log_store: this.log_store,
                     table_data: this.table_data,
+                    custom_execute_handler: this.post_commit_hook_handler,
                 });
             }
 
@@ -613,7 +651,7 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
 
                 match this
                     .log_store
-                    .write_commit_entry(version, commit_or_bytes.clone())
+                    .write_commit_entry(version, commit_or_bytes.clone(), this.operation_id)
                     .await
                 {
                     Ok(()) => {
@@ -630,6 +668,7 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                                 .unwrap_or_default(),
                             log_store: this.log_store,
                             table_data: this.table_data,
+                            custom_execute_handler: this.post_commit_hook_handler,
                         });
                     }
                     Err(TransactionError::VersionAlreadyExists(version)) => {
@@ -640,7 +679,7 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                     }
                     Err(err) => {
                         this.log_store
-                            .abort_commit_entry(version, commit_or_bytes)
+                            .abort_commit_entry(version, commit_or_bytes, this.operation_id)
                             .await?;
                         return Err(err.into());
                     }
@@ -662,12 +701,14 @@ pub struct PostCommit<'a> {
     cleanup_expired_logs: Option<bool>,
     log_store: LogStoreRef,
     table_data: Option<&'a dyn TableReference>,
+    custom_execute_handler: Option<Arc<dyn CustomExecuteHandler>>,
 }
 
 impl PostCommit<'_> {
     /// Runs the post commit activities
     async fn run_post_commit_hook(&self) -> DeltaResult<DeltaTableState> {
         if let Some(table) = self.table_data {
+            let post_commit_operation_id = Uuid::new_v4();
             let mut snapshot = table.eager_snapshot().clone();
             if self.version - snapshot.version() > 1 {
                 // This may only occur during concurrent write actions. We need to update the state first to - 1
@@ -680,31 +721,61 @@ impl PostCommit<'_> {
                 snapshot.advance(vec![&self.data])?;
             }
             let state = DeltaTableState { snapshot };
-            // Execute each hook
-            if self.create_checkpoint {
-                self.create_checkpoint(&state, &self.log_store, self.version)
-                    .await?;
-            }
+
             let cleanup_logs = if let Some(cleanup_logs) = self.cleanup_expired_logs {
                 cleanup_logs
             } else {
                 state.table_config().enable_expired_log_cleanup()
             };
 
+            // Run arbitrary before_post_commit_hook code
+            if let Some(custom_execute_handler) = &self.custom_execute_handler {
+                custom_execute_handler
+                    .before_post_commit_hook(
+                        &self.log_store,
+                        cleanup_logs || self.create_checkpoint,
+                        post_commit_operation_id,
+                    )
+                    .await?
+            }
+
+            if self.create_checkpoint {
+                // Execute create checkpoint hook
+                self.create_checkpoint(
+                    &state,
+                    &self.log_store,
+                    self.version,
+                    post_commit_operation_id,
+                )
+                .await?;
+            }
             if cleanup_logs {
+                // Execute clean up logs hook
                 cleanup_expired_logs_for(
                     self.version,
                     self.log_store.as_ref(),
                     Utc::now().timestamp_millis()
                         - state.table_config().log_retention_duration().as_millis() as i64,
+                    Some(post_commit_operation_id),
                 )
                 .await?;
+            }
+
+            // Run arbitrary after_post_commit_hook code
+            if let Some(custom_execute_handler) = &self.custom_execute_handler {
+                custom_execute_handler
+                    .after_post_commit_hook(
+                        &self.log_store,
+                        cleanup_logs || self.create_checkpoint,
+                        post_commit_operation_id,
+                    )
+                    .await?
             }
             Ok(state)
         } else {
             let state = DeltaTableState::try_new(
                 &Path::default(),
-                self.log_store.object_store(),
+                self.log_store.object_store(None),
                 Default::default(),
                 Some(self.version),
             )
@@ -717,6 +788,7 @@ impl PostCommit<'_> {
         table_state: &DeltaTableState,
         log_store: &LogStoreRef,
         version: i64,
+        operation_id: Uuid,
     ) -> DeltaResult<()> {
         if !table_state.load_config().require_files {
             warn!("Checkpoint creation in post_commit_hook has been skipped due to table being initialized without files.");
@@ -725,7 +797,8 @@ impl PostCommit<'_> {
 
         let checkpoint_interval = table_state.config().checkpoint_interval() as i64;
         if ((version + 1) % checkpoint_interval) == 0 {
-            create_checkpoint_for(version, table_state, log_store.as_ref()).await?
+            create_checkpoint_for(version, table_state, log_store.as_ref(), Some(operation_id))
+                .await?
         }
         Ok(())
     }
@@ -805,14 +878,22 @@ mod tests {
         store.put(&version_path, PutPayload::new()).await.unwrap();
 
         let res = log_store
-            .write_commit_entry(0, CommitOrBytes::LogBytes(PutPayload::new().into()))
+            .write_commit_entry(
+                0,
+                CommitOrBytes::LogBytes(PutPayload::new().into()),
+                Uuid::new_v4(),
+            )
             .await;
         // fails if file version already exists
         assert!(res.is_err());
 
         // succeeds for next version
         log_store
-            .write_commit_entry(1, CommitOrBytes::LogBytes(PutPayload::new().into()))
+            .write_commit_entry(
+                1,
+                CommitOrBytes::LogBytes(PutPayload::new().into()),
+                Uuid::new_v4(),
+            )
             .await
             .unwrap();
     }

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -206,7 +206,7 @@ impl VacuumBuilder {
 
         let mut files_to_delete = vec![];
         let mut file_sizes = vec![];
-        let object_store = self.log_store.object_store();
+        let object_store = self.log_store.object_store(None);
         let mut all_files = object_store.list(None);
         let partition_columns = &self.snapshot.metadata().partition_columns;
 

--- a/crates/core/src/operations/write.rs
+++ b/crates/core/src/operations/write.rs
@@ -48,12 +48,13 @@ use object_store::prefix::PrefixStore;
 use parquet::file::properties::WriterProperties;
 use serde::{Deserialize, Serialize};
 use tracing::log::*;
+use uuid::Uuid;
 
 use super::cdc::should_write_cdc;
 use super::datafusion_utils::Expression;
 use super::transaction::{CommitBuilder, CommitProperties, TableReference, PROTOCOL};
 use super::writer::{DeltaWriter, WriterConfig};
-use super::CreateBuilder;
+use super::{CreateBuilder, CustomExecuteHandler, Operation};
 use crate::delta_datafusion::expr::fmt_expr_to_sql;
 use crate::delta_datafusion::expr::parse_predicate_expression;
 use crate::delta_datafusion::{
@@ -163,6 +164,7 @@ pub struct WriteBuilder {
     description: Option<String>,
     /// Configurations of the delta table, only used when table doesn't exist
     configuration: HashMap<String, Option<String>>,
+    custom_execute_handler: Option<Arc<dyn CustomExecuteHandler>>,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -180,7 +182,14 @@ pub struct WriteMetrics {
     pub execution_time_ms: u64,
 }
 
-impl super::Operation<()> for WriteBuilder {}
+impl super::Operation<()> for WriteBuilder {
+    fn log_store(&self) -> &LogStoreRef {
+        &self.log_store
+    }
+    fn get_custom_execute_handler(&self) -> Option<Arc<dyn CustomExecuteHandler>> {
+        self.custom_execute_handler.clone()
+    }
+}
 
 impl WriteBuilder {
     /// Create a new [`WriteBuilder`]
@@ -203,6 +212,7 @@ impl WriteBuilder {
             name: None,
             description: None,
             configuration: Default::default(),
+            custom_execute_handler: None,
         }
     }
 
@@ -296,6 +306,12 @@ impl WriteBuilder {
         self
     }
 
+    /// Set a custom execute handler, for pre and post execution
+    pub fn with_custom_execute_handler(mut self, handler: Arc<dyn CustomExecuteHandler>) -> Self {
+        self.custom_execute_handler = Some(handler);
+        self
+    }
+
     /// Set configuration on created table
     pub fn with_configuration(
         mut self,
@@ -376,7 +392,7 @@ impl WriteBuilder {
                     builder = builder.with_comment(desc.clone());
                 };
 
-                let (_, actions, _) = builder.into_table_and_actions()?;
+                let (_, actions, _, _) = builder.into_table_and_actions().await?;
                 Ok(actions)
             }
         }
@@ -582,6 +598,7 @@ async fn execute_non_empty_expr(
     writer_stats_config: WriterStatsConfig,
     partition_scan: bool,
     insert_plan: Arc<dyn ExecutionPlan>,
+    operation_id: Uuid,
 ) -> DeltaResult<Vec<Action>> {
     // For each identified file perform a parquet scan + filter + limit (1) + count.
     // If returned count is not zero then append the file to be rewritten and removed from the log. Otherwise do nothing to the file.
@@ -619,7 +636,7 @@ async fn execute_non_empty_expr(
             state.clone(),
             filter,
             partition_columns.clone(),
-            log_store.object_store(),
+            log_store.object_store(Some(operation_id)),
             Some(snapshot.table_config().target_file_size() as usize),
             None,
             writer_properties.clone(),
@@ -647,6 +664,7 @@ async fn execute_non_empty_expr(
             writer_properties,
             writer_stats_config,
             insert_plan,
+            operation_id,
         )
         .await?
         {
@@ -669,6 +687,7 @@ pub(crate) async fn execute_non_empty_expr_cdc(
     writer_properties: Option<WriterProperties>,
     writer_stats_config: WriterStatsConfig,
     insert_plan: Arc<dyn ExecutionPlan>,
+    operation_id: Uuid,
 ) -> DeltaResult<Option<Vec<Action>>> {
     match should_write_cdc(snapshot) {
         // Create CDC scan
@@ -727,7 +746,7 @@ pub(crate) async fn execute_non_empty_expr_cdc(
                 state.clone(),
                 cdc_plan.clone(),
                 table_partition_cols.clone(),
-                log_store.object_store(),
+                log_store.object_store(Some(operation_id)),
                 Some(snapshot.table_config().target_file_size() as usize),
                 None,
                 writer_properties,
@@ -753,6 +772,7 @@ async fn prepare_predicate_actions(
     deletion_timestamp: i64,
     writer_stats_config: WriterStatsConfig,
     insert_plan: Arc<dyn ExecutionPlan>,
+    operation_id: Uuid,
 ) -> DeltaResult<Vec<Action>> {
     let candidates =
         find_files(snapshot, log_store.clone(), &state, Some(predicate.clone())).await?;
@@ -768,6 +788,7 @@ async fn prepare_predicate_actions(
         writer_stats_config,
         candidates.partition_scan,
         insert_plan,
+        operation_id,
     )
     .await?;
 
@@ -798,6 +819,10 @@ impl std::future::IntoFuture for WriteBuilder {
         let this = self;
 
         Box::pin(async move {
+            // Runs pre execution handler.
+            let operation_id = this.get_operation_id();
+            this.pre_execute(operation_id).await?;
+
             let mut metrics = WriteMetrics::default();
             let exec_start = Instant::now();
 
@@ -1032,7 +1057,7 @@ impl std::future::IntoFuture for WriteBuilder {
                 state.clone(),
                 plan.clone(),
                 partition_columns.clone(),
-                this.log_store.object_store().clone(),
+                this.log_store.object_store(Some(operation_id)).clone(),
                 target_file_size,
                 this.write_batch_size,
                 this.writer_properties.clone(),
@@ -1101,6 +1126,7 @@ impl std::future::IntoFuture for WriteBuilder {
                                 deletion_timestamp,
                                 writer_stats_config,
                                 plan,
+                                operation_id,
                             )
                             .await?;
                             if !predicate_actions.is_empty() {
@@ -1143,12 +1169,18 @@ impl std::future::IntoFuture for WriteBuilder {
 
             let commit = CommitBuilder::from(commit_properties)
                 .with_actions(actions)
+                .with_post_commit_hook_handler(this.custom_execute_handler.clone())
+                .with_operation_id(operation_id)
                 .build(
                     this.snapshot.as_ref().map(|f| f as &dyn TableReference),
                     this.log_store.clone(),
                     operation.clone(),
                 )
                 .await?;
+
+            if let Some(handler) = this.custom_execute_handler {
+                handler.post_execute(&this.log_store, operation_id).await?;
+            }
 
             Ok(DeltaTable::new_with_state(this.log_store, commit.snapshot))
         })

--- a/crates/core/src/operations/writer.rs
+++ b/crates/core/src/operations/writer.rs
@@ -488,7 +488,7 @@ mod tests {
         let log_store = DeltaTableBuilder::from_uri("memory://")
             .build_storage()
             .unwrap();
-        let object_store = log_store.object_store();
+        let object_store = log_store.object_store(None);
         let batch = get_record_batch(None, false);
 
         // write single un-partitioned batch
@@ -520,7 +520,7 @@ mod tests {
         let object_store = DeltaTableBuilder::from_uri("memory://")
             .build_storage()
             .unwrap()
-            .object_store();
+            .object_store(None);
         let properties = WriterProperties::builder()
             .set_max_row_group_size(1024)
             .build();
@@ -551,7 +551,7 @@ mod tests {
         let object_store = DeltaTableBuilder::from_uri("memory://")
             .build_storage()
             .unwrap()
-            .object_store();
+            .object_store(None);
         // configure small target file size so we can observe multiple files written
         let mut writer = get_partition_writer(object_store, &batch, None, Some(10_000), None);
         writer.write(&batch).await.unwrap();
@@ -578,7 +578,7 @@ mod tests {
         let object_store = DeltaTableBuilder::from_uri("memory://")
             .build_storage()
             .unwrap()
-            .object_store();
+            .object_store(None);
         // configure high batch size and low file size to observe one file written and flushed immediately
         // upon writing batch, then ensures the buffer is empty upon closing writer
         let mut writer = get_partition_writer(object_store, &batch, None, Some(9000), Some(10000));
@@ -593,7 +593,7 @@ mod tests {
         let log_store = DeltaTableBuilder::from_uri("memory://")
             .build_storage()
             .unwrap();
-        let object_store = log_store.object_store();
+        let object_store = log_store.object_store(None);
         let batch = get_record_batch(None, false);
 
         // write single un-partitioned batch

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -609,7 +609,11 @@ pub(crate) async fn get_last_checkpoint(
 ) -> Result<CheckPoint, ProtocolError> {
     let last_checkpoint_path = Path::from_iter(["_delta_log", "_last_checkpoint"]);
     debug!("loading checkpoint from {last_checkpoint_path}");
-    match log_store.object_store().get(&last_checkpoint_path).await {
+    match log_store
+        .object_store(None)
+        .get(&last_checkpoint_path)
+        .await
+    {
         Ok(data) => Ok(serde_json::from_slice(&data.bytes().await?)?),
         Err(ObjectStoreError::NotFound { .. }) => {
             match find_latest_check_point_for_version(log_store, i64::MAX).await {
@@ -633,7 +637,7 @@ pub(crate) async fn find_latest_check_point_for_version(
     }
 
     let mut cp: Option<CheckPoint> = None;
-    let object_store = log_store.object_store();
+    let object_store = log_store.object_store(None);
     let mut stream = object_store.list(Some(log_store.log_path()));
 
     while let Some(obj_meta) = stream.next().await {

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -373,6 +373,83 @@ impl ObjectStoreFactory for DefaultObjectStoreFactory {
     }
 }
 
+pub trait ObjectStoreRegistry: Send + Sync + std::fmt::Debug + 'static + Clone {
+    /// If a store with the same key existed before, it is replaced and returned
+    fn register_store(
+        &self,
+        url: &Url,
+        store: Arc<dyn ObjectStore>,
+    ) -> Option<Arc<dyn ObjectStore>>;
+
+    /// Get a suitable store for the provided URL. For example:
+    /// If no [`ObjectStore`] found for the `url`, ad-hoc discovery may be executed depending on
+    /// the `url` and [`ObjectStoreRegistry`] implementation. An [`ObjectStore`] may be lazily
+    /// created and registered.
+    fn get_store(&self, url: &Url) -> DeltaResult<Arc<dyn ObjectStore>>;
+
+    fn all_stores(&self) -> &DashMap<String, Arc<dyn ObjectStore>>;
+}
+
+/// The default [`ObjectStoreRegistry`]
+#[derive(Clone)]
+pub struct DefaultObjectStoreRegistry {
+    /// A map from scheme to object store that serve list / read operations for the store
+    object_stores: DashMap<String, Arc<dyn ObjectStore>>,
+}
+
+impl Default for DefaultObjectStoreRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DefaultObjectStoreRegistry {
+    pub fn new() -> Self {
+        let object_stores: DashMap<String, Arc<dyn ObjectStore>> = DashMap::new();
+        Self { object_stores }
+    }
+}
+
+impl std::fmt::Debug for DefaultObjectStoreRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("DefaultObjectStoreRegistry")
+            .field(
+                "schemes",
+                &self
+                    .object_stores
+                    .iter()
+                    .map(|o| o.key().clone())
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+impl ObjectStoreRegistry for DefaultObjectStoreRegistry {
+    fn register_store(
+        &self,
+        url: &Url,
+        store: Arc<dyn ObjectStore>,
+    ) -> Option<Arc<dyn ObjectStore>> {
+        self.object_stores.insert(url.to_string(), store)
+    }
+
+    fn get_store(&self, url: &Url) -> DeltaResult<Arc<dyn ObjectStore>> {
+        self.object_stores
+            .get(&url.to_string())
+            .map(|o| Arc::clone(o.value()))
+            .ok_or_else(|| {
+                DeltaTableError::generic(format!(
+                    "No suitable object store found for {url}. See `RuntimeEnv::register_object_store`"
+                ))
+            })
+    }
+
+    fn all_stores(&self) -> &DashMap<String, Arc<dyn ObjectStore>> {
+        &self.object_stores
+    }
+}
+
 /// TODO
 pub type FactoryRegistry = Arc<DashMap<Url, Arc<dyn ObjectStoreFactory>>>;
 

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -279,7 +279,7 @@ impl DeltaTable {
 
     /// get a shared reference to the delta object store
     pub fn object_store(&self) -> ObjectStoreRef {
-        self.log_store.object_store()
+        self.log_store.object_store(None)
     }
 
     /// Check if the [`DeltaTable`] exists
@@ -346,7 +346,7 @@ impl DeltaTable {
             _ => {
                 let state = DeltaTableState::try_new(
                     &Path::default(),
-                    self.log_store.object_store(),
+                    self.log_store.object_store(None),
                     self.config.clone(),
                     max_version,
                 )
@@ -515,7 +515,7 @@ impl DeltaTable {
         let log_store = self.log_store();
         let prefix = Some(log_store.log_path());
         let offset_path = commit_uri_from_version(min_version);
-        let object_store = log_store.object_store();
+        let object_store = log_store.object_store(None);
         let mut files = object_store.list_with_offset(prefix, &offset_path);
 
         while let Some(obj_meta) = files.next().await {

--- a/crates/core/tests/checkpoint_writer.rs
+++ b/crates/core/tests/checkpoint_writer.rs
@@ -25,7 +25,7 @@ mod simple_checkpoint {
             .unwrap();
 
         // Write a checkpoint
-        checkpoints::create_checkpoint(&table).await.unwrap();
+        checkpoints::create_checkpoint(&table, None).await.unwrap();
 
         // checkpoint should exist
         let checkpoint_path = log_path.join("00000000000000000005.checkpoint.parquet");
@@ -36,7 +36,7 @@ mod simple_checkpoint {
         assert_eq!(5, version);
 
         table.load_version(10).await.unwrap();
-        checkpoints::create_checkpoint(&table).await.unwrap();
+        checkpoints::create_checkpoint(&table, None).await.unwrap();
 
         // checkpoint should exist
         let checkpoint_path = log_path.join("00000000000000000010.checkpoint.parquet");
@@ -134,6 +134,7 @@ mod delete_expired_delta_log_in_checkpoint {
             &table.table_uri(),
             table.version(),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -182,6 +183,7 @@ mod delete_expired_delta_log_in_checkpoint {
         checkpoints::create_checkpoint_from_table_uri_and_cleanup(
             &table.table_uri(),
             table.version(),
+            None,
             None,
         )
         .await
@@ -248,7 +250,7 @@ mod checkpoints_with_tombstones {
 
         assert_eq!(1, fs_common::commit_add(&mut table, &a1).await);
         assert_eq!(2, fs_common::commit_add(&mut table, &a2).await);
-        checkpoints::create_checkpoint(&table).await.unwrap();
+        checkpoints::create_checkpoint(&table, None).await.unwrap();
         table.update().await.unwrap(); // make table to read the checkpoint
         assert_eq!(
             table.get_files_iter().unwrap().collect::<Vec<_>>(),
@@ -275,7 +277,7 @@ mod checkpoints_with_tombstones {
             removes1
         );
 
-        checkpoints::create_checkpoint(&table).await.unwrap();
+        checkpoints::create_checkpoint(&table, None).await.unwrap();
         table.update().await.unwrap(); // make table to read the checkpoint
         assert_eq!(
             table.get_files_iter().unwrap().collect::<Vec<_>>(),
@@ -397,7 +399,7 @@ mod checkpoints_with_tombstones {
         path: &str,
         version: i64,
     ) -> (HashSet<String>, Vec<Remove>) {
-        checkpoints::create_checkpoint(table).await.unwrap();
+        checkpoints::create_checkpoint(table, None).await.unwrap();
         let cp_path = format!("{path}/_delta_log/0000000000000000000{version}.checkpoint.parquet");
         let (schema, actions) = read_checkpoint(&cp_path).await;
 

--- a/crates/core/tests/command_optimize.rs
+++ b/crates/core/tests/command_optimize.rs
@@ -23,6 +23,7 @@ use parquet::file::properties::WriterProperties;
 use rand::prelude::*;
 use serde_json::json;
 use tempfile::TempDir;
+use uuid::Uuid;
 
 struct Context {
     pub tmp_dir: TempDir,
@@ -309,6 +310,8 @@ async fn test_conflict_for_remove_actions() -> Result<(), Box<dyn Error>> {
             20,
             None,
             CommitProperties::default(),
+            Uuid::new_v4(),
+            None,
         )
         .await;
 
@@ -368,6 +371,8 @@ async fn test_no_conflict_for_append_actions() -> Result<(), Box<dyn Error>> {
             20,
             None,
             CommitProperties::default(),
+            Uuid::new_v4(),
+            None,
         )
         .await?;
     assert_eq!(metrics.num_files_added, 1);
@@ -415,6 +420,8 @@ async fn test_commit_interval() -> Result<(), Box<dyn Error>> {
             20,
             Some(Duration::from_secs(0)), // this will cause as many commits as num_files_added
             CommitProperties::default(),
+            Uuid::new_v4(),
+            None,
         )
         .await?;
     assert_eq!(metrics.num_files_added, 2);

--- a/crates/core/tests/command_vacuum.rs
+++ b/crates/core/tests/command_vacuum.rs
@@ -295,6 +295,6 @@ async fn test_non_managed_files() {
 
 async fn is_deleted(context: &mut TestContext, path: &Path) -> bool {
     let backend = context.get_storage();
-    let res = backend.object_store().head(path).await;
+    let res = backend.object_store(None).head(path).await;
     matches!(res, Err(ObjectStoreError::NotFound { .. }))
 }

--- a/crates/core/tests/integration_checkpoint.rs
+++ b/crates/core/tests/integration_checkpoint.rs
@@ -28,7 +28,7 @@ async fn cleanup_metadata_test(context: &IntegrationContext) -> TestResult {
     let log_store = DeltaTableBuilder::from_uri(table_uri)
         .with_allow_http(true)
         .build_storage()?;
-    let object_store = log_store.object_store();
+    let object_store = log_store.object_store(None);
 
     let log_path = |version| log_store.log_path().child(format!("{:020}.json", version));
 

--- a/crates/core/tests/integration_checkpoint.rs
+++ b/crates/core/tests/integration_checkpoint.rs
@@ -61,7 +61,8 @@ async fn cleanup_metadata_test(context: &IntegrationContext) -> TestResult {
     assert!(retention_timestamp > v1time.timestamp_millis());
     assert!(retention_timestamp < v2time.timestamp_millis());
 
-    let removed = cleanup_expired_logs_for(3, log_store.as_ref(), retention_timestamp).await?;
+    let removed =
+        cleanup_expired_logs_for(3, log_store.as_ref(), retention_timestamp, None).await?;
 
     assert_eq!(removed, 2);
     assert!(object_store.head(&log_path(0)).await.is_err());
@@ -101,13 +102,14 @@ async fn test_issue_1420_cleanup_expired_logs_for() -> DeltaResult<()> {
     writer.flush_and_commit(&mut table).await?; // v2
     assert_eq!(table.version(), 2);
 
-    create_checkpoint(&table).await.unwrap(); // v2.checkpoint.parquet
+    create_checkpoint(&table, None).await.unwrap(); // v2.checkpoint.parquet
 
     // Should delete v1 but not v2 or v2.checkpoint.parquet
     cleanup_expired_logs_for(
         table.version(),
         table.log_store().as_ref(),
         ts.timestamp_millis(),
+        None,
     )
     .await?;
 
@@ -150,6 +152,7 @@ async fn test_issue_1420_cleanup_expired_logs_for() -> DeltaResult<()> {
         table.version(),
         table.log_store().as_ref(),
         ts.timestamp_millis(),
+        None,
     )
     .await?;
 

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -243,7 +243,7 @@ mod local {
         let source_store_url: &Url = object_store_url.as_ref();
         state
             .runtime_env()
-            .register_object_store(source_store_url, source_store.object_store());
+            .register_object_store(source_store_url, source_store.object_store(None));
 
         // Execute write to the target table with the proper state
         let target_table = WriteBuilder::new(

--- a/crates/core/tests/read_delta_partitions_test.rs
+++ b/crates/core/tests/read_delta_partitions_test.rs
@@ -32,7 +32,7 @@ async fn read_null_partitions_from_checkpoint() {
 
     fs_common::commit_add(&mut table, &add(Some("red".to_string()))).await;
     fs_common::commit_add(&mut table, &add(None)).await;
-    deltalake_core::checkpoints::create_checkpoint(&table)
+    deltalake_core::checkpoints::create_checkpoint(&table, None)
         .await
         .unwrap();
 

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -21,8 +21,10 @@ deltalake-aws = { version = "0.6.0", path = "../aws", default-features = false, 
 deltalake-azure = { version = "0.6.0", path = "../azure", optional = true }
 deltalake-gcp = { version = "0.7.0", path = "../gcp", optional = true }
 deltalake-hdfs = { version = "0.7.0", path = "../hdfs", optional = true }
+deltalake-lakefs = { version = "0.6.0", path = "../lakefs", optional = true }
 deltalake-catalog-glue = { version = "0.7.0", path = "../catalog-glue", optional = true }
 deltalake-catalog-unity = { version = "0.7.0", path = "../catalog-unity", optional = true }
+
 
 [features]
 # All of these features are just reflected into the core crate until that
@@ -39,6 +41,7 @@ python = ["deltalake-core/python"]
 s3-native-tls = ["deltalake-aws/native-tls"]
 s3 = ["deltalake-aws/rustls"]
 unity-experimental = ["deltalake-catalog-unity"]
+lakefs = ["deltalake-lakefs"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/deltalake/src/lib.rs
+++ b/crates/deltalake/src/lib.rs
@@ -11,3 +11,5 @@ pub use deltalake_azure as azure;
 pub use deltalake_gcp as gcp;
 #[cfg(feature = "hdfs")]
 pub use deltalake_hdfs as hdfs;
+#[cfg(feature = "lakefs")]
+pub use deltalake_lakefs as lakefs;

--- a/crates/gcp/tests/context.rs
+++ b/crates/gcp/tests/context.rs
@@ -33,8 +33,8 @@ pub async fn sync_stores(
     from_store: Arc<dyn LogStore>,
     to_store: Arc<dyn LogStore>,
 ) -> Result<(), DeltaTableError> {
-    let from_store = from_store.object_store().clone();
-    let to_store = to_store.object_store().clone();
+    let from_store = from_store.object_store(None).clone();
+    let to_store = to_store.object_store(None).clone();
     // TODO if a table is copied within the same root store (i.e bucket), using copy would be MUCH more efficient
     let mut meta_stream = from_store.list(None);
     while let Some(file) = meta_stream.next().await {

--- a/crates/lakefs/Cargo.toml
+++ b/crates/lakefs/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "deltalake-lakefs"
+version = "0.6.0"
+authors.workspace = true
+keywords.workspace = true
+readme.workspace = true
+edition.workspace = true
+homepage.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+deltalake-core = { version = "0.23.0", path = "../core" }
+# workspace dependencies
+async-trait = { workspace = true }
+bytes = { workspace = true }
+chrono = { workspace = true }
+futures = { workspace = true }
+tracing = { workspace = true }
+object_store = { workspace = true, features = ["aws"]}
+thiserror = { workspace = true }
+tokio = { workspace = true }
+regex = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v4"] }
+url = { workspace = true }
+dashmap = "6"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+reqwest = {version = "*", features = ["json"]}
+http = "1.0.0"
+delta_kernel = { workspace = true, features = [] }
+
+[dev-dependencies]
+deltalake-core = { path = "../core", features = ["datafusion"] }
+chrono = { workspace = true }
+serial_test = "3"
+deltalake-test = { path = "../test" }
+pretty_env_logger = "0.5.0"
+rand = "0.8"
+which = "7"
+maplit = "1"
+mockito =  { version = "1.6.1"}
+
+[features]
+integration_test_lakefs = []

--- a/crates/lakefs/LICENSE.txt
+++ b/crates/lakefs/LICENSE.txt
@@ -1,0 +1,1 @@
+../../LICENSE.txt

--- a/crates/lakefs/src/client.rs
+++ b/crates/lakefs/src/client.rs
@@ -1,0 +1,453 @@
+use dashmap::DashMap;
+use deltalake_core::operations::transaction::TransactionError;
+use deltalake_core::DeltaResult;
+use reqwest::Client;
+use reqwest::StatusCode;
+use serde::Deserialize;
+use serde_json::json;
+use tracing::debug;
+use url::Url;
+use uuid::Uuid;
+
+use crate::errors::LakeFSOperationError;
+
+#[derive(Debug, Clone)]
+pub struct LakeFSConfig {
+    host: String,
+    username: String,
+    password: String,
+}
+
+impl LakeFSConfig {
+    pub fn new(host: String, username: String, password: String) -> Self {
+        LakeFSConfig {
+            host,
+            username,
+            password,
+        }
+    }
+}
+
+/// Slim LakeFS client for lakefs branch operations.
+#[derive(Debug, Clone)]
+pub struct LakeFSClient {
+    /// configuration of the lakefs client
+    config: LakeFSConfig,
+    http_client: Client,
+    /// Holds the running delta lake operations, each operation propogates the operation ID into execution handler.
+    transactions: DashMap<Uuid, String>,
+}
+
+impl LakeFSClient {
+    pub fn with_config(config: LakeFSConfig) -> Self {
+        let http_client = Client::new();
+        Self {
+            config,
+            http_client,
+            transactions: DashMap::new(),
+        }
+    }
+
+    pub async fn create_branch(
+        &self,
+        source_url: &Url,
+        operation_id: Uuid,
+    ) -> DeltaResult<(Url, String)> {
+        let (repo, source_branch, table) = self.decompose_url(source_url.to_string());
+
+        let request_url = format!("{}/api/v1/repositories/{}/branches", self.config.host, repo);
+
+        let transaction_branch = format!("delta-tx-{}", operation_id);
+        let body = json!({
+            "name": transaction_branch,
+            "source": source_branch,
+            "force": false,
+            "hidden": true,
+        });
+
+        let response = self
+            .http_client
+            .post(&request_url)
+            .json(&body)
+            .basic_auth(&self.config.username, Some(&self.config.password))
+            .send()
+            .await
+            .map_err(|e| LakeFSOperationError::HttpRequestFailed { source: e })?;
+
+        // Handle the response
+        match response.status() {
+            StatusCode::CREATED => {
+                // Branch created successfully
+                let new_url = Url::parse(&format!(
+                    "lakefs://{}/{}/{}",
+                    repo, transaction_branch, table
+                ))
+                .unwrap();
+                Ok((new_url, transaction_branch))
+            }
+            StatusCode::UNAUTHORIZED => Err(LakeFSOperationError::UnauthorizedAction.into()),
+            _ => {
+                let error: LakeFSErrorResponse =
+                    response
+                        .json()
+                        .await
+                        .unwrap_or_else(|_| LakeFSErrorResponse {
+                            message: "Unknown error occurred.".to_string(),
+                        });
+                Err(LakeFSOperationError::CreateBranchFailed(error.message).into())
+            }
+        }
+    }
+
+    pub async fn delete_branch(
+        &self,
+        repo: String,
+        branch: String,
+    ) -> Result<(), TransactionError> {
+        let request_url = format!(
+            "{}/api/v1/repositories/{}/branches/{}",
+            self.config.host, repo, branch
+        );
+        let response = self
+            .http_client
+            .delete(&request_url)
+            .basic_auth(&self.config.username, Some(&self.config.password))
+            .send()
+            .await
+            .map_err(|e| LakeFSOperationError::HttpRequestFailed { source: e })?;
+
+        debug!("Deleting LakeFS Branch.");
+        // Handle the response
+        match response.status() {
+            StatusCode::NO_CONTENT => Ok(()),
+            StatusCode::UNAUTHORIZED => Err(LakeFSOperationError::UnauthorizedAction.into()),
+            _ => {
+                let error: LakeFSErrorResponse =
+                    response
+                        .json()
+                        .await
+                        .unwrap_or_else(|_| LakeFSErrorResponse {
+                            message: "Unknown error occurred.".to_string(),
+                        });
+                Err(LakeFSOperationError::DeleteBranchFailed(error.message).into())
+            }
+        }
+    }
+
+    pub async fn commit(
+        &self,
+        repo: String,
+        branch: String,
+        commit_message: String,
+        allow_empty: bool,
+    ) -> DeltaResult<()> {
+        let request_url = format!(
+            "{}/api/v1/repositories/{}/branches/{}/commits",
+            self.config.host, repo, branch
+        );
+
+        let body = json!({
+            "message": commit_message,
+            "allow_empty": allow_empty,
+        });
+
+        debug!(
+            "Committing to LakeFS Branch: '{}' in repo: '{}'",
+            branch, repo
+        );
+        let response = self
+            .http_client
+            .post(&request_url)
+            .json(&body)
+            .basic_auth(&self.config.username, Some(&self.config.password))
+            .send()
+            .await
+            .map_err(|e| LakeFSOperationError::HttpRequestFailed { source: e })?;
+
+        // Handle the response
+        match response.status() {
+            StatusCode::NO_CONTENT | StatusCode::CREATED => Ok(()),
+            StatusCode::UNAUTHORIZED => Err(LakeFSOperationError::UnauthorizedAction.into()),
+            _ => {
+                let error: LakeFSErrorResponse =
+                    response
+                        .json()
+                        .await
+                        .unwrap_or_else(|_| LakeFSErrorResponse {
+                            message: "Unknown error occurred.".to_string(),
+                        });
+                Err(LakeFSOperationError::CommitFailed(error.message).into())
+            }
+        }
+    }
+
+    pub async fn merge(
+        &self,
+        repo: String,
+        target_branch: String,
+        transaction_branch: String,
+        commit_version: i64,
+        commit_message: String,
+        allow_empty: bool,
+    ) -> Result<(), TransactionError> {
+        let request_url = format!(
+            "{}/api/v1/repositories/{}/refs/{}/merge/{}",
+            self.config.host, repo, transaction_branch, target_branch
+        );
+
+        let body = json!({
+            "message": commit_message,
+            "allow_empty": allow_empty,
+            "squash_merge": true,
+        });
+
+        debug!(
+            "Merging LakeFS, source `{}` into target `{}` in repo: {}",
+            transaction_branch, transaction_branch, repo
+        );
+        let response = self
+            .http_client
+            .post(&request_url)
+            .json(&body)
+            .basic_auth(&self.config.username, Some(&self.config.password))
+            .send()
+            .await
+            .map_err(|e| LakeFSOperationError::HttpRequestFailed { source: e })?;
+
+        // Handle the response;
+        match response.status() {
+            StatusCode::OK => Ok(()),
+            StatusCode::CONFLICT => Err(TransactionError::VersionAlreadyExists(commit_version)),
+            StatusCode::UNAUTHORIZED => Err(LakeFSOperationError::UnauthorizedAction.into()),
+            _ => {
+                let error: LakeFSErrorResponse =
+                    response
+                        .json()
+                        .await
+                        .unwrap_or_else(|_| LakeFSErrorResponse {
+                            message: "Unknown error occurred.".to_string(),
+                        });
+                Err(LakeFSOperationError::MergeFailed(error.message).into())
+            }
+        }
+    }
+
+    pub fn set_transaction(&self, id: Uuid, branch: String) {
+        self.transactions.insert(id, branch);
+        debug!("{}", format!("LakeFS Transaction `{}` has been set.", id));
+    }
+
+    pub fn get_transaction(&self, id: Uuid) -> Result<String, TransactionError> {
+        let transaction_branch = self
+            .transactions
+            .get(&id)
+            .map(|v| v.to_string())
+            .ok_or(LakeFSOperationError::TransactionIdNotFound(id.to_string()))?;
+        debug!(
+            "{}",
+            format!("LakeFS Transaction `{}` has been grabbed.", id)
+        );
+        Ok(transaction_branch)
+    }
+
+    pub fn clear_transaction(&self, id: Uuid) {
+        self.transactions.remove(&id);
+        debug!(
+            "{}",
+            format!("LakeFS Transaction `{}` has been removed.", id)
+        );
+    }
+
+    pub fn decompose_url(&self, url: String) -> (String, String, String) {
+        let url_path = url
+            .strip_prefix("lakefs://")
+            .unwrap()
+            .split("/")
+            .collect::<Vec<&str>>();
+        let repo = url_path[0].to_owned();
+        let branch = url_path[1].to_owned();
+        let table = url_path[2..].join("/");
+
+        (repo, branch, table)
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct LakeFSErrorResponse {
+    message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::OnceLock;
+
+    use super::*;
+    use mockito;
+    use reqwest::StatusCode;
+    use tokio::runtime::Runtime;
+    use uuid::Uuid;
+
+    #[inline]
+    fn rt() -> &'static Runtime {
+        static TOKIO_RT: OnceLock<Runtime> = OnceLock::new();
+        TOKIO_RT.get_or_init(|| Runtime::new().expect("Failed to create a tokio runtime."))
+    }
+
+    #[test]
+    fn test_create_branch() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("POST", "/api/v1/repositories/test_repo/branches")
+            .with_status(StatusCode::CREATED.as_u16().into())
+            .with_body("")
+            .create();
+
+        let config = LakeFSConfig::new(
+            server.url(),
+            "test_user".to_string(),
+            "test_pass".to_string(),
+        );
+        let client = LakeFSClient::with_config(config);
+        let operation_id = Uuid::new_v4();
+        let source_url = Url::parse("lakefs://test_repo/main/table").unwrap();
+
+        let result = rt().block_on(async { client.create_branch(&source_url, operation_id).await });
+        assert!(result.is_ok());
+        let (new_url, branch_name) = result.unwrap();
+        assert_eq!(branch_name, format!("delta-tx-{}", operation_id));
+        assert!(new_url.as_str().contains("lakefs://test_repo"));
+        mock.assert();
+    }
+
+    #[test]
+    fn test_delete_branch() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock(
+                "DELETE",
+                "/api/v1/repositories/test_repo/branches/delta-tx-1234",
+            )
+            .with_status(StatusCode::NO_CONTENT.as_u16().into())
+            .create();
+
+        let config = LakeFSConfig::new(
+            server.url(),
+            "test_user".to_string(),
+            "test_pass".to_string(),
+        );
+        let client = LakeFSClient::with_config(config);
+
+        let result = rt().block_on(async {
+            client
+                .delete_branch("test_repo".to_string(), "delta-tx-1234".to_string())
+                .await
+        });
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[test]
+    fn test_commit() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock(
+                "POST",
+                "/api/v1/repositories/test_repo/branches/delta-tx-1234/commits",
+            )
+            .with_status(StatusCode::CREATED.as_u16().into())
+            .create();
+
+        let config = LakeFSConfig::new(
+            server.url(),
+            "test_user".to_string(),
+            "test_pass".to_string(),
+        );
+        let client = LakeFSClient::with_config(config);
+
+        let result = rt().block_on(async {
+            client
+                .commit(
+                    "test_repo".to_string(),
+                    "delta-tx-1234".to_string(),
+                    "Test commit".to_string(),
+                    false,
+                )
+                .await
+        });
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[test]
+    fn test_merge() {
+        let mut server = mockito::Server::new();
+        let mock = server.mock("POST", "/api/v1/repositories/test_repo/refs/test_transaction_branch/merge/test_target_branch")
+            .with_status(StatusCode::OK.as_u16().into())
+            .create();
+
+        let config = LakeFSConfig::new(
+            server.url(),
+            "test_user".to_string(),
+            "test_pass".to_string(),
+        );
+        let client = LakeFSClient::with_config(config);
+
+        let result = rt().block_on(async {
+            client
+                .merge(
+                    "test_repo".to_string(),
+                    "test_target_branch".to_string(),
+                    "test_transaction_branch".to_string(),
+                    1,
+                    "Merge commit".to_string(),
+                    false,
+                )
+                .await
+        });
+        assert!(result.is_ok());
+        mock.assert();
+    }
+
+    #[test]
+    fn test_decompose_url() {
+        let config = LakeFSConfig::new(
+            "http://localhost:8000".to_string(),
+            "user".to_string(),
+            "pass".to_string(),
+        );
+        let client = LakeFSClient::with_config(config);
+
+        let (repo, branch, table) =
+            client.decompose_url("lakefs://test_repo/test_branch/test_table".to_string());
+        assert_eq!(repo, "test_repo");
+        assert_eq!(branch, "test_branch");
+        assert_eq!(table, "test_table");
+
+        let (repo, branch, table) =
+            client.decompose_url("lakefs://test_repo/test_branch/data/test_table".to_string());
+        assert_eq!(repo, "test_repo");
+        assert_eq!(branch, "test_branch");
+        assert_eq!(table, "data/test_table");
+    }
+
+    #[test]
+    fn test_transaction_management() {
+        let config = LakeFSConfig::new(
+            "http://localhost".to_string(),
+            "user".to_string(),
+            "pass".to_string(),
+        );
+        let client = LakeFSClient::with_config(config);
+
+        let transaction_id = Uuid::new_v4();
+        let branch_name = "test_branch".to_string();
+
+        client.set_transaction(transaction_id, branch_name.clone());
+        let retrieved_branch = client.get_transaction(transaction_id).unwrap();
+        assert_eq!(retrieved_branch, branch_name);
+
+        client.clear_transaction(transaction_id);
+        let result = client.get_transaction(transaction_id);
+        assert!(result.is_err());
+    }
+}

--- a/crates/lakefs/src/errors.rs
+++ b/crates/lakefs/src/errors.rs
@@ -1,0 +1,79 @@
+//! Errors for LakeFS log store
+
+use deltalake_core::operations::transaction::TransactionError;
+use deltalake_core::DeltaTableError;
+use reqwest::Error;
+
+#[derive(thiserror::Error, Debug)]
+pub enum LakeFSConfigError {
+    /// Missing endpoint
+    #[error("LakeFS endpoint is missing in storage options. Set `endpoint`.")]
+    EndpointMissing,
+
+    /// Missing username
+    #[error("LakeFS username is missing in storage options. Set `access_key_id`.")]
+    UsernameCredentialMissing,
+
+    /// Missing password
+    #[error("LakeFS password is missing in storage options. Set `secret_access_key`.")]
+    PasswordCredentialMissing,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum LakeFSOperationError {
+    /// Failed to send http request to LakeFS
+    #[error("Failed to send request to LakeFS: {source}")]
+    HttpRequestFailed { source: Error },
+
+    /// Missing authentication in LakeFS
+    #[error("LakeFS request was unauthorized. Check permissions.")]
+    UnauthorizedAction,
+
+    /// LakeFS commit has failed
+    #[error("LakeFS commit failed. Reason: {0}")]
+    CommitFailed(String),
+
+    /// LakeFS merge has failed
+    #[error("LakeFS merge failed. Reason: {0}")]
+    MergeFailed(String),
+
+    /// LakeFS create branch has failed
+    #[error("LakeFS create branch failed. Reason: {0}")]
+    CreateBranchFailed(String),
+
+    /// LakeFS delete branch has failed
+    #[error("LakeFS delete branch failed. Reason: {0}")]
+    DeleteBranchFailed(String),
+
+    /// LakeFS delete branch has failed
+    #[error("Transaction ID ({0}) not found. Something went wrong.")]
+    TransactionIdNotFound(String),
+}
+
+impl From<LakeFSOperationError> for TransactionError {
+    fn from(err: LakeFSOperationError) -> Self {
+        TransactionError::LogStoreError {
+            msg: err.to_string(),
+            source: Box::new(err),
+        }
+    }
+}
+
+impl From<LakeFSOperationError> for DeltaTableError {
+    fn from(err: LakeFSOperationError) -> Self {
+        DeltaTableError::Transaction {
+            source: TransactionError::LogStoreError {
+                msg: err.to_string(),
+                source: Box::new(err),
+            },
+        }
+    }
+}
+
+impl From<LakeFSConfigError> for DeltaTableError {
+    fn from(err: LakeFSConfigError) -> Self {
+        DeltaTableError::GenericError {
+            source: Box::new(err),
+        }
+    }
+}

--- a/crates/lakefs/src/execute.rs
+++ b/crates/lakefs/src/execute.rs
@@ -1,0 +1,398 @@
+use async_trait::async_trait;
+use deltalake_core::{
+    logstore::LogStoreRef, operations::CustomExecuteHandler, DeltaResult, DeltaTableError,
+};
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::logstore::LakeFSLogStore;
+
+pub struct LakeFSCustomExecuteHandler {}
+
+#[async_trait]
+impl CustomExecuteHandler for LakeFSCustomExecuteHandler {
+    // LakeFS Log store pre execution of delta operation (create branch, logs object store and transaction)
+    async fn pre_execute(&self, log_store: &LogStoreRef, operation_id: Uuid) -> DeltaResult<()> {
+        debug!("Running LakeFS pre execution inside delta operation");
+        if let Some(lakefs_store) = log_store.clone().as_any().downcast_ref::<LakeFSLogStore>() {
+            lakefs_store.pre_execute(operation_id).await
+        } else {
+            Err(DeltaTableError::generic(
+                "LakeFSPreEcuteHandler is used, but no LakeFSLogStore has been found",
+            ))
+        }
+    }
+    // Not required for LakeFS
+    async fn post_execute(&self, log_store: &LogStoreRef, operation_id: Uuid) -> DeltaResult<()> {
+        debug!("Running LakeFS post execution inside delta operation");
+        if let Some(lakefs_store) = log_store.clone().as_any().downcast_ref::<LakeFSLogStore>() {
+            let (repo, _, _) = lakefs_store
+                .client
+                .decompose_url(lakefs_store.config.location.to_string());
+            let result = lakefs_store
+                .client
+                .delete_branch(repo, lakefs_store.client.get_transaction(operation_id)?)
+                .await
+                .map_err(|e| DeltaTableError::Transaction { source: e });
+            lakefs_store.client.clear_transaction(operation_id);
+            result
+        } else {
+            Err(DeltaTableError::generic(
+                "LakeFSPreEcuteHandler is used, but no LakeFSLogStore has been found",
+            ))
+        }
+    }
+
+    // Execute arbitrary code at the start of the post commit hook
+    async fn before_post_commit_hook(
+        &self,
+        log_store: &LogStoreRef,
+        file_operations: bool,
+        operation_id: Uuid,
+    ) -> DeltaResult<()> {
+        if file_operations {
+            debug!("Running LakeFS pre execution inside post_commit_hook");
+            if let Some(lakefs_store) = log_store.clone().as_any().downcast_ref::<LakeFSLogStore>()
+            {
+                lakefs_store.pre_execute(operation_id).await
+            } else {
+                Err(DeltaTableError::generic(
+                    "LakeFSPreEcuteHandler is used, but no LakeFSLogStore has been found",
+                ))
+            }?;
+        }
+        Ok(())
+    }
+
+    // Execute arbitrary code at the end of the post commit hook
+    async fn after_post_commit_hook(
+        &self,
+        log_store: &LogStoreRef,
+        file_operations: bool,
+        operation_id: Uuid,
+    ) -> DeltaResult<()> {
+        if file_operations {
+            debug!("Running LakeFS post execution inside post_commit_hook");
+            if let Some(lakefs_store) = log_store.clone().as_any().downcast_ref::<LakeFSLogStore>()
+            {
+                lakefs_store.commit_merge(operation_id).await
+            } else {
+                Err(DeltaTableError::generic(
+                    "LakeFSPreEcuteHandler is used, but no LakeFSLogStore has been found",
+                ))
+            }?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::register_handlers;
+
+    use super::*;
+    use deltalake_core::{logstore::logstore_for, storage::ObjectStoreRegistry};
+    use http::StatusCode;
+    use maplit::hashmap;
+    use std::{collections::HashMap, sync::OnceLock};
+    use tokio::runtime::Runtime;
+    use url::Url;
+    use uuid::Uuid;
+
+    fn setup_env(server_url: String) -> LogStoreRef {
+        register_handlers(None);
+        let location = Url::parse("lakefs://repo/branch/table").unwrap();
+        let raw_options = hashmap! {
+            "ACCESS_KEY_ID".to_string() => "options_key".to_string(),
+            "ENDPOINT_URL".to_string() => server_url,
+            "SECRET_ACCESS_KEY".to_string() => "options_key".to_string(),
+            "REGION".to_string() => "options_key".to_string()
+        };
+        logstore_for(location, raw_options, None).unwrap()
+    }
+
+    #[inline]
+    fn rt() -> &'static Runtime {
+        static TOKIO_RT: OnceLock<Runtime> = OnceLock::new();
+        TOKIO_RT.get_or_init(|| Runtime::new().expect("Failed to create a tokio runtime."))
+    }
+
+    #[test]
+    fn test_pre_execute() {
+        let handler = LakeFSCustomExecuteHandler {};
+        let operation_id = Uuid::new_v4();
+
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("POST", "/api/v1/repositories/repo/branches")
+            .with_status(StatusCode::CREATED.as_u16().into())
+            .with_body("")
+            .create();
+
+        let lakefs_store = setup_env(server.url());
+
+        let result =
+            rt().block_on(async { handler.pre_execute(&lakefs_store, operation_id).await });
+        mock.assert();
+        assert!(result.is_ok());
+
+        if let Some(lakefs_store) = lakefs_store
+            .clone()
+            .as_any()
+            .downcast_ref::<LakeFSLogStore>()
+        {
+            assert!(lakefs_store
+                .storage
+                .get_store(
+                    &Url::parse(format!("lakefs://repo/delta-tx-{}/table", operation_id).as_str())
+                        .unwrap()
+                )
+                .is_ok());
+
+            assert!(lakefs_store.client.get_transaction(operation_id).is_ok())
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn test_before_post_commit_hook() {
+        let handler = LakeFSCustomExecuteHandler {};
+        let operation_id = Uuid::new_v4();
+
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("POST", "/api/v1/repositories/repo/branches")
+            .with_status(StatusCode::CREATED.as_u16().into())
+            .with_body("")
+            .create();
+
+        let lakefs_store = setup_env(server.url());
+
+        let result = rt().block_on(async {
+            handler
+                .before_post_commit_hook(&lakefs_store, true, operation_id)
+                .await
+        });
+        mock.assert();
+        assert!(result.is_ok());
+
+        if let Some(lakefs_store) = lakefs_store
+            .clone()
+            .as_any()
+            .downcast_ref::<LakeFSLogStore>()
+        {
+            assert!(lakefs_store
+                .storage
+                .get_store(
+                    &Url::parse(format!("lakefs://repo/delta-tx-{}/table", operation_id).as_str())
+                        .unwrap()
+                )
+                .is_ok());
+
+            assert!(lakefs_store.client.get_transaction(operation_id).is_ok())
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn test_post_execute() {
+        let handler = LakeFSCustomExecuteHandler {};
+        let operation_id = Uuid::new_v4();
+
+        let mut server = mockito::Server::new();
+        let mock_1 = server
+            .mock("POST", "/api/v1/repositories/repo/branches")
+            .with_status(StatusCode::CREATED.as_u16().into())
+            .with_body("")
+            .create();
+        let mock_2 = server
+            .mock(
+                "DELETE",
+                format!(
+                    "/api/v1/repositories/repo/branches/delta-tx-{}",
+                    operation_id
+                )
+                .as_str(),
+            )
+            .with_status(StatusCode::NO_CONTENT.as_u16().into())
+            .create();
+
+        let lakefs_store = setup_env(server.url());
+
+        rt().block_on(async { handler.pre_execute(&lakefs_store, operation_id).await })
+            .unwrap();
+        mock_1.assert();
+
+        let result =
+            rt().block_on(async { handler.post_execute(&lakefs_store, operation_id).await });
+
+        assert!(result.is_ok());
+        mock_2.assert();
+
+        if let Some(lakefs_store) = lakefs_store
+            .clone()
+            .as_any()
+            .downcast_ref::<LakeFSLogStore>()
+        {
+            assert!(lakefs_store.client.get_transaction(operation_id).is_err())
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn test_after_post_commit_hook() {
+        let handler = LakeFSCustomExecuteHandler {};
+        let operation_id = Uuid::new_v4();
+
+        let mut server = mockito::Server::new();
+        let create_branch_mock = server
+            .mock("POST", "/api/v1/repositories/repo/branches")
+            .with_status(StatusCode::CREATED.as_u16().into())
+            .with_body("")
+            .create();
+
+        let create_commit_mock = server
+            .mock(
+                "POST",
+                format!(
+                    "/api/v1/repositories/repo/branches/delta-tx-{}/commits",
+                    operation_id
+                )
+                .as_str(),
+            )
+            .with_status(StatusCode::CREATED.as_u16().into())
+            .create();
+
+        let merge_branch_mock = server
+            .mock(
+                "POST",
+                format!(
+                    "/api/v1/repositories/repo/refs/delta-tx-{}/merge/branch",
+                    operation_id
+                )
+                .as_str(),
+            )
+            .with_status(StatusCode::OK.as_u16().into())
+            .create();
+
+        let delete_branch_mock = server
+            .mock(
+                "DELETE",
+                format!(
+                    "/api/v1/repositories/repo/branches/delta-tx-{}",
+                    operation_id
+                )
+                .as_str(),
+            )
+            .with_status(StatusCode::NO_CONTENT.as_u16().into())
+            .create();
+
+        let lakefs_store = setup_env(server.url());
+
+        let result = rt().block_on(async {
+            handler
+                .before_post_commit_hook(&lakefs_store, true, operation_id)
+                .await
+        });
+        create_branch_mock.assert();
+        assert!(result.is_ok());
+
+        let result = rt().block_on(async {
+            handler
+                .after_post_commit_hook(&lakefs_store, true, operation_id)
+                .await
+        });
+
+        create_commit_mock.assert();
+        merge_branch_mock.assert();
+        delete_branch_mock.assert();
+        assert!(result.is_ok());
+
+        if let Some(lakefs_store) = lakefs_store
+            .clone()
+            .as_any()
+            .downcast_ref::<LakeFSLogStore>()
+        {
+            assert!(lakefs_store.client.get_transaction(operation_id).is_err())
+        } else {
+            unreachable!()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_error_with_invalid_log_store() {
+        let location = Url::parse("memory://table").unwrap();
+        let invalid_default_store = logstore_for(location, HashMap::default(), None).unwrap();
+
+        let handler = LakeFSCustomExecuteHandler {};
+        let operation_id = Uuid::new_v4();
+
+        let result = handler
+            .post_execute(&invalid_default_store, operation_id)
+            .await;
+        assert!(result.is_err());
+        if let Err(DeltaTableError::Generic(err)) = result {
+            assert_eq!(
+                err,
+                "LakeFSPreEcuteHandler is used, but no LakeFSLogStore has been found"
+            );
+        }
+
+        let result = handler
+            .pre_execute(&invalid_default_store, operation_id)
+            .await;
+        assert!(result.is_err());
+        if let Err(DeltaTableError::Generic(err)) = result {
+            assert_eq!(
+                err,
+                "LakeFSPreEcuteHandler is used, but no LakeFSLogStore has been found"
+            );
+        }
+
+        let result = handler
+            .before_post_commit_hook(&invalid_default_store, true, operation_id)
+            .await;
+        assert!(result.is_err());
+        if let Err(DeltaTableError::Generic(err)) = result {
+            assert_eq!(
+                err,
+                "LakeFSPreEcuteHandler is used, but no LakeFSLogStore has been found"
+            );
+        }
+
+        let result = handler
+            .after_post_commit_hook(&invalid_default_store, true, operation_id)
+            .await;
+        assert!(result.is_err());
+        if let Err(DeltaTableError::Generic(err)) = result {
+            assert_eq!(
+                err,
+                "LakeFSPreEcuteHandler is used, but no LakeFSLogStore has been found"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_noop_commit_hook_executor() {
+        // When file operations is false, the commit hook executor is a noop, since we don't need
+        // to create any branches, or commit and merge them back.
+        let location = Url::parse("memory://table").unwrap();
+        let invalid_default_store = logstore_for(location, HashMap::default(), None).unwrap();
+
+        let handler = LakeFSCustomExecuteHandler {};
+        let operation_id = Uuid::new_v4();
+
+        let result = handler
+            .before_post_commit_hook(&invalid_default_store, false, operation_id)
+            .await;
+        assert!(result.is_ok());
+
+        let result = handler
+            .after_post_commit_hook(&invalid_default_store, false, operation_id)
+            .await;
+        assert!(result.is_ok());
+    }
+}

--- a/crates/lakefs/src/lib.rs
+++ b/crates/lakefs/src/lib.rs
@@ -1,0 +1,49 @@
+//! LakeFS and similar tooling for delta-rs
+//!
+//! This module also contains the [LakeFSLogStore] implementation for delta operations executed in transaction branches
+//! where deltalake commits only happen when the branch can be safely merged.
+
+pub mod client;
+pub mod errors;
+pub mod execute;
+pub mod logstore;
+pub mod storage;
+use deltalake_core::logstore::{logstores, LogStore, LogStoreFactory};
+use deltalake_core::storage::{factories, url_prefix_handler, ObjectStoreRef, StorageOptions};
+use deltalake_core::{DeltaResult, Path};
+pub use execute::LakeFSCustomExecuteHandler;
+use logstore::lakefs_logstore;
+use std::sync::Arc;
+use storage::LakeFSObjectStoreFactory;
+use storage::S3StorageOptionsConversion;
+use tracing::debug;
+use url::Url;
+
+#[derive(Clone, Debug, Default)]
+pub struct LakeFSLogStoreFactory {}
+
+impl S3StorageOptionsConversion for LakeFSLogStoreFactory {}
+
+impl LogStoreFactory for LakeFSLogStoreFactory {
+    fn with_options(
+        &self,
+        store: ObjectStoreRef,
+        location: &Url,
+        options: &StorageOptions,
+    ) -> DeltaResult<Arc<dyn LogStore>> {
+        let options = self.with_env_s3(options);
+        let store = url_prefix_handler(store, Path::parse(location.path())?);
+        debug!("LakeFSLogStoreFactory has been asked to create a LogStore");
+        lakefs_logstore(store, location, &options)
+    }
+}
+
+/// Register an [ObjectStoreFactory] for common LakeFS [Url] schemes
+pub fn register_handlers(_additional_prefixes: Option<Url>) {
+    let object_stores = Arc::new(LakeFSObjectStoreFactory::default());
+    let log_stores = Arc::new(LakeFSLogStoreFactory::default());
+    let scheme = "lakefs";
+    let url = Url::parse(&format!("{}://", scheme)).unwrap();
+    factories().insert(url.clone(), object_stores.clone());
+    logstores().insert(url.clone(), log_stores.clone());
+}

--- a/crates/lakefs/src/logstore.rs
+++ b/crates/lakefs/src/logstore.rs
@@ -1,0 +1,340 @@
+//! Default implementation of [`LakeFSLogStore`] for LakeFS
+
+use std::sync::{Arc, OnceLock};
+
+use crate::client::LakeFSConfig;
+use crate::errors::LakeFSConfigError;
+
+use super::client::LakeFSClient;
+use bytes::Bytes;
+use deltalake_core::storage::{
+    commit_uri_from_version, DefaultObjectStoreRegistry, ObjectStoreRegistry,
+};
+use deltalake_core::storage::{url_prefix_handler, DeltaIOStorageBackend, IORuntime};
+use deltalake_core::{logstore::*, DeltaTableError, Path};
+use deltalake_core::{
+    operations::transaction::TransactionError,
+    storage::{ObjectStoreRef, StorageOptions},
+    DeltaResult,
+};
+use object_store::{Attributes, Error as ObjectStoreError, ObjectStore, PutOptions, TagSet};
+use tracing::debug;
+use url::Url;
+use uuid::Uuid;
+
+/// Return the [LakeFSLogStore] implementation with the provided configuration options
+pub fn lakefs_logstore(
+    store: ObjectStoreRef,
+    location: &Url,
+    options: &StorageOptions,
+) -> DeltaResult<Arc<dyn LogStore>> {
+    let host = options
+        .0
+        .get("aws_endpoint")
+        .ok_or(LakeFSConfigError::EndpointMissing)?
+        .to_string();
+    let username = options
+        .0
+        .get("aws_access_key_id")
+        .ok_or(LakeFSConfigError::UsernameCredentialMissing)?
+        .to_string();
+    let password = options
+        .0
+        .get("aws_secret_access_key")
+        .ok_or(LakeFSConfigError::PasswordCredentialMissing)?
+        .to_string();
+
+    let client = LakeFSClient::with_config(LakeFSConfig::new(host, username, password));
+    Ok(Arc::new(LakeFSLogStore::new(
+        store,
+        LogStoreConfig {
+            location: location.clone(),
+            options: options.clone(),
+        },
+        client,
+    )))
+}
+
+/// Default [`LogStore`] implementation
+#[derive(Debug, Clone)]
+pub(crate) struct LakeFSLogStore {
+    pub(crate) storage: DefaultObjectStoreRegistry,
+    pub(crate) config: LogStoreConfig,
+    pub(crate) client: LakeFSClient,
+}
+
+impl LakeFSLogStore {
+    /// Create a new instance of [`LakeFSLogStore`]
+    ///
+    /// # Arguments
+    ///
+    /// * `storage` - A shared reference to an [`object_store::ObjectStore`] with "/" pointing at delta table root (i.e. where `_delta_log` is located).
+    /// * `location` - A url corresponding to the storage location of `storage`.
+    pub fn new(storage: ObjectStoreRef, config: LogStoreConfig, client: LakeFSClient) -> Self {
+        let registry = DefaultObjectStoreRegistry::new();
+        registry.register_store(&config.location, storage);
+        Self {
+            storage: registry,
+            config,
+            client,
+        }
+    }
+
+    /// Build a new object store for an URL using the existing storage options. After
+    /// branch creation a new object store needs to be created for the branch uri
+    fn build_new_store(&self, url: &Url) -> DeltaResult<ObjectStoreRef> {
+        // turn location into scheme
+        let scheme = Url::parse(&format!("{}://", url.scheme()))
+            .map_err(|_| DeltaTableError::InvalidTableLocation(url.clone().into()))?;
+
+        if let Some(entry) = deltalake_core::storage::factories().get(&scheme) {
+            debug!("Creating new storage with storage provider for {scheme} ({url})");
+
+            let (store, _prefix) = entry
+                .value()
+                .parse_url_opts(url, &self.config().options.clone())?;
+            return Ok(store);
+        }
+        Err(DeltaTableError::InvalidTableLocation(url.to_string()))
+    }
+
+    fn register_object_store(&self, url: &Url, store: ObjectStoreRef) {
+        self.storage.register_store(url, store);
+    }
+
+    fn get_transaction_objectstore(
+        &self,
+        operation_id: Uuid,
+    ) -> DeltaResult<(String, ObjectStoreRef)> {
+        let (repo, _, table) = self.client.decompose_url(self.config.location.to_string());
+        let string_url = format!(
+            "lakefs://{}/{}/{}",
+            repo,
+            self.client.get_transaction(operation_id)?,
+            table
+        );
+        let transaction_url = Url::parse(&string_url).unwrap();
+        Ok((string_url, self.storage.get_store(&transaction_url)?))
+    }
+
+    pub async fn pre_execute(&self, operation_id: Uuid) -> DeltaResult<()> {
+        // Create LakeFS Branch for transaction
+        let (lakefs_url, tnx_branch) = self
+            .client
+            .create_branch(&self.config.location, operation_id)
+            .await?;
+
+        // Build new object store store using the new lakefs url
+        let txn_store = url_prefix_handler(
+            Arc::new(DeltaIOStorageBackend::new(
+                self.build_new_store(&lakefs_url)?,
+                IORuntime::default().get_handle(),
+            )) as ObjectStoreRef,
+            Path::parse(lakefs_url.path())?,
+        );
+
+        // Register transaction branch as ObjectStore in log_store storages
+        self.register_object_store(&lakefs_url, txn_store);
+
+        // set transaction in client for easy retrieval
+        self.client.set_transaction(operation_id, tnx_branch);
+        Ok(())
+    }
+
+    pub async fn commit_merge(&self, operation_id: Uuid) -> DeltaResult<()> {
+        let (transaction_url, _) = self.get_transaction_objectstore(operation_id)?;
+
+        // Do LakeFS Commit
+        let (repo, transaction_branch, table) = self.client.decompose_url(transaction_url);
+        self.client
+            .commit(
+                repo,
+                transaction_branch,
+                format!("Delta file operations {{ table: {}}}", table),
+                true, // Needs to be true, it could be a file operation but no logs were deleted.
+            )
+            .await?;
+
+        // Try LakeFS Branch merge of transaction branch in source branch
+        let (repo, target_branch, table) =
+            self.client.decompose_url(self.config.location.to_string());
+        match self
+            .client
+            .merge(
+                repo,
+                target_branch,
+                self.client.get_transaction(operation_id)?,
+                0,
+                format!("Finished delta file operations {{ table: {}}}", table),
+                true, // Needs to be true, it could be a file operation but no logs were deleted.
+            )
+            .await
+        {
+            Ok(_) => {
+                let (repo, _, _) = self.client.decompose_url(self.config.location.to_string());
+                self.client
+                    .delete_branch(repo, self.client.get_transaction(operation_id)?)
+                    .await?;
+                Ok(())
+            }
+            // TODO: propagate better LakeFS errors.
+            Err(TransactionError::VersionAlreadyExists(_)) => {
+                Err(TransactionError::LogStoreError {
+                    msg: "Merge Failed".to_string(),
+                    source: Box::new(DeltaTableError::generic("Merge Failed")),
+                })
+            }
+            Err(err) => Err(err),
+        }?;
+
+        self.client.clear_transaction(operation_id);
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl LogStore for LakeFSLogStore {
+    fn name(&self) -> String {
+        "LakeFSLogStore".into()
+    }
+
+    async fn read_commit_entry(&self, version: i64) -> DeltaResult<Option<Bytes>> {
+        read_commit_entry(&self.storage.get_store(&self.config.location)?, version).await
+    }
+
+    /// Tries to commit a prepared commit file. Returns [`TransactionError`]
+    /// if the given `version` already exists. The caller should handle the retry logic itself.
+    /// This is low-level transaction API. If user does not want to maintain the commit loop then
+    /// the `DeltaTransaction.commit` is desired to be used as it handles `try_commit_transaction`
+    /// with retry logic.
+    async fn write_commit_entry(
+        &self,
+        version: i64,
+        commit_or_bytes: CommitOrBytes,
+        operation_id: Uuid,
+    ) -> Result<(), TransactionError> {
+        let (transaction_url, store) =
+            self.get_transaction_objectstore(operation_id)
+                .map_err(|e| TransactionError::LogStoreError {
+                    msg: e.to_string(),
+                    source: Box::new(e),
+                })?;
+
+        match commit_or_bytes {
+            CommitOrBytes::LogBytes(log_bytes) => {
+                // Put commit
+                store
+                    .put_opts(
+                        &commit_uri_from_version(version),
+                        log_bytes.into(),
+                        put_options().clone(),
+                    )
+                    .await
+                    .map_err(|err| -> TransactionError {
+                        match err {
+                            ObjectStoreError::AlreadyExists { .. } => {
+                                TransactionError::VersionAlreadyExists(version)
+                            }
+                            _ => TransactionError::from(err),
+                        }
+                    })?;
+
+                // Do LakeFS Commit
+                let (repo, transaction_branch, table) = self.client.decompose_url(transaction_url);
+                self.client
+                    .commit(
+                        repo,
+                        transaction_branch,
+                        format!("Delta commit {{ table: {}, version: {}}}", table, version),
+                        false,
+                    )
+                    .await
+                    .map_err(|e| TransactionError::LogStoreError {
+                        msg: e.to_string(),
+                        source: Box::new(e),
+                    })?;
+
+                // Try LakeFS Branch merge of transaction branch in source branch
+                let (repo, target_branch, table) =
+                    self.client.decompose_url(self.config.location.to_string());
+                match self
+                    .client
+                    .merge(
+                        repo,
+                        target_branch,
+                        self.client.get_transaction(operation_id)?,
+                        version,
+                        format!(
+                            "Finished deltalake transaction {{ table: {}, version: {} }}",
+                            table, version
+                        ),
+                        false,
+                    )
+                    .await
+                {
+                    Ok(_) => Ok(()),
+                    Err(TransactionError::VersionAlreadyExists(version)) => {
+                        store
+                            .delete(&commit_uri_from_version(version))
+                            .await
+                            .map_err(TransactionError::from)?;
+                        return Err(TransactionError::VersionAlreadyExists(version));
+                    }
+                    Err(err) => Err(err),
+                }?;
+            }
+            _ => unreachable!(), // Default log store should never get a tmp_commit, since this is for conditional put stores
+        };
+        Ok(())
+    }
+
+    async fn abort_commit_entry(
+        &self,
+        _version: i64,
+        commit_or_bytes: CommitOrBytes,
+        operation_id: Uuid,
+    ) -> Result<(), TransactionError> {
+        match &commit_or_bytes {
+            CommitOrBytes::LogBytes(_) => {
+                let (repo, _, _) = self.client.decompose_url(self.config.location.to_string());
+                self.client
+                    .delete_branch(repo, self.client.get_transaction(operation_id)?)
+                    .await?;
+                self.client.clear_transaction(operation_id);
+                Ok(())
+            }
+            _ => unreachable!(), // Default log store should never get a tmp_commit, since this is for conditional put stores
+        }
+    }
+
+    async fn get_latest_version(&self, current_version: i64) -> DeltaResult<i64> {
+        get_latest_version(self, current_version).await
+    }
+
+    async fn get_earliest_version(&self, current_version: i64) -> DeltaResult<i64> {
+        get_earliest_version(self, current_version).await
+    }
+
+    fn object_store(&self, operation_id: Option<Uuid>) -> Arc<dyn ObjectStore> {
+        match operation_id {
+            Some(id) => {
+                let (_, store) = self.get_transaction_objectstore(id).unwrap_or_else(|_| panic!("The object_store registry inside LakeFSLogstore didn't have a store for operation_id {} Something went wrong.", id));
+                store
+            }
+            _ => self.storage.get_store(&self.config.location).unwrap(),
+        }
+    }
+
+    fn config(&self) -> &LogStoreConfig {
+        &self.config
+    }
+}
+
+fn put_options() -> &'static PutOptions {
+    static PUT_OPTS: OnceLock<PutOptions> = OnceLock::new();
+    PUT_OPTS.get_or_init(|| PutOptions {
+        mode: object_store::PutMode::Create, // Creates if file doesn't exists yet
+        tags: TagSet::default(),
+        attributes: Attributes::default(),
+    })
+}

--- a/crates/lakefs/src/storage.rs
+++ b/crates/lakefs/src/storage.rs
@@ -1,0 +1,187 @@
+//! LakeFS storage backend (internally S3).
+
+use deltalake_core::storage::object_store::aws::AmazonS3ConfigKey;
+use deltalake_core::storage::{
+    limit_store_handler, ObjectStoreFactory, ObjectStoreRef, StorageOptions,
+};
+use deltalake_core::{DeltaResult, DeltaTableError, Path};
+use object_store::parse_url_opts;
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::str::FromStr;
+use tracing::log::*;
+use url::Url;
+
+#[derive(Clone, Default, Debug)]
+pub struct LakeFSObjectStoreFactory {}
+
+pub(crate) trait S3StorageOptionsConversion {
+    fn with_env_s3(&self, options: &StorageOptions) -> StorageOptions {
+        let mut options = StorageOptions(
+            options
+                .0
+                .clone()
+                .into_iter()
+                .map(|(k, v)| {
+                    if let Ok(config_key) = AmazonS3ConfigKey::from_str(&k.to_ascii_lowercase()) {
+                        (config_key.as_ref().to_string(), v)
+                    } else {
+                        (k, v)
+                    }
+                })
+                .collect(),
+        );
+
+        for (os_key, os_value) in std::env::vars_os() {
+            if let (Some(key), Some(value)) = (os_key.to_str(), os_value.to_str()) {
+                if let Ok(config_key) = AmazonS3ConfigKey::from_str(&key.to_ascii_lowercase()) {
+                    if !options.0.contains_key(config_key.as_ref()) {
+                        options
+                            .0
+                            .insert(config_key.as_ref().to_string(), value.to_string());
+                    }
+                }
+            }
+        }
+
+        // Conditional put is supported in LakeFS since v1.47
+        if !options.0.keys().any(|key| {
+            let key = key.to_ascii_lowercase();
+            [
+                AmazonS3ConfigKey::ConditionalPut.as_ref(),
+                "conditional_put",
+            ]
+            .contains(&key.as_str())
+        }) {
+            options.0.insert("conditional_put".into(), "etag".into());
+        }
+        options
+    }
+}
+
+impl S3StorageOptionsConversion for LakeFSObjectStoreFactory {}
+
+impl ObjectStoreFactory for LakeFSObjectStoreFactory {
+    fn parse_url_opts(
+        &self,
+        url: &Url,
+        storage_options: &StorageOptions,
+    ) -> DeltaResult<(ObjectStoreRef, Path)> {
+        let options = self.with_env_s3(storage_options);
+
+        // Convert LakeFS URI to equivalent S3 URI.
+        let s3_url = url.to_string().replace("lakefs://", "s3://");
+
+        let s3_url = Url::parse(&s3_url)
+            .map_err(|_| DeltaTableError::InvalidTableLocation(url.clone().into()))?;
+
+        // All S3-likes should start their builder the same way
+        let config = options
+            .clone()
+            .0
+            .into_iter()
+            .filter_map(|(k, v)| {
+                if let Ok(key) = AmazonS3ConfigKey::from_str(&k.to_ascii_lowercase()) {
+                    Some((key, v))
+                } else {
+                    None
+                }
+            })
+            .collect::<HashMap<AmazonS3ConfigKey, String>>();
+        let (inner, prefix) = parse_url_opts(&s3_url, config)?;
+        let store = limit_store_handler(inner, &options);
+        debug!("Initialized the object store: {store:?}");
+        Ok((store, prefix))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use maplit::hashmap;
+    use serial_test::serial;
+
+    struct ScopedEnv {
+        vars: HashMap<std::ffi::OsString, std::ffi::OsString>,
+    }
+
+    impl ScopedEnv {
+        pub fn new() -> Self {
+            let vars = std::env::vars_os().collect();
+            Self { vars }
+        }
+
+        pub fn run<T>(mut f: impl FnMut() -> T) -> T {
+            let _env_scope = Self::new();
+            f()
+        }
+    }
+
+    fn clear_env_of_lakefs_s3_keys() {
+        let keys_to_clear = std::env::vars().filter_map(|(k, _v)| {
+            if AmazonS3ConfigKey::from_str(&k.to_ascii_lowercase()).is_ok() {
+                Some(k)
+            } else {
+                None
+            }
+        });
+
+        for k in keys_to_clear {
+            unsafe {
+                std::env::remove_var(k);
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn when_merging_with_env_unsupplied_options_are_added() {
+        ScopedEnv::run(|| {
+            clear_env_of_lakefs_s3_keys();
+            let raw_options = hashmap! {};
+            std::env::set_var("ACCESS_KEY_ID", "env_key");
+            std::env::set_var("ENDPOINT", "env_key");
+            std::env::set_var("SECRET_ACCESS_KEY", "env_key");
+            std::env::set_var("REGION", "env_key");
+            let combined_options =
+                LakeFSObjectStoreFactory {}.with_env_s3(&StorageOptions(raw_options));
+
+            // Four and then the conditional_put built-in
+            assert_eq!(combined_options.0.len(), 5);
+
+            for (key, v) in combined_options.0 {
+                if key != "conditional_put" {
+                    assert_eq!(v, "env_key");
+                }
+            }
+        });
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn when_merging_with_env_supplied_options_take_precedence() {
+        ScopedEnv::run(|| {
+            clear_env_of_lakefs_s3_keys();
+            let raw_options = hashmap! {
+                "ACCESS_KEY_ID".to_string() => "options_key".to_string(),
+                "ENDPOINT_URL".to_string() => "options_key".to_string(),
+                "SECRET_ACCESS_KEY".to_string() => "options_key".to_string(),
+                "REGION".to_string() => "options_key".to_string()
+            };
+            std::env::set_var("aws_access_key_id", "env_key");
+            std::env::set_var("aws_endpoint", "env_key");
+            std::env::set_var("aws_secret_access_key", "env_key");
+            std::env::set_var("aws_region", "env_key");
+
+            let combined_options =
+                LakeFSObjectStoreFactory {}.with_env_s3(&StorageOptions(raw_options));
+
+            for (key, v) in combined_options.0 {
+                if key != "conditional_put" {
+                    assert_eq!(v, "options_key");
+                }
+            }
+        });
+    }
+}

--- a/crates/lakefs/tests/context.rs
+++ b/crates/lakefs/tests/context.rs
@@ -1,0 +1,74 @@
+#![cfg(feature = "integration_test_lakefs")]
+use deltalake_lakefs::register_handlers;
+use deltalake_test::utils::*;
+use std::process::{Command, ExitStatus};
+
+use which::which;
+
+pub struct LakeFSIntegration {}
+
+impl Default for LakeFSIntegration {
+    fn default() -> Self {
+        register_handlers(None);
+        Self {}
+    }
+}
+
+impl StorageIntegration for LakeFSIntegration {
+    fn prepare_env(&self) {
+        println!("Preparing env");
+
+        set_env_if_not_set("endpoint", "http://127.0.0.1:8000");
+        set_env_if_not_set("access_key_id", "LAKEFSID");
+        set_env_if_not_set("secret_access_key", "LAKEFSKEY");
+        set_env_if_not_set("allow_http", "true");
+
+        set_env_if_not_set("LAKECTL_CREDENTIALS_ACCESS_KEY_ID", "LAKEFSID");
+        set_env_if_not_set("LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY", "LAKEFSKEY");
+        set_env_if_not_set("LAKECTL_SERVER_ENDPOINT_URL", "http://127.0.0.1:8000");
+    }
+
+    fn create_bucket(&self) -> std::io::Result<ExitStatus> {
+        // Bucket is already created in docker-compose
+        Ok(ExitStatus::default())
+    }
+
+    fn bucket_name(&self) -> String {
+        "bronze".to_string()
+    }
+
+    fn root_uri(&self) -> String {
+        // Default branch is always main
+        format!("lakefs://{}/main", self.bucket_name())
+    }
+
+    fn copy_directory(&self, source: &str, destination: &str) -> std::io::Result<ExitStatus> {
+        println!(
+            "Copy directory called with {} {}",
+            source,
+            &format!("{}/{}", self.root_uri(), destination)
+        );
+        let lakectl = which("lakectl").expect("Failed to find lakectl executable");
+
+        // Upload files to branch
+        Command::new(lakectl.clone())
+            .args([
+                "fs",
+                "upload",
+                "-r",
+                "--source",
+                &format!("{}/", source),
+                &format!("{}/{}/", self.root_uri(), destination),
+            ])
+            .status()?;
+
+        // Commit changes
+        Command::new(lakectl)
+            .args([
+                "commit",
+                &format!("{}/", self.root_uri()),
+                "--allow-empty-message",
+            ])
+            .status()
+    }
+}

--- a/crates/lakefs/tests/integration.rs
+++ b/crates/lakefs/tests/integration.rs
@@ -1,0 +1,16 @@
+#![cfg(feature = "integration_test_lakefs")]
+use deltalake_test::{test_read_tables, IntegrationContext, TestResult};
+use serial_test::serial;
+
+mod context;
+use context::*;
+//
+#[tokio::test]
+#[serial]
+async fn test_read_tables_lakefs() -> TestResult {
+    let context = IntegrationContext::new(Box::<LakeFSIntegration>::default())?;
+
+    test_read_tables(&context).await?;
+
+    Ok(())
+}

--- a/crates/test/src/read.rs
+++ b/crates/test/src/read.rs
@@ -142,7 +142,7 @@ async fn verify_store(integration: &IntegrationContext, root_path: &str) -> Test
     let storage = DeltaTableBuilder::from_uri(table_uri.clone())
         .with_allow_http(true)
         .build_storage()?
-        .object_store();
+        .object_store(None);
 
     let files = storage.list_with_delimiter(None).await?;
     assert_eq!(

--- a/crates/test/src/utils.rs
+++ b/crates/test/src/utils.rs
@@ -20,7 +20,7 @@ pub trait StorageIntegration {
         Ok(DeltaTableBuilder::from_uri(self.root_uri())
             .with_allow_http(true)
             .build_storage()?
-            .object_store())
+            .object_store(None))
     }
 }
 

--- a/docker-compose-lakefs.yml
+++ b/docker-compose-lakefs.yml
@@ -1,0 +1,33 @@
+services:
+  lakefs:
+    image: docker.io/treeverse/lakefs:1.48
+    ports:
+      - "8000:8000"
+    environment:
+      - LAKEFS_DATABASE_TYPE=local
+      - LAKEFS_BLOCKSTORE_TYPE=local
+      - LAKEFS_AUTH_ENCRYPT_SECRET_KEY=some random secret string
+      - LAKEFS_LOGGING_LEVEL=INFO
+      - LAKEFS_STATS_ENABLED=${LAKEFS_STATS_ENABLED:-1}
+      - LAKEFS_INSTALLATION_USER_NAME=delta
+      - LAKEFS_INSTALLATION_ACCESS_KEY_ID=LAKEFSID
+      - LAKECTL_CREDENTIALS_ACCESS_KEY_ID=LAKEFSID
+      - LAKEFS_INSTALLATION_SECRET_ACCESS_KEY=LAKEFSKEY
+      - LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY=LAKEFSKEY
+      - LAKECTL_SERVER_ENDPOINT_URL=http://localhost:8000
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+        - |
+          lakefs run --local-settings &
+          echo "---- Creating repository ----"
+          wait-for -t 60 lakefs:8000 -- lakectl repo create lakefs://bronze local://bronze || true
+          echo ""
+          echo "lakeFS Web UI: http://127.0.0.1:8000/      >(.＿.)<"
+          echo "                                             (  )_ "
+          echo ""
+          echo "                Access Key ID    : $$LAKEFS_INSTALLATION_ACCESS_KEY_ID"
+          echo "                Secret Access Key: $$LAKEFS_INSTALLATION_SECRET_ACCESS_KEY"
+          echo ""
+          echo "-------- Let's go and have axolotl fun! --------"
+          echo ""
+          wait

--- a/docs/integrations/object-storage/lakefs.md
+++ b/docs/integrations/object-storage/lakefs.md
@@ -1,0 +1,53 @@
+# LakeFS
+`delta-rs` offers native support for using LakeFS as an object storage backend. Each 
+deltalake operation is executed in a transaction branch and safely merged into your source branch.
+
+You don’t need to install any extra dependencies to read/write Delta tables to LakeFS with engines that use `delta-rs`. You do need to configure your LakeFS access credentials correctly.
+
+## Passing LakeFS Credentials
+
+You can pass your LakeFS credentials explicitly by using:
+
+- the `storage_options `kwarg
+- Environment variables
+
+## Example
+
+Let's work through an example with Polars. The same logic applies to other Python engines like Pandas, Daft, Dask, etc.
+
+Follow the steps below to use Delta Lake on LakeFS with Polars:
+
+1. Install Polars and deltalake. For example, using:
+
+   `pip install polars deltalake`
+
+2. Create a dataframe with some toy data.
+
+   `df = pl.DataFrame({'x': [1, 2, 3]})`
+
+3. Set your `storage_options` correctly.
+
+```python
+storage_options = {
+        "endpoint": "https://mylakefs.intranet.com", # LakeFS endpoint
+        "access_key_id": "LAKEFSID",
+        "secret_access_key": "LAKEFSKEY",
+    }
+```
+
+4. Write data to Delta table using the `storage_options` kwarg. The subpath after the bucket is always the branch you want to write into.
+
+   ```python
+   df.write_delta(
+       "lakefs://bucket/branch/table",
+       storage_options=storage_options,
+   )
+   ```
+
+## Cleaning up failed transaction branches
+
+It might occur that a deltalake operation fails midway. At this point a lakefs transaction branch was created, but never destroyed. The branches are hidden in the UI, but each branch starts with `delta-tx`.
+
+With the lakefs python library you can list these branches and delete stale ones. 
+
+<TODO add example here>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
           - integrations/object-storage/hdfs.md
           - integrations/object-storage/s3.md
           - integrations/object-storage/s3-like.md
+          - integrations/object-storage/lakefs.md
       - Arrow: integrations/delta-lake-arrow.md
       - Daft: integrations/delta-lake-daft.md
       - Dagster: integrations/delta-lake-dagster.md

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -34,6 +34,7 @@ lazy_static = "1"
 regex = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v4"] }
 
 # runtime
 futures = { workspace = true }
@@ -53,7 +54,7 @@ features = ["extension-module", "abi3", "abi3-py39", "gil-refs"]
 [dependencies.deltalake]
 path = "../crates/deltalake"
 version = "0"
-features = ["azure", "gcs", "python", "datafusion", "unity-experimental", "hdfs"]
+features = ["azure", "gcs", "python", "datafusion", "unity-experimental", "hdfs", "lakefs"]
 
 [features]
 default = ["rustls"]

--- a/python/Makefile
+++ b/python/Makefile
@@ -8,7 +8,7 @@ DAT_VERSION := 0.0.2
 .PHONY: setup
 setup: ## Setup the requirements
 	$(info --- Setup dependencies ---)
-	uv sync --extra devel --extra pandas --extra polars
+	uv sync --extra devel --extra pandas --extra polars --extra lakefs --no-install-project
 
 .PHONY: setup-dat
 setup-dat: ## Download DAT test files
@@ -28,7 +28,7 @@ build: setup ## Build Python binding of delta-rs
 .PHONY: develop
 develop: setup ## Install Python binding of delta-rs
 	$(info --- Develop with Python binding ---)
-	uvx --from 'maturin[zig]' maturin develop --extras=devel,pandas,polars $(MATURIN_EXTRA_ARGS)
+	uvx --from 'maturin[zig]' maturin develop --extras=devel,pandas,polars,lakefs $(MATURIN_EXTRA_ARGS)
 
 .PHONY: install
 install: build ## Install Python binding of delta-rs
@@ -36,21 +36,21 @@ install: build ## Install Python binding of delta-rs
 	uv pip uninstall deltalake
 	$(info --- Install Python binding ---)
 	$(eval TARGET_WHEEL := $(shell ls ../target/wheels/deltalake-${PACKAGE_VERSION}-*.whl))
-	uv pip install $(TARGET_WHEEL)[devel,pandas,polars]
+	uv pip install $(TARGET_WHEEL)[devel,pandas,polars,lakefs]
 
 .PHONY: develop-pyspark
 develop-pyspark:
-	uv sync --all-extras
+	uv sync --all-extras --no-install-project
 	$(info --- Develop with Python binding ---)
-	uvx --from 'maturin[zig]' maturin develop --extras=devel,pandas,polars,pyspark $(MATURIN_EXTRA_ARGS)
+	uvx --from 'maturin[zig]' maturin develop --extras=devel,pandas,polars,pyspark,lakefs $(MATURIN_EXTRA_ARGS)
 
 .PHONY: format
 format: ## Format the code
 	$(info --- Rust format ---)
 	cargo fmt
 	$(info --- Python format ---)
-	uv run ruff check . --fix
-	uv run ruff format .
+	uv run --no-sync ruff check . --fix
+	uv run --no-sync ruff format .
 
 .PHONY: check-rust
 check-rust: ## Run check on Rust
@@ -62,30 +62,30 @@ check-rust: ## Run check on Rust
 .PHONY: check-python
 check-python: ## Run check on Python
 	$(info Check Python format)
-	uv run ruff format --check --diff .
+	uv run --no-sync ruff format --check --diff .
 	$(info Check Python linting)
-	uv run ruff check .
+	uv run --no-sync ruff check .
 	$(info Check Python mypy)
-	uv run mypy
+	uv run --no-sync mypy
 
 .PHONY: unit-test
 unit-test: ## Run unit test
 	$(info --- Run Python unit-test ---)
-	uv run pytest --doctest-modules 
+	uv run --no-sync pytest --doctest-modules 
 
 .PHONY: test-cov
 test-cov: ## Create coverage report
 	$(info --- Run Python unit-test ---)
-	uv run pytest --doctest-modules --cov --cov-config=pyproject.toml --cov-report=term --cov-report=html
+	uv run --no-sync pytest --doctest-modules --cov --cov-config=pyproject.toml --cov-report=term --cov-report=html
 
 .PHONY: test-pyspark
 test-pyspark:
-	uv run pytest -m 'pyspark and integration'
+	uv run --no-sync pytest -m 'pyspark and integration'
 
 .PHONY: build-documentation
 build-documentation: ## Build documentation with Sphinx
 	$(info --- Run build of the Sphinx documentation ---)
-	uv run sphinx-build -Wn -b html -d ./docs/build/doctrees ./docs/source ./docs/build/html
+	uv run --no-sync sphinx-build -Wn -b html -d ./docs/build/doctrees ./docs/source ./docs/build/html
 
 .PHONY: build-docs
 build-docs: ## Build documentation with mkdocs

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -351,6 +351,11 @@ def write_deltalake(
                 "Predicate can only be used with Rust engine, use partition_filters instead. PyArrow engine will be removed in 1.0"
             )
 
+        if table_uri.startswith("lakefs://"):
+            raise NotImplementedError(
+                "LakeFS object_store is not supported for PyArrow engine. Set engine to 'rust'."
+            )
+
         if large_dtypes:
             arrow_schema_conversion_mode = "large"
         else:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,6 +39,7 @@ devel = [
     "ruff==0.5.2",
 ]
 polars = ["polars==1.17.1"]
+lakefs = ["lakefs==0.8.0"]
 pyspark = [
     "pyspark",
     "delta-spark",
@@ -95,6 +96,7 @@ markers = [
     "azure: marks tests as integration tests with Azure Blob Store",
     "pandas: marks tests that require pandas",
     "polars: marks tests that require polars",
+    "lakefs: marks tests that require lakefs",
     "pyspark: marks tests that require pyspark",
 ]
 

--- a/python/src/filesystem.rs
+++ b/python/src/filesystem.rs
@@ -51,7 +51,7 @@ impl DeltaFileSystemHandler {
             .with_storage_options(options.clone().unwrap_or_default())
             .build_storage()
             .map_err(PythonError::from)?
-            .object_store();
+            .object_store(None);
 
         Ok(Self {
             inner: storage,

--- a/python/src/merge.rs
+++ b/python/src/merge.rs
@@ -7,6 +7,7 @@ use deltalake::datafusion::datasource::MemTable;
 use deltalake::datafusion::prelude::SessionContext;
 use deltalake::logstore::LogStoreRef;
 use deltalake::operations::merge::MergeBuilder;
+use deltalake::operations::CustomExecuteHandler;
 use deltalake::table::state::DeltaTableState;
 use deltalake::{DeltaResult, DeltaTable};
 use pyo3::prelude::*;
@@ -44,6 +45,7 @@ impl PyMergeBuilder {
         writer_properties: Option<PyWriterProperties>,
         post_commithook_properties: Option<PyPostCommitHookProperties>,
         commit_properties: Option<PyCommitProperties>,
+        custom_execute_handler: Option<Arc<dyn CustomExecuteHandler>>,
     ) -> DeltaResult<Self> {
         let ctx = SessionContext::new();
         let schema = source.schema();
@@ -72,6 +74,11 @@ impl PyMergeBuilder {
         {
             cmd = cmd.with_commit_properties(commit_properties);
         }
+
+        if let Some(handler) = custom_execute_handler {
+            cmd = cmd.with_custom_execute_handler(handler);
+        }
+
         Ok(Self {
             _builder: Some(cmd),
             source_alias,

--- a/python/tests/test_lakefs.py
+++ b/python/tests/test_lakefs.py
@@ -1,0 +1,531 @@
+import os
+import uuid
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+import pyarrow as pa
+import pytest
+
+from deltalake import DeltaTable, TableFeatures
+from deltalake._internal import Field, PrimitiveType
+from deltalake.exceptions import DeltaError, DeltaProtocolError
+from deltalake.table import CommitProperties
+from deltalake.writer import write_deltalake
+from tests.test_alter import _sort_fields
+
+if TYPE_CHECKING:
+    import lakefs as lakefs
+
+
+@pytest.fixture
+def lakefs_client():
+    import lakefs
+
+    return lakefs.Client(
+        username="LAKEFSID", password="LAKEFSKEY", host="http://127.0.0.1:8000"
+    )
+
+
+@pytest.fixture
+def lakefs_path() -> str:
+    return os.path.join("lakefs://bronze/main", str(uuid.uuid4()))
+
+
+@pytest.fixture
+def lakefs_storage_options():
+    return {
+        "endpoint": "http://127.0.0.1:8000",
+        "allow_http": "true",
+        "access_key_id": "LAKEFSID",
+        "secret_access_key": "LAKEFSKEY",
+    }
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_create(lakefs_path: str, sample_data: pa.Table, lakefs_storage_options):
+    dt = DeltaTable.create(
+        lakefs_path,
+        sample_data.schema,
+        mode="error",
+        storage_options=lakefs_storage_options,
+    )
+    last_action = dt.history(1)[0]
+
+    with pytest.raises(DeltaError):
+        dt = DeltaTable.create(
+            lakefs_path,
+            sample_data.schema,
+            mode="error",
+            storage_options=lakefs_storage_options,
+        )
+
+    assert last_action["operation"] == "CREATE TABLE"
+    with pytest.raises(DeltaError):
+        dt = DeltaTable.create(
+            lakefs_path,
+            sample_data.schema,
+            mode="append",
+            storage_options=lakefs_storage_options,
+        )
+
+    dt = DeltaTable.create(
+        lakefs_path,
+        sample_data.schema,
+        mode="ignore",
+        storage_options=lakefs_storage_options,
+    )
+    assert dt.version() == 0
+
+    dt = DeltaTable.create(
+        lakefs_path,
+        sample_data.schema,
+        mode="overwrite",
+        storage_options=lakefs_storage_options,
+    )
+    assert dt.version() == 1
+
+    last_action = dt.history(1)[0]
+
+    assert last_action["operation"] == "CREATE OR REPLACE TABLE"
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_delete(lakefs_path: str, sample_data: pa.Table, lakefs_storage_options):
+    write_deltalake(
+        lakefs_path,
+        sample_data,
+        partition_by=["bool"],
+        storage_options=lakefs_storage_options,
+    )
+
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+    old_version = dt.version()
+    dt.delete(commit_properties=commit_properties)
+
+    last_action = dt.history(1)[0]
+    assert last_action["operation"] == "DELETE"
+    assert dt.version() == old_version + 1
+    assert last_action["userName"] == "John Doe"
+
+    dataset = dt.to_pyarrow_dataset()
+    assert dataset.count_rows() == 0
+    assert len(dt.files()) == 0
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_optimize_min_commit_interval(
+    lakefs_path: str, sample_data: pa.Table, lakefs_storage_options
+):
+    print(lakefs_path)
+    write_deltalake(
+        lakefs_path,
+        sample_data,
+        partition_by="utf8",
+        mode="append",
+        storage_options=lakefs_storage_options,
+    )
+    write_deltalake(
+        lakefs_path,
+        sample_data,
+        partition_by="utf8",
+        mode="append",
+        storage_options=lakefs_storage_options,
+    )
+    write_deltalake(
+        lakefs_path,
+        sample_data,
+        partition_by="utf8",
+        mode="append",
+        storage_options=lakefs_storage_options,
+    )
+
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+    old_version = dt.version()
+
+    dt.optimize.z_order(["date32", "timestamp"], min_commit_interval=timedelta(0))
+
+    last_action = dt.history(1)[0]
+    assert last_action["operation"] == "OPTIMIZE"
+    # The table has 5 distinct partitions, each of which are Z-ordered
+    # independently. So with min_commit_interval=0, each will get its
+    # own commit.
+    assert dt.version() == old_version + 5
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_optimize(lakefs_path: str, sample_data: pa.Table, lakefs_storage_options):
+    write_deltalake(
+        lakefs_path,
+        sample_data,
+        partition_by="utf8",
+        mode="append",
+        storage_options=lakefs_storage_options,
+    )
+    write_deltalake(
+        lakefs_path,
+        sample_data,
+        partition_by="utf8",
+        mode="append",
+        storage_options=lakefs_storage_options,
+    )
+    write_deltalake(
+        lakefs_path,
+        sample_data,
+        partition_by="utf8",
+        mode="append",
+        storage_options=lakefs_storage_options,
+    )
+
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+    old_version = dt.version()
+
+    dt.optimize.z_order(["date32", "timestamp"])
+
+    last_action = dt.history(1)[0]
+    assert last_action["operation"] == "OPTIMIZE"
+    # The table has 5 distinct partitions, each of which are Z-ordered
+    # independently. So with min_commit_interval=0, each will get its
+    # own commit.
+    assert dt.version() == old_version + 1
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_repair_wo_dry_run(
+    lakefs_path, sample_data, lakefs_storage_options, lakefs_client: "lakefs.Client"
+):
+    import lakefs
+
+    write_deltalake(
+        lakefs_path, sample_data, mode="append", storage_options=lakefs_storage_options
+    )
+    write_deltalake(
+        lakefs_path, sample_data, mode="append", storage_options=lakefs_storage_options
+    )
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+
+    branch = lakefs.Branch(
+        repository_id="bronze", branch_id="main", client=lakefs_client
+    )
+    branch.object(dt.file_uris()[0].replace("lakefs://bronze/main/", "")).delete()
+    branch.commit("remove commit file for test")
+
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
+    metrics = dt.repair(dry_run=False, commit_properties=commit_properties)
+    last_action = dt.history(1)[0]
+
+    assert len(metrics["files_removed"]) == 1
+    assert metrics["dry_run"] is False
+    assert last_action["operation"] == "FSCK"
+    assert last_action["userName"] == "John Doe"
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_add_constraint(lakefs_path, sample_table: pa.Table, lakefs_storage_options):
+    write_deltalake(lakefs_path, sample_table, storage_options=lakefs_storage_options)
+
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+
+    dt.alter.add_constraint({"check_price": "price >= 0"})
+
+    last_action = dt.history(1)[0]
+    assert last_action["operation"] == "ADD CONSTRAINT"
+    assert dt.metadata().configuration == {
+        "delta.constraints.check_price": "price >= 0"
+    }
+
+    with pytest.raises(DeltaError):
+        # Invalid constraint
+        dt.alter.add_constraint({"check_price": "price < 0"})
+
+    with pytest.raises(DeltaProtocolError):
+        data = pa.table(
+            {
+                "id": pa.array(["1"]),
+                "price": pa.array([-1], pa.int64()),
+                "sold": pa.array(list(range(1)), pa.int32()),
+                "deleted": pa.array([False] * 1),
+            }
+        )
+        write_deltalake(
+            lakefs_path,
+            data,
+            engine="rust",
+            mode="append",
+            storage_options=lakefs_storage_options,
+        )
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_drop_constraint(lakefs_path, sample_table: pa.Table, lakefs_storage_options):
+    write_deltalake(lakefs_path, sample_table, storage_options=lakefs_storage_options)
+
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+
+    dt.alter.add_constraint({"check_price": "price >= 0"})
+    dt.alter.drop_constraint(name="check_price")
+    last_action = dt.history(1)[0]
+    assert last_action["operation"] == "DROP CONSTRAINT"
+    assert dt.version() == 2
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_set_table_properties(
+    lakefs_path, sample_table: pa.Table, lakefs_storage_options
+):
+    write_deltalake(
+        lakefs_path,
+        sample_table,
+        mode="append",
+        engine="rust",
+        storage_options=lakefs_storage_options,
+    )
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+    dt.alter.set_table_properties({"delta.enableChangeDataFeed": "true"})
+
+    protocol = dt.protocol()
+    assert dt.metadata().configuration == {"delta.enableChangeDataFeed": "true"}
+    assert protocol.min_reader_version == 1
+    assert protocol.min_writer_version == 4
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_add_feautres(lakefs_path, sample_table: pa.Table, lakefs_storage_options):
+    write_deltalake(lakefs_path, sample_table, storage_options=lakefs_storage_options)
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+    dt.alter.add_feature(
+        feature=[
+            TableFeatures.ChangeDataFeed,
+            TableFeatures.DeletionVectors,
+            TableFeatures.ColumnMapping,
+        ],
+        allow_protocol_versions_increase=True,
+    )
+    protocol = dt.protocol()
+
+    assert sorted(protocol.reader_features) == sorted(  # type: ignore
+        ["columnMapping", "deletionVectors"]
+    )
+    assert sorted(protocol.writer_features) == sorted(  # type: ignore
+        [
+            "changeDataFeed",
+            "columnMapping",
+            "deletionVectors",
+        ]
+    )  # type: ignore
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_merge(lakefs_path, sample_table: pa.Table, lakefs_storage_options):
+    write_deltalake(
+        lakefs_path, sample_table, mode="append", storage_options=lakefs_storage_options
+    )
+
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+
+    source_table = pa.table(
+        {
+            "id": pa.array(["5"]),
+            "weight": pa.array([105], pa.int32()),
+        }
+    )
+
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
+    dt.merge(
+        source=source_table,
+        predicate="t.id = s.id",
+        source_alias="s",
+        target_alias="t",
+        commit_properties=commit_properties,
+    ).when_matched_delete().execute()
+
+    nrows = 4
+    expected = pa.table(
+        {
+            "id": pa.array(["1", "2", "3", "4"]),
+            "price": pa.array(list(range(nrows)), pa.int64()),
+            "sold": pa.array(list(range(nrows)), pa.int32()),
+            "deleted": pa.array([False] * nrows),
+        }
+    )
+    result = dt.to_pyarrow_table().sort_by([("id", "ascending")])
+    last_action = dt.history(1)[0]
+
+    assert last_action["operation"] == "MERGE"
+    assert last_action["userName"] == "John Doe"
+    assert result == expected
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_restore(
+    lakefs_path,
+    sample_data: pa.Table,
+    lakefs_storage_options,
+):
+    write_deltalake(
+        lakefs_path, sample_data, mode="append", storage_options=lakefs_storage_options
+    )
+    write_deltalake(
+        lakefs_path, sample_data, mode="append", storage_options=lakefs_storage_options
+    )
+    write_deltalake(
+        lakefs_path, sample_data, mode="append", storage_options=lakefs_storage_options
+    )
+
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+    old_version = dt.version()
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
+    dt.restore(1, commit_properties=commit_properties)
+    last_action = dt.history(1)[0]
+    assert last_action["operation"] == "RESTORE"
+    assert last_action["userName"] == "John Doe"
+    assert dt.version() == old_version + 1
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_add_column(lakefs_path, sample_data: pa.Table, lakefs_storage_options):
+    write_deltalake(
+        lakefs_path, sample_data, mode="append", storage_options=lakefs_storage_options
+    )
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+    current_fields = dt.schema().fields
+
+    new_fields_to_add = [
+        Field("foo", PrimitiveType("integer")),
+        Field("bar", PrimitiveType("float")),
+    ]
+
+    dt.alter.add_columns(new_fields_to_add)
+    new_fields = dt.schema().fields
+
+    assert _sort_fields(new_fields) == _sort_fields(
+        [*current_fields, *new_fields_to_add]
+    )
+
+
+@pytest.fixture()
+def sample_table_update():
+    nrows = 5
+    return pa.table(
+        {
+            "id": pa.array(["1", "2", "3", "4", "5"]),
+            "price": pa.array(list(range(nrows)), pa.int64()),
+            "sold": pa.array(list(range(nrows)), pa.int64()),
+            "price_float": pa.array(list(range(nrows)), pa.float64()),
+            "items_in_bucket": pa.array([["item1", "item2", "item3"]] * nrows),
+            "deleted": pa.array([False] * nrows),
+        }
+    )
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_update(lakefs_path, sample_table_update: pa.Table, lakefs_storage_options):
+    write_deltalake(
+        lakefs_path,
+        sample_table_update,
+        mode="append",
+        storage_options=lakefs_storage_options,
+    )
+
+    dt = DeltaTable(lakefs_path, storage_options=lakefs_storage_options)
+    nrows = 5
+    expected = pa.table(
+        {
+            "id": pa.array(["1", "2", "3", "4", "5"]),
+            "price": pa.array(list(range(nrows)), pa.int64()),
+            "sold": pa.array(list(range(nrows)), pa.int64()),
+            "price_float": pa.array(list(range(nrows)), pa.float64()),
+            "items_in_bucket": pa.array([["item1", "item2", "item3"]] * nrows),
+            "deleted": pa.array([False, False, False, False, True]),
+        }
+    )
+
+    commit_properties = CommitProperties(custom_metadata={"userName": "John Doe"})
+    dt.update(
+        updates={"deleted": "True"},
+        predicate="price > 3",
+        commit_properties=commit_properties,
+    )
+
+    result = dt.to_pyarrow_table()
+    last_action = dt.history(1)[0]
+
+    assert last_action["operation"] == "UPDATE"
+    assert last_action["userName"] == "John Doe"
+    assert result == expected
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_checkpoint(sample_data: pa.Table, lakefs_storage_options, lakefs_client):
+    import lakefs
+
+    table = str(uuid.uuid4())
+    tmp_table_path = os.path.join("lakefs://bronze/main", table)
+    checkpoint_path = os.path.join(table, "_delta_log", "_last_checkpoint")
+    last_checkpoint_path = os.path.join(
+        table, "_delta_log", "00000000000000000000.checkpoint.parquet"
+    )
+
+    branch = lakefs.Branch(
+        repository_id="bronze", branch_id="main", client=lakefs_client
+    )
+
+    # TODO: Include binary after fixing issue "Json error: binary type is not supported"
+    sample_data = sample_data.drop(["binary"])
+    write_deltalake(
+        str(tmp_table_path), sample_data, storage_options=lakefs_storage_options
+    )
+
+    assert not branch.object(checkpoint_path).exists()
+
+    delta_table = DeltaTable(
+        str(tmp_table_path), storage_options=lakefs_storage_options
+    )
+    delta_table.create_checkpoint()
+
+    assert branch.object(last_checkpoint_path).exists()
+    assert branch.object(checkpoint_path).exists()
+
+
+@pytest.mark.lakefs
+@pytest.mark.integration
+def test_storage_options(sample_data: pa.Table):
+    with pytest.raises(
+        DeltaError, match="LakeFS endpoint is missing in storage options."
+    ):
+        write_deltalake(
+            "lakefs://bronze/main/oops",
+            data=sample_data,
+            storage_options={
+                "allow_http": "true",
+                "access_key_id": "LAKEFSID",
+                "secret_access_key": "LAKEFSKEY",
+            },
+        )
+
+    with pytest.raises(
+        DeltaError, match="LakeFS username is missing in storage options."
+    ):
+        write_deltalake(
+            "lakefs://bronze/main/oops",
+            data=sample_data,
+            storage_options={
+                "endpoint": "http://127.0.0.1:8000",
+                "allow_http": "true",
+                "bearer_token": "test",
+            },
+        )


### PR DESCRIPTION
# Description
Makes LakeFS first-class citizen in delta-rs. Operations are executed in a transaction branch, where we write into and then try to commit and merge if there is no conflict. If there is a conflict it means there was a concurrent writer, so we remove the log, and retry with the conflict checker.

Main concepts that this PR introduces through out the core crate:
- LogStore makes distinction between reading and writing objectstore, the writing store can receive an optional `operation_id`
- Every operation has customExecuteHandler which implements a pre_execute and post_execute.
    - pre-execute is executed usually right away, or after sanity checks are done in the operation
    - post-execute is executed after commitbuilder has finished
- CommitBuilder also uses operation_id to pass it to commit_entry functions
