### PR TITLE
feat: introduce VacuumMode::Full for cleaning up orphaned files

### DIFF
--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -104,6 +104,7 @@ class RawDeltaTable:
         enforce_retention_duration: bool,
         commit_properties: CommitProperties | None,
         post_commithook_properties: PostCommitHookProperties | None,
+        full: bool,
     ) -> list[str]: ...
     def compact_optimize(
         self,

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -516,6 +516,7 @@ class DeltaTable:
         enforce_retention_duration: bool = True,
         post_commithook_properties: PostCommitHookProperties | None = None,
         commit_properties: CommitProperties | None = None,
+        full: bool = False,
     ) -> list[str]:
         """
         Run the Vacuum command on the Delta Table: list and delete files no longer referenced by the Delta table and are older than the retention threshold.
@@ -526,6 +527,7 @@ class DeltaTable:
             enforce_retention_duration: when disabled, accepts retention hours smaller than the value from `delta.deletedFileRetentionDuration`.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
             commit_properties: properties of the transaction commit. If None, default values are used.
+            full: when set to True, will perform a "full" vacuum and remove all files not referenced in the transaction log
         Returns:
             the list of files no longer referenced by the Delta Table and are older than the retention threshold.
         """
@@ -539,6 +541,7 @@ class DeltaTable:
             enforce_retention_duration,
             commit_properties,
             post_commithook_properties,
+            full,
         )
 
     def update(


### PR DESCRIPTION
This allows an optional but not-on-by-default mode of removing untracked
files in the delta table directory. Delta/Spark supports a "lite" and
"full" mode for [vacuum]. This change is intentionally not making "full"
the default as it is for Delta/Spark since that may have unintended
consequences for our users who have become accustomed to "lite" being
the default.

Fixes #2349

Signed-off-by: R. Tyler Croy <rtyler@brokenco.de>

[vacuum]: https://docs.delta.io/latest/delta-utility.html#remove-files-no-longer-referenced-by-a-delta-table