### PR TITLE
fix: enable missing cloud features for uc crate

### DIFF
--- a/.github/scripts/retry_integration_test.sh
+++ b/.github/scripts/retry_integration_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set +e
+TEST_NAME=$1
+MAX_RETRIES=$2
+RETRY_DELAY=$3
+ATTEMPT=1
+run_command() {
+  uv run --no-sync pytest -m "($TEST_NAME and integration)" --doctest-modules 2>&1
+}
+until [ $ATTEMPT -gt $MAX_RETRIES ]
+do
+  echo "Attempt $ATTEMPT"
+  OUTPUT=$(run_command)
+  EXIT_CODE=$?
+  echo "$OUTPUT"
+  if [ $EXIT_CODE -eq 0 ]; then
+    echo "Tests passed."
+    exit 0
+  fi
+  echo "Failed. Retrying."
+  ATTEMPT=$((ATTEMPT+1))
+  sleep $RETRY_DELAY
+done
+if [ $ATTEMPT -gt $MAX_RETRIES ]; then
+  echo "Tests failed after $MAX_RETRIES attempts."
+  exit 1
+fi

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -137,7 +137,7 @@ jobs:
         run: make setup-dat
 
       - name: Run tests
-        run: uv run --no-sync pytest -m '(unitycatalog_databricks and integration)' --doctest-modules
+        run: ../../delta-rs/.github/scripts/retry_integration_test.sh unitycatalog_databricks 5 10
 
   test-unitycatalog-oss:
     name: Python Build (Python 3.10 Unity Catalog Integration tests)
@@ -166,7 +166,7 @@ jobs:
         run: make setup-dat
 
       - name: Run tests
-        run: uv run --no-sync pytest -m '(unitycatalog_oss and integration)' --doctest-modules
+        run: ../../delta-rs/.github/scripts/retry_integration_test.sh unitycatalog_oss 5 10
 
   test-pyspark:
     name: PySpark Integration Tests
@@ -191,7 +191,6 @@ jobs:
 
       - name: Run tests
         run: make test-pyspark
-
 
   multi-python-running:
     name: Running with Python ${{ matrix.python-version }}

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -43,11 +43,14 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 deltalake-mount = { path = "../crates/mount" }
 
+# catalog-unity
+deltalake-catalog-unity = { path = "../crates/catalog-unity", features = ["aws", "azure", "gcp", "r2"] }
+
 # Non-unix or emscripten os
 [target.'cfg(any(not(target_family = "unix"), target_os = "emscripten"))'.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 
-# Unix (excluding macOS & emscripten) → jemalloc 
+# Unix (excluding macOS & emscripten) → jemalloc
 [target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten")))'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls", "background_threads"] }
 


### PR DESCRIPTION
# Description
This PR enables the `azure` feature for UC crate to make sure the `deltalake_azure` registered handlers are called [here](https://github.com/delta-io/delta-rs/blob/main/crates/catalog-unity/src/models.rs#L426-L430). Without this feature being enabled, it throws a warning from [here](https://github.com/delta-io/delta-rs/blob/main/crates/catalog-unity/src/models.rs#L432-L436) resulting in a `MissingCredentials` error - "Failed to get a credential from UnityCatalog client configuration".

Update: Also enables `gcp` and `r2` for UC crate.

# Related Issue(s)
<!---
For example:

- closes #106
--->
- closes #3236

# Documentation

<!---
Share links to useful documentation
--->
N/A