### PR TITLE
chore: remove the unnecessary hashbrown dependency

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -54,7 +54,6 @@ strum = { workspace =  true}
 # "stdlib"
 bytes = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["clock"] }
-hashbrown = "0.15.2"
 regex = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/crates/core/src/kernel/snapshot/replay.rs
+++ b/crates/core/src/kernel/snapshot/replay.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Context;
@@ -16,7 +17,6 @@ use delta_kernel::expressions::Scalar;
 use delta_kernel::schema::DataType;
 use delta_kernel::schema::PrimitiveType;
 use futures::Stream;
-use hashbrown::HashSet;
 use itertools::Itertools;
 use percent_encoding::percent_decode_str;
 use pin_project_lite::pin_project;


### PR DESCRIPTION
According to crates.io:

> Since Rust 1.36, this is now the HashMap implementation for the Rust
> standard library. However you may still want to use this crate instead
> since it works in environments without std, such as embedded systems and
> kernels.

So yeah, guesos we don't need this anymore :laughing:
