### PR TITLE
chore: switch to cache@v4

### DIFF
--- a/.github/workflows/python_benchmark.yml
+++ b/.github/workflows/python_benchmark.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark


### PR DESCRIPTION
We got hit by a brownout :D

<https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down>
