### PR TITLE
chore: remove unused code and deps

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -89,10 +89,8 @@ num-bigint = "0.4"
 num-traits = "0.2.15"
 parking_lot = "0.12"
 percent-encoding = "2"
-roaring = "0.10.1"
 tracing = { workspace = true }
 rand = "0.8"
-z85 = "3.0.5"
 maplit = "1"
 sqlparser = { version = "0.56.0" }
 humantime = { version = "2.1.0" }
@@ -107,7 +105,6 @@ fs_extra = "1.2.0"
 maplit = "1"
 pretty_assertions = "1.2.1"
 pretty_env_logger = "0.5.0"
-rand = "0.8"
 rstest = { version = "0.25.0" }
 serial_test = "3"
 tempfile = "3"


### PR DESCRIPTION
# Description

Removes unsused code to read deletion vectors. THis functionality is implemented in delta-kernel and does not need to be replicated here.
