### PR TITLE
fix: pin kernel to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ debug = true
 debug = "line-tables-only"
 
 [workspace.dependencies]
-delta_kernel = { version = "0.6.0", features = ["default-engine"] }
+delta_kernel = { version = "=0.6.0", features = ["default-engine"] }
 #delta_kernel = { path = "../delta-kernel-rs/kernel", features = ["sync-engine"]  }
 
 # arrow


### PR DESCRIPTION
# Description
Latest version broke our builds, so pinning it for now.