### PR TITLE
refactor: remove 'rustls' from default features of 'core'

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -113,7 +113,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [features]
 cdf = []
-default = ["cdf", "rustls"]
+default = ["cdf"]
 datafusion = [
     "dep:datafusion",
     "datafusion-expr",


### PR DESCRIPTION
# Description
The 'rustls' features on by default on the 'core' crate pulls in a lot of optional dependencies even if not used, and it doesn't seem it's required to be on by default.
