### PR TITLE
chore: fix some compiler warnings

### DIFF
--- a/crates/aws/src/credentials.rs
+++ b/crates/aws/src/credentials.rs
@@ -41,6 +41,7 @@ impl AWSForObjectStore {
     }
 
     /// Return true if a credential has been cached
+    #[cfg(test)]
     async fn has_cached_credentials(&self) -> bool {
         let guard = self.cache.lock().await;
         (*guard).is_some()

--- a/crates/core/src/kernel/models/fields.rs
+++ b/crates/core/src/kernel/models/fields.rs
@@ -145,17 +145,6 @@ static REMOVE_FIELD: LazyLock<StructField> = LazyLock::new(|| {
         true,
     )
 });
-static REMOVE_FIELD_CHECKPOINT: LazyLock<StructField> = LazyLock::new(|| {
-    StructField::new(
-        "remove",
-        StructType::new(vec![
-            StructField::new("path", DataType::STRING, false),
-            StructField::new("deletionTimestamp", DataType::LONG, true),
-            StructField::new("dataChange", DataType::BOOLEAN, false),
-        ]),
-        true,
-    )
-});
 // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-cdc-file
 static CDC_FIELD: LazyLock<StructField> = LazyLock::new(|| {
     StructField::new(

--- a/crates/core/src/kernel/models/fields.rs
+++ b/crates/core/src/kernel/models/fields.rs
@@ -145,6 +145,19 @@ static REMOVE_FIELD: LazyLock<StructField> = LazyLock::new(|| {
         true,
     )
 });
+// TODO implement support for this checkpoint
+#[expect(dead_code)]
+static REMOVE_FIELD_CHECKPOINT: LazyLock<StructField> = LazyLock::new(|| {
+    StructField::new(
+        "remove",
+        StructType::new(vec![
+            StructField::new("path", DataType::STRING, false),
+            StructField::new("deletionTimestamp", DataType::LONG, true),
+            StructField::new("dataChange", DataType::BOOLEAN, false),
+        ]),
+        true,
+    )
+});
 // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-cdc-file
 static CDC_FIELD: LazyLock<StructField> = LazyLock::new(|| {
     StructField::new(

--- a/crates/core/src/operations/filesystem_check.rs
+++ b/crates/core/src/operations/filesystem_check.rs
@@ -22,7 +22,7 @@ use futures::future::BoxFuture;
 use futures::StreamExt;
 pub use object_store::path::Path;
 use object_store::ObjectStore;
-use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Serialize, Serializer};
 use url::{ParseError, Url};
 use uuid::Uuid;
 
@@ -77,15 +77,6 @@ where
 {
     let json_string = serde_json::to_string(value).map_err(serde::ser::Error::custom)?;
     serializer.serialize_str(&json_string)
-}
-
-// Custom deserialization that parses a JSON string into MetricDetails
-fn deserialize_vec_string<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: String = Deserialize::deserialize(deserializer)?;
-    serde_json::from_str(&s).map_err(DeError::custom)
 }
 
 fn is_absolute_path(path: &str) -> DeltaResult<bool> {

--- a/crates/core/src/operations/filesystem_check.rs
+++ b/crates/core/src/operations/filesystem_check.rs
@@ -22,7 +22,7 @@ use futures::future::BoxFuture;
 use futures::StreamExt;
 pub use object_store::path::Path;
 use object_store::ObjectStore;
-use serde::{Serialize, Serializer};
+use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 use url::{ParseError, Url};
 use uuid::Uuid;
 
@@ -77,6 +77,16 @@ where
 {
     let json_string = serde_json::to_string(value).map_err(serde::ser::Error::custom)?;
     serializer.serialize_str(&json_string)
+}
+
+// Custom deserialization that parses a JSON string into MetricDetails
+#[expect(dead_code)]
+fn deserialize_vec_string<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+    serde_json::from_str(&s).map_err(DeError::custom)
 }
 
 fn is_absolute_path(path: &str) -> DeltaResult<bool> {

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -487,7 +487,6 @@ pub(crate) mod tests {
     use arrow_array::{Int32Array, RecordBatch, StringArray};
     use arrow_schema::Schema;
     use chrono::NaiveDateTime;
-    use datafusion::physical_plan::ExecutionPlan;
     use datafusion::prelude::SessionContext;
     use datafusion_common::assert_batches_sorted_eq;
     use itertools::Itertools;

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1573,7 +1573,6 @@ mod tests {
     use arrow_schema::DataType as ArrowDataType;
     use arrow_schema::Field;
     use datafusion::assert_batches_sorted_eq;
-    use datafusion::physical_plan::ExecutionPlan;
     use datafusion::prelude::*;
     use datafusion_common::Column;
     use datafusion_common::TableReference;

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -74,7 +74,6 @@
 //!       └───────────────────────────────┘
 //!</pre>
 use std::collections::HashMap;
-use std::future::Future;
 use std::sync::Arc;
 
 use bytes::Bytes;

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -553,7 +553,6 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use arrow_schema::DataType;
     use datafusion::assert_batches_sorted_eq;
-    use datafusion::physical_plan::ExecutionPlan;
     use datafusion::prelude::*;
     use serde_json::json;
     use std::sync::Arc;

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -757,7 +757,6 @@ mod tests {
     use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema, TimeUnit};
     use datafusion::prelude::*;
     use datafusion::{assert_batches_eq, assert_batches_sorted_eq};
-    use datafusion_physical_plan::ExecutionPlan;
     use itertools::Itertools;
     use serde_json::{json, Value};
 

--- a/crates/lakefs/src/storage.rs
+++ b/crates/lakefs/src/storage.rs
@@ -121,14 +121,11 @@ mod tests {
     use maplit::hashmap;
     use serial_test::serial;
 
-    struct ScopedEnv {
-        vars: HashMap<std::ffi::OsString, std::ffi::OsString>,
-    }
+    struct ScopedEnv {}
 
     impl ScopedEnv {
         pub fn new() -> Self {
-            let vars = std::env::vars_os().collect();
-            Self { vars }
+            Self {}
         }
 
         pub fn run<T>(mut f: impl FnMut() -> T) -> T {


### PR DESCRIPTION
# Description
chore: fix compiler warnings

While working on https://github.com/delta-io/delta-rs/pull/3261 I found several items that generated warnings locally for me:

For example:

```shell
/Users/andrewlamb/.cargo/bin/cargo test --color=always --workspace --profile test --no-fail-fast --config env.RUSTC_BOOTSTRAP=\"1\" -- --format=json -Z unstable-options --show-output
Testing started at 2:41 PM ...
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/andrewlamb/Software/delta-rs/python/Cargo.toml
workspace: /Users/andrewlamb/Software/delta-rs/Cargo.toml
warning: unused import: `std::future::Future`
  --> crates/core/src/operations/transaction/mod.rs:77:5
   |
77 | use std::future::Future;
   |     ^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```

I looked at the CI tests and they seem to be passing, so I am not sure why this fails locally for me


# Related Issue(s)
- related to https://github.com/apache/datafusion/issues/14123

# Documentation

<!---
Share links to useful documentation
--->
