### PR TITLE
fix: added restored metadata as action to the next committed version

### DIFF
--- a/crates/core/src/operations/restore.rs
+++ b/crates/core/src/operations/restore.rs
@@ -191,6 +191,9 @@ async fn execute(
             snapshot.version(),
         )));
     }
+
+    let metadata_restored_version = table.metadata()?;
+
     let state_to_restore_files = table.snapshot()?.file_actions()?;
     let latest_state_files = snapshot.file_actions()?;
     let state_to_restore_files_set =
@@ -279,6 +282,8 @@ async fn execute(
     actions.push(Action::Protocol(protocol));
     actions.extend(files_to_add.into_iter().map(Action::Add));
     actions.extend(files_to_remove.into_iter().map(Action::Remove));
+    // Add the metadata from the restored version to undo e.g. constraint or field metadata changes
+    actions.push(Action::Metadata(metadata_restored_version.clone()));
 
     let operation = DeltaOperation::Restore {
         version: version_to_restore,


### PR DESCRIPTION
# Description
This PR spins out of a thread in the Slack `delta-rs` channel.

I was testing out a table where the last two commits were: `ADD CONSTRAINT` and `DROP CONSTRAINT`. Using the `RestoreBuilder` , I attempted to restore the table back to the `ADD CONSTRAINT` to undo the `DROP CONSTRAINT`  metadata action. Nothing happened. Going through the code, I do see code "reversing" `ADD` vs. `REMOVE` actions but nothing for `METADATA`.

I would expect every actions from the restored table to the latest table to be "reversed". 

From a blog post on (Delta.io)[https://delta.io/blog/2022-10-03-rollback-delta-lake-restore/], they state: 

> ... this change does not erase version 2; instead, a metadata-only operation is performed in which the changes in version 2 are undone.

My proposal is to add a `METADATA` action when restoring and use the restored table metadata as the committed metadata. One can argue that every change from the restored table to the latest table does not matter 😄 

Looking forward to discussing this one!

- closes https://github.com/delta-io/delta-rs/issues/3352