### PR TITLE
docs: update CONTRIBUTING.md and Makefile to account for switch to uv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,9 @@ If you want to claim an issue to work on, you can write the word `take` as a com
 ## Quick start
 
 - Install Rust, e.g. as described [here](https://doc.rust-lang.org/cargo/getting-started/installation.html)
-- Have a compatible Python version installed (check `python/pyproject.toml` for current requirement)
-- Create a Python virtual environment (required for development builds), e.g. as described [here](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/)
-    ```sh
-    python -m venv .venv
-    ```
+- Install the [uv Python package manager](https://docs.astral.sh/uv/getting-started/installation/).
 
-- Build the project for development (this requires an active virtual environment and will also install `deltalake` in that virtual environment. [Uv](https://github.com/astral-sh/uv) packet manager needs to be installed)
+- Build the project for development. This will install `deltalake` into the Python virtual environment managed by uv.
     ```sh
     cd python
     make develop
@@ -29,12 +25,12 @@ If you want to claim an issue to work on, you can write the word `take` as a com
 
 - Run some Python code, e.g. to run a specific test
     ```sh
-    python -m pytest tests/test_writer.py -s -k "test_with_deltalake_schema"
+    uv run pytest tests/test_writer.py -s -k "test_with_deltalake_schema"
     ```
 
 - Run some Rust code, e.g. run an example
     ```sh
-    cd crates/deltalake
+    cd ../crates/deltalake
     cargo run --example basic_operations --features="datafusion"
     ```
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,7 +1,5 @@
 .DEFAULT_GOAL := help
 
-VENV := venv
-MATURIN_VERSION := $(shell grep 'requires =' pyproject.toml | cut -d= -f2- | tr -d '[ "]')
 PACKAGE_VERSION := $(shell grep version Cargo.toml | head -n 1 | awk '{print $$3}' | tr -d '"' )
 DAT_VERSION := 0.0.2
 
@@ -96,7 +94,8 @@ build-docs: ## Build documentation with mkdocs
 clean: ## Run clean
 	$(warning --- Clean virtualenv and target directory ---)
 	cargo clean
-	rm -rf $(VENV)
+	# Remove uv's venv
+	rm -rf .venv
 	find . -type f -name '*.pyc' -delete
 
 .PHONY: help


### PR DESCRIPTION
# Description

I wanted to start developing delta-rs and found CONTRIBUTING.md confusing as it asks you to create a Python virtualenv that is never used. This updates the documentation to account for the switch to uv.

This was partly addressed previously in #3085.