### PR TITLE
fix: use tableprovider scan in z-order

### DIFF
--- a/crates/core/src/kernel/scalars.rs
+++ b/crates/core/src/kernel/scalars.rs
@@ -72,8 +72,8 @@ impl ScalarExt for Scalar {
             },
             Self::Binary(val) => create_escaped_binary_string(val.as_slice()),
             Self::Null(_) => "null".to_string(),
-            Self::Struct(_) => unimplemented!(),
-            Self::Array(_) => unimplemented!(),
+            Self::Struct(_) => self.to_string(),
+            Self::Array(_) => self.to_string(),
         }
     }
 
@@ -85,7 +85,7 @@ impl ScalarExt for Scalar {
         encode(Path::from(self.serialize()).as_ref()).to_string()
     }
 
-    /// Create a [`Scalar`] form a row in an arrow array.
+    /// Create a [`Scalar`] from a row in an arrow array.
     fn from_array(arr: &dyn Array, index: usize) -> Option<Self> {
         use arrow_array::*;
         use arrow_schema::DataType::*;


### PR DESCRIPTION
# Description
Our DeltaTableProvider is better to use than reading directly with ctx.read_parquet, since the DeltaTableProvider has a schemaAdapterFactory which maps each batch to the input_schema. This creates consistency while reading. A good side effect is we don't need to that path serialization fix anymore @rtyler 

# Related Issue(s)
- closes https://github.com/delta-io/delta-rs/issues/3185

