### PR TITLE
fix(rust): on write, have a schema evolution maintain metadata table id

### DIFF
--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -111,6 +111,12 @@ impl Metadata {
         self
     }
 
+    /// set the table ID in the metadata action
+    pub fn with_table_id(mut self, id: String) -> Self {
+        self.id = id;
+        self
+    }
+
     /// get the table schema
     pub fn schema(&self) -> DeltaResult<StructType> {
         Ok(serde_json::from_str(&self.schema_string)?)


### PR DESCRIPTION
# Description
When a schema evolution write occurs, if a metadata ID from the table state exists, use that in the new metadata transaction entry. 

This PR has a unit test and a new integration test that runs a Pyspark stream between evolution runs. I confirmed that the integration test failed with the error I've seen in production when I removed the new logic, and passes with the new logic.

# Related Issue(s)
closes #3274 

# Documentation
