### PR TITLE
chore: raise patch versions for rust crate release

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-core"
-version = "0.23.0"
+version = "0.23.1"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake"
-version = "0.23.0"
+version = "0.23.1"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true


### PR DESCRIPTION
This change should be the final one in the 0.23.x release line since we're about to merge LakeFS support and go to 0.24
