### PR TITLE
feat: expose kernel Engine on LogStore

### DIFF
--- a/crates/aws/src/lib.rs
+++ b/crates/aws/src/lib.rs
@@ -55,6 +55,7 @@ impl LogStoreFactory for S3LogStoreFactory {
     fn with_options(
         &self,
         prefixed_store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
@@ -71,6 +72,7 @@ impl LogStoreFactory for S3LogStoreFactory {
             warn!("Most S3 object store support conditional put, remove copy_if_not_exists parameter to use a more performant conditional put.");
             return Ok(logstore::default_s3_logstore(
                 prefixed_store,
+                root_store,
                 location,
                 options,
             ));
@@ -84,9 +86,15 @@ impl LogStoreFactory for S3LogStoreFactory {
                 options,
                 &s3_options,
                 prefixed_store,
+                root_store,
             )?));
         }
-        Ok(default_logstore(prefixed_store, location, options))
+        Ok(default_logstore(
+            prefixed_store,
+            root_store,
+            location,
+            options,
+        ))
     }
 }
 
@@ -765,13 +773,13 @@ mod tests {
     #[serial]
     fn test_logstore_factory_default() {
         let factory = S3LogStoreFactory::default();
-        let store = InMemory::new();
+        let store = Arc::new(InMemory::new());
         let url = Url::parse("s3://test-bucket").unwrap();
         unsafe {
             std::env::remove_var(crate::constants::AWS_S3_LOCKING_PROVIDER);
         }
         let logstore = factory
-            .with_options(Arc::new(store), &url, &Default::default())
+            .with_options(store.clone(), store, &url, &Default::default())
             .unwrap();
         assert_eq!(logstore.name(), "DefaultLogStore");
     }
@@ -780,14 +788,14 @@ mod tests {
     #[serial]
     fn test_logstore_factory_with_locking_provider() {
         let factory = S3LogStoreFactory::default();
-        let store = InMemory::new();
+        let store = Arc::new(InMemory::new());
         let url = Url::parse("s3://test-bucket").unwrap();
         unsafe {
             std::env::set_var(crate::constants::AWS_S3_LOCKING_PROVIDER, "dynamodb");
         }
 
         let logstore = factory
-            .with_options(Arc::new(store), &url, &Default::default())
+            .with_options(store.clone(), store, &url, &Default::default())
             .unwrap();
         assert_eq!(logstore.name(), "S3DynamoDbLogStore");
     }

--- a/crates/aws/src/logstore/default_logstore.rs
+++ b/crates/aws/src/logstore/default_logstore.rs
@@ -31,7 +31,7 @@ pub fn default_s3_logstore(
 /// Default [`LogStore`] implementation
 #[derive(Debug, Clone)]
 pub struct S3LogStore {
-    storage: ObjectStoreRef,
+    prefixed_store: ObjectStoreRef,
     root_store: ObjectStoreRef,
     config: LogStoreConfig,
 }
@@ -41,15 +41,18 @@ impl S3LogStore {
     ///
     /// # Arguments
     ///
-    /// * `storage` - A shared reference to an [`object_store::ObjectStore`] with "/" pointing at delta table root (i.e. where `_delta_log` is located).
+    /// * `prefixed_store` - A shared reference to an [`object_store::ObjectStore`]
+    ///   with "/" pointing at delta table root (i.e. where `_delta_log` is located).
+    /// * `root_store` - A shared reference to an [`object_store::ObjectStore`] with "/"
+    ///   pointing at root of the storage system.
     /// * `location` - A url corresponding to the storage location of `storage`.
     pub fn new(
-        storage: ObjectStoreRef,
+        prefixed_store: ObjectStoreRef,
         root_store: ObjectStoreRef,
         config: LogStoreConfig,
     ) -> Self {
         Self {
-            storage,
+            prefixed_store,
             root_store,
             config,
         }
@@ -120,7 +123,7 @@ impl LogStore for S3LogStore {
     }
 
     fn object_store(&self, _operation_id: Option<Uuid>) -> Arc<dyn ObjectStore> {
-        self.storage.clone()
+        self.prefixed_store.clone()
     }
 
     fn root_object_store(&self, _operation_id: Option<Uuid>) -> Arc<dyn ObjectStore> {

--- a/crates/aws/tests/integration_s3_dynamodb.rs
+++ b/crates/aws/tests/integration_s3_dynamodb.rs
@@ -165,7 +165,8 @@ async fn test_repair_commit_entry() -> TestResult<()> {
         ensure_table_uri(table.table_uri())?,
         &options,
         &S3_OPTIONS,
-        std::sync::Arc::new(table.object_store()),
+        table.log_store().object_store(None),
+        table.log_store().root_object_store(None),
     )?;
 
     // create an incomplete log entry, commit file not yet moved from its temporary location
@@ -240,7 +241,8 @@ async fn test_abort_commit_entry() -> TestResult<()> {
         ensure_table_uri(table.table_uri())?,
         &options,
         &S3_OPTIONS,
-        std::sync::Arc::new(table.object_store()),
+        table.log_store().object_store(None),
+        table.log_store().root_object_store(None),
     )?;
 
     let entry = create_incomplete_commit_entry(&table, 1, "unfinished_commit").await?;
@@ -287,7 +289,8 @@ async fn test_abort_commit_entry_fail_to_delete_entry() -> TestResult<()> {
         ensure_table_uri(table.table_uri())?,
         &options,
         &S3_OPTIONS,
-        std::sync::Arc::new(table.object_store()),
+        table.log_store().object_store(None),
+        table.log_store().root_object_store(None),
     )?;
 
     let entry = create_incomplete_commit_entry(&table, 1, "finished_commit").await?;

--- a/crates/azure/src/lib.rs
+++ b/crates/azure/src/lib.rs
@@ -73,10 +73,16 @@ impl LogStoreFactory for AzureFactory {
     fn with_options(
         &self,
         prefixed_store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(prefixed_store, location, options))
+        Ok(default_logstore(
+            prefixed_store,
+            root_store,
+            location,
+            options,
+        ))
     }
 }
 

--- a/crates/catalog-unity/src/lib.rs
+++ b/crates/catalog-unity/src/lib.rs
@@ -871,10 +871,16 @@ impl LogStoreFactory for UnityCatalogFactory {
     fn with_options(
         &self,
         prefixed_store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(prefixed_store, location, options))
+        Ok(default_logstore(
+            prefixed_store,
+            root_store,
+            location,
+            options,
+        ))
     }
 }
 

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -3144,8 +3144,13 @@ mod tests {
 
         let (object_store, mut operations) =
             RecordingObjectStore::new(table.log_store().object_store(None));
-        let log_store =
-            DefaultLogStore::new(Arc::new(object_store), table.log_store().config().clone());
+        // this uses an in memory store pointing at root...
+        let both_store = Arc::new(object_store);
+        let log_store = DefaultLogStore::new(
+            both_store.clone(),
+            both_store,
+            table.log_store().config().clone(),
+        );
         let provider = DeltaTableProvider::try_new(
             table.snapshot().unwrap().clone(),
             Arc::new(log_store),

--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -947,6 +947,7 @@ mod tests {
         let url = Url::parse("mem://what/is/this").unwrap();
         let log_store = DefaultLogStore::new(
             store.clone(),
+            store.clone(),
             crate::logstore::LogStoreConfig {
                 location: url,
                 options: Default::default(),

--- a/crates/core/src/logstore/default_logstore.rs
+++ b/crates/core/src/logstore/default_logstore.rs
@@ -24,7 +24,8 @@ fn put_options() -> &'static PutOptions {
 /// Default [`LogStore`] implementation
 #[derive(Debug, Clone)]
 pub struct DefaultLogStore {
-    pub(crate) storage: ObjectStoreRef,
+    prefixed_store: ObjectStoreRef,
+    root_store: ObjectStoreRef,
     config: LogStoreConfig,
 }
 
@@ -33,10 +34,21 @@ impl DefaultLogStore {
     ///
     /// # Arguments
     ///
-    /// * `storage` - A shared reference to an [`object_store::ObjectStore`] with "/" pointing at delta table root (i.e. where `_delta_log` is located).
+    /// * `prefixed_store` - A shared reference to an [`object_store::ObjectStore`] with "/"
+    ///   pointing at delta table root (i.e. where `_delta_log` is located).
+    /// * `root_store` - A shared reference to an [`object_store::ObjectStore`] with "/"
+    ///   pointing at root of the storage system.
     /// * `location` - A url corresponding to the storage location of `storage`.
-    pub fn new(storage: ObjectStoreRef, config: LogStoreConfig) -> Self {
-        Self { storage, config }
+    pub fn new(
+        prefixed_store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
+        config: LogStoreConfig,
+    ) -> Self {
+        Self {
+            prefixed_store,
+            root_store,
+            config,
+        }
     }
 }
 
@@ -104,7 +116,11 @@ impl LogStore for DefaultLogStore {
     }
 
     fn object_store(&self, _: Option<Uuid>) -> Arc<dyn ObjectStore> {
-        self.storage.clone()
+        self.prefixed_store.clone()
+    }
+
+    fn root_object_store(&self, _: Option<Uuid>) -> Arc<dyn ObjectStore> {
+        self.root_store.clone()
     }
 
     fn config(&self) -> &LogStoreConfig {

--- a/crates/core/src/logstore/factories.rs
+++ b/crates/core/src/logstore/factories.rs
@@ -119,6 +119,7 @@ pub trait LogStoreFactory: Send + Sync {
     fn with_options(
         &self,
         prefixed_store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>>;
@@ -131,10 +132,16 @@ impl LogStoreFactory for DefaultLogStoreFactory {
     fn with_options(
         &self,
         prefixed_store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(prefixed_store, location, options))
+        Ok(default_logstore(
+            prefixed_store,
+            root_store,
+            location,
+            options,
+        ))
     }
 }
 

--- a/crates/core/src/operations/create.rs
+++ b/crates/core/src/operations/create.rs
@@ -14,7 +14,7 @@ use super::{CustomExecuteHandler, Operation};
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, TableReference, PROTOCOL};
 use crate::kernel::{Action, DataType, Metadata, Protocol, StructField, StructType};
-use crate::logstore::{LogStore, LogStoreRef};
+use crate::logstore::LogStoreRef;
 use crate::protocol::{DeltaOperation, SaveMode};
 use crate::table::builder::ensure_table_uri;
 use crate::table::config::TableProperty;
@@ -229,8 +229,8 @@ impl CreateBuilder {
         self
     }
 
-    /// Provide a [`LogStore`] instance, that points at table location
-    pub fn with_log_store(mut self, log_store: Arc<dyn LogStore>) -> Self {
+    /// Provide a [`LogStore`] instance
+    pub fn with_log_store(mut self, log_store: LogStoreRef) -> Self {
         self.log_store = Some(log_store);
         self
     }

--- a/crates/core/src/table/builder.rs
+++ b/crates/core/src/table/builder.rs
@@ -182,11 +182,15 @@ impl DeltaTableBuilder {
     ///
     /// # Arguments
     ///
-    /// * `storage` - A shared reference to an [`ObjectStore`](object_store::ObjectStore) with
-    ///   "/" pointing at delta table root (i.e. where `_delta_log` is located).
-    /// * `location` - A url corresponding to the storagle location of `storage`.
-    pub fn with_storage_backend(mut self, storage: Arc<DynObjectStore>, location: Url) -> Self {
-        self.storage_backend = Some((storage, location));
+    /// * `root_storage` - A shared reference to an [`ObjectStore`](object_store::ObjectStore) with
+    ///   "/" pointing at the root of the object store.
+    /// * `location` - A url corresponding to the storage location of the delta table.
+    pub fn with_storage_backend(
+        mut self,
+        root_storage: Arc<DynObjectStore>,
+        location: Url,
+    ) -> Self {
+        self.storage_backend = Some((root_storage, location));
         self
     }
 

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -70,8 +70,6 @@ pub struct DeltaTable {
     pub state: Option<DeltaTableState>,
     /// the load options used during load
     pub config: DeltaTableConfig,
-    /// Kernel engine sitting under the [DeltaTable]
-    //engine: Arc<dyn delta_kernel::Engine>,
     /// log store
     pub(crate) log_store: LogStoreRef,
 }

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -1250,13 +1250,14 @@ mod local {
     #[tokio::test]
     async fn test_issue_2105() -> Result<()> {
         use datafusion::arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
-        let path = tempfile::tempdir().unwrap();
-        let path = path.into_path();
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let path = tmp_dir.path();
 
-        let file_store = LocalFileSystem::new_with_prefix(path.clone()).unwrap();
+        let file_store = LocalFileSystem::new_with_prefix(path).unwrap();
         let log_store = default_logstore(
             Arc::new(file_store),
-            &Url::from_file_path(path.clone()).unwrap(),
+            Arc::new(LocalFileSystem::new()),
+            &Url::from_file_path(path).unwrap(),
             &Default::default(),
         );
 

--- a/crates/gcp/src/lib.rs
+++ b/crates/gcp/src/lib.rs
@@ -74,10 +74,16 @@ impl LogStoreFactory for GcpFactory {
     fn with_options(
         &self,
         prefixed_store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(prefixed_store, location, options))
+        Ok(default_logstore(
+            prefixed_store,
+            root_store,
+            location,
+            options,
+        ))
     }
 }
 

--- a/crates/hdfs/src/lib.rs
+++ b/crates/hdfs/src/lib.rs
@@ -39,10 +39,16 @@ impl LogStoreFactory for HdfsFactory {
     fn with_options(
         &self,
         prefixed_store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(prefixed_store, location, options))
+        Ok(default_logstore(
+            prefixed_store,
+            root_store,
+            location,
+            options,
+        ))
     }
 }
 

--- a/crates/lakefs/src/execute.rs
+++ b/crates/lakefs/src/execute.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 use deltalake_core::{
-    logstore::LogStoreRef, operations::CustomExecuteHandler, DeltaResult, DeltaTableError,
+    logstore::{LogStore as _, LogStoreRef},
+    operations::CustomExecuteHandler,
+    DeltaResult, DeltaTableError,
 };
 use tracing::debug;
 use uuid::Uuid;
@@ -28,7 +30,7 @@ impl CustomExecuteHandler for LakeFSCustomExecuteHandler {
         if let Some(lakefs_store) = log_store.clone().as_any().downcast_ref::<LakeFSLogStore>() {
             let (repo, _, _) = lakefs_store
                 .client
-                .decompose_url(lakefs_store.config.location.to_string());
+                .decompose_url(lakefs_store.config().location.to_string());
             let result = lakefs_store
                 .client
                 .delete_branch(repo, lakefs_store.client.get_transaction(operation_id)?)
@@ -144,7 +146,7 @@ mod tests {
             .downcast_ref::<LakeFSLogStore>()
         {
             assert!(lakefs_store
-                .storage
+                .prefixed_registry
                 .get_store(
                     &Url::parse(format!("lakefs://repo/delta-tx-{operation_id}/table").as_str())
                         .unwrap()
@@ -185,7 +187,7 @@ mod tests {
             .downcast_ref::<LakeFSLogStore>()
         {
             assert!(lakefs_store
-                .storage
+                .prefixed_registry
                 .get_store(
                     &Url::parse(format!("lakefs://repo/delta-tx-{operation_id}/table").as_str())
                         .unwrap()

--- a/crates/lakefs/src/lib.rs
+++ b/crates/lakefs/src/lib.rs
@@ -28,12 +28,13 @@ impl LogStoreFactory for LakeFSLogStoreFactory {
     fn with_options(
         &self,
         prefixed_store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
         location: &Url,
         config: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
         let options = StorageConfig::parse_options(self.with_env_s3(&config.raw.clone()))?;
         debug!("LakeFSLogStoreFactory has been asked to create a LogStore");
-        lakefs_logstore(prefixed_store, location, &options)
+        lakefs_logstore(prefixed_store, root_store, location, &options)
     }
 }
 

--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -91,10 +91,16 @@ impl LogStoreFactory for MountFactory {
     fn with_options(
         &self,
         prefixed_store: ObjectStoreRef,
+        root_store: ObjectStoreRef,
         location: &Url,
         options: &StorageConfig,
     ) -> DeltaResult<Arc<dyn LogStore>> {
-        Ok(default_logstore(prefixed_store, location, options))
+        Ok(default_logstore(
+            prefixed_store,
+            root_store,
+            location,
+            options,
+        ))
     }
 }
 


### PR DESCRIPTION
# Description

One last pre-factor before starting to use kernel on more actively in our codebase. In this PR we expose an `Engine` on `LogStore` as well as introduce a distinction between `prefixed_store` and `root_store` exposed on log store. This structure is far from ideal, but allowsd us to begin migration. As we progress there, we should see many opportunities to simplify the API surface again.

@ion-elgreco - there was a little bit more handlin needed on the lake fs integration, but I "think" this should work for now.