### PR TITLE
chore: fix clippy warnings on main

### DIFF
--- a/crates/catalog-unity/src/datafusion.rs
+++ b/crates/catalog-unity/src/datafusion.rs
@@ -193,7 +193,7 @@ impl UnitySchemaProvider {
             .map(|resp| match resp {
                 Ok(TableTempCredentialsResponse::Success(temp_creds)) => Ok(temp_creds),
                 Ok(TableTempCredentialsResponse::Error(err)) => Err(err.into()),
-                Err(err) => Err(err.into()),
+                Err(err) => Err(err),
             })
             .await
     }

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -910,7 +910,7 @@ impl TableProvider for LazyTableProvider {
             if projection != &current_projection {
                 let execution_props = &ExecutionProps::new();
                 let fields: DeltaResult<Vec<(Arc<dyn PhysicalExpr>, String)>> = projection
-                    .into_iter()
+                    .iter()
                     .map(|i| {
                         let (table_ref, field) = df_schema.qualified_field(*i);
                         create_physical_expr(
@@ -2865,6 +2865,7 @@ mod tests {
         let expected = vec![
             ObjectStoreOperation::GetRange(LocationType::Data, 4920..4928),
             ObjectStoreOperation::GetRange(LocationType::Data, 2399..4920),
+            #[expect(clippy::single_range_in_vec_init)]
             ObjectStoreOperation::GetRanges(LocationType::Data, vec![4..58]),
         ];
         let mut actual = Vec::new();

--- a/crates/core/src/kernel/snapshot/log_segment.rs
+++ b/crates/core/src/kernel/snapshot/log_segment.rs
@@ -831,7 +831,7 @@ pub(super) mod tests {
 
         assert_eq!(commit.metrics.num_retries, 0);
         assert_eq!(commit.metrics.num_log_files_cleaned_up, 0);
-        assert_eq!(commit.metrics.new_checkpoint_created, false);
+        assert!(!commit.metrics.new_checkpoint_created);
 
         let batches = LogSegment::try_new(
             &Path::default(),

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -104,11 +104,10 @@ impl CdfLoadBuilder {
         for v in 0..self.snapshot.version() {
             if let Ok(Some(bytes)) = self.log_store.read_commit_entry(v).await {
                 if let Ok(actions) = get_actions(v, bytes).await {
-                    if actions.iter().any(|action| match action {
-                        Action::CommitInfo(CommitInfo {
+                    if actions.iter().any(|action| {
+                        matches!(action, Action::CommitInfo(CommitInfo {
                             timestamp: Some(t), ..
-                        }) if ts.timestamp_millis() < *t => true,
-                        _ => false,
+                        }) if ts.timestamp_millis() < *t)
                     }) {
                         return Ok(v);
                     }

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1462,7 +1462,7 @@ fn modify_schema(
             return Err(DeltaTableError::Arrow { source: error });
         }
 
-        if let Some(target_field) = target_schema.field_from_column(columns).ok() {
+        if let Ok(target_field) = target_schema.field_from_column(columns) {
             // for nested data types we need to first merge then see if there a change then replace the pre-existing field
             let new_field = merge_arrow_field(target_field, source_field, true)?;
             if &new_field == target_field {

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -698,8 +698,8 @@ mod tests {
             0, finalized_commit.metrics.num_log_files_cleaned_up,
             "Expected no log files cleaned up"
         );
-        assert_eq!(
-            false, finalized_commit.metrics.new_checkpoint_created,
+        assert!(
+            !finalized_commit.metrics.new_checkpoint_created,
             "Expected checkpoint created."
         );
         table.load().await.expect("Failed to reload table");

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -194,8 +194,6 @@ mod local {
         // We want to emulate that this occurs on another node, so that all we have access to is the
         // plan byte serialization.
         let source_scan_bytes = {
-            let ctx = SessionContext::new();
-            let state = ctx.state();
             let source_table = open_table("../test/tests/data/delta-0.8.0-date").await?;
 
             let target_provider = provider_as_source(Arc::new(source_table));
@@ -1185,8 +1183,6 @@ async fn simple_query(context: &IntegrationContext) -> TestResult {
 }
 
 mod date_partitions {
-    use tempfile::TempDir;
-
     use super::*;
 
     async fn setup_test(table_uri: &str) -> Result<DeltaTable, Box<dyn Error>> {

--- a/crates/gcp/tests/context.rs
+++ b/crates/gcp/tests/context.rs
@@ -101,11 +101,7 @@ impl StorageIntegration for GcpIntegration {
     }
 }
 
-impl GcpIntegration {
-    fn delete_bucket(&self) -> std::io::Result<ExitStatus> {
-        gs_cli::delete_bucket(self.bucket_name.clone())
-    }
-}
+impl GcpIntegration {}
 
 /// small wrapper around google api
 pub mod gs_cli {


### PR DESCRIPTION
# Description
Similarly to https://github.com/delta-io/delta-rs/pull/3262 I would like to use compiler warnings and clippy locally to find places that need to be changed after DataFusion upgrade. This means I would to have main have a clean clippy run

I just did what clippy told me to mostly

# Related Issue(s)
- Related to https://github.com/delta-io/delta-rs/pull/3261
- Related to https://github.com/apache/datafusion/issues/14123

# Documentation

<!---
Share links to useful documentation
--->
