### PR TITLE
fix: chrono 0.4.40 causes disambiguation syntax when building arrow deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ strum = { version = "0.26"}
 
 # "stdlib"
 bytes = { version = "1" }
-chrono = { version = ">0.4.34", default-features = false, features = ["clock"] }
+chrono = { version = "=0.4.39", default-features = false, features = ["clock"] }
 tracing = { version = "0.1", features = ["log"] }
 regex = { version = "1" }
 thiserror = { version = "2" }


### PR DESCRIPTION
# Description
The crate Chrono has been updated to 0.4.40. This has caused a breaking change in Arrow - as I understand it. This causes Arrow to fail when building due to disambigious syntax. Pinning Chrono to its `=0.4.39` release will fix the build issue until the next Arrow release in March. 


# Related Issue(s)
[Arrow Issue 7198](https://github.com/apache/arrow-rs/pull/7198#issuecomment-2685365216)
[Chrono Discussion of the breaking change](https://github.com/chronotope/chrono/pull/1666#discussion_r1971811769)

# Documentation
None