### PR TITLE
fix: aarch64 ssl handshakes

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -59,9 +59,9 @@ jobs:
           command: publish
           args: --skip-existing -m python/Cargo.toml --no-sdist
 
-  release-pypi-manylinux:
+  release-pypi-manylinux-x86-64:
     needs: validate-release-tag
-    name: PyPI release manylinux
+    name: PyPI release manylinux-2_17 x86_64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -78,6 +78,13 @@ jobs:
           # for openssl build
           before-script-linux: yum install -y perl-IPC-Cmd
 
+  release-pypi-manylinux-217-aarch64:
+    needs: validate-release-tag
+    name: PyPI release manylinux-2_17 aarch64 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
       - name: Publish manylinux to pypi aarch64 (without sdist)
         uses: messense/maturin-action@v1
         env:
@@ -91,11 +98,30 @@ jobs:
             # https://github.com/briansmith/ring/issues/1728
             export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"
 
+  release-pypi-manylinux-228-aarch64:
+    needs: validate-release-tag
+    name: PyPI release manylinux-2_28 aarch64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Publish manylinux to pypi aarch64 manylinux-2_28 (without sdist)
+        uses: messense/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        with:
+          target: aarch64-unknown-linux-gnu
+          command: publish
+          args: --skip-existing -m python/Cargo.toml --no-sdist
+          manylinux: "2_28"
+
   release-docs:
     needs:
       [
         validate-release-tag,
-        release-pypi-manylinux,
+        release-pypi-manylinux-x86-64,
+        release-pypi-manylinux-217-aarch64,
+        release-pypi-manylinux-228-aarch64,
         release-pypi-mac,
         release-pypi-windows,
       ]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"


### PR DESCRIPTION
# Description
This was a very pesky issue to figure out but finally nailed it down to being a manylinux glibc compatibility issue. Essentially with glibc 2.17 we were seeing ssl handshake failures which has some relation to the ring crate. Anyway, the fix is to release additional wheels for manylinux 2_28.

I also took the liberty in splitting up the manylinux job in to separate jobs.

# Related Issue(s)
- closes https://github.com/delta-io/delta-rs/issues/3241
- closes https://github.com/delta-io/delta-rs/issues/3243
- closes https://github.com/delta-io/delta-rs/issues/2192
- closes https://github.com/delta-io/delta-rs/issues/1978
- closes https://github.com/delta-io/delta-rs/issues/3193
