### PR TITLE
feat: use LazyTableProvider by default for write_to_deltalake for memory efficiency

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -876,14 +876,6 @@ impl TableProvider for LazyTableProvider {
         TableType::Base
     }
 
-    fn get_table_definition(&self) -> Option<&str> {
-        None
-    }
-
-    fn get_logical_plan(&self) -> Option<Cow<'_, LogicalPlan>> {
-        None
-    }
-
     async fn scan(
         &self,
         _session: &dyn Session,
@@ -909,7 +901,7 @@ impl TableProvider for LazyTableProvider {
             if projection != &current_projection {
                 let execution_props = &ExecutionProps::new();
                 let fields: DeltaResult<Vec<(Arc<dyn PhysicalExpr>, String)>> = projection
-                    .into_iter()
+                    .iter()
                     .map(|i| {
                         let (table_ref, field) = df_schema.qualified_field(*i);
                         create_physical_expr(
@@ -940,10 +932,6 @@ impl TableProvider for LazyTableProvider {
             .iter()
             .map(|_| TableProviderFilterPushDown::Inexact)
             .collect())
-    }
-
-    fn statistics(&self) -> Option<Statistics> {
-        None
     }
 }
 

--- a/python/src/write.rs
+++ b/python/src/write.rs
@@ -1,0 +1,66 @@
+//! The write module contains shared code used for writes by the write_to_deltalake function and
+//! the merge cod
+
+use deltalake::arrow::ffi_stream::ArrowArrayStreamReader;
+use deltalake::datafusion::catalog::TableProvider;
+use deltalake::datafusion::physical_plan::memory::LazyBatchGenerator;
+use deltalake::delta_datafusion::LazyTableProvider;
+use deltalake::DeltaResult;
+use parking_lot::RwLock;
+use std::fmt::{self};
+use std::sync::{Arc, Mutex};
+
+/// Convert an [ArrowArrayStreamReader] into a [LazyTableProvider]
+pub(crate) fn to_lazy_table(source: ArrowArrayStreamReader) -> DeltaResult<Arc<dyn TableProvider>> {
+    use deltalake::arrow::array::RecordBatchReader;
+    let schema = source.schema();
+    let arrow_stream: Arc<Mutex<ArrowArrayStreamReader>> = Arc::new(Mutex::new(source));
+    let arrow_stream_batch_generator: Arc<RwLock<dyn LazyBatchGenerator>> =
+        Arc::new(RwLock::new(ArrowStreamBatchGenerator::new(arrow_stream)));
+
+    Ok(Arc::new(LazyTableProvider::try_new(
+        schema.clone(),
+        vec![arrow_stream_batch_generator],
+    )?))
+}
+
+#[derive(Debug)]
+pub(crate) struct ArrowStreamBatchGenerator {
+    pub array_stream: Arc<Mutex<ArrowArrayStreamReader>>,
+}
+
+impl fmt::Display for ArrowStreamBatchGenerator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ArrowStreamBatchGenerator {{ array_stream: {:?} }}",
+            self.array_stream
+        )
+    }
+}
+
+impl ArrowStreamBatchGenerator {
+    pub fn new(array_stream: Arc<Mutex<ArrowArrayStreamReader>>) -> Self {
+        Self { array_stream }
+    }
+}
+
+impl LazyBatchGenerator for ArrowStreamBatchGenerator {
+    fn generate_next_batch(
+        &mut self,
+    ) -> deltalake::datafusion::error::Result<Option<deltalake::arrow::array::RecordBatch>> {
+        let mut stream_reader = self.array_stream.lock().map_err(|_| {
+            deltalake::datafusion::error::DataFusionError::Execution(
+                "Failed to lock the ArrowArrayStreamReader".to_string(),
+            )
+        })?;
+
+        match stream_reader.next() {
+            Some(Ok(record_batch)) => Ok(Some(record_batch)),
+            Some(Err(err)) => Err(deltalake::datafusion::error::DataFusionError::ArrowError(
+                err, None,
+            )),
+            None => Ok(None), // End of stream
+        }
+    }
+}

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1589,13 +1589,6 @@ def test_schema_cols_diff_order(tmp_path: pathlib.Path, engine):
     assert dt.to_pyarrow_table(columns=["baz", "bar", "foo"]) == expected
 
 
-def test_empty(existing_table: DeltaTable):
-    schema = existing_table.schema().to_pyarrow()
-    empty_table = pa.Table.from_pylist([], schema=schema)
-    with pytest.raises(DeltaError, match="No data source supplied to write command"):
-        write_deltalake(existing_table, empty_table, mode="append", engine="rust")
-
-
 def test_rust_decimal_cast(tmp_path: pathlib.Path):
     import re
 
@@ -1811,13 +1804,6 @@ def test_roundtrip_cdc_evolution(tmp_path: pathlib.Path):
     print(os.listdir(tmp_path))
     # This is kind of a weak test to verify that CDFs were written
     assert os.path.isdir(os.path.join(tmp_path, "_change_data"))
-
-
-def test_empty_dataset_write(tmp_path: pathlib.Path, sample_data: pa.Table):
-    empty_arrow_table = sample_data.schema.empty_table()
-    empty_dataset = dataset(empty_arrow_table)
-    with pytest.raises(DeltaError, match="No data source supplied to write command"):
-        write_deltalake(tmp_path, empty_dataset, mode="append")
 
 
 @pytest.mark.pandas


### PR DESCRIPTION
This defaults write_to_deltalake in Python to attempt to use the LazytableProvider for a more stream-like execution. It's currently opted out for schewma evolution since that's not supported by default.

Some improvements in schema mismatch detection inside of the operations::write module are required as well

- closes https://github.com/delta-io/delta-rs/issues/2968
- closes https://github.com/delta-io/delta-rs/issues/2522