### PR TITLE
docs: Fix broken markdown syntax

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1975,6 +1975,7 @@ class TableAlterer:
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
 
         Example:
+            ```python
             from deltalake.schema import Field, PrimitiveType, StructType
             dt = DeltaTable("test_table")
             new_fields = [


### PR DESCRIPTION
# Description
Fix the broken markdown syntax that caused rendering problems on the documentation webpage.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
