### PR TITLE
refactor: more specific factory parameter names

### DIFF
--- a/crates/aws/src/lib.rs
+++ b/crates/aws/src/lib.rs
@@ -54,7 +54,7 @@ impl S3StorageOptionsConversion for S3LogStoreFactory {}
 impl LogStoreFactory for S3LogStoreFactory {
     fn with_options(
         &self,
-        store: ObjectStoreRef,
+        prefixed_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
@@ -69,7 +69,11 @@ impl LogStoreFactory for S3LogStoreFactory {
         }) {
             debug!("S3LogStoreFactory has been asked to create a LogStore where the underlying store has copy-if-not-exists enabled - no locking provider required");
             warn!("Most S3 object store support conditional put, remove copy_if_not_exists parameter to use a more performant conditional put.");
-            return Ok(logstore::default_s3_logstore(store, location, options));
+            return Ok(logstore::default_s3_logstore(
+                prefixed_store,
+                location,
+                options,
+            ));
         }
 
         let s3_options = S3StorageOptions::from_map(&s3_options)?;
@@ -79,10 +83,10 @@ impl LogStoreFactory for S3LogStoreFactory {
                 location.clone(),
                 options,
                 &s3_options,
-                store,
+                prefixed_store,
             )?));
         }
-        Ok(default_logstore(store, location, options))
+        Ok(default_logstore(prefixed_store, location, options))
     }
 }
 

--- a/crates/azure/src/lib.rs
+++ b/crates/azure/src/lib.rs
@@ -72,11 +72,11 @@ impl ObjectStoreFactory for AzureFactory {
 impl LogStoreFactory for AzureFactory {
     fn with_options(
         &self,
-        store: ObjectStoreRef,
+        prefixed_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(store, location, options))
+        Ok(default_logstore(prefixed_store, location, options))
     }
 }
 

--- a/crates/catalog-unity/src/lib.rs
+++ b/crates/catalog-unity/src/lib.rs
@@ -870,11 +870,11 @@ impl ObjectStoreFactory for UnityCatalogFactory {
 impl LogStoreFactory for UnityCatalogFactory {
     fn with_options(
         &self,
-        store: ObjectStoreRef,
+        prefixed_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(store, location, options))
+        Ok(default_logstore(prefixed_store, location, options))
     }
 }
 

--- a/crates/core/src/logstore/factories.rs
+++ b/crates/core/src/logstore/factories.rs
@@ -111,14 +111,14 @@ pub trait LogStoreFactory: Send + Sync {
     /// This method is responsible for creating a new instance of the [LogStore] implementation.
     ///
     /// ## Parameters
-    /// - `store`: A reference to the object store.
+    /// - `prefixed_store`: A reference to the object store.
     /// - `location`: A reference to the URL of the location.
     /// - `options`: A reference to the storage configuration options.
     ///
     /// It returns a [DeltaResult] containing an [Arc] to the newly created [LogStore] implementation.
     fn with_options(
         &self,
-        store: ObjectStoreRef,
+        prefixed_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>>;
@@ -130,11 +130,11 @@ struct DefaultLogStoreFactory {}
 impl LogStoreFactory for DefaultLogStoreFactory {
     fn with_options(
         &self,
-        store: ObjectStoreRef,
+        prefixed_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(store, location, options))
+        Ok(default_logstore(prefixed_store, location, options))
     }
 }
 

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -92,9 +92,17 @@ pub(crate) mod storage;
 
 /// Internal trait to handle object store configuration and initialization.
 trait LogStoreFactoryExt {
+    /// Create a new log store with the given options.
+    ///
+    /// ## Parameters
+    ///
+    /// - `root_store`: and instance of [`ObjectStoreRef`] with no prefix o.a. applied.
+    ///   I.e. pointing to the root of the onject store.
+    /// - `location`: The location of the the delta table (where the `_delta_log` directory is).
+    /// - `options`: The options for the log store.
     fn with_options_internal(
         &self,
-        store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>>;

--- a/crates/gcp/src/lib.rs
+++ b/crates/gcp/src/lib.rs
@@ -73,11 +73,11 @@ impl ObjectStoreFactory for GcpFactory {
 impl LogStoreFactory for GcpFactory {
     fn with_options(
         &self,
-        store: ObjectStoreRef,
+        prefixed_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(store, location, options))
+        Ok(default_logstore(prefixed_store, location, options))
     }
 }
 

--- a/crates/hdfs/src/lib.rs
+++ b/crates/hdfs/src/lib.rs
@@ -38,11 +38,11 @@ impl ObjectStoreFactory for HdfsFactory {
 impl LogStoreFactory for HdfsFactory {
     fn with_options(
         &self,
-        store: ObjectStoreRef,
+        prefixed_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(store, location, options))
+        Ok(default_logstore(prefixed_store, location, options))
     }
 }
 

--- a/crates/lakefs/src/lib.rs
+++ b/crates/lakefs/src/lib.rs
@@ -27,13 +27,13 @@ impl S3StorageOptionsConversion for LakeFSLogStoreFactory {}
 impl LogStoreFactory for LakeFSLogStoreFactory {
     fn with_options(
         &self,
-        store: ObjectStoreRef,
+        prefixed_store: ObjectStoreRef,
         location: &Url,
         config: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
         let options = StorageConfig::parse_options(self.with_env_s3(&config.raw.clone()))?;
         debug!("LakeFSLogStoreFactory has been asked to create a LogStore");
-        lakefs_logstore(store, location, &options)
+        lakefs_logstore(prefixed_store, location, &options)
     }
 }
 

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -90,11 +90,11 @@ impl ObjectStoreFactory for MountFactory {
 impl LogStoreFactory for MountFactory {
     fn with_options(
         &self,
-        store: ObjectStoreRef,
+        prefixed_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(store, location, options))
+        Ok(default_logstore(prefixed_store, location, options))
     }
 }
 


### PR DESCRIPTION
# Description

In preparation for adopting engine we rename same paramerters on the factory methods to be more specific. I.e. we distinguish in docs and names if one can expect an objectst store with a prefix applied, or one pointing at the storeage root.
