### PR TITLE
chore(deps): bump foyer to v0.17.2 to prevent from wrong result

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,19 +32,19 @@ delta_kernel = { version = "0.10.0", features = [
 ] }
 
 # arrow
-arrow = { version = "55" }
-arrow-arith = { version = "55" }
-arrow-array = { version = "55", features = ["chrono-tz"] }
-arrow-buffer = { version = "55" }
-arrow-cast = { version = "55" }
-arrow-ipc = { version = "55" }
-arrow-json = { version = "55" }
-arrow-ord = { version = "55" }
-arrow-row = { version = "55" }
-arrow-schema = { version = "55" }
-arrow-select = { version = "55" }
-object_store = { version = "0.12.0" }
-parquet = { version = "55" }
+arrow = { version = "=55.0.0" }
+arrow-arith = { version = "=55.0.0" }
+arrow-array = { version = "=55.0.0", features = ["chrono-tz"] }
+arrow-buffer = { version = "=55.0.0" }
+arrow-cast = { version = "=55.0.0" }
+arrow-ipc = { version = "=55.0.0" }
+arrow-json = { version = "=55.0.0" }
+arrow-ord = { version = "=55.0.0" }
+arrow-row = { version = "=55.0.0" }
+arrow-schema = { version = "=55.0.0" }
+arrow-select = { version = "=55.0.0" }
+object_store = { version = "0.12.1" }
+parquet = { version = "=55.0.0" }
 
 # datafusion
 datafusion = "47.0.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -76,7 +76,7 @@ tokio = { workspace = true, features = [
 ] }
 
 # caching
-foyer = { version = "0.17.0", optional = true, features = ["serde"] }
+foyer = { version = "0.17.2", optional = true, features = ["serde"] }
 tempfile = { version = "3.19.1", optional = true }
 
 # other deps (these should be organized and pulled into workspace.dependencies as necessary)


### PR DESCRIPTION
# Description
The description of the main changes of your pull request

Bump foyer to v0.17.2 to prevent from wrong disk cache returned entry on key hash collision.

# Related Issue(s)
<!---
For example:

- closes #106
--->

https://github.com/foyer-rs/foyer/pull/1004

# Documentation

<!---
Share links to useful documentation
--->
