### PR TITLE
feat: during LakeFS file operations, skip merge when 0 changes

### DIFF
--- a/crates/lakefs/src/client.rs
+++ b/crates/lakefs/src/client.rs
@@ -195,7 +195,7 @@ impl LakeFSClient {
             "squash_merge": true,
         });
 
-        debug!("Merging LakeFS, source `{transaction_branch}` into target `{transaction_branch}` in repo: {repo}");
+        debug!("Merging LakeFS, source `{transaction_branch}` into target `{target_branch}` in repo: {repo}");
         let response = self
             .http_client
             .post(&request_url)
@@ -226,16 +226,16 @@ impl LakeFSClient {
     pub async fn has_changes(
         &self,
         repo: &str,
-        source_branch: &str,
-        target_branch: &str,
+        base_branch: &str,
+        compare_branch: &str,
     ) -> Result<bool, TransactionError> {
         let request_url = format!(
-            "{}/api/v1/repositories/{repo}/refs/{source_branch}/diff/{target_branch}",
+            "{}/api/v1/repositories/{repo}/refs/{base_branch}/diff/{compare_branch}",
             self.config.host
         );
 
         debug!(
-            "Checking for changes between `{source_branch}` and `{target_branch}` in repo: {repo}"
+            "Checking for changes from `{base_branch}` to `{compare_branch}` in repo: {repo}"
         );
         let response = self
             .http_client
@@ -501,7 +501,7 @@ mod tests {
             let mock = server
                 .mock(
                     "GET",
-                    "/api/v1/repositories/test_repo/refs/source_branch/diff/target_branch",
+                    "/api/v1/repositories/test_repo/refs/base_branch/diff/compare_branch",
                 )
                 .with_status(StatusCode::OK.as_u16().into())
                 .with_body(response_body)
@@ -516,7 +516,7 @@ mod tests {
 
             let result = rt().block_on(async {
                 client
-                    .has_changes("test_repo", "source_branch", "target_branch")
+                    .has_changes("test_repo", "base_branch", "compare_branch")
                     .await
             });
 

--- a/crates/lakefs/src/client.rs
+++ b/crates/lakefs/src/client.rs
@@ -234,9 +234,7 @@ impl LakeFSClient {
             self.config.host
         );
 
-        debug!(
-            "Checking for changes from `{base_branch}` to `{compare_branch}` in repo: {repo}"
-        );
+        debug!("Checking for changes from `{base_branch}` to `{compare_branch}` in repo: {repo}");
         let response = self
             .http_client
             .get(&request_url)

--- a/crates/lakefs/src/execute.rs
+++ b/crates/lakefs/src/execute.rs
@@ -259,6 +259,16 @@ mod tests {
             .with_status(StatusCode::CREATED.as_u16().into())
             .create();
 
+        let diff_mock = server
+            .mock(
+                "GET",
+                format!("/api/v1/repositories/repo/refs/delta-tx-{operation_id}/diff/branch")
+                    .as_str(),
+            )
+            .with_status(StatusCode::OK.as_u16().into())
+            .with_body(r#"{"results": [{"some": "change"}]}"#)
+            .create();
+
         let merge_branch_mock = server
             .mock(
                 "POST",
@@ -293,6 +303,7 @@ mod tests {
         });
 
         create_commit_mock.assert();
+        diff_mock.assert();
         merge_branch_mock.assert();
         delete_branch_mock.assert();
         assert!(result.is_ok());

--- a/crates/lakefs/src/execute.rs
+++ b/crates/lakefs/src/execute.rs
@@ -262,7 +262,7 @@ mod tests {
         let diff_mock = server
             .mock(
                 "GET",
-                format!("/api/v1/repositories/repo/refs/delta-tx-{operation_id}/diff/branch")
+                format!("/api/v1/repositories/repo/refs/branch/diff/delta-tx-{operation_id}")
                     .as_str(),
             )
             .with_status(StatusCode::OK.as_u16().into())

--- a/crates/lakefs/src/logstore.rs
+++ b/crates/lakefs/src/logstore.rs
@@ -155,7 +155,7 @@ impl LakeFSLogStore {
         // Check if there are any changes before attempting to merge
         let has_changes = self
             .client
-            .has_changes(&repo, &transaction_branch, &target_branch)
+            .has_changes(&repo, &target_branch, &transaction_branch)
             .await
             .map_err(|e| DeltaTableError::generic(format!("Failed to check for changes: {}", e)))?;
 

--- a/python/tests/test_lakefs.py
+++ b/python/tests/test_lakefs.py
@@ -514,13 +514,13 @@ def test_no_empty_commits(
     branch = lakefs.Branch(
         repository_id="bronze", branch_id="main", client=lakefs_client
     )
-    commits_before = list(branch.commits())
+    commits_before = list(branch.log())
     before_commit_id = commits_before[0].id if commits_before else None
 
-    # Perform a noop operation
-    dt.repair(dry_run=True)
+    # Since there should be no files to vacuum in a fresh table this should be a no-op operation
+    dt.vacuum(dry_run=False)
 
-    commits_after = list(branch.commits())
+    commits_after = list(branch.log())
     after_commit_id = commits_after[0].id if commits_after else None
 
     assert before_commit_id == after_commit_id, "Empty commit should be skipped"


### PR DESCRIPTION
# Description
If a branch does not have any file changes, we no longer merge the branch to avoid empty commits.

# Related Issue(s)
- closes #3190 

# Documentation
N/A
