### PR TITLE
chore: bump python 0.25

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.24.1"
+version = "0.25.0"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"


### PR DESCRIPTION
# Description
Let's also merge this: https://github.com/delta-io/delta-rs/pull/3178 before the 0.25 release :) @rtyler  