### PR TITLE
chore: bump crate versions which are due for release

### DIFF
--- a/crates/catalog-unity/Cargo.toml
+++ b/crates/catalog-unity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-catalog-unity"
-version = "0.10.0"
+version = "0.10.1"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-core"
-version = "0.26.1"
+version = "0.26.2"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake"
-version = "0.26.1"
+version = "0.26.2"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/lakefs/Cargo.toml
+++ b/crates/lakefs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-lakefs"
-version = "0.9.1"
+version = "0.9.2"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true


### PR DESCRIPTION
only the crates which had changes since 0.26.1