### PR TITLE
fix: commitlint config

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -41,10 +41,8 @@ jobs:
           node-version: "18"
       - run: npm install -g @commitlint/cli @commitlint/config-conventional
       # Checkout to get the commitlint configuration.
-      - uses: actions/checkout@v3
-      - run: >
-          npx commitlint \
-            --verbose <<< $COMMIT_MSG
+      - uses: actions/checkout@v4
+      - run: commitlint --verbose <<< $COMMIT_MSG
         env:
           COMMIT_MSG: >
             ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Out commitlint check for PRs is currently overly agressive. Specifically it will complian, when the body of a PR is a bit more verbose. However we should not punish contributors who put in the time to elaborate on theor PRs by enforcing a line length on the PR body. I seems that other share this assessment, since it should already be configured in our commitlint config. So just seeing whats going wrong and trying to get the cli to pick up the config. Being deliberately chatty here to have a long PR body ...