### PR TITLE
chore: remove cdf feature

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -112,8 +112,7 @@ tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [features]
-cdf = []
-default = ["cdf", "rustls"]
+default = ["rustls"]
 datafusion = [
     "dep:datafusion",
     "datafusion-expr",

--- a/crates/core/src/operations/mod.rs
+++ b/crates/core/src/operations/mod.rs
@@ -49,7 +49,7 @@ pub mod transaction;
 pub mod update_field_metadata;
 pub mod vacuum;
 
-#[cfg(all(feature = "cdf", feature = "datafusion"))]
+#[cfg(feature = "datafusion")]
 mod cdc;
 #[cfg(feature = "datafusion")]
 pub mod constraints;

--- a/crates/core/src/operations/transaction/protocol.rs
+++ b/crates/core/src/operations/transaction/protocol.rs
@@ -214,12 +214,9 @@ pub static INSTANCE: LazyLock<ProtocolChecker> = LazyLock::new(|| {
     let mut writer_features = HashSet::new();
     writer_features.insert(WriterFeatures::AppendOnly);
     writer_features.insert(WriterFeatures::TimestampWithoutTimezone);
-    #[cfg(feature = "cdf")]
-    {
-        writer_features.insert(WriterFeatures::ChangeDataFeed);
-    }
     #[cfg(feature = "datafusion")]
     {
+        writer_features.insert(WriterFeatures::ChangeDataFeed);
         writer_features.insert(WriterFeatures::Invariants);
         writer_features.insert(WriterFeatures::CheckConstraints);
         writer_features.insert(WriterFeatures::GeneratedColumns);


### PR DESCRIPTION
# Description
@rtyler the cdf feature actually won't be used without datafusion, so just to simplify it we can gate it behind the datafusion feature
