### PR TITLE
feat(python, rust): add statistics_enabled to ColumnProperties

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -218,7 +218,6 @@ class ColumnProperties:
         self,
         dictionary_enabled: Optional[bool] = None,
         statistics_enabled: Optional[Literal["NONE", "CHUNK", "PAGE"]] = None,
-        max_statistics_size: Optional[int] = None,
         bloom_filter_properties: Optional[BloomFilterProperties] = None,
     ):
         """Create a Column Properties instance for the Rust parquet writer:
@@ -226,18 +225,16 @@ class ColumnProperties:
         Args:
             dictionary_enabled: Enable dictionary encoding for the column.
             statistics_enabled: Statistics level for the column.
-            max_statistics_size: Maximum size of statistics for the column.
             bloom_filter_properties: Bloom Filter Properties for the column.
         """
         self.dictionary_enabled = dictionary_enabled
         self.statistics_enabled = statistics_enabled
-        self.max_statistics_size = max_statistics_size
         self.bloom_filter_properties = bloom_filter_properties
 
     def __str__(self) -> str:
         return (
             f"dictionary_enabled: {self.dictionary_enabled}, statistics_enabled: {self.statistics_enabled}, "
-            f"max_statistics_size: {self.max_statistics_size}, bloom_filter_properties: {self.bloom_filter_properties}"
+            f"bloom_filter_properties: {self.bloom_filter_properties}"
         )
 
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -217,6 +217,7 @@ class ColumnProperties:
     def __init__(
         self,
         dictionary_enabled: Optional[bool] = None,
+        statistics_enabled: Optional[Literal["NONE", "CHUNK", "PAGE"]] = None,
         max_statistics_size: Optional[int] = None,
         bloom_filter_properties: Optional[BloomFilterProperties] = None,
     ):
@@ -224,15 +225,20 @@ class ColumnProperties:
 
         Args:
             dictionary_enabled: Enable dictionary encoding for the column.
+            statistics_enabled: Statistics level for the column.
             max_statistics_size: Maximum size of statistics for the column.
             bloom_filter_properties: Bloom Filter Properties for the column.
         """
         self.dictionary_enabled = dictionary_enabled
+        self.statistics_enabled = statistics_enabled
         self.max_statistics_size = max_statistics_size
         self.bloom_filter_properties = bloom_filter_properties
 
     def __str__(self) -> str:
-        return f"dictionary_enabled: {self.dictionary_enabled}, max_statistics_size: {self.max_statistics_size}, bloom_filter_properties: {self.bloom_filter_properties}"
+        return (
+            f"dictionary_enabled: {self.dictionary_enabled}, statistics_enabled: {self.statistics_enabled}, "
+            f"max_statistics_size: {self.max_statistics_size}, bloom_filter_properties: {self.bloom_filter_properties}"
+        )
 
 
 @dataclass(init=True)

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1573,9 +1573,6 @@ fn set_writer_properties(writer_properties: PyWriterProperties) -> DeltaResult<W
 
             properties = properties.set_statistics_enabled(enabled_statistics);
         }
-        if let Some(max_statistics_size) = default_column_properties.max_statistics_size {
-            properties = properties.set_max_statistics_size(max_statistics_size);
-        }
         if let Some(bloom_filter_properties) = default_column_properties.bloom_filter_properties {
             if let Some(set_bloom_filter_enabled) = bloom_filter_properties.set_bloom_filter_enabled
             {
@@ -1937,7 +1934,6 @@ pub struct BloomFilterProperties {
 pub struct ColumnProperties {
     pub dictionary_enabled: Option<bool>,
     pub statistics_enabled: Option<String>,
-    pub max_statistics_size: Option<usize>,
     pub bloom_filter_properties: Option<BloomFilterProperties>,
 }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -52,7 +52,7 @@ use deltalake::operations::vacuum::VacuumBuilder;
 use deltalake::operations::{collect_sendable_stream, CustomExecuteHandler};
 use deltalake::parquet::basic::Compression;
 use deltalake::parquet::errors::ParquetError;
-use deltalake::parquet::file::properties::WriterProperties;
+use deltalake::parquet::file::properties::{EnabledStatistics, WriterProperties};
 use deltalake::partitions::PartitionFilter;
 use deltalake::protocol::{DeltaOperation, SaveMode};
 use deltalake::storage::{IORuntime, ObjectStoreRef};
@@ -1566,6 +1566,13 @@ fn set_writer_properties(writer_properties: PyWriterProperties) -> DeltaResult<W
         if let Some(dictionary_enabled) = default_column_properties.dictionary_enabled {
             properties = properties.set_dictionary_enabled(dictionary_enabled);
         }
+        if let Some(statistics_enabled) = default_column_properties.statistics_enabled {
+            let enabled_statistics: EnabledStatistics = statistics_enabled
+                .parse()
+                .map_err(|err: String| DeltaTableError::Generic(err))?;
+
+            properties = properties.set_statistics_enabled(enabled_statistics);
+        }
         if let Some(max_statistics_size) = default_column_properties.max_statistics_size {
             properties = properties.set_max_statistics_size(max_statistics_size);
         }
@@ -1589,6 +1596,16 @@ fn set_writer_properties(writer_properties: PyWriterProperties) -> DeltaResult<W
                     properties = properties.set_column_dictionary_enabled(
                         column_name.clone().into(),
                         dictionary_enabled,
+                    );
+                }
+                if let Some(statistics_enabled) = column_prop.statistics_enabled {
+                    let enabled_statistics: EnabledStatistics = statistics_enabled
+                        .parse()
+                        .map_err(|err: String| DeltaTableError::Generic(err))?;
+
+                    properties = properties.set_column_statistics_enabled(
+                        column_name.clone().into(),
+                        enabled_statistics,
                     );
                 }
                 if let Some(bloom_filter_properties) = column_prop.bloom_filter_properties {
@@ -1919,6 +1936,7 @@ pub struct BloomFilterProperties {
 #[derive(FromPyObject)]
 pub struct ColumnProperties {
     pub dictionary_enabled: Option<bool>,
+    pub statistics_enabled: Option<String>,
     pub max_statistics_size: Option<usize>,
     pub bloom_filter_properties: Option<BloomFilterProperties>,
 }

--- a/python/tests/test_writerproperties.py
+++ b/python/tests/test_writerproperties.py
@@ -29,7 +29,6 @@ def test_writer_properties_all_filled():
             "a": ColumnProperties(
                 dictionary_enabled=True,
                 statistics_enabled="CHUNK",
-                max_statistics_size=40,
                 bloom_filter_properties=BloomFilterProperties(
                     set_bloom_filter_enabled=True, fpp=0.2, ndv=30
                 ),
@@ -37,7 +36,6 @@ def test_writer_properties_all_filled():
             "b": ColumnProperties(
                 dictionary_enabled=True,
                 statistics_enabled="PAGE",
-                max_statistics_size=400,
                 bloom_filter_properties=BloomFilterProperties(
                     set_bloom_filter_enabled=False, fpp=0.2, ndv=30
                 ),

--- a/python/tests/test_writerproperties.py
+++ b/python/tests/test_writerproperties.py
@@ -28,6 +28,7 @@ def test_writer_properties_all_filled():
         column_properties={
             "a": ColumnProperties(
                 dictionary_enabled=True,
+                statistics_enabled="CHUNK",
                 max_statistics_size=40,
                 bloom_filter_properties=BloomFilterProperties(
                     set_bloom_filter_enabled=True, fpp=0.2, ndv=30
@@ -35,6 +36,7 @@ def test_writer_properties_all_filled():
             ),
             "b": ColumnProperties(
                 dictionary_enabled=True,
+                statistics_enabled="PAGE",
                 max_statistics_size=400,
                 bloom_filter_properties=BloomFilterProperties(
                     set_bloom_filter_enabled=False, fpp=0.2, ndv=30


### PR DESCRIPTION
# Description

- Add support for [`statistics_enabled`](https://arrow.apache.org/rust/parquet/file/properties/struct.ColumnProperties.html#structfield.statistics_enabled) in `ColumnProperties`.
- Remove deprecated and unused `max_statistics_size` from `ColumnProperties`.

# Related Issue(s)

- #2965

# Documentation

The only available way currently to avoid writing statistics to the transaction log for a column is via `max_statistics_size`. However, that has been [deprecated](https://arrow.apache.org/rust/parquet/file/properties/struct.ColumnProperties.html#structfield.max_statistics_size) in `arrow-rs`, furthermore it appears to be ignored: https://github.com/apache/arrow-rs/issues/2033. Being able to skip statistics is necessary for large data columns, as otherwise transaction log explodes after a few tens of thousands of transactions and becomes non-scalable.

# Examples

```python
from deltalake import DeltaTable, write_deltalake, WriterProperties, ColumnProperties
import pandas as pd
import pyarrow as pa
from pathlib import Path
import shutil

data = {'int': [0, 1, 2], 'data': [b'0' * 100000, b'1' * 100000, b'2' * 100000]}

df = pd.DataFrame(data)

def check_size(data_column_properties: ColumnProperties):
    TMP_PATH = "/tmp/delta-test/delta-test-0"

    shutil.rmtree(TMP_PATH, ignore_errors=True)
    write_deltalake(
        TMP_PATH,
        df.sort_values(["int"]),
        schema=pa.schema([pa.field("int", pa.int64()), pa.field("data", pa.binary())]),
        mode="append",
        writer_properties=WriterProperties(
            compression="zstd",
            column_properties={"data": data_column_properties},
        ),
        engine="rust",
    )

    print(DeltaTable(TMP_PATH).to_pandas())

    return (Path(TMP_PATH) / "_delta_log/00000000000000000000.json").stat().st_size

[check_size(c)
 for c
 in [ColumnProperties(max_statistics_size=0), ColumnProperties(statistics_enabled="NONE")]]

#    int                                               data
# 0    0  b'00000000000000000000000000000000000000000000...
# 1    1  b'11111111111111111111111111111111111111111111...
# 2    2  b'22222222222222222222222222222222222222222222...
#    int                                               data
# 0    0  b'00000000000000000000000000000000000000000000...
# 1    1  b'11111111111111111111111111111111111111111111...
# 2    2  b'22222222222222222222222222222222222222222222...
# [201143, 1100]
```