### PR TITLE
fix(pandas): retain pyarrow decimal datatype in to_pandas() by adding types_mapper to prevent precision loss

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Generator,
     Iterable,
@@ -899,6 +900,7 @@ class DeltaTable:
         columns: Optional[List[str]] = None,
         filesystem: Optional[Union[str, pa_fs.FileSystem]] = None,
         filters: Optional[Union[FilterType, Expression]] = None,
+        types_mapper: Optional[Callable[[pyarrow.DataType], Any]] = None,
     ) -> "pd.DataFrame":
         """
         Build a pandas dataframe using data from the DeltaTable.
@@ -914,7 +916,7 @@ class DeltaTable:
             columns=columns,
             filesystem=filesystem,
             filters=filters,
-        ).to_pandas()
+        ).to_pandas(types_mapper=types_mapper)
 
     def update_incremental(self) -> None:
         """


### PR DESCRIPTION
# Description
Currently, to_pandas() in delta-rs does not retain PyArrow decimal types. Instead, it converts all decimal columns into object dtype in pandas.

## How This Causes Issues

**1. Loss of Decimal Precision Metadata**

- A column stored as Decimal(18,0) in Delta Lake is converted to an object dtype in pandas.
- This conversion strips away the original precision (18,0), leading to issues when writing back.

**2. Schema Re-Inference in write_deltalake()**

- Since pandas lacks native decimal types, write_deltalake() re-infers the column schema based on the actual data instead of preserving the original Decimal(18,0).
- The schema is inferred as Decimal(11,0) if the longest number has 11 digits (e.g., `12345678901`).

**3. Decimal Overflow Errors on Write**

- But since the column is a Decimal datatype, it stores the same value as `12345678901.0`, which takes the precision of this value to (12, 0), thereby exceeding the inferred precision (11,0) and triggering a "Parse Decimal Overflow" error.
- Also, if a new value with 12 digits (`123456789012`) appears in the column (taking the precision of this value to (13, 0) as it will be stored as `123456789012.0`), it exceeds the inferred precision (11,0), triggering a "Parse Decimal Overflow" error.
- The actual value should have been stored as Decimal(18,0), but because of schema inference issues, it now conflicts with Decimal(11,0)

# Root Cause Analysis
The issue occurs because to_pandas() does not retain PyArrow’s schema information, which includes decimal precision/scale.

- PyArrow stores Decimal(18,0) correctly.
- Pandas does not have a native decimal type, so it converts it to object.
- When writing back, write_deltalake() re-infers schema from the data instead of keeping Decimal(18,0), leading to mismatches.

# Proposed Solution
## Enhancement: Add types_mapper Parameter to to_pandas()
Instead of requiring users to manually call:
`df = dt.to_pyarrow_table().to_pandas(types_mapper=pd.ArrowDtype)`
or
`df = dt.to_pyarrow_table().to_pandas(types_mapper="custom_mapper_to_retain_decimal_columns")`

this PR enhances to_pandas() by adding a types_mapper argument:
`df = dt.to_pandas(types_mapper=pd.ArrowDtype)`
or
`df = dt.to_pandas(types_mapper="custom_mapper_to_retain_decimal_columns")`

# Why This Fix Works

**1. Preserves Decimal(18,0) in Pandas**

- Users can pass `types_mapper=pd.ArrowDtype` or a custom mapper function to just retain decimal columns.

**2. Prevents Schema Mismatch in write_deltalake()**

- Since the decimal type is not lost in pandas, write_deltalake() now correctly retains the original Decimal(18,0).

**3. Avoids "Parse Decimal Overflow" Errors**

- The schema no longer gets re-inferred incorrectly, preventing precision mismatches.

# Usage Example
## Before (Current Issue)
```
df = dt.to_pandas()
# amount    object  <- Decimal type lost

df.to_deltalake("s3://my-delta-table", mode="append")  
# **"Parse Decimal Overflow" error**
```

## After (With Fix)
```
df = dt.to_pandas(types_mapper=pd.ArrowDtype)
# amount    decimal128(18,0)  <- Correctly retains precision

df.to_deltalake("s3://my-delta-table", mode="append")  
# **No errors, schema remains Decimal(18,0)**
```