### PR TITLE
refactor: replaced asterisk with constraint name in get_constraints

### DIFF
--- a/crates/core/src/kernel/mod.rs
+++ b/crates/core/src/kernel/mod.rs
@@ -3,7 +3,7 @@
 //! The Kernel module contains all the logic for reading and processing the Delta Lake transaction log.
 
 use delta_kernel::engine::arrow_expression::ArrowExpressionHandler;
-use std::sync::LazyLock;
+use std::{any::Any, sync::LazyLock};
 
 pub mod arrow;
 pub mod error;
@@ -21,6 +21,8 @@ pub trait DataCheck {
     fn get_name(&self) -> &str;
     /// The SQL expression to use for the check
     fn get_expression(&self) -> &str;
+
+    fn as_any(&self) -> &dyn Any;
 }
 
 static ARROW_HANDLER: LazyLock<ArrowExpressionHandler> =

--- a/crates/core/src/kernel/models/schema.rs
+++ b/crates/core/src/kernel/models/schema.rs
@@ -1,5 +1,6 @@
 //! Delta table schema
 
+use std::any::Any;
 use std::sync::Arc;
 
 pub use delta_kernel::schema::{
@@ -43,6 +44,10 @@ impl DataCheck for Invariant {
 
     fn get_expression(&self) -> &str {
         &self.invariant_sql
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/crates/core/src/table/config.rs
+++ b/crates/core/src/table/config.rs
@@ -363,7 +363,8 @@ impl TableConfig<'_> {
             .iter()
             .filter_map(|(field, value)| {
                 if field.starts_with("delta.constraints") {
-                    value.as_ref().map(|f| Constraint::new("*", f))
+                    let constraint_name = field.replace("delta.constraints.", "");
+                    value.as_ref().map(|f| Constraint::new(&constraint_name, f))
                 } else {
                     None
                 }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -1,5 +1,6 @@
 //! Delta Table read and write implementation
 
+use std::any::Any;
 use std::cmp::{min, Ordering};
 use std::collections::HashMap;
 use std::fmt;
@@ -155,6 +156,10 @@ impl DataCheck for Constraint {
     fn get_expression(&self) -> &str {
         &self.expr
     }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 /// A generated column
@@ -194,6 +199,10 @@ impl DataCheck for GeneratedColumn {
 
     fn get_expression(&self) -> &str {
         &self.validation_expr
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 


### PR DESCRIPTION
# Description
When retrieving constraints from the table config, the name is set to an asterisk (*). The name is needed if you want to e.g. drop the constraint again. I have modified the code to use the found keys excluding `delta.constraints.`.

**Before:**
```
"name": "*",
"expr": "double LIKE 'DO%' AND double LIKE '%IT%'"
```
**After:**
```
"name": "my_new_constraint_name",
"expr": "double LIKE 'DO%' AND double LIKE '%IT%'"
```

Going through the code, I discovered the reason behind using the asterisk. It was for the `delta_datafusion::enforce_checks` function to format its `SQL`-query with `SELECT * ...` in a constraint check. To ensure the `enforce_checks` function still works, I have expanded the `DeltaCheck` trait to include `as_any()` to allow type checking in `enforce_checks` to condition how the `SQL`-query must be formatted for different checks.

# Related Issue(s)
No related issues

# Documentation
No documentation