### PR TITLE
chore: more manual inline format args

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ async fn main() -> Result<(), DeltaTableError> {
 
     // show all active files in the table
     let files: Vec<_> = table.get_file_uris()?.collect();
-    println!("{:?}", files);
+    println!("{files:?}");
 
     Ok(())
 }

--- a/crates/aws/helpers.rs
+++ b/crates/aws/helpers.rs
@@ -13,7 +13,7 @@ pub async fn setup_s3_context() -> TestContext {
     let cli = S3Cli::default();
     let endpoint = "http://localhost:4566".to_string();
     let bucket_name = "delta-rs-tests";
-    let uri = format!("s3://{}/{}/{}/", bucket_name, Utc::now().timestamp(), rand);
+    let uri = format!("s3://{bucket_name}/{}/{rand}/", Utc::now().timestamp());
     let lock_table = format!("delta_rs_lock_table_{rand}");
 
     let region = "us-east-1".to_string();

--- a/crates/aws/src/logstore/dynamodb_logstore.rs
+++ b/crates/aws/src/logstore/dynamodb_logstore.rs
@@ -127,7 +127,7 @@ impl S3DynamoDbLogStore {
         entry: &CommitEntry,
         copy_performed: bool,
     ) -> Result<RepairLogEntryResult, TransactionError> {
-        debug!("try_complete_entry for {:?}, {}", entry, copy_performed);
+        debug!("try_complete_entry for {entry:?}, {copy_performed}");
         for retry in 0..=MAX_REPAIR_RETRIES {
             match self
                 .lock_client

--- a/crates/aws/tests/common.rs
+++ b/crates/aws/tests/common.rs
@@ -36,7 +36,7 @@ impl StorageIntegration for S3Integration {
     }
 
     fn root_uri(&self) -> String {
-        format!("s3://{}", &self.bucket_name())
+        format!("s3://{}", self.bucket_name())
     }
 
     /// prepare_env

--- a/crates/aws/tests/integration_s3_dynamodb.rs
+++ b/crates/aws/tests/integration_s3_dynamodb.rs
@@ -338,7 +338,7 @@ async fn test_concurrent_writers() -> TestResult<()> {
 
     let mut workers = Vec::new();
     for w in 0..WORKERS {
-        workers.push(Worker::new(&table_uri, format!("w{:02}", w)).await);
+        workers.push(Worker::new(&table_uri, format!("w{w:02}")).await);
     }
     let mut futures = Vec::new();
     for mut w in workers {
@@ -384,7 +384,7 @@ impl Worker {
     }
 
     async fn commit_file(&mut self, seq_no: i64) -> (i64, String) {
-        let name = format!("{}-{}", self.name, seq_no);
+        let name = format!("{}-{seq_no}", self.name);
         let metadata = Some(maplit::hashmap! {
             "worker".to_owned() => Value::String(self.name.clone()),
             "current_version".to_owned() => Value::Number( seq_no.into() ),
@@ -431,7 +431,7 @@ fn add_action(name: &str) -> Action {
         .unwrap()
         .as_millis();
     Add {
-        path: format!("{}.parquet", name),
+        path: format!("{name}.parquet"),
         size: 396,
         partition_values: HashMap::new(),
         modification_time: ts as i64,
@@ -448,7 +448,7 @@ fn add_action(name: &str) -> Action {
 }
 
 async fn prepare_table(context: &IntegrationContext, table_name: &str) -> TestResult<DeltaTable> {
-    let table_name = format!("{}_{}", table_name, Uuid::new_v4());
+    let table_name = format!("{table_name}_{}", Uuid::new_v4());
     let table_uri = context.uri_for_table(TestTables::Custom(table_name.to_owned()));
     let schema = StructType::new(vec![StructField::new(
         "Id".to_string(),

--- a/crates/aws/tests/repair_s3_rename_test.rs
+++ b/crates/aws/tests/repair_s3_rename_test.rs
@@ -39,7 +39,7 @@ async fn repair_when_worker_pauses_after_rename_test() {
     // here worker is paused after copy but before delete,
     // so when it wakes up the delete operation will succeed since the file is already deleted,
     // but it'll fail on releasing a lock, since it's expired
-    assert!(format!("{:?}", err).contains("ReleaseLock"));
+    assert!(format!("{err:?}").contains("ReleaseLock"));
 }
 
 async fn run_repair_test_case(path: &str, pause_copy: bool) -> Result<(), ObjectStoreError> {
@@ -102,9 +102,9 @@ fn rename(
     let lsrc = src.clone();
     let ldst = dst.clone();
     tokio::spawn(async move {
-        println!("rename({}, {}) started", &lsrc, &ldst);
+        println!("rename({lsrc}, {ldst}) started");
         let result = s3.rename_if_not_exists(&lsrc, &ldst).await;
-        println!("rename({}, {}) finished", &lsrc, &ldst);
+        println!("rename({lsrc}, {ldst}) finished");
         result
     })
 }

--- a/crates/azure/tests/context.rs
+++ b/crates/azure/tests/context.rs
@@ -60,7 +60,7 @@ impl StorageIntegration for MsftIntegration {
     }
 
     fn copy_directory(&self, source: &str, destination: &str) -> std::io::Result<ExitStatus> {
-        let destination = format!("{}/{}", self.bucket_name(), destination);
+        let destination = format!("{}/{destination}", self.bucket_name());
         az_cli::copy_directory(source, destination)
     }
 }

--- a/crates/benchmarks/src/bin/merge.rs
+++ b/crates/benchmarks/src/bin/merge.rs
@@ -530,7 +530,7 @@ async fn main() {
 
             for bench in benches {
                 for sample in 0..num_samples {
-                    println!("Test: {} Sample: {}", bench.name, sample);
+                    println!("Test: {} Sample: {sample}", bench.name);
                     let res =
                         benchmark_merge_tpcds(delta_path.clone(), bench.params.clone(), bench.op)
                             .await

--- a/crates/catalog-unity/src/credential.rs
+++ b/crates/catalog-unity/src/credential.rs
@@ -131,8 +131,7 @@ impl ClientSecretOAuthProvider {
 
         Self {
             token_url: format!(
-                "{}/{}/oauth2/v2.0/token",
-                authority_host,
+                "{authority_host}/{}/oauth2/v2.0/token",
                 authority_id.as_ref()
             ),
             client_id: client_id.into(),
@@ -312,11 +311,7 @@ impl WorkloadIdentityOAuthProvider {
             authority_host.unwrap_or_else(|| authority_hosts::AZURE_PUBLIC_CLOUD.to_owned());
 
         Self {
-            token_url: format!(
-                "{}/{}/oauth2/v2.0/token",
-                authority_host,
-                tenant_id.as_ref()
-            ),
+            token_url: format!("{authority_host}/{}/oauth2/v2.0/token", tenant_id.as_ref()),
             client_id: client_id.into(),
             federated_token_file: federated_token_file.into(),
         }

--- a/crates/catalog-unity/src/datafusion.rs
+++ b/crates/catalog-unity/src/datafusion.rs
@@ -130,7 +130,7 @@ impl Expiry<String, TemporaryTableCredentials> for TokenExpiry {
         _last_modified_at: Instant,
     ) -> Option<Duration> {
         let time_to_expire = value.expiration_time - Utc::now();
-        tracing::info!("Token {} expires in {}", _key, time_to_expire);
+        tracing::info!("Token {_key} expires in {time_to_expire}");
         time_to_expire.to_std().ok()
     }
 }
@@ -182,12 +182,7 @@ impl UnitySchemaProvider {
         schema: &str,
         table: &str,
     ) -> Result<TemporaryTableCredentials, UnityCatalogError> {
-        tracing::debug!(
-            "Fetching new credential for: {}.{}.{}",
-            catalog,
-            schema,
-            table
-        );
+        tracing::debug!("Fetching new credential for: {catalog}.{schema}.{table}",);
         self.client
             .get_temp_table_credentials(catalog, schema, table)
             .map(|resp| match resp {

--- a/crates/catalog-unity/src/lib.rs
+++ b/crates/catalog-unity/src/lib.rs
@@ -434,11 +434,11 @@ impl UnityCatalogBuilder {
         for (os_key, os_value) in std::env::vars_os() {
             if let (Some(key), Some(value)) = (os_key.to_str(), os_value.to_str()) {
                 if key.starts_with("UNITY_") || key.starts_with("DATABRICKS_") {
-                    tracing::debug!("Found relevant env: {}", key);
+                    tracing::debug!("Found relevant env: {key}");
                     if let Ok(config_key) =
                         UnityCatalogConfigKey::from_str(&key.to_ascii_lowercase())
                     {
-                        tracing::debug!("Trying: {} with {}", key, value);
+                        tracing::debug!("Trying: {key} with {value}");
                         builder = builder.try_with_option(config_key, value).unwrap();
                     }
                 }
@@ -666,7 +666,7 @@ impl UnityCatalog {
     }
 
     fn catalog_url(&self) -> String {
-        format!("{}/api/2.1/unity-catalog", &self.workspace_url)
+        format!("{}/api/2.1/unity-catalog", self.workspace_url)
     }
 
     /// Gets an array of catalogs in the metastore. If the caller is the metastore admin,
@@ -879,7 +879,7 @@ impl LogStoreFactory for UnityCatalogFactory {
 pub fn register_handlers(_additional_prefixes: Option<Url>) {
     let factory = Arc::new(UnityCatalogFactory::default());
     let scheme = "uc";
-    let url = Url::parse(&format!("{}://", scheme)).unwrap();
+    let url = Url::parse(&format!("{scheme}://")).unwrap();
     factories().insert(url.clone(), factory.clone());
     logstores().insert(url.clone(), factory.clone());
 }

--- a/crates/core/src/data_catalog/storage/mod.rs
+++ b/crates/core/src/data_catalog/storage/mod.rs
@@ -80,7 +80,7 @@ impl ListingSchemaProvider {
                 .ok_or_else(|| DataFusionError::Internal("Cannot parse file name!".to_string()))?
                 .to_string();
             if !self.table_exist(&table_name) {
-                let table_url = format!("{}/{}", self.authority, table_path);
+                let table_url = format!("{}/{table_path}", self.authority);
                 self.tables.insert(table_name.to_string(), table_url);
             }
         }

--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -364,7 +364,7 @@ impl Display for SqlFormat<'_> {
             Expr::BinaryExpr(expr) => write!(f, "{}", BinaryExprFormat { expr }),
             Expr::ScalarFunction(func) => fmt_function(f, func.func.name(), false, &func.args),
             Expr::Cast(Cast { expr, data_type }) => {
-                write!(f, "arrow_cast({}, '{}')", SqlFormat { expr }, data_type)
+                write!(f, "arrow_cast({}, '{data_type}')", SqlFormat { expr })
             }
             Expr::Between(Between {
                 expr,
@@ -464,7 +464,7 @@ fn fmt_function(f: &mut fmt::Formatter, fun: &str, distinct: bool, args: &[Expr]
         true => "DISTINCT ",
         false => "",
     };
-    write!(f, "{}({}{})", fun, distinct_str, args.join(", "))
+    write!(f, "{fun}({distinct_str}{})", args.join(", "))
 }
 
 macro_rules! format_option {

--- a/crates/core/src/delta_datafusion/logical.rs
+++ b/crates/core/src/delta_datafusion/logical.rs
@@ -47,7 +47,7 @@ impl UserDefinedLogicalNodeCore for MetricObserver {
     }
 
     fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "MetricObserver id={}", &self.id)
+        write!(f, "MetricObserver id={}", self.id)
     }
 
     fn from_template(

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -1416,9 +1416,8 @@ impl DeltaDataChecker {
             }
 
             let sql = format!(
-                "SELECT {} FROM `{}` WHERE NOT ({}) LIMIT 1",
+                "SELECT {} FROM `{table_name}` WHERE NOT ({}) LIMIT 1",
                 check.get_name(),
-                table_name,
                 check.get_expression()
             );
 
@@ -1431,9 +1430,8 @@ impl DeltaDataChecker {
                     .join(", ");
 
                 let msg = format!(
-                    "Check or Invariant ({}) violated by value in row: [{}]",
+                    "Check or Invariant ({}) violated by value in row: [{value}]",
                     check.get_expression(),
-                    value
                 );
                 violations.push(msg);
             }

--- a/crates/core/src/kernel/arrow/extract.rs
+++ b/crates/core/src/kernel/arrow/extract.rs
@@ -76,8 +76,7 @@ pub(crate) fn extract_column<'a>(
                     Ok(child)
                     // if maparr.entries().num_columns() != 2 {
                     //     return Err(ArrowError::SchemaError(format!(
-                    //         "Map {} has {} columns, expected 2",
-                    //         path_step,
+                    //         "Map {path_step} has {} columns, expected 2",
                     //         maparr.entries().num_columns()
                     //     )));
                     // }

--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -668,9 +668,8 @@ impl DeletionVectorDescriptor {
                 let mut dv_suffix = format!("deletion_vector_{uuid}.bin");
                 if prefix_len > 0 {
                     dv_suffix = format!(
-                        "{}/{}",
+                        "{}/{dv_suffix}",
                         &self.path_or_inline_dv[..(prefix_len as usize)],
-                        dv_suffix
                     );
                 }
                 let dv_path = parent
@@ -724,7 +723,7 @@ impl DeletionVectorDescriptor {
     //                 i32::from_le_bytes(buf.try_into().map_err(|_| {
     //                     Error::DeletionVector("filed to read magic bytes".to_string())
     //                 })?);
-    //             println!("magic  --> : {}", magic);
+    //             println!("magic  --> : {magic}");
     //             // assert!(magic == 1681511377);
     //
     //             let mut buf = vec![0; size_in_bytes as usize];

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -440,8 +440,8 @@ impl<'a> FileStatsAccessor<'a> {
     pub(crate) fn get(&self, index: usize) -> DeltaResult<LogicalFile<'a>> {
         if index >= self.length {
             return Err(DeltaTableError::Generic(format!(
-                "index out of bounds: {} >= {}",
-                index, self.length
+                "index out of bounds: {index} >= {}",
+                self.length,
             )));
         }
         Ok(LogicalFile {

--- a/crates/core/src/kernel/snapshot/log_segment.rs
+++ b/crates/core/src/kernel/snapshot/log_segment.rs
@@ -142,10 +142,7 @@ impl LogSegment {
         end_version: Option<i64>,
         log_store: &dyn LogStore,
     ) -> DeltaResult<Self> {
-        debug!(
-            "try_new_slice: start_version: {}, end_version: {:?}",
-            start_version, end_version
-        );
+        debug!("try_new_slice: start_version: {start_version}, end_version: {end_version:?}",);
         log_store.refresh().await?;
         let log_url = table_root.child("_delta_log");
         let (mut commit_files, checkpoint_files) = list_log_files(

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -656,8 +656,7 @@ fn stats_schema(schema: &StructType, config: TableConfig<'_>) -> DeltaResult<Str
                 Some(field) => match field.data_type() {
                     DataType::Map(_) | DataType::Array(_) | &DataType::BINARY => {
                         Err(DeltaTableError::Generic(format!(
-                            "Stats column {} has unsupported type {}",
-                            col,
+                            "Stats column {col} has unsupported type {}",
                             field.data_type()
                         )))
                     }

--- a/crates/core/src/kernel/snapshot/replay.rs
+++ b/crates/core/src/kernel/snapshot/replay.rs
@@ -447,11 +447,11 @@ fn seen_key(info: &FileInfo<'_>) -> String {
         }
         if let Some(offset) = &dv.offset {
             format!(
-                "{}::{}{}@{offset}",
-                path, dv.storage_type, dv.path_or_inline_dv
+                "{path}::{}{}@{offset}",
+                dv.storage_type, dv.path_or_inline_dv
             )
         } else {
-            format!("{}::{}{}", path, dv.storage_type, dv.path_or_inline_dv)
+            format!("{path}::{}{}", dv.storage_type, dv.path_or_inline_dv)
         }
     } else {
         path.to_string()
@@ -515,10 +515,7 @@ impl LogReplayScanner {
                     // NOTE: there should always be only one action per row.
                     (None, None) => debug!("WARNING: no action found for row"),
                     (Some(a), Some(r)) => {
-                        debug!(
-                            "WARNING: both add and remove actions found for row: {:?} {:?}",
-                            a, r
-                        )
+                        debug!("WARNING: both add and remove actions found for row: {a:?} {r:?}",)
                     }
                 }
             }

--- a/crates/core/src/operations/cast/mod.rs
+++ b/crates/core/src/operations/cast/mod.rs
@@ -106,9 +106,8 @@ fn cast_field(
                 .downcast_ref::<GenericListArray<i32>>()
                 .ok_or_else(|| {
                     ArrowError::CastError(format!(
-                        "Expected a list for {} but got {}",
+                        "Expected a list for {} but got {col_type}",
                         field.name(),
-                        col_type
                     ))
                 })?,
             child_fields,
@@ -120,9 +119,8 @@ fn cast_field(
                 .downcast_ref::<GenericListArray<i64>>()
                 .ok_or_else(|| {
                     ArrowError::CastError(format!(
-                        "Expected a list for {} but got {}",
+                        "Expected a list for {} but got {col_type}",
                         field.name(),
-                        col_type
                     ))
                 })?,
             child_fields,
@@ -133,9 +131,8 @@ fn cast_field(
         (DataType::Map(_, _), DataType::Map(child_fields, sorted)) => Ok(Arc::new(cast_map(
             col.as_map_opt().ok_or_else(|| {
                 ArrowError::CastError(format!(
-                    "Expected a map for {} but got {}",
+                    "Expected a map for {} but got {col_type}",
                     field.name(),
-                    col_type
                 ))
             })?,
             child_fields,
@@ -147,11 +144,8 @@ fn cast_field(
             cast_with_options(col, field_type, cast_options).map_err(|err| {
                 if let ArrowError::CastError(err) = err {
                     ArrowError::CastError(format!(
-                        "Failed to cast {} from {} to {}: {}",
+                        "Failed to cast {} from {field_type} to {col_type}: {err}",
                         field.name(),
-                        field_type,
-                        col_type,
-                        err
                     ))
                 } else {
                     err

--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -523,7 +523,7 @@ mod tests {
             .to_str()
             .expect("Failed to convert Path to string slice");
         // Copy all files to a temp directory to perform testing. Skip Delta log
-        copy_files(format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path), temp_dir);
+        copy_files(format!("{}/{path}", env!("CARGO_MANIFEST_DIR")), temp_dir);
         let builder = if from_path {
             ConvertToDeltaBuilder::new().with_location(
                 ensure_table_uri(temp_dir).expect("Failed to turn temp dir into a URL"),
@@ -549,7 +549,7 @@ mod tests {
             .to_str()
             .expect("Failed to convert to string slice");
         // Copy all files to a temp directory to perform testing. Skip Delta log
-        copy_files(format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path), temp_dir);
+        copy_files(format!("{}/{path}", env!("CARGO_MANIFEST_DIR")), temp_dir);
         ConvertToDeltaBuilder::new()
             .with_log_store(log_store(temp_dir))
             .with_partition_schema(partition_schema)

--- a/crates/core/src/operations/filesystem_check.rs
+++ b/crates/core/src/operations/filesystem_check.rs
@@ -94,8 +94,7 @@ fn is_absolute_path(path: &str) -> DeltaResult<bool> {
         Ok(_) => Ok(true),
         Err(ParseError::RelativeUrlWithoutBase) => Ok(false),
         Err(_) => Err(DeltaTableError::Generic(format!(
-            "Unable to parse path: {}",
-            &path
+            "Unable to parse path: {path}"
         ))),
     }
 }

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -196,11 +196,9 @@ impl CdfLoadBuilder {
         }
 
         log::debug!(
-            "starting timestamp = {:?}, ending timestamp = {:?}",
-            &starting_timestamp,
-            &ending_timestamp
+            "starting timestamp = {starting_timestamp:?}, ending timestamp = {ending_timestamp:?}"
         );
-        log::debug!("starting version = {}, ending version = {:?}", start, end);
+        log::debug!("starting version = {start}, ending version = {end:?}");
 
         for version in start..=end {
             let snapshot_bytes = self
@@ -227,7 +225,7 @@ impl CdfLoadBuilder {
                     if starting_timestamp.timestamp_millis() > *t
                         || *t > ending_timestamp.timestamp_millis()
                     {
-                        log::debug!("Version: {} skipped, due to commit timestamp", version);
+                        log::debug!("Version: {version} skipped, due to commit timestamp");
                         continue;
                     }
                 }
@@ -237,7 +235,7 @@ impl CdfLoadBuilder {
                 match action {
                     Action::Cdc(f) => cdc_actions.push(f.clone()),
                     Action::Metadata(md) => {
-                        log::info!("Metadata: {:?}", &md);
+                        log::info!("Metadata: {md:?}");
                         if let Some(Some(key)) = &md.configuration.get("delta.enableChangeDataFeed")
                         {
                             let key = key.to_lowercase();
@@ -263,9 +261,8 @@ impl CdfLoadBuilder {
 
             if !cdc_actions.is_empty() {
                 log::debug!(
-                    "Located {} cdf actions for version: {}",
+                    "Located {} cdf actions for version: {version}",
                     cdc_actions.len(),
-                    version
                 );
                 change_files.push(CdcDataSpec::new(version, ts, cdc_actions))
             } else {
@@ -287,18 +284,16 @@ impl CdfLoadBuilder {
 
                 if !add_actions.is_empty() {
                     log::debug!(
-                        "Located {} cdf actions for version: {}",
+                        "Located {} cdf actions for version: {version}",
                         add_actions.len(),
-                        version
                     );
                     add_files.push(CdcDataSpec::new(version, ts, add_actions));
                 }
 
                 if !remove_actions.is_empty() {
                     log::debug!(
-                        "Located {} cdf actions for version: {}",
+                        "Located {} cdf actions for version: {version}",
                         remove_actions.len(),
-                        version
                     );
                     remove_files.push(CdcDataSpec::new(version, ts, remove_actions));
                 }

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -680,9 +680,8 @@ impl MergePlan {
                 })
                 .map(|(partition, files)| {
                     debug!(
-                        "merging a group of {} files in partition {:?}",
+                        "merging a group of {} files in partition {partition:?}",
                         files.len(),
-                        partition,
                     );
                     for file in files.iter() {
                         debug!("  file {}", file.path);

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -481,7 +481,7 @@ impl MergePlan {
     where
         F: Future<Output = Result<ParquetReadStream, DeltaTableError>> + Send + 'static,
     {
-        debug!("Rewriting files in partition: {:?}", partition_values);
+        debug!("Rewriting files in partition: {partition_values:?}");
         // First, initialize metrics
         let mut partial_actions = files
             .iter()
@@ -557,10 +557,7 @@ impl MergePlan {
         });
         partial_actions.extend(add_actions);
 
-        debug!(
-            "Finished rewriting files in partition: {:?}",
-            partition_values
-        );
+        debug!("Finished rewriting files in partition: {partition_values:?}");
 
         Ok((partial_actions, partial_metrics))
     }
@@ -619,7 +616,7 @@ impl MergePlan {
         Ok(
             util::interleave_batches(batches, indices, 10_000, context.use_inner_threads)
                 .await
-                .map_err(|err| ParquetError::General(format!("Failed to reorder data: {:?}", err)))
+                .map_err(|err| ParquetError::General(format!("Failed to reorder data: {err:?}")))
                 .boxed(),
         )
     }

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -69,7 +69,7 @@ pub(crate) async fn write_execution_plan_cdc(
             Action::Add(add) => {
                 Action::Cdc(AddCDCFile {
                     // This is a gnarly hack, but the action needs the nested path, not the
-                    // path isnide the prefixed store
+                    // path inside the prefixed store
                     path: format!("_change_data/{}", add.path),
                     size: add.size,
                     partition_values: add.partition_values,
@@ -421,7 +421,7 @@ pub(crate) async fn write_execution_plan_v2(
                                 {
                                     Action::Cdc(AddCDCFile {
                                         // This is a gnarly hack, but the action needs the nested path, not the
-                                        // path isnide the prefixed store
+                                        // path inside the prefixed store
                                         path: format!("_change_data/{}", add.path),
                                         size: add.size,
                                         partition_values: add.partition_values,

--- a/crates/core/src/operations/write/generated_columns.rs
+++ b/crates/core/src/operations/write/generated_columns.rs
@@ -21,10 +21,7 @@ pub fn add_missing_generated_columns(
             .is_err()
         // implies it doesn't exist
         {
-            debug!(
-                "Adding missing generated column {} in source as placeholder",
-                col_name
-            );
+            debug!("Adding missing generated column {col_name} in source as placeholder");
             // If column doesn't exist, we add a null column, later we will generate the values after
             // all the merge is projected.
             // Other generated columns that were provided upon the start we only validate during write

--- a/crates/core/src/operations/writer.rs
+++ b/crates/core/src/operations/writer.rs
@@ -416,10 +416,7 @@ impl PartitionWriter {
             // flush currently buffered data to disk once we meet or exceed the target file size.
             let estimated_size = self.buffer.len() + self.arrow_writer.in_progress_size();
             if estimated_size >= self.config.target_file_size {
-                debug!(
-                    "Writing file with estimated size {:?} to disk.",
-                    estimated_size
-                );
+                debug!("Writing file with estimated size {estimated_size:?} to disk.");
                 self.flush_arrow_writer().await?;
             }
         }

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -144,7 +144,7 @@ pub async fn create_checkpoint_from_table_uri_and_cleanup(
 
     if table.version() >= 0 && enable_expired_log_cleanup {
         let deleted_log_num = cleanup_metadata(&table, operation_id).await?;
-        debug!("Deleted {:?} log files.", deleted_log_num);
+        debug!("Deleted {deleted_log_num:?} log files.");
     }
 
     Ok(())
@@ -188,7 +188,7 @@ pub async fn create_checkpoint_for(
     let checkpoint_path = log_store.log_path().child(file_name);
 
     let object_store = log_store.object_store(operation_id);
-    debug!("Writing checkpoint to {:?}.", checkpoint_path);
+    debug!("Writing checkpoint to {checkpoint_path:?}.");
     object_store
         .put(&checkpoint_path, parquet_bytes.into())
         .await?;
@@ -196,7 +196,7 @@ pub async fn create_checkpoint_for(
     let last_checkpoint_content: Value = serde_json::to_value(checkpoint)?;
     let last_checkpoint_content = bytes::Bytes::from(serde_json::to_vec(&last_checkpoint_content)?);
 
-    debug!("Writing _last_checkpoint to {:?}.", last_checkpoint_path);
+    debug!("Writing _last_checkpoint to {last_checkpoint_path:?}.");
     object_store
         .put(&last_checkpoint_path, last_checkpoint_content.into())
         .await?;
@@ -241,7 +241,7 @@ pub async fn cleanup_expired_logs_for(
                 // match the given timestamp range
                 .filter_map(|meta: Result<crate::ObjectMeta, _>| async move {
                     if meta.is_err() {
-                        error!("Error received while cleaning up expired logs: {:?}", meta);
+                        error!("Error received while cleaning up expired logs: {meta:?}");
                         return None;
                     }
                     let meta = meta.unwrap();
@@ -512,15 +512,9 @@ fn typed_partition_value_from_string(
                 })?;
                 Ok((ts.and_utc().timestamp_millis() * 1000).into())
             }
-            s => unimplemented!(
-                "Primitive type {} is not supported for partition column values.",
-                s
-            ),
+            s => unimplemented!("Primitive type {s} is not supported for partition column values."),
         },
-        d => unimplemented!(
-            "Data type {:?} is not supported for partition column values.",
-            d
-        ),
+        d => unimplemented!("Data type {d:?} is not supported for partition column values."),
     }
 }
 

--- a/crates/core/src/protocol/parquet_read/mod.rs
+++ b/crates/core/src/protocol/parquet_read/mod.rs
@@ -90,10 +90,7 @@ impl DeletionVectorDescriptor {
                     })?;
                 }
                 _ => {
-                    debug!(
-                        "Unexpected field name `{}` for deletion vector: {:?}",
-                        name, record
-                    );
+                    debug!("Unexpected field name `{name}` for deletion vector: {record:?}");
                 }
             }
         }
@@ -209,10 +206,7 @@ impl Add {
                     }
                 },
                 _ => {
-                    debug!(
-                        "Unexpected field name `{}` for add action: {:?}",
-                        name, record
-                    );
+                    debug!("Unexpected field name `{name}` for add action: {record:?}");
                 }
             }
         }
@@ -231,7 +225,7 @@ impl Add {
                         "numRecords" => if let Ok(v) = record.get_long(i) {
                                 stats.num_records = v;
                             } else {
-                                error!("Expect type of stats_parsed field numRecords to be long, got: {}", record);
+                                error!("Expect type of stats_parsed field numRecords to be long, got: {record}");
                             }
                         "minValues" => if let Ok(row) = record.get_group(i) {
                             for (name, field) in row.get_column_iter() {
@@ -242,7 +236,7 @@ impl Add {
                                 }
                             }
                         } else {
-                            error!("Expect type of stats_parsed field minRecords to be struct, got: {}", record);
+                            error!("Expect type of stats_parsed field minRecords to be struct, got: {record}");
                         }
                         "maxValues" => if let Ok(row) = record.get_group(i) {
                             for (name, field) in row.get_column_iter() {
@@ -253,7 +247,7 @@ impl Add {
                                 }
                             }
                         } else {
-                            error!("Expect type of stats_parsed field maxRecords to be struct, got: {}", record);
+                            error!("Expect type of stats_parsed field maxRecords to be struct, got: {record}");
                         }
                         "nullCount" => if let Ok(row) = record.get_group(i) {
                             for (name, field) in row.get_column_iter() {
@@ -264,14 +258,10 @@ impl Add {
                                 }
                             }
                         } else {
-                            error!("Expect type of stats_parsed field nullCount to be struct, got: {}", record);
+                            error!("Expect type of stats_parsed field nullCount to be struct, got: {record}");
                         }
                         _ => {
-                            debug!(
-                                "Unexpected field name `{}` for stats_parsed: {:?}",
-                                name,
-                                record,
-                            );
+                            debug!("Unexpected field name `{name}` for stats_parsed: {record:?}");
                         }
                     }
                 }
@@ -294,8 +284,7 @@ fn field_to_value_stat(field: &Field, field_name: &str) -> Option<ColumnValueSta
                 Some(ColumnValueStat::Value(val))
             } else {
                 warn!(
-                    "Unexpected type when parsing min/max values for {}. Found {}",
-                    field_name, field
+                    "Unexpected type when parsing min/max values for {field_name}. Found {field}"
                 );
                 None
             }
@@ -313,10 +302,7 @@ fn field_to_count_stat(field: &Field, field_name: &str) -> Option<ColumnCountSta
         }
         Field::Long(value) => Some(ColumnCountStat::Value(*value)),
         _ => {
-            warn!(
-                "Unexpected type when parsing nullCounts for {}. Found {}",
-                field_name, field
-            );
+            warn!("Unexpected type when parsing nullCounts for {field_name}. Found {field}");
             None
         }
     }
@@ -484,10 +470,7 @@ impl Metadata {
                     }
                 }
                 _ => {
-                    debug!(
-                        "Unexpected field name `{}` for metaData action: {:?}",
-                        name, record
-                    );
+                    debug!("Unexpected field name `{name}` for metaData action: {record:?}");
                 }
             }
         }
@@ -574,10 +557,7 @@ impl Remove {
                 }
                 "numRecords" => {}
                 _ => {
-                    debug!(
-                        "Unexpected field name `{}` for remove action: {:?}",
-                        name, record
-                    );
+                    debug!("Unexpected field name `{name}` for remove action: {record:?}");
                 }
             }
         }
@@ -609,10 +589,7 @@ impl Transaction {
                     re.last_updated = record.get_long(i).map(Some).unwrap_or(None);
                 }
                 _ => {
-                    debug!(
-                        "Unexpected field name `{}` for txn action: {:?}",
-                        name, record
-                    );
+                    debug!("Unexpected field name `{name}` for txn action: {record:?}");
                 }
             }
         }
@@ -675,10 +652,7 @@ impl Protocol {
                         .ok()
                 }
                 _ => {
-                    debug!(
-                        "Unexpected field name `{}` for protocol action: {:?}",
-                        name, record
-                    );
+                    debug!("Unexpected field name `{name}` for protocol action: {record:?}");
                 }
             }
         }

--- a/crates/core/src/schema/partitions.rs
+++ b/crates/core/src/schema/partitions.rs
@@ -170,12 +170,12 @@ impl Serialize for PartitionFilter {
         S: Serializer,
     {
         let s = match &self.value {
-            PartitionValue::Equal(value) => format!("{} = '{}'", self.key, value),
-            PartitionValue::NotEqual(value) => format!("{} != '{}'", self.key, value),
-            PartitionValue::GreaterThan(value) => format!("{} > '{}'", self.key, value),
-            PartitionValue::GreaterThanOrEqual(value) => format!("{} >= '{}'", self.key, value),
-            PartitionValue::LessThan(value) => format!("{} < '{}'", self.key, value),
-            PartitionValue::LessThanOrEqual(value) => format!("{} <= '{}'", self.key, value),
+            PartitionValue::Equal(value) => format!("{} = '{value}'", self.key),
+            PartitionValue::NotEqual(value) => format!("{} != '{value}'", self.key),
+            PartitionValue::GreaterThan(value) => format!("{} > '{value}'", self.key),
+            PartitionValue::GreaterThanOrEqual(value) => format!("{} >= '{value}'", self.key),
+            PartitionValue::LessThan(value) => format!("{} < '{value}'", self.key),
+            PartitionValue::LessThanOrEqual(value) => format!("{} <= '{value}'", self.key),
             // used upper case for IN and NOT similar to SQL
             PartitionValue::In(values) => {
                 let quoted_values: Vec<String> = values.iter().map(|v| format!("'{v}'")).collect();

--- a/crates/core/src/storage/retry_ext.rs
+++ b/crates/core/src/storage/retry_ext.rs
@@ -39,10 +39,7 @@ pub trait ObjectStoreRetryExt: ObjectStore {
                     return Err(err);
                 }
                 Err(Error::Generic { store, source }) => {
-                    debug!(
-                        "put_with_retries attempt {} failed: {} {}",
-                        attempt_number, store, source
-                    );
+                    debug!("put_with_retries attempt {attempt_number} failed: {store} {source}");
                     attempt_number += 1;
                 }
                 Err(err) => {
@@ -63,10 +60,7 @@ pub trait ObjectStoreRetryExt: ObjectStore {
                     return Err(err);
                 }
                 Err(Error::Generic { store, source }) => {
-                    debug!(
-                        "delete_with_retries attempt {} failed: {} {}",
-                        attempt_number, store, source
-                    );
+                    debug!("delete_with_retries attempt {attempt_number} failed: {store} {source}");
                     attempt_number += 1;
                 }
                 Err(err) => {

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -177,7 +177,7 @@ impl GeneratedColumn {
             name: field_name.to_string(),
             generation_expr: sql_generation.to_string(),
             validation_expr: format!("{field_name} = {sql_generation} OR ({field_name} IS NULL AND {sql_generation} IS NULL)"),
-            // validation_expr: format!("{} <=> {}", field_name, sql_generation), // update to 
+            // validation_expr: format!("{field_name} <=> {sql_generation}"), // update to
             data_type: data_type.clone()
         }
     }

--- a/crates/core/src/writer/utils.rs
+++ b/crates/core/src/writer/utils.rs
@@ -52,9 +52,7 @@ pub(crate) fn next_data_path(
 
     // TODO: what does c000 mean?
     let file_name = format!(
-        "part-{}-{}-c000{}.parquet",
-        part,
-        writer_id,
+        "part-{part}-{writer_id}-c000{}.parquet",
         compression_to_str(&compression)
     );
     prefix.child(file_name)

--- a/crates/core/tests/checkpoint_writer.rs
+++ b/crates/core/tests/checkpoint_writer.rs
@@ -196,7 +196,7 @@ mod delete_expired_delta_log_in_checkpoint {
 
         let table_path = table.table_uri();
         let set_file_last_modified = |version: usize, last_modified_millis: u64| {
-            let path = format!("{}_delta_log/{:020}.json", &table_path, version);
+            let path = format!("{table_path}_delta_log/{version:020}.json");
             let file = OpenOptions::new().write(true).open(path).unwrap();
             let last_modified = SystemTime::now().sub(Duration::from_millis(last_modified_millis));
             let times = FileTimes::new()

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -838,7 +838,7 @@ mod local {
         // Logically this should prune. See above
         let e = col("k").eq(lit("A")).and(col("k").is_not_null());
         let metrics = get_scan_metrics(&table, &state, &[e]).await.unwrap();
-        println!("{:?}", metrics);
+        println!("{metrics:?}");
         assert!(metrics.num_scanned_files() == 1);
 
         let e = col("k").eq(lit("B"));

--- a/crates/deltalake/examples/recordbatch-writer.rs
+++ b/crates/deltalake/examples/recordbatch-writer.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), DeltaTableError> {
     let table_uri = std::env::var("TABLE_URI").map_err(|e| DeltaTableError::GenericError {
         source: Box::new(e),
     })?;
-    info!("Using the location of: {:?}", table_uri);
+    info!("Using the location of: {table_uri:?}");
 
     let table_path = Path::parse(&table_uri)?;
 
@@ -63,7 +63,7 @@ async fn main() -> Result<(), DeltaTableError> {
         .flush_and_commit(&mut table)
         .await
         .expect("Failed to flush write");
-    info!("{} adds written", adds);
+    info!("{adds} adds written");
 
     Ok(())
 }

--- a/crates/gcp/tests/context.rs
+++ b/crates/gcp/tests/context.rs
@@ -95,7 +95,7 @@ impl StorageIntegration for GcpIntegration {
     fn copy_directory(&self, source: &str, destination: &str) -> std::io::Result<ExitStatus> {
         use futures::executor::block_on;
 
-        let to = format!("{}/{}", self.root_uri(), destination);
+        let to = format!("{}/{destination}", self.root_uri());
         let _ = block_on(copy_table(source.to_owned(), None, to, None, true));
         Ok(ExitStatus::default())
     }

--- a/crates/hdfs/tests/context.rs
+++ b/crates/hdfs/tests/context.rs
@@ -44,7 +44,7 @@ impl StorageIntegration for HdfsIntegration {
     }
 
     fn copy_directory(&self, source: &str, destination: &str) -> std::io::Result<ExitStatus> {
-        println!("Copy directory called with {} {}", source, destination);
+        println!("Copy directory called with {source} {destination}");
         let hadoop_exc = which("hadoop").expect("Failed to find hadoop executable");
         Ok(Command::new(hadoop_exc)
             .args([

--- a/crates/hdfs/tests/context.rs
+++ b/crates/hdfs/tests/context.rs
@@ -52,7 +52,7 @@ impl StorageIntegration for HdfsIntegration {
                 "-copyFromLocal",
                 "-p",
                 source,
-                &format!("{}/{}", self.root_uri(), destination),
+                &format!("{}/{destination}", self.root_uri()),
             ])
             .status()
             .unwrap())

--- a/crates/lakefs/src/client.rs
+++ b/crates/lakefs/src/client.rs
@@ -148,10 +148,7 @@ impl LakeFSClient {
             "allow_empty": allow_empty,
         });
 
-        debug!(
-            "Committing to LakeFS Branch: '{}' in repo: '{}'",
-            branch, repo
-        );
+        debug!("Committing to LakeFS Branch: '{branch}' in repo: '{repo}'");
         let response = self
             .http_client
             .post(&request_url)
@@ -198,10 +195,7 @@ impl LakeFSClient {
             "squash_merge": true,
         });
 
-        debug!(
-            "Merging LakeFS, source `{}` into target `{}` in repo: {}",
-            transaction_branch, transaction_branch, repo
-        );
+        debug!("Merging LakeFS, source `{transaction_branch}` into target `{transaction_branch}` in repo: {repo}");
         let response = self
             .http_client
             .post(&request_url)
@@ -231,7 +225,7 @@ impl LakeFSClient {
 
     pub fn set_transaction(&self, id: Uuid, branch: String) {
         self.transactions.insert(id, branch);
-        debug!("{}", format!("LakeFS Transaction `{}` has been set.", id));
+        debug!("{}", format!("LakeFS Transaction `{id}` has been set."));
     }
 
     pub fn get_transaction(&self, id: Uuid) -> Result<String, TransactionError> {
@@ -240,19 +234,13 @@ impl LakeFSClient {
             .get(&id)
             .map(|v| v.to_string())
             .ok_or(LakeFSOperationError::TransactionIdNotFound(id.to_string()))?;
-        debug!(
-            "{}",
-            format!("LakeFS Transaction `{}` has been grabbed.", id)
-        );
+        debug!("{}", format!("LakeFS Transaction `{id}` has been grabbed."));
         Ok(transaction_branch)
     }
 
     pub fn clear_transaction(&self, id: Uuid) {
         self.transactions.remove(&id);
-        debug!(
-            "{}",
-            format!("LakeFS Transaction `{}` has been removed.", id)
-        );
+        debug!("{}", format!("LakeFS Transaction `{id}` has been removed."));
     }
 
     pub fn decompose_url(&self, url: String) -> (String, String, String) {

--- a/crates/lakefs/src/client.rs
+++ b/crates/lakefs/src/client.rs
@@ -55,7 +55,7 @@ impl LakeFSClient {
     ) -> DeltaResult<(Url, String)> {
         let (repo, source_branch, table) = self.decompose_url(source_url.to_string());
 
-        let request_url = format!("{}/api/v1/repositories/{}/branches", self.config.host, repo);
+        let request_url = format!("{}/api/v1/repositories/{repo}/branches", self.config.host);
 
         let transaction_branch = format!("delta-tx-{operation_id}");
         let body = json!({
@@ -102,8 +102,8 @@ impl LakeFSClient {
         branch: String,
     ) -> Result<(), TransactionError> {
         let request_url = format!(
-            "{}/api/v1/repositories/{}/branches/{}",
-            self.config.host, repo, branch
+            "{}/api/v1/repositories/{repo}/branches/{branch}",
+            self.config.host,
         );
         let response = self
             .http_client
@@ -139,8 +139,8 @@ impl LakeFSClient {
         allow_empty: bool,
     ) -> DeltaResult<()> {
         let request_url = format!(
-            "{}/api/v1/repositories/{}/branches/{}/commits",
-            self.config.host, repo, branch
+            "{}/api/v1/repositories/{repo}/branches/{branch}/commits",
+            self.config.host,
         );
 
         let body = json!({
@@ -185,8 +185,8 @@ impl LakeFSClient {
         allow_empty: bool,
     ) -> Result<(), TransactionError> {
         let request_url = format!(
-            "{}/api/v1/repositories/{}/refs/{}/merge/{}",
-            self.config.host, repo, transaction_branch, target_branch
+            "{}/api/v1/repositories/{repo}/refs/{transaction_branch}/merge/{target_branch}",
+            self.config.host,
         );
 
         let body = json!({

--- a/crates/lakefs/src/logstore.rs
+++ b/crates/lakefs/src/logstore.rs
@@ -108,10 +108,8 @@ impl LakeFSLogStore {
     ) -> DeltaResult<(String, ObjectStoreRef)> {
         let (repo, _, table) = self.client.decompose_url(self.config.location.to_string());
         let string_url = format!(
-            "lakefs://{}/{}/{}",
-            repo,
+            "lakefs://{repo}/{}/{table}",
             self.client.get_transaction(operation_id)?,
-            table
         );
         let transaction_url = Url::parse(&string_url).unwrap();
         Ok((string_url, self.storage.get_store(&transaction_url)?))

--- a/crates/lakefs/tests/context.rs
+++ b/crates/lakefs/tests/context.rs
@@ -45,7 +45,7 @@ impl StorageIntegration for LakeFSIntegration {
     fn copy_directory(&self, source: &str, destination: &str) -> std::io::Result<ExitStatus> {
         println!(
             "Copy directory called with {source} {}",
-            format!("{}/{}", self.root_uri(), destination)
+            format!("{}/{destination}", self.root_uri())
         );
         let lakectl = which("lakectl").expect("Failed to find lakectl executable");
 

--- a/crates/lakefs/tests/context.rs
+++ b/crates/lakefs/tests/context.rs
@@ -44,9 +44,8 @@ impl StorageIntegration for LakeFSIntegration {
 
     fn copy_directory(&self, source: &str, destination: &str) -> std::io::Result<ExitStatus> {
         println!(
-            "Copy directory called with {} {}",
-            source,
-            &format!("{}/{}", self.root_uri(), destination)
+            "Copy directory called with {source} {}",
+            format!("{}/{}", self.root_uri(), destination)
         );
         let lakectl = which("lakectl").expect("Failed to find lakectl executable");
 
@@ -57,8 +56,8 @@ impl StorageIntegration for LakeFSIntegration {
                 "upload",
                 "-r",
                 "--source",
-                &format!("{}/", source),
-                &format!("{}/{}/", self.root_uri(), destination),
+                &format!("{source}/"),
+                &format!("{}/{destination}/", self.root_uri()),
             ])
             .status()?;
 

--- a/crates/mount/tests/context.rs
+++ b/crates/mount/tests/context.rs
@@ -74,9 +74,8 @@ impl StorageIntegration for DbfsIntegration {
         let mut options = CopyOptions::new();
         options.content_only = true;
         let dest_path = format!(
-            "/dbfs{}/{}",
+            "/dbfs{}/{destination}",
             self.tmp_dir.as_ref().to_str().unwrap(),
-            destination
         );
         std::fs::create_dir_all(&dest_path)?;
         copy(source, &dest_path, &options).expect("Failed to copy");

--- a/crates/test/src/concurrent.rs
+++ b/crates/test/src/concurrent.rs
@@ -108,7 +108,7 @@ impl Worker {
     async fn commit_sequence(&mut self, n: i64) -> HashMap<i64, String> {
         let mut result = HashMap::new();
         for i in 0..n {
-            let name = format!("{}-{}", self.name, i);
+            let name = format!("{}-{i}", self.name);
             let v = self.commit_file(&name).await;
             result.insert(v, name);
             tokio::time::sleep(Duration::from_millis(100)).await;

--- a/crates/test/src/read.rs
+++ b/crates/test/src/read.rs
@@ -137,7 +137,7 @@ pub async fn read_golden(integration: &IntegrationContext) -> TestResult {
 }
 
 async fn verify_store(integration: &IntegrationContext, root_path: &str) -> TestResult {
-    let table_uri = format!("{}/{}", integration.root_uri(), root_path);
+    let table_uri = format!("{}/{root_path}", integration.root_uri());
 
     let storage = DeltaTableBuilder::from_uri(table_uri.clone())
         .with_allow_http(true)
@@ -158,7 +158,7 @@ async fn verify_store(integration: &IntegrationContext, root_path: &str) -> Test
 }
 
 async fn read_encoded_table(integration: &IntegrationContext, root_path: &str) -> TestResult {
-    let table_uri = format!("{}/{}", integration.root_uri(), root_path);
+    let table_uri = format!("{}/{root_path}", integration.root_uri());
 
     let table = DeltaTableBuilder::from_uri(table_uri)
         .with_allow_http(true)

--- a/crates/test/src/utils.rs
+++ b/crates/test/src/utils.rs
@@ -296,8 +296,7 @@ macro_rules! assert_batches_sorted_eq {
 
         assert_eq!(
             expected_lines, actual_lines,
-            "\n\nexpected:\n\n{:#?}\nactual:\n\n{:#?}\n\n",
-            expected_lines, actual_lines
+            "\n\nexpected:\n\n{expected_lines:#?}\nactual:\n\n{actual_lines:#?}\n\n",
         );
     };
 }

--- a/proofs/src/main.rs
+++ b/proofs/src/main.rs
@@ -148,7 +148,7 @@ impl AtomicRenameState {
 
 #[inline]
 fn source_key_from_wid(wid: WriterId) -> String {
-    format!("writer_{}", wid)
+    format!("writer_{wid}")
 }
 
 impl AtomicRenameSys {
@@ -507,7 +507,7 @@ impl Model for AtomicRenameSys {
         Self::State: std::fmt::Debug,
     {
         self.next_state(last_state, action).map(|next_state| {
-            let mut lines = vec![format!("{:#?}", next_state)];
+            let mut lines = vec![format!("{next_state:#?}")];
             lines.push(format!(
                 "expected_deletes: {:?}",
                 self.derive_expected_deletes()
@@ -594,7 +594,7 @@ impl Model for AtomicRenameSys {
                     && writer_versions.len() >= sys.writer_cnt
                     // all versions have been written into blobl store
                     && blob_store_obj_keys.is_superset(&writer_versions)
-                    && blob_store_obj_values == writer_versions.into_iter().map(|s| format!("writer_{}", s)).collect()
+                    && blob_store_obj_values == writer_versions.into_iter().map(|s| format!("writer_{s}")).collect()
             }),
             Property::<Self>::sometimes("lock expires", |_, state| {
                 state

--- a/proofs/src/main.rs
+++ b/proofs/src/main.rs
@@ -519,16 +519,14 @@ impl Model for AtomicRenameSys {
 
             let writer_versions = next_state.writer_versions();
             lines.push(format!(
-                "writer_versions({}): {:?}",
+                "writer_versions({}): {writer_versions:?}",
                 writer_versions.len(),
-                writer_versions,
             ));
 
             let blob_store_obj_keys = next_state.blob_store_obj_keys();
             lines.push(format!(
-                "blob_store_obj_keys({}): {:?}",
+                "blob_store_obj_keys({}): {blob_store_obj_keys:?}",
                 blob_store_obj_keys.len(),
-                blob_store_obj_keys,
             ));
 
             lines.join("\n")

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -894,12 +894,9 @@ impl RawDeltaTable {
         };
 
         let sql = if let Some(predicate) = predicate {
-            format!(
-                "SELECT {} FROM `{}` WHERE ({}) ",
-                select_string, &table_name, predicate
-            )
+            format!("SELECT {select_string} FROM `{table_name}` WHERE ({predicate}) ")
         } else {
-            format!("SELECT {} FROM `{}`", select_string, &table_name,)
+            format!("SELECT {select_string} FROM `{table_name}`")
         };
 
         let plan = rt()

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -497,15 +497,13 @@ impl Field {
             format!(", metadata={metadata_repr}")
         };
         Ok(format!(
-            "Field({}, {}, nullable={}{})",
+            "Field({}, {type_repr}, nullable={}{maybe_metadata})",
             self.inner.name(),
-            type_repr,
             if self.inner.is_nullable() {
                 "True"
             } else {
                 "False"
             },
-            maybe_metadata,
         ))
     }
 

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -198,8 +198,7 @@ impl ArrayType {
             .call_method0("__repr__")?
             .extract()?;
         Ok(format!(
-            "ArrayType({}, contains_null={})",
-            type_repr,
+            "ArrayType({type_repr}, contains_null={})",
             if self.inner_type.contains_null() {
                 "True"
             } else {
@@ -326,9 +325,7 @@ impl MapType {
             .call_method0("__repr__")?
             .extract()?;
         Ok(format!(
-            "MapType({}, {}, value_contains_null={})",
-            key_repr,
-            value_repr,
+            "MapType({key_repr}, {value_repr}, value_contains_null={})",
             if self.inner_type.value_contains_null() {
                 "True"
             } else {


### PR DESCRIPTION
Manually fixed format argument inlining to improve readability, and fix a few minor related styling issues like trailing commas in a single line.

Note that in many places I have removed the `&` because it is rarely needed in a format arg, but makes code run ~5% slower (compiler cannot yet eliminate that)