### PR TITLE
fix: removing openssl from the dependency tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ debug = true
 debug = "line-tables-only"
 
 [workspace.dependencies]
-delta_kernel = { version = "=0.6.1", features = ["default-engine"] }
+delta_kernel = { version = "=0.6.1", features = ["default-engine-rustls"] }
 #delta_kernel = { path = "../delta-kernel-rs/kernel", features = ["sync-engine"]  }
 
 # arrow

--- a/crates/lakefs/Cargo.toml
+++ b/crates/lakefs/Cargo.toml
@@ -28,7 +28,7 @@ url = { workspace = true }
 dashmap = "6"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-reqwest = {version = "0.12", features = ["json"]}
+reqwest = {version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls-native-roots"]}
 http = "1.0.0"
 delta_kernel = { workspace = true, features = [] }
 

--- a/dev/publish.sh
+++ b/dev/publish.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-for crate in "mount" "catalog-glue" "hdfs" "azure" "aws" "gcp" "core" "deltalake"; do
+for crate in "core" "mount" "catalog-glue" "catalog-unity" "hdfs" "lakefs" "azure" "aws" "gcp" "deltalake"; do
         echo ">> Dry-run publishing ${crate}"
         (cd crates/${crate} && \
                 cargo publish \

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -41,10 +41,6 @@ futures = { workspace = true }
 num_cpus = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
-# reqwest is pulled in by azure sdk, but not used by python binding itself
-# for binary wheel best practice, statically link openssl
-reqwest = { version = "*", features = ["native-tls-vendored"] }
-
 deltalake-mount = { path = "../crates/mount" }
 
 # Non-unix or emscripten os
@@ -72,9 +68,6 @@ features = ["azure", "gcs", "python", "datafusion", "unity-experimental", "hdfs"
 default = ["rustls"]
 native-tls = ["deltalake/s3-native-tls", "deltalake/glue"]
 rustls = ["deltalake/s3", "deltalake/glue"]
-
-[build-dependencies]
-openssl-src = "=300.3.1"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
This is still marked as draft for the time being because there is not a released version of delta-kernel-rs which has the `default-engine-rustls` flag _and_ a compatible set of arrow dependencies :see_no_evil: 

Fixes #2857 