### PR TITLE
refactor: make "cloud" feature in object_store optional

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -32,7 +32,7 @@ arrow-row = { workspace = true }
 arrow-schema = { workspace = true, features = ["serde"] }
 arrow-select = { workspace = true }
 parquet = { workspace = true, features = ["async", "object_store"] }
-object_store = { workspace = true, features = ["cloud"] }
+object_store = { workspace = true }
 pin-project-lite = "^0.2.7"
 
 # datafusion

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -105,6 +105,9 @@ pub use arrow;
 pub use datafusion;
 pub use parquet;
 
+#[cfg(not(any(feature = "rustls", feature = "native-tls")))]
+compile_error!("You must enable at least one of the features: `rustls` or `native-tls`.");
+
 /// Creates and loads a DeltaTable from the given path with current metadata.
 /// Infers the storage backend to use from the scheme in the given table path.
 ///

--- a/crates/core/src/logstore/config.rs
+++ b/crates/core/src/logstore/config.rs
@@ -95,6 +95,7 @@ pub struct StorageConfig {
     /// Configuration to set up a dedicated IO runtime to execute IO related operations.
     pub runtime: Option<RuntimeConfig>,
 
+    #[cfg(feature = "cloud")]
     pub retry: ::object_store::RetryConfig,
 
     /// Limit configuration.

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -176,11 +176,16 @@ where
 
     if let Some(entry) = object_store_factories().get(&scheme) {
         debug!("Found a storage provider for {scheme} ({location})");
+        #[cfg(feature = "cloud")]
         let (store, _prefix) = entry.value().parse_url_opts(
             &location,
             &storage_options.raw,
             &storage_options.retry,
         )?;
+        #[cfg(not(feature = "cloud"))]
+        let (store, _prefix) = entry
+            .value()
+            .parse_url_opts(&location, &storage_options.raw)?;
         return logstore_with(store, location, storage_options.raw, io_runtime);
     }
 

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -25,7 +25,7 @@ features = [
 ]
 
 [dependencies]
-deltalake-core = { version = "0.25.0", path = "../core" }
+deltalake-core = { version = "0.25.0", path = "../core", default-features = false }
 deltalake-aws = { version = "0.8.0", path = "../aws", default-features = false, optional = true }
 deltalake-azure = { version = "0.8.0", path = "../azure", optional = true }
 deltalake-gcp = { version = "0.9.0", path = "../gcp", optional = true }

--- a/crates/deltalake/src/lib.rs
+++ b/crates/deltalake/src/lib.rs
@@ -3,6 +3,9 @@
  */
 pub use deltalake_core::*;
 
+#[cfg(not(any(feature = "rustls", feature = "native-tls")))]
+compile_error!("You must enable at least one of the features: `rustls` or `native-tls`.");
+
 #[cfg(any(feature = "s3", feature = "s3-native-tls"))]
 pub use deltalake_aws as aws;
 #[cfg(feature = "azure")]


### PR DESCRIPTION
# Description
Make "cloud" feature of object_store be optional, if not required then parse_url_opts() doesn't need to take a "RetryConfig"

This removes a lot of dependencies for users who don't need "cloud": ["serde", "serde_json", "quick-xml", "hyper", "reqwest", "reqwest/stream", "chrono/serde", "base64", "rand", "ring", "http-body-util", "form_urlencoded", "serde_urlencoded"]


# Related Issue(s)

- closes #3397

