### PR TITLE
chore: update delta_kernel to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ debug = true
 debug = "line-tables-only"
 
 [workspace.dependencies]
-delta_kernel = { version = "0.9.0", features = [
-    "arrow_54",
-    "developer-visibility",
+delta_kernel = { version = "0.10.0", features = [
+    "arrow-54",
+    "internal-api",
 ] }
 
 # arrow
@@ -61,11 +61,11 @@ datafusion-sql = "46"
 # serde
 serde = { version = "1.0.194", features = ["derive"] }
 serde_json = "1"
-strum = { version = "0.26" }
+strum = { version = "0.27" }
 
 # "stdlib"
 bytes = { version = "1" }
-chrono = { version = "=0.4.39", default-features = false, features = ["clock"] }
+chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
 tracing = { version = "0.1", features = ["log"] }
 regex = { version = "1" }
 thiserror = { version = "2" }

--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -638,7 +638,7 @@ mod test {
             ),
             StructField::new(
                 "money".to_string(),
-                DataType::Primitive(PrimitiveType::Decimal(12, 2)),
+                DataType::Primitive(PrimitiveType::decimal(12, 2).unwrap()),
                 true,
             ),
             StructField::new(
@@ -663,7 +663,7 @@ mod test {
             ),
             StructField::new(
                 "_decimal".to_string(),
-                DataType::Primitive(PrimitiveType::Decimal(2, 2)),
+                DataType::Primitive(PrimitiveType::decimal(2, 2).unwrap()),
                 true,
             ),
             StructField::new(

--- a/crates/core/src/kernel/snapshot/replay.rs
+++ b/crates/core/src/kernel/snapshot/replay.rs
@@ -290,13 +290,13 @@ fn parse_partitions(batch: RecordBatch, partition_schema: &StructType) -> DeltaR
                                 _ => panic!("unexpected scalar type"),
                             })),
                         ) as ArrayRef,
-                        PrimitiveType::Decimal(p, s) => Arc::new(
+                        PrimitiveType::Decimal(decimal) => Arc::new(
                             Decimal128Array::from_iter(values.iter().map(|v| match v {
-                                Scalar::Decimal(d, _, _) => Some(*d),
+                                Scalar::Decimal(decimal) => Some(decimal.bits()),
                                 Scalar::Null(_) => None,
                                 _ => panic!("unexpected scalar type"),
                             }))
-                            .with_precision_and_scale(*p, *s as i8)?,
+                            .with_precision_and_scale(decimal.precision(), decimal.scale() as i8)?,
                         ) as ArrayRef,
                     };
                     Ok(arr)

--- a/crates/core/src/schema/partitions.rs
+++ b/crates/core/src/schema/partitions.rs
@@ -53,12 +53,14 @@ impl PartialOrd for ScalarHelper<'_> {
             (TimestampNtz(a), TimestampNtz(b)) => a.partial_cmp(b),
             (Date(a), Date(b)) => a.partial_cmp(b),
             (Binary(a), Binary(b)) => a.partial_cmp(b),
-            (Decimal(a, p1, s1), Decimal(b, p2, s2)) => {
+            (Decimal(decimal1), Decimal(decimal2)) => {
                 // TODO implement proper decimal comparison
-                if p1 != p2 || s1 != s2 {
+                if decimal1.precision() != decimal2.precision()
+                    || decimal1.scale() != decimal2.scale()
+                {
                     return None;
                 };
-                a.partial_cmp(b)
+                decimal1.bits().partial_cmp(&decimal2.bits())
             }
             // TODO should we make an assumption about the ordering of nulls?
             // rigth now this is only used for internal purposes.

--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 deltalake-core = { version = "0.25.0", path = "../core" }
-hdfs-native-object-store = "0.12"
+hdfs-native-object-store = "0.13"
 
 # workspace dependecies
 object_store = { workspace = true }

--- a/docs/integrations/delta-lake-daft.md
+++ b/docs/integrations/delta-lake-daft.md
@@ -85,7 +85,7 @@ You can use `write_deltalake` to write a Daft DataFrame to a Delta table:
 df.write_deltalake("tmp/daft-table", mode="overwrite")
 ```
 
-Daft supports multiple write modes. See the [Daft documentation](https://www.getdaft.io/projects/docs/en/latest/api_docs/doc_gen/dataframe_methods/daft.DataFrame.write_deltalake.html#daft.DataFrame.write_deltalake) for more information.
+Daft supports multiple write modes. See the [Daft documentation](https://www.getdaft.io/projects/docs/en/stable/api/dataframe/?h=write+delta#daft.DataFrame.write_deltalake) for more information.
 
 ## What can I do with a Daft DataFrame?
 
@@ -198,7 +198,7 @@ Read [High-Performance Querying on Massive Delta Lake Tables with Daft](https://
 
 Daft has a rich multimodal type-system with support for Python objects, Images, URLs, Tensors and more.
 
-The [Expressions API](https://www.getdaft.io/projects/docs/en/latest/api_docs/expressions.html) provides useful tools to work with these data types. By combining multimodal data support with the [User-Defined Functions API](https://www.getdaft.io/projects/docs/en/latest/api_docs/udf.html) you can run ML workloads right within your DataFrame.
+The [Expressions API](https://www.getdaft.io/projects/docs/en/stable/api/expressions) provides useful tools to work with these data types. By combining multimodal data support with the [User-Defined Functions API](https://www.getdaft.io/projects/docs/en/stable/api/udf) you can run ML workloads right within your DataFrame.
 
 Take a look at the notebook in the [`delta-examples` Github repository](https://github.com/delta-io/delta-examples) for a closer look at how Daft handles URLs, images and ML applications.
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1910,7 +1910,7 @@ fn scalar_to_py<'py>(value: &Scalar, py_date: &Bound<'py, PyAny>) -> PyResult<Bo
             let date = py_date.call_method1("fromisoformat", (value.serialize(),))?;
             date.into_py_any(py)?
         }
-        Decimal(_, _, _) => value.serialize().into_py_any(py)?,
+        Decimal(_) => value.serialize().into_py_any(py)?,
         Struct(data) => {
             let py_struct = PyDict::new(py);
             for (field, value) in data.fields().iter().zip(data.values().iter()) {


### PR DESCRIPTION
# Description
Updating delta_kernel to `0.10.0`. This included:
- unpinning `chrono` dependency
- upgrading `strum` from `0.26` to `0.27`
- updrading `hdfs-native-object-store` to `0.13`
- migrating to the new `Scalar::Decimal(decimal_data)` API (instead of the old `Scalar::Decimal(value, precision, scale)`)

# Related Issue(s)
(please let me know if I should file an issue!)

# Documentation
N/A