### PR TITLE
chore: inline format args to improve readability

### DIFF
--- a/crates/aws/src/lib.rs
+++ b/crates/aws/src/lib.rs
@@ -89,7 +89,7 @@ pub fn register_handlers(_additional_prefixes: Option<Url>) {
     let object_stores = Arc::new(S3ObjectStoreFactory::default());
     let log_stores = Arc::new(S3LogStoreFactory::default());
     for scheme in ["s3", "s3a"].iter() {
-        let url = Url::parse(&format!("{}://", scheme)).unwrap();
+        let url = Url::parse(&format!("{scheme}://")).unwrap();
         factories().insert(url.clone(), object_stores.clone());
         logstores().insert(url.clone(), log_stores.clone());
     }
@@ -310,7 +310,7 @@ impl DynamoDbLockClient {
     fn get_primary_key(&self, version: i64, table_path: &str) -> HashMap<String, AttributeValue> {
         maplit::hashmap! {
             constants::ATTR_TABLE_PATH.to_owned()  => string_attr(table_path),
-            constants::ATTR_FILE_NAME.to_owned()   => string_attr(format!("{:020}.json", version)),
+            constants::ATTR_FILE_NAME.to_owned()   => string_attr(format!("{version:020}.json")),
         }
     }
 
@@ -669,8 +669,7 @@ fn extract_required_string_field<'a>(
         .as_s()
         .map_err(|v| LockClientError::InconsistentData {
             description: format!(
-                "mandatory string field '{field_name}' exists, but is not a string: {:#?}",
-                v,
+                "mandatory string field '{field_name}' exists, but is not a string: {v:#?}",
             ),
         })
         .map(|s| s.as_str())

--- a/crates/aws/src/logstore/dynamodb_logstore.rs
+++ b/crates/aws/src/logstore/dynamodb_logstore.rs
@@ -277,7 +277,7 @@ impl LogStore for S3DynamoDbLogStore {
                 LockClientError::VersionAlreadyCompleted { version, .. } => {
                     error!("Trying to abort a completed commit");
                     TransactionError::LogStoreError {
-                        msg: format!("trying to abort a completed log entry: {}", version),
+                        msg: format!("trying to abort a completed log entry: {version}"),
                         source: Box::new(err),
                     }
                 }

--- a/crates/azure/src/lib.rs
+++ b/crates/azure/src/lib.rs
@@ -82,7 +82,7 @@ impl LogStoreFactory for AzureFactory {
 pub fn register_handlers(_additional_prefixes: Option<Url>) {
     let factory = Arc::new(AzureFactory {});
     for scheme in ["az", "adl", "azure", "abfs", "abfss"].iter() {
-        let url = Url::parse(&format!("{}://", scheme)).unwrap();
+        let url = Url::parse(&format!("{scheme}://")).unwrap();
         factories().insert(url.clone(), factory.clone());
         logstores().insert(url.clone(), factory.clone());
     }

--- a/crates/azure/tests/context.rs
+++ b/crates/azure/tests/context.rs
@@ -43,20 +43,14 @@ impl StorageIntegration for MsftIntegration {
                     std::env::var("AZURE_STORAGE_ACCOUNT_NAME").unwrap_or(String::from("onelake"));
                 let container_name = std::env::var("AZURE_STORAGE_CONTAINER_NAME")
                     .unwrap_or(String::from("delta-rs"));
-                format!(
-                    "{0}.dfs.fabric.microsoft.com/{1}",
-                    account_name, container_name
-                )
+                format!("{account_name}.dfs.fabric.microsoft.com/{container_name}")
             }
             Self::OnelakeAbfs => {
                 let account_name =
                     std::env::var("AZURE_STORAGE_ACCOUNT_NAME").unwrap_or(String::from("onelake"));
                 let container_name = std::env::var("AZURE_STORAGE_CONTAINER_NAME")
                     .unwrap_or(String::from("delta-rs"));
-                format!(
-                    "{0}@{1}.dfs.fabric.microsoft.com",
-                    container_name, account_name
-                )
+                format!("{container_name}@{account_name}.dfs.fabric.microsoft.com")
             }
         }
     }

--- a/crates/benchmarks/src/bin/merge.rs
+++ b/crates/benchmarks/src/bin/merge.rs
@@ -247,9 +247,9 @@ async fn benchmark_merge_tpcds(
 
     let duration = end.duration_since(start);
 
-    println!("Total File count: {}", file_count);
-    println!("File sample count: {}", file_sample_count);
-    println!("{:?}", metrics);
+    println!("Total File count: {file_count}");
+    println!("File sample count: {file_sample_count}");
+    println!("{metrics:?}");
     println!("Seconds: {}", duration.as_secs_f32());
 
     // Clean up and restore to original state.
@@ -597,10 +597,9 @@ async fn main() {
                     "
                 select name as before_name,
                  avg(cast(duration_ms as float)) as before_duration_avg 
-                from before where group_id = {} 
+                from before where group_id = {before_group_id}
                 group by name
             ",
-                    before_group_id
                 ))
                 .await
                 .unwrap();
@@ -610,10 +609,9 @@ async fn main() {
                     "
                 select name as after_name,
                  avg(cast(duration_ms as float)) as after_duration_avg 
-                from after where group_id = {} 
+                from after where group_id = {after_group_id}
                 group by name
             ",
-                    after_group_id
                 ))
                 .await
                 .unwrap();

--- a/crates/catalog-unity/src/credential.rs
+++ b/crates/catalog-unity/src/credential.rs
@@ -154,7 +154,7 @@ impl TokenCredential for ClientSecretOAuthProvider {
             .form(&[
                 ("client_id", self.client_id.as_str()),
                 ("client_secret", self.client_secret.as_str()),
-                ("scope", &format!("{}/.default", DATABRICKS_RESOURCE_SCOPE)),
+                ("scope", &format!("{DATABRICKS_RESOURCE_SCOPE}/.default")),
                 ("grant_type", "client_credentials"),
             ])
             .send()
@@ -250,7 +250,7 @@ impl TokenCredential for AzureCliCredential {
 
                 let token_response = serde_json::from_str::<AzureCliTokenResponse>(output)
                     .map_err(|err| UnityCatalogError::AzureCli {
-                        message: format!("failed seserializing token response: {:?}", err),
+                        message: format!("failed seserializing token response: {err:?}"),
                     })?;
                 if !token_response.token_type.eq_ignore_ascii_case("bearer") {
                     return Err(UnityCatalogError::AzureCli {
@@ -344,7 +344,7 @@ impl TokenCredential for WorkloadIdentityOAuthProvider {
                     "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
                 ),
                 ("client_assertion", token_str.as_str()),
-                ("scope", &format!("{}/.default", DATABRICKS_RESOURCE_SCOPE)),
+                ("scope", &format!("{DATABRICKS_RESOURCE_SCOPE}/.default")),
                 ("grant_type", "client_credentials"),
             ])
             .send()
@@ -420,7 +420,7 @@ impl TokenCredential for ImdsManagedIdentityOAuthProvider {
         &self,
         _client: &ClientWithMiddleware,
     ) -> Result<TemporaryToken<String>, UnityCatalogError> {
-        let resource_scope = format!("{}/.default", DATABRICKS_RESOURCE_SCOPE);
+        let resource_scope = format!("{DATABRICKS_RESOURCE_SCOPE}/.default");
         let mut query_items = vec![
             ("api-version", MSI_API_VERSION),
             ("resource", &resource_scope),

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -417,8 +417,7 @@ impl DeltaScanConfigBuilder {
                 Some(name) => {
                     if column_names.contains(name) {
                         return Err(DeltaTableError::Generic(format!(
-                            "Unable to add file path column since column with name {} exits",
-                            name
+                            "Unable to add file path column since column with name {name} exits"
                         )));
                     }
 
@@ -431,7 +430,7 @@ impl DeltaScanConfigBuilder {
 
                     while column_names.contains(&name) {
                         idx += 1;
-                        name = format!("{}_{}", prefix, idx);
+                        name = format!("{prefix}_{idx}");
                     }
 
                     Some(name)
@@ -1112,8 +1111,7 @@ pub(crate) fn get_null_of_arrow_type(t: &ArrowDataType) -> DeltaResult<ScalarVal
         | ArrowDataType::LargeListView(_)
         | ArrowDataType::ListView(_)
         | ArrowDataType::Map(_, _) => Err(DeltaTableError::Generic(format!(
-            "Unsupported data type for Delta Lake {}",
-            t
+            "Unsupported data type for Delta Lake {t}"
         ))),
     }
 }
@@ -1622,8 +1620,7 @@ impl TreeNodeVisitor<'_> for FindFilesExprProperties {
             }
             _ => {
                 self.result = Err(DeltaTableError::Generic(format!(
-                    "Find files predicate contains unsupported expression {}",
-                    expr
+                    "Find files predicate contains unsupported expression {expr}"
                 )));
                 return Ok(TreeNodeRecursion::Stop);
             }
@@ -1670,8 +1667,7 @@ fn join_batches_with_add_actions(
 
         for path in iter {
             let path = path.ok_or(DeltaTableError::Generic(format!(
-                "{} cannot be null",
-                path_column
+                "{path_column} cannot be null"
             )))?;
 
             match actions.remove(path) {
@@ -2923,7 +2919,7 @@ mod tests {
             } else if value.to_string().starts_with("part-") {
                 LocationType::Data
             } else {
-                panic!("Unknown location type: {:?}", value)
+                panic!("Unknown location type: {value:?}")
             }
         }
     }

--- a/crates/core/src/kernel/arrow/extract.rs
+++ b/crates/core/src/kernel/arrow/extract.rs
@@ -34,10 +34,8 @@ pub(crate) fn extract_and_cast<'a, T: Array + 'static>(
     arr: &'a dyn ProvidesColumnByName,
     name: &'a str,
 ) -> DeltaResult<&'a T> {
-    extract_and_cast_opt::<T>(arr, name).ok_or(DeltaTableError::Generic(format!(
-        "missing-column: {}",
-        name
-    )))
+    extract_and_cast_opt::<T>(arr, name)
+        .ok_or(DeltaTableError::Generic(format!("missing-column: {name}")))
 }
 
 /// Extracts a column by name and casts it to the given type array type `T`.
@@ -63,8 +61,7 @@ pub(crate) fn extract_column<'a>(
     let child = array
         .column_by_name(path_step)
         .ok_or(ArrowError::SchemaError(format!(
-            "No such field: {}",
-            path_step,
+            "No such field: {path_step}",
         )))?;
 
     if let Some(next_path_step) = remaining_path_steps.next() {
@@ -119,12 +116,11 @@ fn cast_column_as<'a, T: Array + 'static>(
     column: &Option<&'a Arc<dyn Array>>,
 ) -> Result<&'a T, ArrowError> {
     column
-        .ok_or(ArrowError::SchemaError(format!("No such column: {}", name)))?
+        .ok_or(ArrowError::SchemaError(format!("No such column: {name}")))?
         .as_any()
         .downcast_ref::<T>()
         .ok_or(ArrowError::SchemaError(format!(
-            "{} is not of esxpected type.",
-            name
+            "{name} is not of expected type."
         )))
 }
 

--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -323,8 +323,7 @@ impl Protocol {
                 parsed_properties.insert(parsed_key, value.to_string());
             } else if raise_if_not_exists {
                 return Err(Error::Generic(format!(
-                    "Error parsing property '{}':'{}'",
-                    key, value
+                    "Error parsing property '{key}':'{value}'",
                 )));
             }
         }
@@ -340,17 +339,11 @@ impl Protocol {
                         }
                     }
                     _ => {
-                        return Err(Error::Generic(format!(
-                        "delta.minReaderVersion = '{}' is invalid, valid values are ['1','2','3']",
-                        min_reader_version
-                    )))
+                        return Err(Error::Generic(format!("delta.minReaderVersion = '{min_reader_version}' is invalid, valid values are ['1','2','3']")))
                     }
                 },
                 Err(_) => {
-                    return Err(Error::Generic(format!(
-                        "delta.minReaderVersion = '{}' is invalid, valid values are ['1','2','3']",
-                        min_reader_version
-                    )))
+                    return Err(Error::Generic(format!("delta.minReaderVersion = '{min_reader_version}' is invalid, valid values are ['1','2','3']")))
                 }
             }
         }
@@ -366,17 +359,11 @@ impl Protocol {
                         }
                     }
                     _ => {
-                        return Err(Error::Generic(format!(
-                            "delta.minWriterVersion = '{}' is invalid, valid values are ['2','3','4','5','6','7']",
-                            min_writer_version
-                        )))
+                        return Err(Error::Generic(format!("delta.minWriterVersion = '{min_writer_version}' is invalid, valid values are ['2','3','4','5','6','7']")))
                     }
                 },
                 Err(_) => {
-                    return Err(Error::Generic(format!(
-                        "delta.minWriterVersion = '{}' is invalid, valid values are ['2','3','4','5','6','7']",
-                        min_writer_version
-                    )))
+                    return Err(Error::Generic(format!("delta.minWriterVersion = '{min_writer_version}' is invalid, valid values are ['2','3','4','5','6','7']")))
                 }
             }
         }
@@ -403,10 +390,7 @@ impl Protocol {
                 }
                 Ok(false) => {}
                 _ => {
-                    return Err(Error::Generic(format!(
-                        "delta.enableChangeDataFeed = '{}' is invalid, valid values are ['true']",
-                        enable_cdf
-                    )))
+                    return Err(Error::Generic(format!("delta.enableChangeDataFeed = '{enable_cdf}' is invalid, valid values are ['true']")))
                 }
             }
         }
@@ -436,10 +420,7 @@ impl Protocol {
                 }
                 Ok(false) => {}
                 _ => {
-                    return Err(Error::Generic(format!(
-                        "delta.enableDeletionVectors = '{}' is invalid, valid values are ['true']",
-                        enable_dv
-                    )))
+                    return Err(Error::Generic(format!("delta.enableDeletionVectors = '{enable_dv}' is invalid, valid values are ['true']")))
                 }
             }
         }
@@ -694,7 +675,7 @@ impl DeletionVectorDescriptor {
                 }
                 let dv_path = parent
                     .join(&dv_suffix)
-                    .map_err(|_| Error::DeletionVector(format!("invalid path: {}", dv_suffix)))?;
+                    .map_err(|_| Error::DeletionVector(format!("invalid path: {dv_suffix}")))?;
                 Ok(Some(dv_path))
             }
             StorageType::AbsolutePath => {
@@ -1221,7 +1202,7 @@ mod tests {
     #[test]
     fn test_primitive() {
         let types: PrimitiveType = serde_json::from_str("\"string\"").unwrap();
-        println!("{:?}", types);
+        println!("{types:?}");
     }
 
     // #[test]

--- a/crates/core/src/kernel/models/schema.rs
+++ b/crates/core/src/kernel/models/schema.rs
@@ -83,17 +83,17 @@ impl StructTypeExt for StructType {
                     )),
                     Value::Number(sql) => generated_cols.push(GeneratedColumn::new(
                         &field_path,
-                        &format!("{}", sql),
+                        &format!("{sql}"),
                         field.data_type(),
                     )),
                     Value::Bool(sql) => generated_cols.push(GeneratedColumn::new(
                         &field_path,
-                        &format!("{}", sql),
+                        &format!("{sql}"),
                         field.data_type(),
                     )),
                     Value::Array(sql) => generated_cols.push(GeneratedColumn::new(
                         &field_path,
-                        &format!("{:?}", sql),
+                        &format!("{sql:?}"),
                         field.data_type(),
                     )),
                     _ => (), // Other types not sure what to do then

--- a/crates/core/src/kernel/scalars.rs
+++ b/crates/core/src/kernel/scalars.rs
@@ -285,7 +285,7 @@ fn create_escaped_binary_string(data: &[u8]) -> String {
     let mut escaped_string = String::new();
     for &byte in data {
         // Convert each byte to its two-digit hexadecimal representation
-        let hex_representation = format!("{:04X}", byte);
+        let hex_representation = format!("{byte:04X}");
         // Append the hexadecimal representation with an escape sequence
         escaped_string.push_str("\\u");
         escaped_string.push_str(&hex_representation);

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -893,6 +893,6 @@ mod tests {
             .log_data();
 
         let col_stats = file_stats.statistics();
-        println!("{:?}", col_stats);
+        println!("{col_stats:?}");
     }
 }

--- a/crates/core/src/kernel/snapshot/log_segment.rs
+++ b/crates/core/src/kernel/snapshot/log_segment.rs
@@ -787,7 +787,7 @@ pub(super) mod tests {
         let mut actions = vec![Action::Metadata(metadata), Action::Protocol(protocol)];
         for i in 0..10 {
             actions.push(Action::Add(Add {
-                path: format!("part-{}.parquet", i),
+                path: format!("part-{i}.parquet"),
                 modification_time: chrono::Utc::now().timestamp_millis(),
                 ..Default::default()
             }));
@@ -811,7 +811,7 @@ pub(super) mod tests {
         // remove all but one file
         for i in 0..9 {
             actions.push(Action::Remove(Remove {
-                path: format!("part-{}.parquet", i),
+                path: format!("part-{i}.parquet"),
                 deletion_timestamp: Some(chrono::Utc::now().timestamp_millis()),
                 ..Default::default()
             }))

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -668,8 +668,7 @@ fn stats_schema(schema: &StructType, config: TableConfig<'_>) -> DeltaResult<Str
                     )),
                 },
                 _ => Err(DeltaTableError::Generic(format!(
-                    "Stats column {} not found in schema",
-                    col
+                    "Stats column {col} not found in schema"
                 ))),
             })
             .collect::<Result<Vec<_>, _>>()?
@@ -706,10 +705,7 @@ pub(crate) fn partitions_schema(
             .iter()
             .map(|col| {
                 schema.field(col).cloned().ok_or_else(|| {
-                    DeltaTableError::Generic(format!(
-                        "Partition column {} not found in schema",
-                        col
-                    ))
+                    DeltaTableError::Generic(format!("Partition column {col} not found in schema"))
                 })
             })
             .collect::<Result<Vec<_>, _>>()?,

--- a/crates/core/src/kernel/snapshot/replay.rs
+++ b/crates/core/src/kernel/snapshot/replay.rs
@@ -168,8 +168,7 @@ fn parse_partitions(batch: RecordBatch, partition_schema: &StructType) -> DeltaR
                 let field = partition_schema
                     .field(k.as_str())
                     .ok_or(DeltaTableError::generic(format!(
-                        "Partition column {} not found in schema.",
-                        k
+                        "Partition column {k} not found in schema."
                     )))?;
                 let field_type = match field.data_type() {
                     DataType::Primitive(p) => Ok(p),

--- a/crates/core/src/kernel/snapshot/serde.rs
+++ b/crates/core/src/kernel/snapshot/serde.rs
@@ -166,16 +166,12 @@ impl<'de> Visitor<'de> for EagerSnapshotVisitor {
             .ok_or_else(|| de::Error::invalid_length(2, &self))?;
         let mut files = Vec::new();
         while let Some(elem) = seq.next_element::<Vec<u8>>()? {
-            let mut reader =
-                FileReader::try_new(std::io::Cursor::new(elem), None).map_err(|e| {
-                    de::Error::custom(format!("failed to read ipc record batch: {}", e))
-                })?;
+            let mut reader = FileReader::try_new(std::io::Cursor::new(elem), None)
+                .map_err(|e| de::Error::custom(format!("failed to read ipc record batch: {e}")))?;
             let rb = reader
                 .next()
                 .ok_or(de::Error::custom("missing ipc data"))?
-                .map_err(|e| {
-                    de::Error::custom(format!("failed to read ipc record batch: {}", e))
-                })?;
+                .map_err(|e| de::Error::custom(format!("failed to read ipc record batch: {e}")))?;
             files.push(rb);
         }
         Ok(EagerSnapshot {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -679,8 +679,7 @@ mod tests {
 
         let error = crate::open_table(non_existing_path_str).await.unwrap_err();
         let _expected_error_msg = format!(
-            "Local path \"{}\" does not exist or you don't have access!",
-            non_existing_path_str
+            "Local path \"{non_existing_path_str}\" does not exist or you don't have access!"
         );
         assert!(matches!(
             error,

--- a/crates/core/src/operations/cast/merge_schema.rs
+++ b/crates/core/src/operations/cast/merge_schema.rs
@@ -19,8 +19,7 @@ fn try_merge_metadata<T: std::cmp::PartialEq + Clone>(
         if let Some(vl) = left.get(k) {
             if vl != v {
                 return Err(ArrowError::SchemaError(format!(
-                    "Cannot merge metadata with different values for key {}",
-                    k
+                    "Cannot merge metadata with different values for key {k}"
                 )));
             }
         } else {
@@ -30,8 +29,7 @@ fn try_merge_metadata<T: std::cmp::PartialEq + Clone>(
                 left.insert(k.clone(), v.clone());
             } else {
                 return Err(ArrowError::SchemaError(format!(
-                    "Cannot add generated expressions to exists columns {}",
-                    k
+                    "Cannot add generated expressions to exists columns {k}"
                 )));
             }
         }
@@ -68,8 +66,7 @@ pub(crate) fn merge_delta_type(
             Ok(DeltaDataType::Struct(Box::new(merged)))
         }
         (a, b) => Err(ArrowError::SchemaError(format!(
-            "Cannot merge types {} and {}",
-            a, b
+            "Cannot merge types {a} and {b}"
         ))),
     }
 }

--- a/crates/core/src/operations/constraints.rs
+++ b/crates/core/src/operations/constraints.rs
@@ -124,12 +124,11 @@ impl std::future::IntoFuture for ConstraintBuilder {
                 .ok_or_else(|| DeltaTableError::Generic("No Expression provided".to_string()))?;
 
             let mut metadata = this.snapshot.metadata().clone();
-            let configuration_key = format!("delta.constraints.{}", name);
+            let configuration_key = format!("delta.constraints.{name}");
 
             if metadata.configuration.contains_key(&configuration_key) {
                 return Err(DeltaTableError::Generic(format!(
-                    "Constraint with name: {} already exists",
-                    name
+                    "Constraint with name: {name} already exists"
                 )));
             }
 
@@ -180,10 +179,9 @@ impl std::future::IntoFuture for ConstraintBuilder {
             // We have validated the table passes it's constraints, now to add the constraint to
             // the table.
 
-            metadata.configuration.insert(
-                format!("delta.constraints.{}", name),
-                Some(expr_str.clone()),
-            );
+            metadata
+                .configuration
+                .insert(format!("delta.constraints.{name}"), Some(expr_str.clone()));
 
             let old_protocol = this.snapshot.protocol();
             let protocol = Protocol {

--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -91,8 +91,7 @@ impl FromStr for PartitionStrategy {
         match s.to_ascii_lowercase().as_str() {
             "hive" => Ok(PartitionStrategy::Hive),
             _ => Err(DeltaTableError::Generic(format!(
-                "Invalid partition strategy provided {}",
-                s
+                "Invalid partition strategy provided {s}"
             ))),
         }
     }

--- a/crates/core/src/operations/drop_constraints.rs
+++ b/crates/core/src/operations/drop_constraints.rs
@@ -93,13 +93,12 @@ impl std::future::IntoFuture for DropConstraintBuilder {
             this.pre_execute(operation_id).await?;
 
             let mut metadata = this.snapshot.metadata().clone();
-            let configuration_key = format!("delta.constraints.{}", name);
+            let configuration_key = format!("delta.constraints.{name}");
 
             if metadata.configuration.remove(&configuration_key).is_none() {
                 if this.raise_if_not_exists {
                     return Err(DeltaTableError::Generic(format!(
-                        "Constraint with name: {} doesn't exists",
-                        name
+                        "Constraint with name: {name} doesn't exists"
                     )));
                 }
                 return Ok(DeltaTable::new_with_state(this.log_store, this.snapshot));

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -682,7 +682,7 @@ impl MergePlan {
             .execute_stream()
             .await?
             .map_err(|err| {
-                ParquetError::General(format!("Z-order failed while scanning data: {:?}", err))
+                ParquetError::General(format!("Z-order failed while scanning data: {err:?}"))
             })
             .boxed();
 

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -117,10 +117,7 @@ impl FromStr for SchemaMode {
         match s.to_ascii_lowercase().as_str() {
             "overwrite" => Ok(SchemaMode::Overwrite),
             "merge" => Ok(SchemaMode::Merge),
-            _ => Err(DeltaTableError::Generic(format!(
-                "Invalid schema write mode provided: {}, only these are supported: ['overwrite', 'merge']",
-                s
-            ))),
+            _ => Err(DeltaTableError::Generic(format!("Invalid schema write mode provided: {s}, only these are supported: ['overwrite', 'merge']"))),
         }
     }
 }

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -949,7 +949,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(count, 0);
-        println!("{:?}", count);
+        println!("{count:?}");
 
         let path = Path::from("_delta_log/00000000000000000000.json");
         let res = table.log_store().object_store(None).get(&path).await;

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -593,10 +593,7 @@ impl FromStr for SaveMode {
             "overwrite" => Ok(SaveMode::Overwrite),
             "error" => Ok(SaveMode::ErrorIfExists),
             "ignore" => Ok(SaveMode::Ignore),
-            _ => Err(DeltaTableError::Generic(format!(
-                "Invalid save mode provided: {}, only these are supported: ['append', 'overwrite', 'error', 'ignore']",
-                s
-            ))),
+            _ => Err(DeltaTableError::Generic(format!("Invalid save mode provided: {s}, only these are supported: ['append', 'overwrite', 'error', 'ignore']"))),
         }
     }
 }

--- a/crates/core/src/schema/partitions.rs
+++ b/crates/core/src/schema/partitions.rs
@@ -178,13 +178,11 @@ impl Serialize for PartitionFilter {
             PartitionValue::LessThanOrEqual(value) => format!("{} <= '{}'", self.key, value),
             // used upper case for IN and NOT similar to SQL
             PartitionValue::In(values) => {
-                let quoted_values: Vec<String> =
-                    values.iter().map(|v| format!("'{}'", v)).collect();
+                let quoted_values: Vec<String> = values.iter().map(|v| format!("'{v}'")).collect();
                 format!("{} IN ({})", self.key, quoted_values.join(", "))
             }
             PartitionValue::NotIn(values) => {
-                let quoted_values: Vec<String> =
-                    values.iter().map(|v| format!("'{}'", v)).collect();
+                let quoted_values: Vec<String> = values.iter().map(|v| format!("'{v}'")).collect();
                 format!("{} NOT IN ({})", self.key, quoted_values.join(", "))
             }
         };

--- a/crates/core/src/table/builder.rs
+++ b/crates/core/src/table/builder.rs
@@ -349,7 +349,7 @@ fn resolve_uri_type(table_uri: impl AsRef<str>) -> DeltaResult<UriType> {
         let scheme = url.scheme().to_string();
         if url.scheme() == "file" {
             Ok(UriType::LocalPath(url.to_file_path().map_err(|err| {
-                let msg = format!("Invalid table location: {}\nError: {:?}", table_uri, err);
+                let msg = format!("Invalid table location: {table_uri}\nError: {err:?}");
                 DeltaTableError::InvalidTableLocation(msg)
             })?))
         // NOTE this check is required to support absolute windows paths which may properly parse as url
@@ -361,8 +361,7 @@ fn resolve_uri_type(table_uri: impl AsRef<str>) -> DeltaResult<UriType> {
             Ok(UriType::LocalPath(PathBuf::from(table_uri)))
         } else {
             Err(DeltaTableError::InvalidTableLocation(format!(
-                "Unknown scheme: {}. Known schemes: {}",
-                scheme,
+                "Unknown scheme: {scheme}. Known schemes: {}",
                 known_schemes.join(",")
             )))
         }
@@ -392,22 +391,19 @@ pub fn ensure_table_uri(table_uri: impl AsRef<str>) -> DeltaResult<Url> {
         UriType::LocalPath(path) => {
             if !path.exists() {
                 std::fs::create_dir_all(&path).map_err(|err| {
-                    let msg = format!(
-                        "Could not create local directory: {}\nError: {:?}",
-                        table_uri, err
-                    );
+                    let msg =
+                        format!("Could not create local directory: {table_uri}\nError: {err:?}");
                     DeltaTableError::InvalidTableLocation(msg)
                 })?;
             }
             let path = std::fs::canonicalize(path).map_err(|err| {
-                let msg = format!("Invalid table location: {}\nError: {:?}", table_uri, err);
+                let msg = format!("Invalid table location: {table_uri}\nError: {err:?}");
                 DeltaTableError::InvalidTableLocation(msg)
             })?;
             Url::from_directory_path(path).map_err(|_| {
                 let msg = format!(
-                    "Could not construct a URL from the canonical path: {}.\n\
+                    "Could not construct a URL from the canonical path: {table_uri}.\n\
                     Something must be very wrong with the table path.",
-                    table_uri
                 );
                 DeltaTableError::InvalidTableLocation(msg)
             })?

--- a/crates/core/src/table/state_arrow.rs
+++ b/crates/core/src/table/state_arrow.rs
@@ -153,8 +153,7 @@ impl DeltaTableState {
                         schema
                             .field(name)
                             .ok_or(DeltaTableError::MetadataError(format!(
-                                "Invalid partition column {0}",
-                                name
+                                "Invalid partition column {name}"
                             )))?;
                     Ok(field.data_type().try_into()?)
                 },
@@ -183,8 +182,7 @@ impl DeltaTableState {
                         .schema()
                         .field(name)
                         .ok_or(DeltaTableError::MetadataError(format!(
-                            "Invalid partition column {0}",
-                            name
+                            "Invalid partition column {name}"
                         )))?
                         .physical_name()
                         .to_string();
@@ -201,8 +199,7 @@ impl DeltaTableState {
                     ColumnMappingMode::Id | ColumnMappingMode::Name => {
                         physical_name_to_logical_name.get(name.as_str()).ok_or(
                             DeltaTableError::MetadataError(format!(
-                                "Invalid partition column {0}",
-                                name
+                                "Invalid partition column {name}"
                             )),
                         )?
                     }
@@ -770,8 +767,7 @@ fn json_value_to_array_general<'a>(
                 .with_timezone("UTC"),
             )),
             _ => Err(DeltaTableError::Generic(format!(
-                "Invalid datatype {}",
-                datatype
+                "Invalid datatype {datatype}"
             ))),
         },
         DataType::Date32 => Ok(Arc::new(Date32Array::from(
@@ -780,8 +776,7 @@ fn json_value_to_array_general<'a>(
                 .collect_vec(),
         ))),
         _ => Err(DeltaTableError::Generic(format!(
-            "Invalid datatype {}",
-            datatype
+            "Invalid datatype {datatype}"
         ))),
     }
 }

--- a/crates/core/src/test_utils/factories/actions.rs
+++ b/crates/core/src/test_utils/factories/actions.rs
@@ -149,5 +149,5 @@ pub fn add_as_remove(add: &Add, data_change: bool) -> Remove {
 
 fn generate_file_name() -> String {
     let file_name = uuid::Uuid::new_v4().hyphenated().to_string();
-    format!("part-0001-{}.parquet", file_name)
+    format!("part-0001-{file_name}.parquet")
 }

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -820,8 +820,7 @@ mod tests {
                 .await;
             assert!(
                 result.is_ok(),
-                "Failed to write with WriteMode::MergeSchema, {:?}",
-                result
+                "Failed to write with WriteMode::MergeSchema, {result:?}",
             );
             let version = writer.flush_and_commit(&mut table).await.unwrap();
             assert_eq!(version, 2);
@@ -946,8 +945,7 @@ mod tests {
                 .await;
             assert!(
                 result.is_err(),
-                "Did not expect to successfully add new writes with different column types: {:?}",
-                result
+                "Did not expect to successfully add new writes with different column types: {result:?}",
             );
         }
 
@@ -1029,8 +1027,7 @@ mod tests {
                 .await;
             assert!(
                 result.is_err(),
-                "Should not have been able to write with a missing non-nullable column: {:?}",
-                result
+                "Should not have been able to write with a missing non-nullable column: {result:?}",
             );
         }
     }

--- a/crates/core/src/writer/test_utils.rs
+++ b/crates/core/src/writer/test_utils.rs
@@ -331,15 +331,12 @@ pub mod datafusion {
         );
         let ctx = SessionContext::new();
         ctx.register_table("test", Arc::new(table)).unwrap();
-        ctx.sql(&format!(
-            "select {} from test order by {}",
-            columns, columns
-        ))
-        .await
-        .unwrap()
-        .collect()
-        .await
-        .unwrap()
+        ctx.sql(&format!("select {columns} from test order by {columns}"))
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap()
     }
 
     pub async fn write_batch(table: DeltaTable, batch: RecordBatch) -> DeltaTable {

--- a/crates/core/src/writer/utils.rs
+++ b/crates/core/src/writer/utils.rs
@@ -48,7 +48,7 @@ pub(crate) fn next_data_path(
     let column_path = ColumnPath::new(Vec::new());
     let compression = writer_properties.compression(&column_path);
 
-    let part = format!("{:0>5}", part_count);
+    let part = format!("{part_count:0>5}");
 
     // TODO: what does c000 mean?
     let file_name = format!(

--- a/crates/core/tests/integration_checkpoint.rs
+++ b/crates/core/tests/integration_checkpoint.rs
@@ -30,7 +30,7 @@ async fn cleanup_metadata_test(context: &IntegrationContext) -> TestResult {
         .build_storage()?;
     let object_store = log_store.object_store(None);
 
-    let log_path = |version| log_store.log_path().child(format!("{:020}.json", version));
+    let log_path = |version| log_store.log_path().child(format!("{version:020}.json"));
 
     // we don't need to actually populate files with content as cleanup works only with file's metadata
     object_store

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -652,7 +652,7 @@ mod local {
             if column == "decimal" || column == "date" || column == "binary" {
                 continue;
             }
-            println!("[Unwrapped] Test Column: {} value: {}", column, file1_value);
+            println!("[Unwrapped] Test Column: {column} value: {file1_value}");
 
             // Equality
             let e = col(column).eq(file1_value.clone());
@@ -754,7 +754,7 @@ mod local {
                 continue;
             }
 
-            println!("[Wrapped] Test Column: {} value: {}", column, file1_value);
+            println!("[Wrapped] Test Column: {column} value: {file1_value}");
 
             let partitions = vec![column.to_owned()];
             let batch = create_all_types_batch(3, 0, 0);

--- a/crates/deltalake/examples/basic_operations.rs
+++ b/crates/deltalake/examples/basic_operations.rs
@@ -111,7 +111,7 @@ async fn main() -> Result<(), deltalake::errors::DeltaTableError> {
     let (_table, stream) = DeltaOps(table).load().await?;
     let data: Vec<RecordBatch> = collect_sendable_stream(stream).await?;
 
-    println!("{:?}", data);
+    println!("{data:?}");
 
     Ok(())
 }

--- a/crates/deltalake/examples/load_table.rs
+++ b/crates/deltalake/examples/load_table.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), deltalake::errors::DeltaTableError> {
     let (_table, stream) = ops.load().await?;
     let data: Vec<RecordBatch> = collect_sendable_stream(stream).await?;
 
-    println!("{:?}", data);
+    println!("{data:?}");
 
     Ok(())
 }

--- a/crates/deltalake/examples/recordbatch-writer.rs
+++ b/crates/deltalake/examples/recordbatch-writer.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), DeltaTableError> {
             info!("It doesn't look like our delta table has been created");
             create_initialized_table(&table_path).await
         }
-        Err(err) => panic!("{:?}", err),
+        Err(err) => panic!("{err:?}"),
     };
 
     let writer_properties = WriterProperties::builder()

--- a/crates/gcp/src/lib.rs
+++ b/crates/gcp/src/lib.rs
@@ -84,7 +84,7 @@ impl LogStoreFactory for GcpFactory {
 pub fn register_handlers(_additional_prefixes: Option<Url>) {
     let factory = Arc::new(GcpFactory {});
     let scheme = &"gs";
-    let url = Url::parse(&format!("{}://", scheme)).unwrap();
+    let url = Url::parse(&format!("{scheme}://")).unwrap();
     factories().insert(url.clone(), factory.clone());
     logstores().insert(url.clone(), factory.clone());
 }

--- a/crates/gcp/src/storage.rs
+++ b/crates/gcp/src/storage.rs
@@ -105,7 +105,7 @@ impl ObjectStore for GcsStorageBackend {
                         // That means we're experiencing concurrency conflicts, so return a transaction error
                         // Source would be a reqwest error which we don't have access to so the easiest thing to do is check
                         // for "429" in the error message
-                        if format!("{:?}", source).contains("429") {
+                        if format!("{source:?}").contains("429") {
                             Err(object_store::Error::AlreadyExists {
                                 path: to.to_string(),
                                 source,

--- a/crates/hdfs/src/lib.rs
+++ b/crates/hdfs/src/lib.rs
@@ -41,7 +41,7 @@ impl LogStoreFactory for HdfsFactory {
 pub fn register_handlers(_additional_prefixes: Option<Url>) {
     let factory = Arc::new(HdfsFactory {});
     for scheme in ["hdfs", "viewfs"].iter() {
-        let url = Url::parse(&format!("{}://", scheme)).unwrap();
+        let url = Url::parse(&format!("{scheme}://")).unwrap();
         factories().insert(url.clone(), factory.clone());
         logstores().insert(url.clone(), factory.clone());
     }

--- a/crates/lakefs/src/client.rs
+++ b/crates/lakefs/src/client.rs
@@ -57,7 +57,7 @@ impl LakeFSClient {
 
         let request_url = format!("{}/api/v1/repositories/{}/branches", self.config.host, repo);
 
-        let transaction_branch = format!("delta-tx-{}", operation_id);
+        let transaction_branch = format!("delta-tx-{operation_id}");
         let body = json!({
             "name": transaction_branch,
             "source": source_branch,
@@ -78,11 +78,8 @@ impl LakeFSClient {
         match response.status() {
             StatusCode::CREATED => {
                 // Branch created successfully
-                let new_url = Url::parse(&format!(
-                    "lakefs://{}/{}/{}",
-                    repo, transaction_branch, table
-                ))
-                .unwrap();
+                let new_url =
+                    Url::parse(&format!("lakefs://{repo}/{transaction_branch}/{table}")).unwrap();
                 Ok((new_url, transaction_branch))
             }
             StatusCode::UNAUTHORIZED => Err(LakeFSOperationError::UnauthorizedAction.into()),
@@ -314,7 +311,7 @@ mod tests {
         let result = rt().block_on(async { client.create_branch(&source_url, operation_id).await });
         assert!(result.is_ok());
         let (new_url, branch_name) = result.unwrap();
-        assert_eq!(branch_name, format!("delta-tx-{}", operation_id));
+        assert_eq!(branch_name, format!("delta-tx-{operation_id}"));
         assert!(new_url.as_str().contains("lakefs://test_repo"));
         mock.assert();
     }

--- a/crates/lakefs/src/execute.rs
+++ b/crates/lakefs/src/execute.rs
@@ -144,7 +144,7 @@ mod tests {
             assert!(lakefs_store
                 .storage
                 .get_store(
-                    &Url::parse(format!("lakefs://repo/delta-tx-{}/table", operation_id).as_str())
+                    &Url::parse(format!("lakefs://repo/delta-tx-{operation_id}/table").as_str())
                         .unwrap()
                 )
                 .is_ok());
@@ -185,7 +185,7 @@ mod tests {
             assert!(lakefs_store
                 .storage
                 .get_store(
-                    &Url::parse(format!("lakefs://repo/delta-tx-{}/table", operation_id).as_str())
+                    &Url::parse(format!("lakefs://repo/delta-tx-{operation_id}/table").as_str())
                         .unwrap()
                 )
                 .is_ok());
@@ -210,11 +210,7 @@ mod tests {
         let mock_2 = server
             .mock(
                 "DELETE",
-                format!(
-                    "/api/v1/repositories/repo/branches/delta-tx-{}",
-                    operation_id
-                )
-                .as_str(),
+                format!("/api/v1/repositories/repo/branches/delta-tx-{operation_id}").as_str(),
             )
             .with_status(StatusCode::NO_CONTENT.as_u16().into())
             .create();
@@ -257,11 +253,8 @@ mod tests {
         let create_commit_mock = server
             .mock(
                 "POST",
-                format!(
-                    "/api/v1/repositories/repo/branches/delta-tx-{}/commits",
-                    operation_id
-                )
-                .as_str(),
+                format!("/api/v1/repositories/repo/branches/delta-tx-{operation_id}/commits")
+                    .as_str(),
             )
             .with_status(StatusCode::CREATED.as_u16().into())
             .create();
@@ -269,11 +262,8 @@ mod tests {
         let merge_branch_mock = server
             .mock(
                 "POST",
-                format!(
-                    "/api/v1/repositories/repo/refs/delta-tx-{}/merge/branch",
-                    operation_id
-                )
-                .as_str(),
+                format!("/api/v1/repositories/repo/refs/delta-tx-{operation_id}/merge/branch")
+                    .as_str(),
             )
             .with_status(StatusCode::OK.as_u16().into())
             .create();
@@ -281,11 +271,7 @@ mod tests {
         let delete_branch_mock = server
             .mock(
                 "DELETE",
-                format!(
-                    "/api/v1/repositories/repo/branches/delta-tx-{}",
-                    operation_id
-                )
-                .as_str(),
+                format!("/api/v1/repositories/repo/branches/delta-tx-{operation_id}").as_str(),
             )
             .with_status(StatusCode::NO_CONTENT.as_u16().into())
             .create();

--- a/crates/lakefs/src/lib.rs
+++ b/crates/lakefs/src/lib.rs
@@ -43,7 +43,7 @@ pub fn register_handlers(_additional_prefixes: Option<Url>) {
     let object_stores = Arc::new(LakeFSObjectStoreFactory::default());
     let log_stores = Arc::new(LakeFSLogStoreFactory::default());
     let scheme = "lakefs";
-    let url = Url::parse(&format!("{}://", scheme)).unwrap();
+    let url = Url::parse(&format!("{scheme}://")).unwrap();
     factories().insert(url.clone(), object_stores.clone());
     logstores().insert(url.clone(), log_stores.clone());
 }

--- a/crates/lakefs/src/logstore.rs
+++ b/crates/lakefs/src/logstore.rs
@@ -150,7 +150,7 @@ impl LakeFSLogStore {
             .commit(
                 repo,
                 transaction_branch,
-                format!("Delta file operations {{ table: {}}}", table),
+                format!("Delta file operations {{ table: {table}}}"),
                 true, // Needs to be true, it could be a file operation but no logs were deleted.
             )
             .await?;
@@ -165,7 +165,7 @@ impl LakeFSLogStore {
                 target_branch,
                 self.client.get_transaction(operation_id)?,
                 0,
-                format!("Finished delta file operations {{ table: {}}}", table),
+                format!("Finished delta file operations {{ table: {table}}}"),
                 true, // Needs to be true, it could be a file operation but no logs were deleted.
             )
             .await
@@ -245,7 +245,7 @@ impl LogStore for LakeFSLogStore {
                     .commit(
                         repo,
                         transaction_branch,
-                        format!("Delta commit {{ table: {}, version: {}}}", table, version),
+                        format!("Delta commit {{ table: {table}, version: {version}}}"),
                         false,
                     )
                     .await
@@ -264,10 +264,7 @@ impl LogStore for LakeFSLogStore {
                         target_branch,
                         self.client.get_transaction(operation_id)?,
                         version,
-                        format!(
-                            "Finished deltalake transaction {{ table: {}, version: {} }}",
-                            table, version
-                        ),
+                        format!("Finished deltalake transaction {{ table: {table}, version: {version} }}"),
                         false,
                     )
                     .await
@@ -318,7 +315,7 @@ impl LogStore for LakeFSLogStore {
     fn object_store(&self, operation_id: Option<Uuid>) -> Arc<dyn ObjectStore> {
         match operation_id {
             Some(id) => {
-                let (_, store) = self.get_transaction_objectstore(id).unwrap_or_else(|_| panic!("The object_store registry inside LakeFSLogstore didn't have a store for operation_id {} Something went wrong.", id));
+                let (_, store) = self.get_transaction_objectstore(id).unwrap_or_else(|_| panic!("The object_store registry inside LakeFSLogstore didn't have a store for operation_id {id} Something went wrong."));
                 store
             }
             _ => self.storage.get_store(&self.config.location).unwrap(),

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -95,7 +95,7 @@ impl LogStoreFactory for MountFactory {
 pub fn register_handlers(_additional_prefixes: Option<Url>) {
     let factory = Arc::new(MountFactory {});
     for scheme in ["dbfs", "file"].iter() {
-        let url = Url::parse(&format!("{}://", scheme)).unwrap();
+        let url = Url::parse(&format!("{scheme}://")).unwrap();
         factories().insert(url.clone(), factory.clone());
         logstores().insert(url.clone(), factory.clone());
     }

--- a/crates/sql/src/lib.rs
+++ b/crates/sql/src/lib.rs
@@ -11,8 +11,7 @@ mod tests {
         let actual_lines: Vec<_> = formatted.trim().lines().collect();
         assert_eq!(
             &actual_lines, expected_lines,
-            "\n\nexpected:\n\n{:#?}\nactual:\n\n{:#?}\n\n",
-            expected_lines, actual_lines
+            "\n\nexpected:\n\n{expected_lines:#?}\nactual:\n\n{actual_lines:#?}\n\n",
         );
     }
 }

--- a/crates/sql/src/logical_plan.rs
+++ b/crates/sql/src/logical_plan.rs
@@ -113,8 +113,7 @@ impl UserDefinedLogicalNodeCore for DeltaStatement {
                 Ok(self.clone())
             }
             _ => Err(DataFusionError::NotImplemented(format!(
-                "with_exprs_and_inputs not implemented for {:?}",
-                self
+                "with_exprs_and_inputs not implemented for {self:?}",
             ))),
         }
     }

--- a/crates/test/src/concurrent.rs
+++ b/crates/test/src/concurrent.rs
@@ -55,7 +55,7 @@ where
 {
     let mut workers = Vec::new();
     for w in 0..WORKERS {
-        workers.push(create_worker(format!("w{}", w)).await);
+        workers.push(create_worker(format!("w{w}")).await);
     }
 
     let mut futures = Vec::new();
@@ -83,7 +83,7 @@ where
     let mut expected = Vec::new();
     for w in 0..WORKERS {
         for c in 0..COMMITS {
-            expected.push(format!("w{}-{}", w, c))
+            expected.push(format!("w{w}-{c}"))
         }
     }
     assert_eq!(files, expected);
@@ -124,7 +124,7 @@ impl Worker {
             predicate: None,
         };
         let actions = vec![Action::Add(Add {
-            path: format!("{}.parquet", name),
+            path: format!("{name}.parquet"),
             size: 396,
             partition_values: HashMap::new(),
             modification_time: 1564524294000,

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -23,7 +23,7 @@ fn inner_to_py_err(err: DeltaTableError) -> PyErr {
         DeltaTableError::InvalidJsonLog { .. } => DeltaProtocolError::new_err(err.to_string()),
         DeltaTableError::InvalidStatsJson { .. } => DeltaProtocolError::new_err(err.to_string()),
         DeltaTableError::InvalidData { violations } => {
-            DeltaProtocolError::new_err(format!("Invariant violations: {:?}", violations))
+            DeltaProtocolError::new_err(format!("Invariant violations: {violations:?}"))
         }
 
         // commit errors

--- a/python/src/filesystem.rs
+++ b/python/src/filesystem.rs
@@ -305,9 +305,8 @@ impl DeltaFileSystemHandler {
                 py,
                 "UserWarning",
                 format!(
-                    "You specified a `max_buffer_size` of {} bits less than {} bits. Most object 
+                    "You specified a `max_buffer_size` of {max_buffer_size} bits less than {DEFAULT_MAX_BUFFER_SIZE} bits. Most object
                     stores expect greater than that number, you may experience issues",
-                    max_buffer_size, DEFAULT_MAX_BUFFER_SIZE
                 )
                 .as_str(),
                 Some(2),

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1816,7 +1816,7 @@ fn scalar_to_py<'py>(value: &Scalar, py_date: &Bound<'py, PyAny>) -> PyResult<Bo
             // We need to manually append 'Z' add to end so that pyarrow can cast the
             // scalar value to pa.timestamp("us","UTC")
             let value = value.serialize();
-            format!("{}Z", value).into_py_any(py)?
+            format!("{value}Z").into_py_any(py)?
         }
         TimestampNtz(_) => {
             let value = value.serialize();

--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -15,11 +15,10 @@ pub fn rt() -> &'static Runtime {
     let runtime_pid = *PID.get_or_init(|| pid);
     if pid != runtime_pid {
         panic!(
-            "Forked process detected - current PID is {} but the tokio runtime was created by {}. The tokio \
+            "Forked process detected - current PID is {pid} but the tokio runtime was created by {runtime_pid}. The tokio \
             runtime does not support forked processes https://github.com/tokio-rs/tokio/issues/4301. If you are \
             seeing this message while using Python multithreading make sure to use the `spawn` or `forkserver` \
             mode.", 
-            pid, runtime_pid
         );
     }
     TOKIO_RT.get_or_init(|| Runtime::new().expect("Failed to create a tokio runtime."))


### PR DESCRIPTION
Using this command, fixed format argument inlining to improve readability, and fix a few minor related styling issues like trailing commas in a single line.

```
cargo clippy --all-targets --workspace -- -D clippy::uninlined_format_args
```