### PR TITLE
fix(rust, python): treat FSCK files_removed as strings

### DIFF
--- a/crates/core/src/operations/filesystem_check.rs
+++ b/crates/core/src/operations/filesystem_check.rs
@@ -22,7 +22,7 @@ use futures::future::BoxFuture;
 use futures::StreamExt;
 pub use object_store::path::Path;
 use object_store::ObjectStore;
-use serde::Serialize;
+use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 use url::{ParseError, Url};
 use uuid::Uuid;
 
@@ -56,6 +56,10 @@ pub struct FileSystemCheckMetrics {
     /// Was this a dry run
     pub dry_run: bool,
     /// Files that wrere removed successfully
+    #[serde(
+        serialize_with = "serialize_vec_string",
+        deserialize_with = "deserialize_vec_string"
+    )]
     pub files_removed: Vec<String>,
 }
 
@@ -64,6 +68,24 @@ struct FileSystemCheckPlan {
     log_store: LogStoreRef,
     /// Files that no longer exists in undlying ObjectStore but have active add actions
     pub files_to_remove: Vec<Add>,
+}
+
+// Custom serialization function that serializes metric details as a string
+fn serialize_vec_string<S>(value: &Vec<String>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let json_string = serde_json::to_string(value).map_err(serde::ser::Error::custom)?;
+    serializer.serialize_str(&json_string)
+}
+
+// Custom deserialization that parses a JSON string into MetricDetails
+fn deserialize_vec_string<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+    serde_json::from_str(&s).map_err(DeError::custom)
 }
 
 fn is_absolute_path(path: &str) -> DeltaResult<bool> {

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -69,6 +69,8 @@ MAX_SUPPORTED_READER_VERSION = 3
 NOT_SUPPORTED_READER_VERSION = 2
 SUPPORTED_READER_FEATURES = {"timestampNtz"}
 
+FSCK_METRICS_FILES_REMOVED_LABEL = "files_removed"
+
 FilterLiteralType = Tuple[str, str, Any]
 FilterConjunctionType = List[FilterLiteralType]
 FilterDNFType = List[FilterConjunctionType]
@@ -1430,7 +1432,11 @@ class DeltaTable:
             commit_properties,
             post_commithook_properties,
         )
-        return json.loads(metrics)
+        deserialized_metrics = json.loads(metrics)
+        deserialized_metrics[FSCK_METRICS_FILES_REMOVED_LABEL] = json.loads(
+            deserialized_metrics[FSCK_METRICS_FILES_REMOVED_LABEL]
+        )
+        return deserialized_metrics
 
     def transaction_versions(self) -> Dict[str, Transaction]:
         return self._table.transaction_versions()


### PR DESCRIPTION
# Description
This changes how the files_removed array is serialized, making it a stringified representation of the list of files. This is done to ensure compatibility with Spark.

To maintain the current behavior with the python bindings, the repair method wrapper in python will deserialize back to a list.

# Related Issue(s)
 closes #3140 


