### PR TITLE
fix: serialize empty deletionVector in add actions as absent

### DIFF
--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -777,6 +777,7 @@ pub struct Add {
     /// Map containing metadata about this logical file.
     pub tags: Option<HashMap<String, Option<String>>>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Information about deletion vector (DV) associated with this add action
     pub deletion_vector: Option<DeletionVectorDescriptor>,
 


### PR DESCRIPTION
Alright, let's go to [Chotchkie's](https://officespace.fandom.com/wiki/Chotchkie%27s)

Fixes #3211
