### PR TITLE
feat: make Add:get_stats public

### DIFF
--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -243,7 +243,7 @@ impl Eq for Add {}
 
 impl Add {
     /// Get whatever stats are available. Uses (parquet struct) parsed_stats if present falling back to json stats.
-    pub(crate) fn get_stats(&self) -> Result<Option<Stats>, serde_json::error::Error> {
+    pub fn get_stats(&self) -> Result<Option<Stats>, serde_json::error::Error> {
         match self.get_stats_parsed() {
             Ok(Some(stats)) => Ok(Some(stats)),
             Ok(None) => self.get_json_stats(),


### PR DESCRIPTION
# Description
The description of the main changes of your pull request

This method is likely at least as useful as the existing public methods get_json_stats and get_stats_parsed (which should probably be non-public).

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
