### PR TITLE
chore: remove unused dev dependency on `home`

### DIFF
--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -24,8 +24,6 @@ url = { workspace = true }
 serial_test = "3"
 deltalake-test = { path = "../test" }
 which = "7"
-# 0.5.11 and later require Rust 1.81
-home = "=0.5.9"
 
 [features]
 integration_test = ["hdfs-native-object-store/integration-test"]


### PR DESCRIPTION
# Description
I noticed the `home` dependency was pinned on some old version while working on https://github.com/delta-io/delta-rs/pull/3261 and when I went to update it turns out it wasn't even  used 🤔 

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
