### PR TITLE
feat: set clientVersion for python binding

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -97,6 +97,7 @@ pub use self::table::config::TableProperty;
 pub use self::table::DeltaTable;
 pub use object_store::{path::Path, Error as ObjectStoreError, ObjectMeta, ObjectStore};
 pub use operations::DeltaOps;
+use std::sync::OnceLock;
 
 // convenience exports for consumers to avoid aligning crate versions
 pub use arrow;
@@ -161,9 +162,18 @@ pub async fn open_table_with_ds(
     Ok(table)
 }
 
-/// Returns rust crate version, can be use used in language bindings to expose Rust core version
+static CLIENT_VERSION: OnceLock<String> = OnceLock::new();
+
+pub fn init_client_version(version: &str) {
+    let _ = CLIENT_VERSION.set(version.to_string());
+}
+
+/// Returns Rust core version or custom set client_version such as the py-binding
 pub fn crate_version() -> &'static str {
-    env!("CARGO_PKG_VERSION")
+    CLIENT_VERSION
+        .get()
+        .map(|s| s.as_str())
+        .unwrap_or(env!("CARGO_PKG_VERSION"))
 }
 
 #[cfg(test)]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -60,7 +60,7 @@ use deltalake::partitions::PartitionFilter;
 use deltalake::protocol::{DeltaOperation, SaveMode};
 use deltalake::storage::{IORuntime, ObjectStoreRef};
 use deltalake::table::state::DeltaTableState;
-use deltalake::DeltaTableBuilder;
+use deltalake::{init_client_version, DeltaTableBuilder};
 use deltalake::{DeltaOps, DeltaResult};
 use error::DeltaError;
 use futures::future::join_all;
@@ -2489,6 +2489,8 @@ fn _internal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     deltalake_mount::register_handlers(None);
     deltalake::lakefs::register_handlers(None);
     deltalake::unity_catalog::register_handlers(None);
+
+    init_client_version(format!("py-{}", env!("CARGO_PKG_VERSION")).as_str());
 
     let py = m.py();
     m.add("DeltaError", py.get_type::<DeltaError>())?;


### PR DESCRIPTION
# Description
We initialize the client version when we init the python module. Makes it easier to see which tables got written with which binding and the version :)

- closes https://github.com/delta-io/delta-rs/issues/2008
