### PR TITLE
fix: aws credential resolving, reduce api calls

### DIFF
--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-aws"
-version = "0.6.0"
+version = "0.6.1"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.23.2"
+version = "0.23.3"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"


### PR DESCRIPTION
# Description
- Adds a trait to logstore and objectstore factory to parse options
- LogStoreFactory gets correct credentials as well now
- Reduces latency by only construction SDK config once for object store
- Fixes is_aws by also checking the env vars for locking provider and force_aws_credential_load, tested it and doesn't show aws sdk config logs anymore when you use endpoint url

cc @rtyler 