### PR TITLE
feat: spawn io with spawn service

### DIFF
--- a/crates/aws/tests/integration_s3_dynamodb.rs
+++ b/crates/aws/tests/integration_s3_dynamodb.rs
@@ -107,7 +107,8 @@ async fn test_create_s3_table() -> TestResult<()> {
         deltalake_aws::constants::AWS_FORCE_CREDENTIAL_LOAD.into() => "true".into(),
         deltalake_aws::constants::AWS_ENDPOINT_URL.into()  => "http://localhost:4566".into(),
     };
-    let log_store = logstore_for(Url::parse(&table_uri)?, storage_options, None)?;
+    let storage_config = StorageConfig::parse_options(storage_options)?;
+    let log_store = logstore_for(Url::parse(&table_uri)?, storage_config)?;
 
     let payload = PutPayload::from_static(b"test-drivin");
     let _put = log_store

--- a/crates/azure/src/lib.rs
+++ b/crates/azure/src/lib.rs
@@ -8,7 +8,9 @@ use deltalake_core::logstore::{
 };
 use deltalake_core::{DeltaResult, DeltaTableError, Path};
 use object_store::azure::{AzureConfigKey, MicrosoftAzureBuilder};
+use object_store::client::SpawnedReqwestConnector;
 use object_store::{ObjectStoreScheme, RetryConfig};
+use tokio::runtime::Handle;
 use url::Url;
 
 mod config;
@@ -40,12 +42,18 @@ impl ObjectStoreFactory for AzureFactory {
         url: &Url,
         options: &HashMap<String, String>,
         retry: &RetryConfig,
+        handle: Option<Handle>,
     ) -> DeltaResult<(ObjectStoreRef, Path)> {
         let config = config::AzureConfigHelper::try_new(options.as_azure_options())?.build()?;
 
         let mut builder = MicrosoftAzureBuilder::new()
             .with_url(url.to_string())
             .with_retry(retry.clone());
+
+        if let Some(handle) = handle {
+            builder = builder.with_http_connector(SpawnedReqwestConnector::new(handle));
+        }
+
         for (key, value) in config.iter() {
             builder = builder.with_config(*key, value.clone());
         }

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -152,7 +152,8 @@ static DELTA_LOG_PATH: LazyLock<Path> = LazyLock::new(|| Path::from("_delta_log"
 /// # use std::collections::HashMap;
 /// # use url::Url;
 /// let location = Url::parse("memory:///").expect("Failed to make location");
-/// let logstore = logstore_for(location, HashMap::<String, String>::new(), None).expect("Failed to get a logstore");
+/// let storage_config = StorageConfig::default();
+/// let logstore = logstore_for(location, storage_config).expect("Failed to get a logstore");
 /// ```
 pub fn logstore_for(location: Url, storage_config: StorageConfig) -> DeltaResult<LogStoreRef> {
     // turn location into scheme

--- a/crates/core/src/logstore/storage/runtime.rs
+++ b/crates/core/src/logstore/storage/runtime.rs
@@ -78,20 +78,6 @@ pub struct RuntimeConfig {
     pub(crate) enable_time: Option<bool>,
 }
 
-impl RuntimeConfig {
-    pub fn decorate<T: ObjectStore + Clone>(
-        &self,
-        store: T,
-        handle: Option<Handle>,
-    ) -> DeltaIOStorageBackend<T> {
-        let handle = handle.unwrap_or_else(|| io_rt(Some(self)).handle().clone());
-        DeltaIOStorageBackend {
-            inner: store,
-            rt_handle: handle,
-        }
-    }
-}
-
 /// Provide custom Tokio RT or a runtime config
 #[derive(Debug, Clone)]
 pub enum IORuntime {
@@ -121,8 +107,20 @@ impl IORuntime {
 /// Wraps any object store and runs IO in it's own runtime [EXPERIMENTAL]
 #[derive(Clone)]
 pub struct DeltaIOStorageBackend<T: ObjectStore + Clone> {
-    pub(crate) inner: T,
-    pub(crate) rt_handle: Handle,
+    pub inner: T,
+    pub rt_handle: Handle,
+}
+
+impl<T> DeltaIOStorageBackend<T>
+where
+    T: ObjectStore + Clone,
+{
+    pub fn new(store: T, handle: Handle) -> Self {
+        Self {
+            inner: store,
+            rt_handle: handle,
+        }
+    }
 }
 
 impl<T: ObjectStore + Clone> DeltaIOStorageBackend<T> {

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -282,12 +282,9 @@ impl<'de> Deserialize<'de> for DeltaTable {
                 let storage_config: LogStoreConfig = seq
                     .next_element()?
                     .ok_or_else(|| A::Error::invalid_length(0, &self))?;
-                let log_store = crate::logstore::logstore_for(
-                    storage_config.location,
-                    storage_config.options.raw,
-                    None,
-                )
-                .map_err(|_| A::Error::custom("Failed deserializing LogStore"))?;
+                let log_store =
+                    crate::logstore::logstore_for(storage_config.location, storage_config.options)
+                        .map_err(|_| A::Error::custom("Failed deserializing LogStore"))?;
 
                 let table = DeltaTable {
                     state,

--- a/crates/lakefs/src/execute.rs
+++ b/crates/lakefs/src/execute.rs
@@ -91,10 +91,10 @@ mod tests {
     use crate::register_handlers;
 
     use super::*;
-    use deltalake_core::{logstore::logstore_for, logstore::ObjectStoreRegistry};
+    use deltalake_core::logstore::{logstore_for, ObjectStoreRegistry, StorageConfig};
     use http::StatusCode;
     use maplit::hashmap;
-    use std::{collections::HashMap, sync::OnceLock};
+    use std::sync::OnceLock;
     use tokio::runtime::Runtime;
     use url::Url;
     use uuid::Uuid;
@@ -108,7 +108,9 @@ mod tests {
             "SECRET_ACCESS_KEY".to_string() => "options_key".to_string(),
             "REGION".to_string() => "options_key".to_string()
         };
-        logstore_for(location, raw_options, None).unwrap()
+
+        let storage_config = StorageConfig::parse_options(raw_options).unwrap();
+        logstore_for(location, storage_config).unwrap()
     }
 
     #[inline]
@@ -322,8 +324,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_error_with_invalid_log_store() {
         let location = Url::parse("memory:///table").unwrap();
-        let invalid_default_store =
-            logstore_for(location, HashMap::<String, String>::default(), None).unwrap();
+        let invalid_default_store = logstore_for(location, StorageConfig::default()).unwrap();
 
         let handler = LakeFSCustomExecuteHandler {};
         let operation_id = Uuid::new_v4();
@@ -378,8 +379,7 @@ mod tests {
         // When file operations is false, the commit hook executor is a noop, since we don't need
         // to create any branches, or commit and merge them back.
         let location = Url::parse("memory:///table").unwrap();
-        let invalid_default_store =
-            logstore_for(location, HashMap::<String, String>::default(), None).unwrap();
+        let invalid_default_store = logstore_for(location, StorageConfig::default()).unwrap();
 
         let handler = LakeFSCustomExecuteHandler {};
         let operation_id = Uuid::new_v4();


### PR DESCRIPTION
# Description
Using the superior spawn request connector over the deltaIOStoragebackend: https://github.com/apache/arrow-rs-object-store/pull/332/files#diff-3afe0961b5df6dc75c903371865daa9b80c8da3912c9b96df5b51613a5695335

Had to slightly refactor logstore_with and logstore_for to pass the StorageConfig around, which now can hold on the IORuntime directly, so that the `lakefs` integration and others can rebuild a new store with the same io_runtime

- closes https://github.com/delta-io/delta-rs/issues/3427