### PR TITLE
chore: prevent the pr actions from filing on merge_group

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -2,7 +2,6 @@ name: dev_pr
 
 # Trigger whenever a PR is changed (title as well as new / changed commits)
 on:
-  merge_group:
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
I _believe_ I can remove this in order to prevent the check from failing on merges. I'm not sure if this is required in order for the merge group to pass required checks though :thinking:
