### PR TITLE
fix: refresh snapshot after vacuuming logs

### DIFF
--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -234,6 +234,21 @@ class RawDeltaTable:
         post_commithook_properties: Optional[PostCommitHookProperties],
     ) -> None: ...
     def __datafusion_table_provider__(self) -> Any: ...
+    def write(
+        self,
+        data: pyarrow.RecordBatchReader,
+        partition_by: Optional[List[str]],
+        mode: str,
+        schema_mode: Optional[str],
+        predicate: Optional[str],
+        target_file_size: Optional[int],
+        name: Optional[str],
+        description: Optional[str],
+        configuration: Optional[Mapping[str, Optional[str]]],
+        writer_properties: Optional[WriterProperties],
+        commit_properties: Optional[CommitProperties],
+        post_commithook_properties: Optional[PostCommitHookProperties],
+    ) -> None: ...
 
 def rust_core_version() -> str: ...
 def write_new_deltalake(
@@ -253,7 +268,6 @@ def write_to_deltalake(
     data: pyarrow.RecordBatchReader,
     partition_by: Optional[List[str]],
     mode: str,
-    table: Optional[RawDeltaTable],
     schema_mode: Optional[str],
     predicate: Optional[str],
     target_file_size: Optional[int],

--- a/python/deltalake/writer.py
+++ b/python/deltalake/writer.py
@@ -320,25 +320,38 @@ def write_deltalake(
             conversion_mode=ArrowSchemaConversionMode.PASSTHROUGH,
         )
         data = RecordBatchReader.from_batches(schema, (batch for batch in data))
-        write_deltalake_rust(
-            table_uri=table_uri,
-            data=data,
-            partition_by=partition_by,
-            mode=mode,
-            table=table._table if table is not None else None,
-            schema_mode=schema_mode,
-            predicate=predicate,
-            target_file_size=target_file_size,
-            name=name,
-            description=description,
-            configuration=configuration,
-            storage_options=storage_options,
-            writer_properties=writer_properties,
-            commit_properties=commit_properties,
-            post_commithook_properties=post_commithook_properties,
-        )
         if table:
-            table.update_incremental()
+            table._table.write(
+                data=data,
+                partition_by=partition_by,
+                mode=mode,
+                schema_mode=schema_mode,
+                predicate=predicate,
+                target_file_size=target_file_size,
+                name=name,
+                description=description,
+                configuration=configuration,
+                writer_properties=writer_properties,
+                commit_properties=commit_properties,
+                post_commithook_properties=post_commithook_properties,
+            )
+        else:
+            write_deltalake_rust(
+                table_uri=table_uri,
+                data=data,
+                partition_by=partition_by,
+                mode=mode,
+                schema_mode=schema_mode,
+                predicate=predicate,
+                target_file_size=target_file_size,
+                name=name,
+                description=description,
+                configuration=configuration,
+                storage_options=storage_options,
+                writer_properties=writer_properties,
+                commit_properties=commit_properties,
+                post_commithook_properties=post_commithook_properties,
+            )
     elif engine == "pyarrow":
         warnings.warn(
             "pyarrow engine is deprecated and will be removed in v1.0",


### PR DESCRIPTION
# Description
As per @roeap  suggestion to simply reload the table state after cleaning up logs so that we get a proper snapshot.

Introduces a write function on the DeltaTable which allows us to update the state after writing, which we couldn't do properly before.

# Related Issue(s)
- closes https://github.com/delta-io/delta-rs/issues/3057
- closes https://github.com/delta-io/delta-rs/issues/3062