### PR TITLE
feat: move some core path handling to use URLs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ debug = true
 debug = "line-tables-only"
 
 [workspace.dependencies]
-delta_kernel = { version = "0.10.0", features = [
+delta_kernel = { git = "https://github.com/roeap/delta-kernel-rs", branch = "fix/cp-send", features = [
     "arrow-55",
     "internal-api",
 ] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -57,7 +57,7 @@ chrono = { workspace = true, default-features = false, features = ["clock"] }
 regex = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
-url = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 urlencoding = { workspace = true }
 
 # runtime

--- a/crates/core/src/kernel/scalars.rs
+++ b/crates/core/src/kernel/scalars.rs
@@ -76,6 +76,7 @@ impl ScalarExt for Scalar {
             Self::Null(_) => "null".to_string(),
             Self::Struct(_) => self.to_string(),
             Self::Array(_) => self.to_string(),
+            Self::Map(_) => unimplemented!(),
         }
     }
 
@@ -282,6 +283,7 @@ impl ScalarExt for Scalar {
             Self::Null(_) => Value::Null,
             Self::Struct(_) => unimplemented!(),
             Self::Array(_) => unimplemented!(),
+            Self::Map(_) => unimplemented!(),
         }
     }
 }

--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -868,8 +868,7 @@ impl PostCommit {
 
         let checkpoint_interval = table_state.config().checkpoint_interval() as i64;
         if ((version + 1) % checkpoint_interval) == 0 {
-            create_checkpoint_for(version, table_state, log_store.as_ref(), Some(operation_id))
-                .await?;
+            create_checkpoint_for(version, log_store.clone(), Some(operation_id)).await?;
             Ok(true)
         } else {
             Ok(false)

--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -812,7 +812,7 @@ impl PostCommit {
                 if num_log_files_cleaned_up > 0 {
                     state = DeltaTableState::try_new(
                         &state.snapshot().table_root(),
-                        self.log_store.object_store(None),
+                        self.log_store.root_object_store(None),
                         state.load_config().clone(),
                         Some(self.version),
                     )
@@ -839,8 +839,8 @@ impl PostCommit {
             ))
         } else {
             let state = DeltaTableState::try_new(
-                &Path::default(),
-                self.log_store.object_store(None),
+                &self.log_store.table_url(),
+                self.log_store.root_object_store(None),
                 Default::default(),
                 Some(self.version),
             )

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -205,7 +205,7 @@ mod tests {
         let tombstones = table
             .snapshot()
             .unwrap()
-            .all_tombstones(table.object_store().clone())
+            .all_tombstones(table.log_store().root_object_store(None))
             .await
             .unwrap()
             .collect_vec();
@@ -322,7 +322,7 @@ mod tests {
         let tombstones = table
             .snapshot()
             .unwrap()
-            .all_tombstones(table.object_store().clone())
+            .all_tombstones(table.log_store().root_object_store(None))
             .await
             .unwrap()
             .collect_vec();

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -1,50 +1,34 @@
 //! Implementation for writing delta checkpoints.
 
-use std::collections::HashMap;
 use std::iter::Iterator;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
-use arrow_json::ReaderBuilder;
+use arrow::compute::filter_record_batch;
+use arrow_array::{BooleanArray, RecordBatch};
 use arrow_schema::ArrowError;
 
-use chrono::{Datelike, NaiveDate, NaiveDateTime, Utc};
+use chrono::Utc;
+use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::engine_data::FilteredEngineData;
+use delta_kernel::{FileMeta, Table};
 use futures::{StreamExt, TryStreamExt};
-use itertools::Itertools;
+use object_store::path::Path;
 use object_store::{Error, ObjectStore};
-use parquet::arrow::ArrowWriter;
-use parquet::basic::Compression;
-use parquet::basic::Encoding;
+use parquet::arrow::async_writer::ParquetObjectWriter;
+use parquet::arrow::AsyncArrowWriter;
 use parquet::errors::ParquetError;
-use parquet::file::properties::WriterProperties;
 use regex::Regex;
-use serde_json::Value;
 use tracing::{debug, error};
 use uuid::Uuid;
 
-use super::{time_utils, ProtocolError};
-use crate::kernel::arrow::delta_log_schema_for_table;
-use crate::kernel::{
-    Action, Add as AddAction, DataType, PrimitiveType, Protocol, Remove, StructField,
-};
+use super::ProtocolError;
 use crate::logstore::LogStore;
-use crate::table::state::DeltaTableState;
-use crate::table::{get_partition_col_data_types, CheckPoint, CheckPointBuilder};
+use crate::table::CheckPoint;
 use crate::{open_table_with_version, DeltaTable};
-
-type SchemaPath = Vec<String>;
 
 /// Error returned when there is an error during creating a checkpoint.
 #[derive(thiserror::Error, Debug)]
 enum CheckpointError {
-    /// Error returned when a string formatted partition value cannot be parsed to its appropriate
-    /// data type.
-    #[error("Partition value {0} cannot be parsed from string.")]
-    PartitionValueNotParseable(String),
-
-    /// Caller attempt to create a checkpoint for a version which does not exist on the table state
-    #[error("Attempted to create a checkpoint for a version {0} that does not match the table state {1}")]
-    StaleTableVersion(i64, i64),
-
     /// Error returned when the parquet writer fails while writing the checkpoint.
     #[error("Failed to write parquet: {}", .source)]
     Parquet {
@@ -60,19 +44,13 @@ enum CheckpointError {
         #[from]
         source: ArrowError,
     },
-
-    #[error("missing required action type in snapshot: {0}")]
-    MissingActionType(String),
 }
 
 impl From<CheckpointError> for ProtocolError {
     fn from(value: CheckpointError) -> Self {
         match value {
-            CheckpointError::PartitionValueNotParseable(_) => Self::InvalidField(value.to_string()),
             CheckpointError::Arrow { source } => Self::Arrow { source },
-            CheckpointError::StaleTableVersion(..) => Self::Generic(value.to_string()),
             CheckpointError::Parquet { source } => Self::ParquetParseError { source },
-            CheckpointError::MissingActionType(_) => Self::Generic(value.to_string()),
         }
     }
 }
@@ -92,13 +70,7 @@ pub async fn create_checkpoint(
     table: &DeltaTable,
     operation_id: Option<Uuid>,
 ) -> Result<(), ProtocolError> {
-    create_checkpoint_for(
-        table.version(),
-        table.snapshot().map_err(|_| ProtocolError::NoMetaData)?,
-        table.log_store.as_ref(),
-        operation_id,
-    )
-    .await?;
+    create_checkpoint_for(table.version(), table.log_store(), operation_id).await?;
     Ok(())
 }
 
@@ -137,7 +109,7 @@ pub async fn create_checkpoint_from_table_uri_and_cleanup(
         .await
         .map_err(|err| ProtocolError::Generic(err.to_string()))?;
     let snapshot = table.snapshot().map_err(|_| ProtocolError::NoMetaData)?;
-    create_checkpoint_for(version, snapshot, table.log_store.as_ref(), None).await?;
+    create_checkpoint_for(version, table.log_store(), operation_id).await?;
 
     let enable_expired_log_cleanup =
         cleanup.unwrap_or_else(|| snapshot.table_config().enable_expired_log_cleanup());
@@ -153,55 +125,60 @@ pub async fn create_checkpoint_from_table_uri_and_cleanup(
 /// Creates checkpoint for a given table version, table state and object store
 pub async fn create_checkpoint_for(
     version: i64,
-    state: &DeltaTableState,
-    log_store: &dyn LogStore,
+    log_store: Arc<dyn LogStore>,
     operation_id: Option<Uuid>,
 ) -> Result<(), ProtocolError> {
-    if !state.load_config().require_files {
-        return Err(ProtocolError::Generic(
-            "Table has not yet been initialized with files, therefore creating a checkpoint is not possible.".to_string()
-        ));
+    let engine = log_store.engine(operation_id).await;
+    let object_store = log_store.root_object_store(operation_id);
+
+    let table = Table::try_from_uri(log_store.table_url())?;
+
+    let task_engine = engine.clone();
+    let (batches, cp_data, cp_writer) = tokio::task::spawn_blocking(move || {
+        let cp_writer = table.checkpoint(task_engine.as_ref(), Some(version as u64))?;
+        let mut cp_data = cp_writer.checkpoint_data(task_engine.as_ref())?;
+        let mut cp_batches = Vec::new();
+        while let Some(Ok(batch)) = cp_data.next() {
+            cp_batches.push(to_batch(batch)?);
+        }
+        Ok::<_, ProtocolError>((cp_batches, cp_data, cp_writer))
+    })
+    .await
+    .map_err(|e| ProtocolError::Generic(e.to_string()))??;
+
+    let cp_path = cp_writer.checkpoint_path()?;
+    let obj_path =
+        Path::from_url_path(cp_path.path()).map_err(|e| ProtocolError::Generic(e.to_string()))?;
+
+    let object_store_writer = ParquetObjectWriter::new(object_store.clone(), obj_path.clone());
+    let mut writer = AsyncArrowWriter::try_new(object_store_writer, batches[0].schema(), None)?;
+    for batch in batches {
+        writer.write(&batch).await?;
     }
+    writer.close().await?;
 
-    if version != state.version() {
-        error!(
-            "create_checkpoint_for called with version {version} but table state contains: {}. The table state may need to be reloaded",
-            state.version()
-        );
-        return Err(CheckpointError::StaleTableVersion(version, state.version()).into());
-    }
+    let obj_meta = object_store.head(&obj_path).await?;
+    let file_meta = FileMeta {
+        location: cp_path,
+        last_modified: obj_meta.last_modified.timestamp_millis(),
+        size: obj_meta.size,
+    };
 
-    // TODO: checkpoints _can_ be multi-part... haven't actually found a good reference for
-    // an appropriate split point yet though so only writing a single part currently.
-    // See https://github.com/delta-io/delta-rs/issues/288
-    let last_checkpoint_path = log_store.log_path().child("_last_checkpoint");
-
-    debug!("Writing parquet bytes to checkpoint buffer.");
-    let tombstones = state
-        .unexpired_tombstones(log_store.object_store(None).clone())
-        .await
-        .map_err(|_| ProtocolError::Generic("filed to get tombstones".into()))?
-        .collect::<Vec<_>>();
-    let (checkpoint, parquet_bytes) = parquet_bytes_from_state(state, tombstones)?;
-
-    let file_name = format!("{version:020}.checkpoint.parquet");
-    let checkpoint_path = log_store.log_path().child(file_name);
-
-    let object_store = log_store.object_store(operation_id);
-    debug!("Writing checkpoint to {checkpoint_path:?}.");
-    object_store
-        .put(&checkpoint_path, parquet_bytes.into())
-        .await?;
-
-    let last_checkpoint_content: Value = serde_json::to_value(checkpoint)?;
-    let last_checkpoint_content = bytes::Bytes::from(serde_json::to_vec(&last_checkpoint_content)?);
-
-    debug!("Writing _last_checkpoint to {last_checkpoint_path:?}.");
-    object_store
-        .put(&last_checkpoint_path, last_checkpoint_content.into())
-        .await?;
+    tokio::task::spawn_blocking(move || {
+        cp_writer.finalize(engine.as_ref(), &file_meta, cp_data)?;
+        Ok::<(), ProtocolError>(())
+    })
+    .await
+    .map_err(|e| ProtocolError::Generic(e.to_string()))??;
 
     Ok(())
+}
+
+fn to_batch(data: FilteredEngineData) -> Result<RecordBatch, ProtocolError> {
+    let engine_data = ArrowEngineData::try_from_engine_data(data.data)?;
+    let predicate = BooleanArray::from(data.selection_vector);
+    let batch = filter_record_batch(engine_data.record_batch(), &predicate)?;
+    Ok(batch)
 }
 
 /// Deletes all delta log commits that are older than the cutoff time
@@ -216,10 +193,11 @@ pub async fn cleanup_expired_logs_for(
         Regex::new(r"_delta_log/(\d{20})\.(json|checkpoint|json.tmp).*$").unwrap()
     });
 
-    let object_store = log_store.object_store(None);
-    let maybe_last_checkpoint = object_store
-        .get(&log_store.log_path().child("_last_checkpoint"))
-        .await;
+    let object_store = log_store.root_object_store(None);
+    let table_path = Path::from_url_path(log_store.table_url().path()).unwrap();
+    let log_path = table_path.child("_delta_log");
+    let last_checkpoint_path = log_path.child("_last_checkpoint");
+    let maybe_last_checkpoint = object_store.get(&last_checkpoint_path).await;
 
     if let Err(Error::NotFound { path: _, source: _ }) = maybe_last_checkpoint {
         return Ok(0);
@@ -236,7 +214,7 @@ pub async fn cleanup_expired_logs_for(
     let deleted = object_store
         .delete_stream(
             object_store
-                .list(Some(log_store.log_path()))
+                .list(Some(&log_path))
                 // This predicate function will filter out any locations that don't
                 // match the given timestamp range
                 .filter_map(|meta: Result<crate::ObjectMeta, _>| async move {
@@ -270,328 +248,9 @@ pub async fn cleanup_expired_logs_for(
     Ok(deleted.len())
 }
 
-fn parquet_bytes_from_state(
-    state: &DeltaTableState,
-    mut tombstones: Vec<Remove>,
-) -> Result<(CheckPoint, bytes::Bytes), ProtocolError> {
-    let current_metadata = state.metadata();
-    let schema = current_metadata.schema()?;
-
-    let partition_col_data_types = get_partition_col_data_types(&schema, current_metadata);
-
-    // Collect a map of paths that require special stats conversion.
-    let mut stats_conversions: Vec<(SchemaPath, DataType)> = Vec::new();
-    let fields = schema.fields().collect_vec();
-    collect_stats_conversions(&mut stats_conversions, fields.as_slice());
-
-    // if any, tombstones do not include extended file metadata, we must omit the extended metadata fields from the remove schema
-    // See https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-file-and-remove-file
-    //
-    // DBR version 8.x and greater have different behaviors of reading the parquet file depending
-    // on the `extended_file_metadata` flag, hence this is safer to set `extended_file_metadata=false`
-    // and omit metadata columns if at least one remove action has `extended_file_metadata=false`.
-    // We've added the additional check on `size.is_some` because in delta-spark the primitive long type
-    // is used, hence we want to omit possible errors when `extended_file_metadata=true`, but `size=null`
-    let use_extended_remove_schema = tombstones
-        .iter()
-        .all(|r| r.extended_file_metadata == Some(true) && r.size.is_some());
-
-    // If use_extended_remove_schema=false for some of the tombstones, then it should be for each.
-    if !use_extended_remove_schema {
-        for remove in tombstones.iter_mut() {
-            remove.extended_file_metadata = Some(false);
-        }
-    }
-    let files = state
-        .file_actions_iter()
-        .map_err(|e| ProtocolError::Generic(e.to_string()))?;
-    // protocol
-    let jsons = std::iter::once(Action::Protocol(Protocol {
-        min_reader_version: state.protocol().min_reader_version,
-        min_writer_version: state.protocol().min_writer_version,
-        writer_features: if state.protocol().min_writer_version >= 7 {
-            Some(state.protocol().writer_features.clone().unwrap_or_default())
-        } else {
-            None
-        },
-        reader_features: if state.protocol().min_reader_version >= 3 {
-            Some(state.protocol().reader_features.clone().unwrap_or_default())
-        } else {
-            None
-        },
-    }))
-    // metaData
-    .chain(std::iter::once(Action::Metadata(current_metadata.clone())))
-    // txns
-    .chain(
-        state
-            .app_transaction_version()
-            .map_err(|_| CheckpointError::MissingActionType("txn".to_string()))?
-            .map(Action::Txn),
-    )
-    // removes
-    .chain(tombstones.iter().map(|r| {
-        let mut r = (*r).clone();
-
-        // As a "new writer", we should always set `extendedFileMetadata` when writing, and include/ignore the other three fields accordingly.
-        // https://github.com/delta-io/delta/blob/fb0452c2fb142310211c6d3604eefb767bb4a134/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala#L311-L314
-        if r.extended_file_metadata.is_none() {
-            r.extended_file_metadata = Some(false);
-        }
-
-        Action::Remove(r)
-    }))
-    .map(|a| serde_json::to_value(a).map_err(ProtocolError::from))
-    // adds
-    .chain(files.map(|f| {
-        checkpoint_add_from_state(
-            &f,
-            partition_col_data_types.as_slice(),
-            &stats_conversions,
-            state.table_config().write_stats_as_json(),
-            state.table_config().write_stats_as_struct(),
-        )
-    }));
-
-    // Create the arrow schema that represents the Checkpoint parquet file.
-    let arrow_schema = delta_log_schema_for_table(
-        (&schema).try_into()?,
-        current_metadata.partition_columns.as_slice(),
-        use_extended_remove_schema,
-        state.table_config().write_stats_as_json(),
-        state.table_config().write_stats_as_struct(),
-    );
-
-    debug!("Writing to checkpoint parquet buffer...");
-
-    let writer_properties = if state.table_config().use_checkpoint_rle() {
-        WriterProperties::builder()
-            .set_compression(Compression::SNAPPY)
-            .build()
-    } else {
-        WriterProperties::builder()
-            .set_compression(Compression::SNAPPY)
-            .set_dictionary_enabled(false)
-            .set_encoding(Encoding::PLAIN)
-            .build()
-    };
-
-    // Write the Checkpoint parquet file.
-    let mut bytes = vec![];
-    let mut writer =
-        ArrowWriter::try_new(&mut bytes, arrow_schema.clone(), Some(writer_properties))?;
-    let mut decoder = ReaderBuilder::new(arrow_schema)
-        .with_batch_size(CHECKPOINT_RECORD_BATCH_SIZE)
-        .build_decoder()?;
-
-    // Count of actions
-    let mut total_actions = 0;
-
-    let span = tracing::debug_span!("serialize_checkpoint").entered();
-    for chunk in &jsons.chunks(CHECKPOINT_RECORD_BATCH_SIZE) {
-        let mut buf = Vec::new();
-        for j in chunk {
-            serde_json::to_writer(&mut buf, &j?)?;
-            total_actions += 1;
-        }
-        let _ = decoder.decode(&buf)?;
-        while let Some(batch) = decoder.flush()? {
-            writer.write(&batch)?;
-        }
-    }
-    drop(span);
-
-    let _ = writer.close()?;
-    debug!(total_actions, "Finished writing checkpoint parquet buffer.");
-
-    let checkpoint = CheckPointBuilder::new(state.version(), total_actions)
-        .with_size_in_bytes(bytes.len() as i64)
-        .build();
-    Ok((checkpoint, bytes::Bytes::from(bytes)))
-}
-
-fn checkpoint_add_from_state(
-    add: &AddAction,
-    partition_col_data_types: &[(&String, &DataType)],
-    stats_conversions: &[(SchemaPath, DataType)],
-    write_stats_as_json: bool,
-    write_stats_as_struct: bool,
-) -> Result<Value, ProtocolError> {
-    let mut v = serde_json::to_value(Action::Add(add.clone()))
-        .map_err(|err| ArrowError::JsonError(err.to_string()))?;
-
-    v["add"]["dataChange"] = Value::Bool(false);
-
-    // Only created partitionValues_parsed when delta.checkpoint.writeStatsAsStruct is enabled
-    if !add.partition_values.is_empty() && write_stats_as_struct {
-        let mut partition_values_parsed: HashMap<String, Value> = HashMap::new();
-
-        for (field_name, data_type) in partition_col_data_types.iter() {
-            if let Some(string_value) = add.partition_values.get(*field_name) {
-                let v = typed_partition_value_from_option_string(string_value, data_type)?;
-
-                partition_values_parsed.insert(field_name.to_string(), v);
-            }
-        }
-
-        let partition_values_parsed = serde_json::to_value(partition_values_parsed)
-            .map_err(|err| ArrowError::JsonError(err.to_string()))?;
-        v["add"]["partitionValues_parsed"] = partition_values_parsed;
-    }
-
-    // Only created stats_parsed when delta.checkpoint.writeStatsAsStruct is enabled
-    if write_stats_as_struct {
-        if let Ok(Some(stats)) = add.get_stats() {
-            let mut stats = serde_json::to_value(stats)
-                .map_err(|err| ArrowError::JsonError(err.to_string()))?;
-            let min_values = stats.get_mut("minValues").and_then(|v| v.as_object_mut());
-
-            if let Some(min_values) = min_values {
-                for (path, data_type) in stats_conversions {
-                    apply_stats_conversion(min_values, path.as_slice(), data_type)
-                }
-            }
-
-            let max_values = stats.get_mut("maxValues").and_then(|v| v.as_object_mut());
-            if let Some(max_values) = max_values {
-                for (path, data_type) in stats_conversions {
-                    apply_stats_conversion(max_values, path.as_slice(), data_type)
-                }
-            }
-
-            v["add"]["stats_parsed"] = stats;
-        }
-    }
-
-    // Don't write stats when delta.checkpoint.writeStatsAsJson is disabled
-    if !write_stats_as_json {
-        v.get_mut("add")
-            .and_then(|v| v.as_object_mut())
-            .and_then(|v| v.remove("stats"));
-    }
-    Ok(v)
-}
-
-fn typed_partition_value_from_string(
-    string_value: &str,
-    data_type: &DataType,
-) -> Result<Value, ProtocolError> {
-    match data_type {
-        DataType::Primitive(primitive_type) => match primitive_type {
-            PrimitiveType::String | PrimitiveType::Binary => Ok(string_value.to_owned().into()),
-            PrimitiveType::Long
-            | PrimitiveType::Integer
-            | PrimitiveType::Short
-            | PrimitiveType::Byte => Ok(string_value
-                .parse::<i64>()
-                .map_err(|_| CheckpointError::PartitionValueNotParseable(string_value.to_owned()))?
-                .into()),
-            PrimitiveType::Boolean => Ok(string_value
-                .parse::<bool>()
-                .map_err(|_| CheckpointError::PartitionValueNotParseable(string_value.to_owned()))?
-                .into()),
-            PrimitiveType::Float | PrimitiveType::Double => Ok(string_value
-                .parse::<f64>()
-                .map_err(|_| CheckpointError::PartitionValueNotParseable(string_value.to_owned()))?
-                .into()),
-            PrimitiveType::Date => {
-                let d = NaiveDate::parse_from_str(string_value, "%Y-%m-%d").map_err(|_| {
-                    CheckpointError::PartitionValueNotParseable(string_value.to_owned())
-                })?;
-                // day 0 is 1970-01-01 (719163 days from ce)
-                Ok((d.num_days_from_ce() - 719_163).into())
-            }
-            PrimitiveType::Timestamp | PrimitiveType::TimestampNtz => {
-                let ts = NaiveDateTime::parse_from_str(string_value, "%Y-%m-%d %H:%M:%S.%6f");
-                let ts: NaiveDateTime = match ts {
-                    Ok(_) => ts,
-                    Err(_) => NaiveDateTime::parse_from_str(string_value, "%Y-%m-%d %H:%M:%S"),
-                }
-                .map_err(|_| {
-                    CheckpointError::PartitionValueNotParseable(string_value.to_owned())
-                })?;
-                Ok((ts.and_utc().timestamp_millis() * 1000).into())
-            }
-            s => unimplemented!("Primitive type {s} is not supported for partition column values."),
-        },
-        d => unimplemented!("Data type {d:?} is not supported for partition column values."),
-    }
-}
-
-fn typed_partition_value_from_option_string(
-    string_value: &Option<String>,
-    data_type: &DataType,
-) -> Result<Value, ProtocolError> {
-    match string_value {
-        Some(s) => {
-            if s.is_empty() {
-                Ok(Value::Null) // empty string should be deserialized as null
-            } else {
-                typed_partition_value_from_string(s, data_type)
-            }
-        }
-        None => Ok(Value::Null),
-    }
-}
-
-fn collect_stats_conversions(paths: &mut Vec<(SchemaPath, DataType)>, fields: &[&StructField]) {
-    let mut _path = SchemaPath::new();
-    fields
-        .iter()
-        .for_each(|f| collect_field_conversion(&mut _path, paths, f));
-}
-
-fn collect_field_conversion(
-    current_path: &mut SchemaPath,
-    all_paths: &mut Vec<(SchemaPath, DataType)>,
-    field: &StructField,
-) {
-    match field.data_type() {
-        DataType::Primitive(PrimitiveType::Timestamp) => {
-            let mut key_path = current_path.clone();
-            key_path.push(field.name().to_owned());
-            all_paths.push((key_path, field.data_type().to_owned()));
-        }
-        DataType::Struct(struct_field) => {
-            let struct_fields = struct_field.fields();
-            current_path.push(field.name().to_owned());
-            struct_fields.for_each(|f| collect_field_conversion(current_path, all_paths, f));
-            current_path.pop();
-        }
-        _ => { /* noop */ }
-    }
-}
-
-fn apply_stats_conversion(
-    context: &mut serde_json::Map<String, Value>,
-    path: &[String],
-    data_type: &DataType,
-) {
-    if path.len() == 1 {
-        if let DataType::Primitive(PrimitiveType::Timestamp) = data_type {
-            let v = context.get_mut(&path[0]);
-
-            if let Some(v) = v {
-                let ts = v
-                    .as_str()
-                    .and_then(|s| time_utils::timestamp_micros_from_stats_string(s).ok())
-                    .map(|n| Value::Number(serde_json::Number::from(n)));
-
-                if let Some(ts) = ts {
-                    *v = ts;
-                }
-            }
-        }
-    } else {
-        let next_context = context.get_mut(&path[0]).and_then(|v| v.as_object_mut());
-        if let Some(next_context) = next_context {
-            apply_stats_conversion(next_context, &path[1..], data_type);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use arrow_array::builder::{Int32Builder, ListBuilder, StructBuilder};
@@ -599,11 +258,10 @@ mod tests {
     use arrow_schema::Schema as ArrowSchema;
     use chrono::Duration;
     use object_store::path::Path;
-    use serde_json::json;
 
     use super::*;
     use crate::kernel::transaction::{CommitBuilder, TableReference};
-    use crate::kernel::StructType;
+    use crate::kernel::Action;
     use crate::operations::DeltaOps;
     use crate::protocol::Metadata;
     use crate::writer::test_utils::get_delta_schema;
@@ -621,9 +279,7 @@ mod tests {
             .unwrap();
         assert_eq!(table.version(), 0);
         assert_eq!(table.get_schema().unwrap(), &table_schema);
-        let res =
-            create_checkpoint_for(0, table.snapshot().unwrap(), table.log_store.as_ref(), None)
-                .await;
+        let res = create_checkpoint_for(0, table.log_store.clone(), None).await;
         assert!(res.is_ok());
 
         // Look at the "files" and verify that the _last_checkpoint has the right version
@@ -703,13 +359,7 @@ mod tests {
             "The loaded version of the table is not up to date"
         );
 
-        let res = create_checkpoint_for(
-            table.version(),
-            table.state.as_ref().unwrap(),
-            table.log_store.as_ref(),
-            None,
-        )
-        .await;
+        let res = create_checkpoint_for(table.version(), table.log_store.clone(), None).await;
         assert!(res.is_ok());
 
         // Look at the "files" and verify that the _last_checkpoint has the right version
@@ -746,9 +396,7 @@ mod tests {
             .unwrap();
         assert_eq!(table.version(), 0);
         assert_eq!(table.get_schema().unwrap(), &table_schema);
-        match create_checkpoint_for(1, table.snapshot().unwrap(), table.log_store.as_ref(), None)
-            .await
-        {
+        match create_checkpoint_for(1, table.log_store.clone(), None).await {
             Ok(_) => {
                 /*
                  * If a checkpoint is allowed to be created here, it will use the passed in
@@ -767,134 +415,6 @@ mod tests {
             }
             Err(_) => { /* We should expect an error in the "right" case */ }
         }
-    }
-
-    #[test]
-    fn typed_partition_value_from_string_test() {
-        let string_value: Value = "Hello World!".into();
-        assert_eq!(
-            string_value,
-            typed_partition_value_from_option_string(
-                &Some("Hello World!".to_string()),
-                &DataType::Primitive(PrimitiveType::String),
-            )
-            .unwrap()
-        );
-
-        let bool_value: Value = true.into();
-        assert_eq!(
-            bool_value,
-            typed_partition_value_from_option_string(
-                &Some("true".to_string()),
-                &DataType::Primitive(PrimitiveType::Boolean),
-            )
-            .unwrap()
-        );
-
-        let number_value: Value = 42.into();
-        assert_eq!(
-            number_value,
-            typed_partition_value_from_option_string(
-                &Some("42".to_string()),
-                &DataType::Primitive(PrimitiveType::Integer),
-            )
-            .unwrap()
-        );
-
-        for (s, v) in [
-            ("2021-08-08", 18_847),
-            ("1970-01-02", 1),
-            ("1970-01-01", 0),
-            ("1969-12-31", -1),
-            ("1-01-01", -719_162),
-        ] {
-            let date_value: Value = v.into();
-            assert_eq!(
-                date_value,
-                typed_partition_value_from_option_string(
-                    &Some(s.to_string()),
-                    &DataType::Primitive(PrimitiveType::Date),
-                )
-                .unwrap()
-            );
-        }
-
-        for (s, v) in [
-            ("2021-08-08 01:00:01.000000", 1628384401000000i64),
-            ("2021-08-08 01:00:01", 1628384401000000i64),
-            ("1970-01-02 12:59:59.000000", 133199000000i64),
-            ("1970-01-02 12:59:59", 133199000000i64),
-            ("1970-01-01 13:00:01.000000", 46801000000i64),
-            ("1970-01-01 13:00:01", 46801000000i64),
-            ("1969-12-31 00:00:00", -86400000000i64),
-            ("1677-09-21 00:12:44", -9223372036000000i64),
-        ] {
-            let timestamp_value: Value = v.into();
-            assert_eq!(
-                timestamp_value,
-                typed_partition_value_from_option_string(
-                    &Some(s.to_string()),
-                    &DataType::Primitive(PrimitiveType::Timestamp),
-                )
-                .unwrap()
-            );
-        }
-
-        let binary_value: Value = "\u{2081}\u{2082}\u{2083}\u{2084}".into();
-        assert_eq!(
-            binary_value,
-            typed_partition_value_from_option_string(
-                &Some("₁₂₃₄".to_string()),
-                &DataType::Primitive(PrimitiveType::Binary),
-            )
-            .unwrap()
-        );
-    }
-
-    #[test]
-    fn null_partition_value_from_string_test() {
-        assert_eq!(
-            Value::Null,
-            typed_partition_value_from_option_string(
-                &None,
-                &DataType::Primitive(PrimitiveType::Integer),
-            )
-            .unwrap()
-        );
-
-        // empty string should be treated as null
-        assert_eq!(
-            Value::Null,
-            typed_partition_value_from_option_string(
-                &Some("".to_string()),
-                &DataType::Primitive(PrimitiveType::Integer),
-            )
-            .unwrap()
-        );
-    }
-
-    #[test]
-    fn collect_stats_conversions_test() {
-        let delta_schema: StructType = serde_json::from_value(SCHEMA.clone()).unwrap();
-        let fields = delta_schema.fields().collect_vec();
-        let mut paths = Vec::new();
-        collect_stats_conversions(&mut paths, fields.as_slice());
-
-        assert_eq!(2, paths.len());
-        assert_eq!(
-            (
-                vec!["some_struct".to_string(), "struct_timestamp".to_string()],
-                DataType::Primitive(PrimitiveType::Timestamp)
-            ),
-            paths[0]
-        );
-        assert_eq!(
-            (
-                vec!["some_timestamp".to_string()],
-                DataType::Primitive(PrimitiveType::Timestamp)
-            ),
-            paths[1]
-        );
     }
 
     async fn setup_table() -> DeltaTable {
@@ -990,95 +510,6 @@ mod tests {
         assert!(res.is_ok());
     }
 
-    #[test]
-    fn apply_stats_conversion_test() {
-        let mut stats = STATS_JSON.clone();
-
-        let min_values = stats.get_mut("minValues").unwrap().as_object_mut().unwrap();
-
-        apply_stats_conversion(
-            min_values,
-            &["some_struct".to_string(), "struct_string".to_string()],
-            &DataType::Primitive(PrimitiveType::String),
-        );
-        apply_stats_conversion(
-            min_values,
-            &["some_struct".to_string(), "struct_timestamp".to_string()],
-            &DataType::Primitive(PrimitiveType::Timestamp),
-        );
-        apply_stats_conversion(
-            min_values,
-            &["some_string".to_string()],
-            &DataType::Primitive(PrimitiveType::String),
-        );
-        apply_stats_conversion(
-            min_values,
-            &["some_timestamp".to_string()],
-            &DataType::Primitive(PrimitiveType::Timestamp),
-        );
-
-        let max_values = stats.get_mut("maxValues").unwrap().as_object_mut().unwrap();
-
-        apply_stats_conversion(
-            max_values,
-            &["some_struct".to_string(), "struct_string".to_string()],
-            &DataType::Primitive(PrimitiveType::String),
-        );
-        apply_stats_conversion(
-            max_values,
-            &["some_struct".to_string(), "struct_timestamp".to_string()],
-            &DataType::Primitive(PrimitiveType::Timestamp),
-        );
-        apply_stats_conversion(
-            max_values,
-            &["some_string".to_string()],
-            &DataType::Primitive(PrimitiveType::String),
-        );
-        apply_stats_conversion(
-            max_values,
-            &["some_timestamp".to_string()],
-            &DataType::Primitive(PrimitiveType::Timestamp),
-        );
-
-        // minValues
-        assert_eq!(
-            "A",
-            stats["minValues"]["some_struct"]["struct_string"]
-                .as_str()
-                .unwrap()
-        );
-        assert_eq!(
-            1627668684594000i64,
-            stats["minValues"]["some_struct"]["struct_timestamp"]
-                .as_i64()
-                .unwrap()
-        );
-        assert_eq!("P", stats["minValues"]["some_string"].as_str().unwrap());
-        assert_eq!(
-            1627668684594000i64,
-            stats["minValues"]["some_timestamp"].as_i64().unwrap()
-        );
-
-        // maxValues
-        assert_eq!(
-            "B",
-            stats["maxValues"]["some_struct"]["struct_string"]
-                .as_str()
-                .unwrap()
-        );
-        assert_eq!(
-            1627668685594000i64,
-            stats["maxValues"]["some_struct"]["struct_timestamp"]
-                .as_i64()
-                .unwrap()
-        );
-        assert_eq!("Q", stats["maxValues"]["some_string"].as_str().unwrap());
-        assert_eq!(
-            1627668685594000i64,
-            stats["maxValues"]["some_timestamp"].as_i64().unwrap()
-        );
-    }
-
     #[tokio::test]
     async fn test_struct_with_single_list_field() {
         // you need another column otherwise the entire stats struct is empty
@@ -1115,54 +546,6 @@ mod tests {
 
         create_checkpoint(&table, None).await.unwrap();
     }
-
-    static SCHEMA: LazyLock<Value> = LazyLock::new(|| {
-        json!({
-            "type": "struct",
-            "fields": [
-                {
-                    "name": "some_struct",
-                    "type": {
-                        "type": "struct",
-                        "fields": [
-                            {
-                                "name": "struct_string",
-                                "type": "string",
-                                "nullable": true, "metadata": {}
-                            },
-                            {
-                                "name": "struct_timestamp",
-                                "type": "timestamp",
-                                "nullable": true, "metadata": {}
-                            }]
-                    },
-                    "nullable": true, "metadata": {}
-                },
-                { "name": "some_string", "type": "string", "nullable": true, "metadata": {} },
-                { "name": "some_timestamp", "type": "timestamp", "nullable": true, "metadata": {} },
-            ]
-        })
-    });
-    static STATS_JSON: LazyLock<Value> = LazyLock::new(|| {
-        json!({
-            "minValues": {
-                "some_struct": {
-                    "struct_string": "A",
-                    "struct_timestamp": "2021-07-30T18:11:24.594Z"
-                },
-                "some_string": "P",
-                "some_timestamp": "2021-07-30T18:11:24.594Z"
-            },
-            "maxValues": {
-                "some_struct": {
-                    "struct_string": "B",
-                    "struct_timestamp": "2021-07-30T18:11:25.594Z"
-                },
-                "some_string": "Q",
-                "some_timestamp": "2021-07-30T18:11:25.594Z"
-            }
-        })
-    });
 
     #[ignore = "This test is only useful if the batch size has been made small"]
     #[tokio::test]
@@ -1280,7 +663,12 @@ mod tests {
             "| A  | 0     | 2021-02-02 |",
             "+----+-------+------------+",
         ];
+        println!("version: {}", 4);
+
         let actual = get_data_sorted(&table, "id,value,modified").await;
+
+        println!("version: {}", 5);
+
         assert_batches_sorted_eq!(&expected, &actual);
         Ok(())
     }

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -98,6 +98,12 @@ pub enum ProtocolError {
         #[from]
         source: crate::kernel::Error,
     },
+
+    #[error("DeltaKernel: {source}")]
+    DeltaKernel {
+        #[from]
+        source: delta_kernel::Error,
+    },
 }
 
 /// Struct used to represent minValues and maxValues in add action statistics.

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -213,8 +213,8 @@ impl DeltaTable {
             Some(state) => state.update(self.log_store.clone(), max_version).await,
             _ => {
                 let state = DeltaTableState::try_new(
-                    &Path::default(),
-                    self.log_store.object_store(None),
+                    &self.log_store.table_url(),
+                    self.log_store.root_object_store(None),
                     self.config.clone(),
                     max_version,
                 )
@@ -262,7 +262,7 @@ impl DeltaTable {
             .snapshot()?
             .snapshot
             .snapshot()
-            .commit_infos(self.object_store(), limit)
+            .commit_infos(self.log_store().root_object_store(None), limit)
             .await?
             .try_collect::<Vec<_>>()
             .await?;

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -29,14 +29,14 @@ pub struct DeltaTableState {
 impl DeltaTableState {
     /// Create a new DeltaTableState
     pub async fn try_new(
-        table_root: &Path,
-        store: Arc<dyn ObjectStore>,
+        table_root: &url::Url,
+        root_store: Arc<dyn ObjectStore>,
         config: DeltaTableConfig,
         version: Option<i64>,
     ) -> DeltaResult<Self> {
         let snapshot = EagerSnapshot::try_new_with_visitor(
             table_root,
-            store.clone(),
+            root_store,
             config,
             version,
             HashSet::from([ActionType::Txn]),
@@ -102,12 +102,12 @@ impl DeltaTableState {
     /// Full list of tombstones (remove actions) representing files removed from table state).
     pub async fn all_tombstones(
         &self,
-        store: Arc<dyn ObjectStore>,
+        root_store: Arc<dyn ObjectStore>,
     ) -> DeltaResult<impl Iterator<Item = Remove>> {
         Ok(self
             .snapshot
             .snapshot()
-            .tombstones(store)?
+            .tombstones(root_store)?
             .try_collect::<Vec<_>>()
             .await?
             .into_iter()

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -138,6 +138,7 @@ fn checkpoint_to_py(err: ProtocolError) -> PyErr {
         ProtocolError::IO { source } => PyIOError::new_err(source.to_string()),
         ProtocolError::Generic(msg) => DeltaError::new_err(msg),
         ProtocolError::Kernel { source } => DeltaError::new_err(source.to_string()),
+        ProtocolError::DeltaKernel { source } => DeltaError::new_err(source.to_string()),
     }
 }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1404,7 +1404,7 @@ impl RawDeltaTable {
                             Some(
                                 DeltaTableState::try_new(
                                     &table.state.clone().unwrap().snapshot().table_root(),
-                                    table.object_store(),
+                                    table.log_store().root_object_store(None),
                                     table.config.clone(),
                                     Some(table.version()),
                                 )
@@ -1926,6 +1926,7 @@ fn scalar_to_py<'py>(value: &Scalar, py_date: &Bound<'py, PyAny>) -> PyResult<Bo
             py_struct.into_py_any(py)?
         }
         Array(_val) => todo!("how should this be converted!"),
+        Map(_val) => todo!("how should this be converted!"),
     };
 
     Ok(val.into_bound(py))


### PR DESCRIPTION
# Description

Delta Kernel uses `Url`s as means of handling file paths. In delta-rs we so par have focussed on object stores `Path`s which also comes with limitiations.

In this PR (this time really the last one before checkpoints :D) we move a significant portion of the path handling to use Urls or at paths relative to the object store root. This also allows us to leverage url parsing into typed log files from kernel.