### PR TITLE
fix: build Unity Catalog crate without DataFusion

### DIFF
--- a/crates/catalog-unity/Cargo.toml
+++ b/crates/catalog-unity/Cargo.toml
@@ -20,9 +20,7 @@ thiserror.workspace = true
 futures.workspace = true
 chrono.workspace = true
 tracing.workspace = true
-deltalake-core = { version = "0.26.0", path = "../core", features = [
-    "datafusion",
-] }
+deltalake-core = { version = "0.26.0", path = "../core" }
 deltalake-aws = { version = "0.9.0", path = "../aws", optional = true }
 deltalake-azure = { version = "0.9.0", path = "../azure", optional = true }
 deltalake-gcp = { version = "0.10.0", path = "../gcp", optional = true }

--- a/crates/catalog-unity/src/lib.rs
+++ b/crates/catalog-unity/src/lib.rs
@@ -7,7 +7,6 @@ compile_error!(
     for this crate to function properly."
 );
 
-use datafusion_common::DataFusionError;
 use deltalake_core::logstore::{
     default_logstore, logstore_factories, object_store::RetryConfig, LogStore, LogStoreFactory,
     StorageConfig,
@@ -556,11 +555,9 @@ impl UnityCatalogBuilder {
             .get_temp_table_credentials(catalog_id, database_name, table_name)
             .await?;
         let credentials = match temp_creds_res {
-            TableTempCredentialsResponse::Success(temp_creds) => {
-                temp_creds.get_credentials().ok_or_else(|| {
-                    DataFusionError::External(UnityCatalogError::MissingCredential.into())
-                })?
-            }
+            TableTempCredentialsResponse::Success(temp_creds) => temp_creds
+                .get_credentials()
+                .ok_or_else(|| UnityCatalogError::MissingCredential)?,
             TableTempCredentialsResponse::Error(_error) => {
                 return Err(UnityCatalogError::TemporaryCredentialsFetchFailure)
             }


### PR DESCRIPTION
# Description

I was trying to build the `deltalake-catalog-unity` crate without the `datafusion` feature. Here is the command I used:

```bash
cargo build -p deltalake-catalog-unity --no-default-features --features "aws"
```

I encountered the following error.

```text
error[E0432]: unresolved import `datafusion_common`
  --> crates/catalog-unity/src/lib.rs:10:5
   |
10 | use datafusion_common::DataFusionError;
   |     ^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `datafusion_common`
   |
   = help: if you wanted to use a crate named `datafusion_common`, use `cargo add datafusion_common` to add it to your `Cargo.toml`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `deltalake-catalog-unity` (lib) due to 1 previous error
```

This PR fixes the build error.

# Related Issue(s)

N/A

# Documentation

N/A
