### PR TITLE
fix: clippy warnings

### DIFF
--- a/crates/aws/src/credentials.rs
+++ b/crates/aws/src/credentials.rs
@@ -259,13 +259,13 @@ fn assume_session_name(options: &HashMap<String, String>) -> String {
 pub async fn resolve_credentials(options: &HashMap<String, String>) -> DeltaResult<SdkConfig> {
     let default_provider = DefaultCredentialsChain::builder().build().await;
 
-    let credentials_provider = match assume_role_arn(&options) {
+    let credentials_provider = match assume_role_arn(options) {
         Some(arn) => {
             debug!("Configuring AssumeRoleProvider with role arn: {arn}");
             CredentialsProviderChain::first_try(
                 "AssumeRoleProvider",
                 AssumeRoleProvider::builder(arn)
-                    .session_name(assume_session_name(&options))
+                    .session_name(assume_session_name(options))
                     .build()
                     .await,
             )

--- a/crates/aws/src/lib.rs
+++ b/crates/aws/src/lib.rs
@@ -58,7 +58,7 @@ impl LogStoreFactory for S3LogStoreFactory {
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        let s3_options = self.with_env_s3(&options.raw.clone().into());
+        let s3_options = self.with_env_s3(&options.raw.clone());
         if s3_options.keys().any(|key| {
             let key = key.to_ascii_lowercase();
             [
@@ -82,7 +82,7 @@ impl LogStoreFactory for S3LogStoreFactory {
                 store,
             )?));
         }
-        Ok(default_logstore(store, location, &options))
+        Ok(default_logstore(store, location, options))
     }
 }
 

--- a/crates/aws/src/native.rs
+++ b/crates/aws/src/native.rs
@@ -1,12 +1,12 @@
 use aws_sdk_sts::config::SharedHttpClient;
 use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
 
+#[allow(dead_code)]
 pub fn use_native_tls_client(allow_http: bool) -> SharedHttpClient {
     let mut tls_connector = hyper_tls::HttpsConnector::new();
     if allow_http {
         tls_connector.https_only(false);
     }
 
-    let client = HyperClientBuilder::new().build(tls_connector);
-    client
+    HyperClientBuilder::new().build(tls_connector)
 }

--- a/crates/aws/src/storage.rs
+++ b/crates/aws/src/storage.rs
@@ -190,12 +190,12 @@ impl S3StorageOptions {
             .map(|val| str_is_truthy(&val))
             .unwrap_or(false);
 
-        let sdk_config = match is_aws(&options) {
+        let sdk_config = match is_aws(options) {
             false => None,
             true => {
                 debug!("Detected AWS S3 Storage options, resolving AWS credentials");
                 Some(execute_sdk_future(
-                    crate::credentials::resolve_credentials(&options),
+                    crate::credentials::resolve_credentials(options),
                 )??)
             }
         };

--- a/crates/aws/tests/integration_s3_dynamodb.rs
+++ b/crates/aws/tests/integration_s3_dynamodb.rs
@@ -64,13 +64,10 @@ fn client_configs_via_env_variables() -> TestResult<()> {
         deltalake_aws::constants::MAX_ELAPSED_REQUEST_TIME_KEY_NAME,
         "64",
     );
-    std::env::set_var(
-        deltalake_aws::constants::LOCK_TABLE_KEY_NAME,
-        "some_table".to_owned(),
-    );
+    std::env::set_var(deltalake_aws::constants::LOCK_TABLE_KEY_NAME, "some_table");
     std::env::set_var(
         deltalake_aws::constants::BILLING_MODE_KEY_NAME,
-        "PAY_PER_REQUEST".to_owned(),
+        "PAY_PER_REQUEST",
     );
     let client = make_client()?;
     let config = client.get_dynamodb_config();
@@ -300,16 +297,14 @@ async fn test_abort_commit_entry_fail_to_delete_entry() -> TestResult<()> {
         .await?;
 
     // Abort will fail since we marked the entry as complete
-    assert!(matches!(
-        log_store
-            .abort_commit_entry(
-                entry.version,
-                CommitOrBytes::TmpCommit(entry.temp_path.clone()),
-                Uuid::new_v4(),
-            )
-            .await,
-        Err(_),
-    ));
+    assert!(log_store
+        .abort_commit_entry(
+            entry.version,
+            CommitOrBytes::TmpCommit(entry.temp_path.clone()),
+            Uuid::new_v4(),
+        )
+        .await
+        .is_err());
 
     // Check temp commit file still exists
     assert!(log_store
@@ -503,7 +498,7 @@ async fn validate_lock_table_state(table: &DeltaTable, expected_version: i64) ->
     let latest = client
         .get_latest_entries(&table.table_uri(), WORKERS * COMMITS)
         .await?;
-    let max_version = latest.get(0).unwrap().version;
+    let max_version = latest.first().unwrap().version;
     assert_eq!(max_version, expected_version);
 
     // Pull out pairs of consecutive commit entries and verify invariants.

--- a/crates/azure/tests/integration.rs
+++ b/crates/azure/tests/integration.rs
@@ -70,7 +70,7 @@ async fn test_object_store_onelake_abfs() -> TestResult {
 
 #[allow(dead_code)]
 async fn read_write_test_onelake(context: &IntegrationContext, path: &Path) -> TestResult {
-    let delta_store = DeltaTableBuilder::from_uri(&context.root_uri())
+    let delta_store = DeltaTableBuilder::from_uri(context.root_uri())
         .with_allow_http(true)
         .build_storage()?
         .object_store(None);
@@ -104,7 +104,7 @@ fn list_delta_tables_using_listing_provider_with_missing_account_name() -> TestR
 
     let storage_options = HashMap::<String, String>::new();
     if let Err(read_error) =
-        ListingSchemaProvider::try_new(&context.root_uri(), Some(storage_options))
+        ListingSchemaProvider::try_new(context.root_uri(), Some(storage_options))
     {
         assert_eq!(read_error.to_string(), "Failed to read delta log object: Generic MicrosoftAzure error: Account must be specified".to_string());
     };
@@ -123,7 +123,7 @@ async fn list_delta_tables_using_listing_provider_with_account_name() -> TestRes
 
     let mut storage_options = HashMap::<String, String>::new();
     storage_options.insert("account_name".to_string(), "test_account".to_string());
-    let schema = ListingSchemaProvider::try_new(&context.root_uri(), Some(storage_options));
+    let schema = ListingSchemaProvider::try_new(context.root_uri(), Some(storage_options));
     assert!(
         schema.is_ok(),
         "Capable of reading the storage options. Fails if e.g. `account_name` is missing"

--- a/crates/catalog-unity/src/lib.rs
+++ b/crates/catalog-unity/src/lib.rs
@@ -879,7 +879,7 @@ impl LogStoreFactory for UnityCatalogFactory {
 /// Register an [ObjectStoreFactory] for common UnityCatalogFactory [Url] schemes
 pub fn register_handlers(_additional_prefixes: Option<Url>) {
     let factory = Arc::new(UnityCatalogFactory::default());
-    let url = Url::parse(&format!("uc://")).unwrap();
+    let url = Url::parse("uc://").unwrap();
     object_store_factories().insert(url.clone(), factory.clone());
     logstore_factories().insert(url.clone(), factory.clone());
 }

--- a/crates/core/src/kernel/arrow/mod.rs
+++ b/crates/core/src/kernel/arrow/mod.rs
@@ -177,7 +177,7 @@ macro_rules! arrow_defs {
 /// * `table_schema` - The arrow schema representing the table backed by the delta log
 /// * `partition_columns` - The list of partition columns of the table.
 /// * `use_extended_remove_schema` - Whether to include extended file metadata in remove action schema.
-///    Required for compatibility with different versions of Databricks runtime.
+///   Required for compatibility with different versions of Databricks runtime.
 pub(crate) fn delta_log_schema_for_table(
     table_schema: ArrowSchema,
     partition_columns: &[String],

--- a/crates/core/src/logstore/config.rs
+++ b/crates/core/src/logstore/config.rs
@@ -163,11 +163,13 @@ where
     V: AsRef<str> + Into<String>,
 {
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
-        let mut config = Self::default();
-        config.raw = iter
-            .into_iter()
-            .map(|(k, v)| (k.into(), v.into()))
-            .collect();
+        let mut config = StorageConfig {
+            raw: iter
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+            ..Default::default()
+        };
 
         let result = ParseResult::<RuntimeConfig>::from_iter(&config.raw);
         config.runtime = (!result.is_default).then_some(result.config);
@@ -209,11 +211,13 @@ impl StorageConfig {
         K: AsRef<str> + Into<String>,
         V: AsRef<str> + Into<String>,
     {
-        let mut props = StorageConfig::default();
-        props.raw = options
-            .into_iter()
-            .map(|(k, v)| (k.into(), v.into()))
-            .collect();
+        let mut props = StorageConfig {
+            raw: options
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+            ..Default::default()
+        };
 
         let (runtime, remainder): (RuntimeConfig, _) = try_parse_impl(&props.raw)?;
         // NOTE: we only want to assign an actual runtime config we consumed an option

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -123,7 +123,7 @@ impl<T: LogStoreFactory> LogStoreFactoryExt for Arc<T> {
         options: &StorageConfig,
         io_runtime: Option<IORuntime>,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        T::with_options_internal(&self, store, location, options, io_runtime)
+        T::with_options_internal(self, store, location, options, io_runtime)
     }
 }
 
@@ -494,11 +494,10 @@ impl<'de> Deserialize<'de> for LogStoreConfig {
                 let options: HashMap<String, String> = seq
                     .next_element()?
                     .ok_or_else(|| A::Error::invalid_length(0, &self))?;
-                let location = Url::parse(&location_str).map_err(|e| A::Error::custom(e))?;
+                let location = Url::parse(&location_str).map_err(A::Error::custom)?;
                 Ok(LogStoreConfig {
                     location,
-                    options: StorageConfig::parse_options(options)
-                        .map_err(|e| A::Error::custom(e))?,
+                    options: StorageConfig::parse_options(options).map_err(A::Error::custom)?,
                 })
             }
         }

--- a/crates/core/src/logstore/storage/runtime.rs
+++ b/crates/core/src/logstore/storage/runtime.rs
@@ -100,7 +100,7 @@ impl RuntimeConfig {
         store: T,
         handle: Option<Handle>,
     ) -> DeltaIOStorageBackend<T> {
-        let handle = handle.unwrap_or_else(|| io_rt(Some(&self)).handle().clone());
+        let handle = handle.unwrap_or_else(|| io_rt(Some(self)).handle().clone());
         DeltaIOStorageBackend {
             inner: store,
             rt_handle: handle,

--- a/crates/core/src/operations/write/async_utils.rs
+++ b/crates/core/src/operations/write/async_utils.rs
@@ -28,6 +28,7 @@ impl AsyncShareableBuffer {
     }
 
     /// Returns a clone of the underlying buffer as a `Vec`.
+    #[allow(dead_code)]
     pub async fn to_vec(&self) -> Vec<u8> {
         let inner = self.buffer.read().await;
         inner.clone()
@@ -40,12 +41,14 @@ impl AsyncShareableBuffer {
     }
 
     /// Returns `true` if the underlying buffer is empty.
+    #[allow(dead_code)]
     pub async fn is_empty(&self) -> bool {
         let inner = self.buffer.read().await;
         inner.is_empty()
     }
 
     /// Creates a new instance with the buffer initialized from the provided bytes.
+    #[allow(dead_code)]
     pub fn from_bytes(bytes: &[u8]) -> Self {
         Self {
             buffer: Arc::new(TokioRwLock::new(bytes.to_vec())),

--- a/crates/lakefs/src/lib.rs
+++ b/crates/lakefs/src/lib.rs
@@ -31,7 +31,7 @@ impl LogStoreFactory for LakeFSLogStoreFactory {
         location: &Url,
         config: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        let options = StorageConfig::parse_options(self.with_env_s3(&config.raw.clone().into()))?;
+        let options = StorageConfig::parse_options(self.with_env_s3(&config.raw.clone()))?;
         debug!("LakeFSLogStoreFactory has been asked to create a LogStore");
         lakefs_logstore(store, location, &options)
     }

--- a/crates/lakefs/tests/context.rs
+++ b/crates/lakefs/tests/context.rs
@@ -44,8 +44,8 @@ impl StorageIntegration for LakeFSIntegration {
 
     fn copy_directory(&self, source: &str, destination: &str) -> std::io::Result<ExitStatus> {
         println!(
-            "Copy directory called with {source} {}",
-            format!("{}/{destination}", self.root_uri())
+            "Copy directory called with {source} {}/{destination}",
+            self.root_uri()
         );
         let lakectl = which("lakectl").expect("Failed to find lakectl executable");
 

--- a/crates/mount/src/file.rs
+++ b/crates/mount/src/file.rs
@@ -12,7 +12,6 @@ use object_store::{
 use object_store::{MultipartUpload, PutMode, PutMultipartOpts, PutPayload};
 use std::ops::Range;
 use std::sync::Arc;
-use url::Url;
 
 pub(crate) const STORE_NAME: &str = "MountObjectStore";
 
@@ -240,19 +239,6 @@ impl ObjectStore for MountFileStorageBackend {
     ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
         self.inner.put_multipart_opts(location, options).await
     }
-}
-
-fn path_to_root_url(path: &std::path::Path) -> ObjectStoreResult<Url> {
-    let root_path = std::fs::canonicalize(path).map_err(|e| object_store::Error::InvalidPath {
-        source: object_store::path::Error::Canonicalize {
-            path: path.into(),
-            source: e,
-        },
-    })?;
-
-    Url::from_file_path(root_path).map_err(|_| object_store::Error::InvalidPath {
-        source: object_store::path::Error::InvalidPath { path: path.into() },
-    })
 }
 
 /// Regular renames `from` to `to`.

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -59,7 +59,7 @@ impl ObjectStoreFactory for MountFactory {
                     return Err(error::Error::AllowUnsafeRenameNotSpecified.into());
                 }
                 // We need to convert the dbfs url to a file url
-                let new_url = Url::parse(&format!("file:///dbfs{}", url.path())).unwrap();
+                Url::parse(&format!("file:///dbfs{}", url.path())).unwrap();
                 let store = Arc::new(file::MountFileStorageBackend::try_new()?) as ObjectStoreRef;
                 Ok((store, Path::from("/")))
             }


### PR DESCRIPTION
# Description
I would like to get a clean clippy run, to make it easier to find what deprecated APIs I need to update when upgrading to DataFusion 47:
- https://github.com/delta-io/delta-rs/pull/3378

I ran this command:
```shell
cargo clippy --all-features --all-targets
```

And basically did what clippy told me. I am happy to add a check for clippy to the CI as well, but figured that might be better as a follow on PR if you would like it.


# Related Issue(s)
- https://github.com/delta-io/delta-rs/pull/3378

# Documentation

<!---
Share links to useful documentation
--->
