### PR TITLE
refactor: use LogStore in Snapshot / LogSegment APIs

### DIFF
--- a/crates/core/src/kernel/snapshot/log_segment.rs
+++ b/crates/core/src/kernel/snapshot/log_segment.rs
@@ -109,21 +109,19 @@ impl LogSegment {
     /// Try to create a new [`LogSegment`]
     ///
     /// This will list the entire log directory and find all relevant files for the given table version.
-    pub async fn try_new(
-        table_root: &Path,
-        version: Option<i64>,
-        store: &dyn ObjectStore,
-    ) -> DeltaResult<Self> {
-        let log_url = table_root.child("_delta_log");
-        let maybe_cp = read_last_checkpoint(store, &log_url).await?;
+    pub async fn try_new(log_store: &dyn LogStore, version: Option<i64>) -> DeltaResult<Self> {
+        let store = log_store.object_store(None);
+
+        let log_url = Path::from("_delta_log");
+        let maybe_cp = read_last_checkpoint(&store, &log_url).await?;
 
         // List relevant files from log
         let (mut commit_files, checkpoint_files) = match (maybe_cp, version) {
-            (Some(cp), None) => list_log_files_with_checkpoint(&cp, store, &log_url).await?,
+            (Some(cp), None) => list_log_files_with_checkpoint(&cp, &store, &log_url).await?,
             (Some(cp), Some(v)) if cp.version <= v => {
-                list_log_files_with_checkpoint(&cp, store, &log_url).await?
+                list_log_files_with_checkpoint(&cp, &store, &log_url).await?
             }
-            _ => list_log_files(store, &log_url, version, None).await?,
+            _ => list_log_files(&store, &log_url, version, None).await?,
         };
 
         // remove all files above requested version
@@ -273,10 +271,12 @@ impl LogSegment {
 
     pub(super) fn commit_stream(
         &self,
-        store: Arc<dyn ObjectStore>,
+        log_store: &dyn LogStore,
         read_schema: &Schema,
         config: &DeltaTableConfig,
     ) -> DeltaResult<BoxStream<'_, DeltaResult<RecordBatch>>> {
+        let store = log_store.object_store(None);
+
         let decoder = json::get_decoder(Arc::new(read_schema.try_into()?), config)?;
         let stream = futures::stream::iter(self.commit_files.iter())
             .map(move |meta| {
@@ -289,10 +289,12 @@ impl LogSegment {
 
     pub(super) fn checkpoint_stream(
         &self,
-        store: Arc<dyn ObjectStore>,
+        log_store: &dyn LogStore,
         read_schema: &Schema,
         config: &DeltaTableConfig,
     ) -> BoxStream<'_, DeltaResult<RecordBatch>> {
+        let store = log_store.object_store(None);
+
         let batch_size = config.log_batch_size;
         let read_schema = Arc::new(read_schema.clone());
         futures::stream::iter(self.checkpoint_files.clone())
@@ -341,7 +343,7 @@ impl LogSegment {
     /// Read [`Protocol`] and [`Metadata`] actions
     pub(super) async fn read_metadata(
         &self,
-        store: Arc<dyn ObjectStore>,
+        log_store: &dyn LogStore,
         config: &DeltaTableConfig,
     ) -> DeltaResult<(Option<Protocol>, Option<Metadata>)> {
         static READ_SCHEMA: LazyLock<StructType> = LazyLock::new(|| {
@@ -354,7 +356,7 @@ impl LogSegment {
         let mut maybe_protocol = None;
         let mut maybe_metadata = None;
 
-        let mut commit_stream = self.commit_stream(store.clone(), &READ_SCHEMA, config)?;
+        let mut commit_stream = self.commit_stream(log_store, &READ_SCHEMA, config)?;
         while let Some(batch) = commit_stream.next().await {
             let batch = batch?;
             if maybe_protocol.is_none() {
@@ -372,7 +374,7 @@ impl LogSegment {
             }
         }
 
-        let mut checkpoint_stream = self.checkpoint_stream(store.clone(), &READ_SCHEMA, config);
+        let mut checkpoint_stream = self.checkpoint_stream(log_store, &READ_SCHEMA, config);
         while let Some(batch) = checkpoint_stream.next().await {
             let batch = batch?;
             if maybe_protocol.is_none() {
@@ -602,12 +604,9 @@ pub(super) mod tests {
     }
 
     async fn log_segment_serde() -> TestResult {
-        let store = TestTables::Simple
-            .table_builder()
-            .build_storage()?
-            .object_store(None);
+        let log_store = TestTables::Simple.table_builder().build_storage()?;
 
-        let segment = LogSegment::try_new(&Path::default(), None, store.as_ref()).await?;
+        let segment = LogSegment::try_new(&log_store, None).await?;
         let bytes = serde_json::to_vec(&segment).unwrap();
         let actual: LogSegment = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(actual.version(), segment.version());
@@ -621,49 +620,45 @@ pub(super) mod tests {
     }
 
     async fn read_log_files() -> TestResult {
-        let store = TestTables::SimpleWithCheckpoint
+        let log_store = TestTables::SimpleWithCheckpoint
             .table_builder()
-            .build_storage()?
-            .object_store(None);
+            .build_storage()?;
+        let store = log_store.object_store(None);
 
         let log_path = Path::from("_delta_log");
-        let cp = read_last_checkpoint(store.as_ref(), &log_path)
-            .await?
-            .unwrap();
+        let cp = read_last_checkpoint(&store, &log_path).await?.unwrap();
         assert_eq!(cp.version, 10);
 
-        let (log, check) = list_log_files_with_checkpoint(&cp, store.as_ref(), &log_path).await?;
+        let (log, check) = list_log_files_with_checkpoint(&cp, &store, &log_path).await?;
         assert_eq!(log.len(), 0);
         assert_eq!(check.len(), 1);
 
-        let (log, check) = list_log_files(store.as_ref(), &log_path, None, None).await?;
+        let (log, check) = list_log_files(&store, &log_path, None, None).await?;
         assert_eq!(log.len(), 0);
         assert_eq!(check.len(), 1);
 
-        let (log, check) = list_log_files(store.as_ref(), &log_path, Some(8), None).await?;
+        let (log, check) = list_log_files(&store, &log_path, Some(8), None).await?;
         assert_eq!(log.len(), 9);
         assert_eq!(check.len(), 0);
 
-        let segment = LogSegment::try_new(&Path::default(), None, store.as_ref()).await?;
+        let segment = LogSegment::try_new(&log_store, None).await?;
         assert_eq!(segment.version, 10);
         assert_eq!(segment.commit_files.len(), 0);
         assert_eq!(segment.checkpoint_files.len(), 1);
 
-        let segment = LogSegment::try_new(&Path::default(), Some(8), store.as_ref()).await?;
+        let segment = LogSegment::try_new(&log_store, Some(8)).await?;
         assert_eq!(segment.version, 8);
         assert_eq!(segment.commit_files.len(), 9);
         assert_eq!(segment.checkpoint_files.len(), 0);
 
-        let store = TestTables::Simple
-            .table_builder()
-            .build_storage()?
-            .object_store(None);
+        let log_store = TestTables::Simple.table_builder().build_storage()?;
+        let store = log_store.object_store(None);
 
-        let (log, check) = list_log_files(store.as_ref(), &log_path, None, None).await?;
+        let (log, check) = list_log_files(&store, &log_path, None, None).await?;
         assert_eq!(log.len(), 5);
         assert_eq!(check.len(), 0);
 
-        let (log, check) = list_log_files(store.as_ref(), &log_path, Some(2), None).await?;
+        let (log, check) = list_log_files(&store, &log_path, Some(2), None).await?;
         assert_eq!(log.len(), 3);
         assert_eq!(check.len(), 0);
 
@@ -671,13 +666,10 @@ pub(super) mod tests {
     }
 
     async fn read_metadata() -> TestResult {
-        let store = TestTables::WithDvSmall
-            .table_builder()
-            .build_storage()?
-            .object_store(None);
-        let segment = LogSegment::try_new(&Path::default(), None, store.as_ref()).await?;
+        let log_store = TestTables::WithDvSmall.table_builder().build_storage()?;
+        let segment = LogSegment::try_new(&log_store, None).await?;
         let (protocol, _metadata) = segment
-            .read_metadata(store.clone(), &Default::default())
+            .read_metadata(&log_store, &Default::default())
             .await?;
         let protocol = protocol.unwrap();
 
@@ -697,17 +689,17 @@ pub(super) mod tests {
             .table_builder()
             .load()
             .await?;
-        let store = TestTables::LatestNotCheckpointed
+
+        let base_store = table_to_checkpoint.log_store().root_object_store(None);
+        let slow_list_store = Arc::new(slow_store::SlowListStore { store: base_store });
+        let slow_log_store = TestTables::LatestNotCheckpointed
             .table_builder()
-            .build_storage()?
-            .object_store(None);
-        let slow_list_store = Arc::new(slow_store::SlowListStore { store });
+            .with_storage_backend(slow_list_store, url::Url::parse("dummy:///").unwrap())
+            .build_storage()?;
 
         let version = table_to_checkpoint.version();
         let load_task: JoinHandle<Result<LogSegment, DeltaTableError>> = tokio::spawn(async move {
-            let segment =
-                LogSegment::try_new(&Path::default(), Some(version), slow_list_store.as_ref())
-                    .await?;
+            let segment = LogSegment::try_new(&slow_log_store, Some(version)).await?;
             Ok(segment)
         });
 
@@ -870,25 +862,21 @@ pub(super) mod tests {
         assert_eq!(commit.metrics.num_log_files_cleaned_up, 0);
         assert!(!commit.metrics.new_checkpoint_created);
 
-        let batches = LogSegment::try_new(
-            &Path::default(),
-            Some(commit.version),
-            log_store.object_store(None).as_ref(),
-        )
-        .await
-        .unwrap()
-        .checkpoint_stream(
-            log_store.object_store(None),
-            &StructType::new(vec![
-                ActionType::Metadata.schema_field().clone(),
-                ActionType::Protocol.schema_field().clone(),
-                ActionType::Add.schema_field().clone(),
-            ]),
-            &Default::default(),
-        )
-        .try_collect::<Vec<_>>()
-        .await
-        .unwrap();
+        let batches = LogSegment::try_new(&log_store, Some(commit.version))
+            .await
+            .unwrap()
+            .checkpoint_stream(
+                &log_store,
+                &StructType::new(vec![
+                    ActionType::Metadata.schema_field().clone(),
+                    ActionType::Protocol.schema_field().clone(),
+                    ActionType::Add.schema_field().clone(),
+                ]),
+                &Default::default(),
+            )
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
 
         let batch = arrow::compute::concat_batches(&batches[0].schema(), batches.iter()).unwrap();
 

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -17,7 +17,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Cursor};
-use std::sync::Arc;
 
 use ::serde::{Deserialize, Serialize};
 use arrow_array::RecordBatch;
@@ -67,13 +66,12 @@ pub struct Snapshot {
 impl Snapshot {
     /// Create a new [`Snapshot`] instance
     pub async fn try_new(
-        table_root: &Path,
-        store: Arc<dyn ObjectStore>,
+        log_store: &dyn LogStore,
         config: DeltaTableConfig,
         version: Option<i64>,
     ) -> DeltaResult<Self> {
-        let log_segment = LogSegment::try_new(table_root, version, store.as_ref()).await?;
-        let (protocol, metadata) = log_segment.read_metadata(store.clone(), &config).await?;
+        let log_segment = LogSegment::try_new(log_store, version).await?;
+        let (protocol, metadata) = log_segment.read_metadata(log_store, &config).await?;
         if metadata.is_none() || protocol.is_none() {
             return Err(DeltaTableError::Generic(
                 "Cannot read metadata from log segment".into(),
@@ -90,7 +88,7 @@ impl Snapshot {
             protocol,
             metadata,
             schema,
-            table_url: table_root.to_string(),
+            table_url: "/".to_string(),
         })
     }
 
@@ -121,7 +119,7 @@ impl Snapshot {
     /// Update the snapshot to the given version
     pub async fn update(
         &mut self,
-        log_store: Arc<dyn LogStore>,
+        log_store: &dyn LogStore,
         target_version: Option<i64>,
     ) -> DeltaResult<()> {
         self.update_inner(log_store, target_version).await?;
@@ -130,7 +128,7 @@ impl Snapshot {
 
     async fn update_inner(
         &mut self,
-        log_store: Arc<dyn LogStore>,
+        log_store: &dyn LogStore,
         target_version: Option<i64>,
     ) -> DeltaResult<Option<LogSegment>> {
         if let Some(version) = target_version {
@@ -145,16 +143,14 @@ impl Snapshot {
             &Path::default(),
             self.version() + 1,
             target_version,
-            log_store.as_ref(),
+            log_store,
         )
         .await?;
         if log_segment.commit_files.is_empty() && log_segment.checkpoint_files.is_empty() {
             return Ok(None);
         }
 
-        let (protocol, metadata) = log_segment
-            .read_metadata(log_store.object_store(None).clone(), &self.config)
-            .await?;
+        let (protocol, metadata) = log_segment.read_metadata(log_store, &self.config).await?;
         if let Some(protocol) = protocol {
             self.protocol = protocol;
         }
@@ -215,7 +211,7 @@ impl Snapshot {
     /// Get the files in the snapshot
     pub fn files<'a>(
         &self,
-        store: Arc<dyn ObjectStore>,
+        log_store: &dyn LogStore,
         visitors: &'a mut Vec<Box<dyn ReplayVisitor>>,
     ) -> DeltaResult<ReplayStream<'a, BoxStream<'_, DeltaResult<RecordBatch>>>> {
         let mut schema_actions: HashSet<_> =
@@ -223,14 +219,14 @@ impl Snapshot {
 
         schema_actions.insert(ActionType::Add);
         let checkpoint_stream = self.log_segment.checkpoint_stream(
-            store.clone(),
+            log_store,
             &StructType::new(schema_actions.iter().map(|a| a.schema_field().clone())),
             &self.config,
         );
 
         schema_actions.insert(ActionType::Remove);
         let log_stream = self.log_segment.commit_stream(
-            store.clone(),
+            log_store,
             &StructType::new(schema_actions.iter().map(|a| a.schema_field().clone())),
             &self.config,
         )?;
@@ -241,9 +237,11 @@ impl Snapshot {
     /// Get the commit infos in the snapshot
     pub(crate) async fn commit_infos(
         &self,
-        store: Arc<dyn ObjectStore>,
+        log_store: &dyn LogStore,
         limit: Option<usize>,
     ) -> DeltaResult<BoxStream<'_, DeltaResult<Option<CommitInfo>>>> {
+        let store = log_store.object_store(None);
+
         let log_root = self.table_root().child("_delta_log");
         let start_from = log_root.child(
             format!(
@@ -287,16 +285,18 @@ impl Snapshot {
 
     pub(crate) fn tombstones(
         &self,
-        store: Arc<dyn ObjectStore>,
+        log_store: &dyn LogStore,
     ) -> DeltaResult<BoxStream<'_, DeltaResult<Vec<Remove>>>> {
         let log_stream = self.log_segment.commit_stream(
-            store.clone(),
+            log_store,
             &log_segment::TOMBSTONE_SCHEMA,
             &self.config,
         )?;
-        let checkpoint_stream =
-            self.log_segment
-                .checkpoint_stream(store, &log_segment::TOMBSTONE_SCHEMA, &self.config);
+        let checkpoint_stream = self.log_segment.checkpoint_stream(
+            log_store,
+            &log_segment::TOMBSTONE_SCHEMA,
+            &self.config,
+        );
 
         Ok(log_stream
             .chain(checkpoint_stream)
@@ -343,18 +343,16 @@ pub struct EagerSnapshot {
 impl EagerSnapshot {
     /// Create a new [`EagerSnapshot`] instance
     pub async fn try_new(
-        table_root: &Path,
-        store: Arc<dyn ObjectStore>,
+        log_store: &dyn LogStore,
         config: DeltaTableConfig,
         version: Option<i64>,
     ) -> DeltaResult<Self> {
-        Self::try_new_with_visitor(table_root, store, config, version, Default::default()).await
+        Self::try_new_with_visitor(log_store, config, version, Default::default()).await
     }
 
     /// Create a new [`EagerSnapshot`] instance
     pub async fn try_new_with_visitor(
-        table_root: &Path,
-        store: Arc<dyn ObjectStore>,
+        log_store: &dyn LogStore,
         config: DeltaTableConfig,
         version: Option<i64>,
         tracked_actions: HashSet<ActionType>,
@@ -363,11 +361,15 @@ impl EagerSnapshot {
             .iter()
             .flat_map(get_visitor)
             .collect::<Vec<_>>();
-        let snapshot =
-            Snapshot::try_new(table_root, store.clone(), config.clone(), version).await?;
+        let snapshot = Snapshot::try_new(log_store, config.clone(), version).await?;
 
         let files = match config.require_files {
-            true => snapshot.files(store, &mut visitors)?.try_collect().await?,
+            true => {
+                snapshot
+                    .files(log_store, &mut visitors)?
+                    .try_collect()
+                    .await?
+            }
             false => vec![],
         };
 
@@ -422,7 +424,7 @@ impl EagerSnapshot {
     /// Update the snapshot to the given version
     pub async fn update(
         &mut self,
-        log_store: Arc<dyn LogStore>,
+        log_store: &dyn LogStore,
         target_version: Option<i64>,
     ) -> DeltaResult<()> {
         if Some(self.version()) == target_version {
@@ -431,7 +433,7 @@ impl EagerSnapshot {
 
         let new_slice = self
             .snapshot
-            .update_inner(log_store.clone(), target_version)
+            .update_inner(log_store, target_version)
             .await?;
 
         if new_slice.is_none() {
@@ -457,21 +459,13 @@ impl EagerSnapshot {
             let read_schema =
                 StructType::new(schema_actions.iter().map(|a| a.schema_field().clone()));
             new_slice
-                .checkpoint_stream(
-                    log_store.object_store(None),
-                    &read_schema,
-                    &self.snapshot.config,
-                )
+                .checkpoint_stream(log_store, &read_schema, &self.snapshot.config)
                 .boxed()
         };
 
         schema_actions.insert(ActionType::Remove);
         let read_schema = StructType::new(schema_actions.iter().map(|a| a.schema_field().clone()));
-        let log_stream = new_slice.commit_stream(
-            log_store.object_store(None).clone(),
-            &read_schema,
-            &self.snapshot.config,
-        )?;
+        let log_stream = new_slice.commit_stream(log_store, &read_schema, &self.snapshot.config)?;
 
         let mapper = LogMapper::try_new(&self.snapshot, None)?;
 
@@ -842,13 +836,9 @@ mod tests {
     }
 
     async fn test_snapshot() -> TestResult {
-        let store = TestTables::Simple
-            .table_builder()
-            .build_storage()?
-            .object_store(None);
+        let log_store = TestTables::Simple.table_builder().build_storage()?;
 
-        let snapshot =
-            Snapshot::try_new(&Path::default(), store.clone(), Default::default(), None).await?;
+        let snapshot = Snapshot::try_new(&log_store, Default::default(), None).await?;
 
         let bytes = serde_json::to_vec(&snapshot).unwrap();
         let actual: Snapshot = serde_json::from_slice(&bytes).unwrap();
@@ -859,7 +849,7 @@ mod tests {
         assert_eq!(snapshot.schema(), &expected);
 
         let infos = snapshot
-            .commit_infos(store.clone(), None)
+            .commit_infos(&log_store, None)
             .await?
             .try_collect::<Vec<_>>()
             .await?;
@@ -867,14 +857,14 @@ mod tests {
         assert_eq!(infos.len(), 5);
 
         let tombstones = snapshot
-            .tombstones(store.clone())?
+            .tombstones(&log_store)?
             .try_collect::<Vec<_>>()
             .await?;
         let tombstones = tombstones.into_iter().flatten().collect_vec();
         assert_eq!(tombstones.len(), 31);
 
         let batches = snapshot
-            .files(store.clone(), &mut vec![])?
+            .files(&log_store, &mut vec![])?
             .try_collect::<Vec<_>>()
             .await?;
         let expected = [
@@ -890,21 +880,12 @@ mod tests {
         ];
         assert_batches_sorted_eq!(expected, &batches);
 
-        let store = TestTables::Checkpoints
-            .table_builder()
-            .build_storage()?
-            .object_store(None);
+        let log_store = TestTables::Checkpoints.table_builder().build_storage()?;
 
         for version in 0..=12 {
-            let snapshot = Snapshot::try_new(
-                &Path::default(),
-                store.clone(),
-                Default::default(),
-                Some(version),
-            )
-            .await?;
+            let snapshot = Snapshot::try_new(&log_store, Default::default(), Some(version)).await?;
             let batches = snapshot
-                .files(store.clone(), &mut vec![])?
+                .files(&log_store, &mut vec![])?
                 .try_collect::<Vec<_>>()
                 .await?;
             let num_files = batches.iter().map(|b| b.num_rows() as i64).sum::<i64>();
@@ -915,14 +896,9 @@ mod tests {
     }
 
     async fn test_eager_snapshot() -> TestResult {
-        let store = TestTables::Simple
-            .table_builder()
-            .build_storage()?
-            .object_store(None);
+        let log_store = TestTables::Simple.table_builder().build_storage()?;
 
-        let snapshot =
-            EagerSnapshot::try_new(&Path::default(), store.clone(), Default::default(), None)
-                .await?;
+        let snapshot = EagerSnapshot::try_new(&log_store, Default::default(), None).await?;
 
         let bytes = serde_json::to_vec(&snapshot).unwrap();
         let actual: EagerSnapshot = serde_json::from_slice(&bytes).unwrap();
@@ -932,19 +908,11 @@ mod tests {
         let expected: StructType = serde_json::from_str(schema_string)?;
         assert_eq!(snapshot.schema(), &expected);
 
-        let store = TestTables::Checkpoints
-            .table_builder()
-            .build_storage()?
-            .object_store(None);
+        let log_store = TestTables::Checkpoints.table_builder().build_storage()?;
 
         for version in 0..=12 {
-            let snapshot = EagerSnapshot::try_new(
-                &Path::default(),
-                store.clone(),
-                Default::default(),
-                Some(version),
-            )
-            .await?;
+            let snapshot =
+                EagerSnapshot::try_new(&log_store, Default::default(), Some(version)).await?;
             let batches = snapshot.file_actions()?.collect::<Vec<_>>();
             assert_eq!(batches.len(), version as usize);
         }

--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -686,7 +686,7 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                     }
                     // Update snapshot to latest version after successful conflict check
                     read_snapshot
-                        .update(this.log_store.clone(), Some(latest_version))
+                        .update(&this.log_store, Some(latest_version))
                         .await?;
                 }
                 let version: i64 = latest_version + 1;
@@ -760,7 +760,7 @@ impl PostCommit {
                 // This may only occur during concurrent write actions. We need to update the state first to - 1
                 // then we can advance.
                 snapshot
-                    .update(self.log_store.clone(), Some(self.version - 1))
+                    .update(&self.log_store, Some(self.version - 1))
                     .await?;
                 snapshot.advance(vec![&self.data])?;
             } else {
@@ -811,8 +811,7 @@ impl PostCommit {
                 .await? as u64;
                 if num_log_files_cleaned_up > 0 {
                     state = DeltaTableState::try_new(
-                        &state.snapshot().table_root(),
-                        self.log_store.object_store(None),
+                        &self.log_store,
                         state.load_config().clone(),
                         Some(self.version),
                     )
@@ -838,13 +837,9 @@ impl PostCommit {
                 },
             ))
         } else {
-            let state = DeltaTableState::try_new(
-                &Path::default(),
-                self.log_store.object_store(None),
-                Default::default(),
-                Some(self.version),
-            )
-            .await?;
+            let state =
+                DeltaTableState::try_new(&self.log_store, Default::default(), Some(self.version))
+                    .await?;
             Ok((
                 state,
                 PostCommitMetrics {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -205,7 +205,7 @@ mod tests {
         let tombstones = table
             .snapshot()
             .unwrap()
-            .all_tombstones(table.object_store().clone())
+            .all_tombstones(&table.log_store())
             .await
             .unwrap()
             .collect_vec();
@@ -322,7 +322,7 @@ mod tests {
         let tombstones = table
             .snapshot()
             .unwrap()
-            .all_tombstones(table.object_store().clone())
+            .all_tombstones(&table.log_store())
             .await
             .unwrap()
             .collect_vec();

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -376,6 +376,9 @@ pub trait LogStore: Send + Sync + AsAny {
         Ok(false)
     }
 
+    /// Get configuration representing configured log store.
+    fn config(&self) -> &LogStoreConfig;
+
     #[cfg(feature = "datafusion")]
     /// Generate a unique enough url to identify the store in datafusion.
     /// The DF object store registry only cares about the scheme and the host of the url for
@@ -385,9 +388,88 @@ pub trait LogStore: Send + Sync + AsAny {
     fn object_store_url(&self) -> ObjectStoreUrl {
         crate::logstore::object_store_url(&self.config().location)
     }
+}
 
-    /// Get configuration representing configured log store.
-    fn config(&self) -> &LogStoreConfig;
+#[async_trait::async_trait]
+impl<T: LogStore + ?Sized> LogStore for Arc<T> {
+    fn name(&self) -> String {
+        T::name(self)
+    }
+
+    async fn refresh(&self) -> DeltaResult<()> {
+        T::refresh(self).await
+    }
+
+    async fn read_commit_entry(&self, version: i64) -> DeltaResult<Option<Bytes>> {
+        T::read_commit_entry(self, version).await
+    }
+
+    async fn write_commit_entry(
+        &self,
+        version: i64,
+        commit_or_bytes: CommitOrBytes,
+        operation_id: Uuid,
+    ) -> Result<(), TransactionError> {
+        T::write_commit_entry(self, version, commit_or_bytes, operation_id).await
+    }
+
+    async fn abort_commit_entry(
+        &self,
+        version: i64,
+        commit_or_bytes: CommitOrBytes,
+        operation_id: Uuid,
+    ) -> Result<(), TransactionError> {
+        T::abort_commit_entry(self, version, commit_or_bytes, operation_id).await
+    }
+
+    async fn get_latest_version(&self, start_version: i64) -> DeltaResult<i64> {
+        T::get_latest_version(self, start_version).await
+    }
+
+    async fn get_earliest_version(&self, start_version: i64) -> DeltaResult<i64> {
+        T::get_earliest_version(self, start_version).await
+    }
+
+    async fn peek_next_commit(&self, current_version: i64) -> DeltaResult<PeekCommit> {
+        T::peek_next_commit(self, current_version).await
+    }
+
+    fn object_store(&self, operation_id: Option<Uuid>) -> Arc<dyn ObjectStore> {
+        T::object_store(self, operation_id)
+    }
+
+    fn root_object_store(&self, operation_id: Option<Uuid>) -> Arc<dyn ObjectStore> {
+        T::root_object_store(self, operation_id)
+    }
+
+    async fn engine(&self, operation_id: Option<Uuid>) -> Arc<dyn Engine> {
+        T::engine(self, operation_id).await
+    }
+
+    fn to_uri(&self, location: &Path) -> String {
+        T::to_uri(self, location)
+    }
+
+    fn root_uri(&self) -> String {
+        T::root_uri(self)
+    }
+
+    fn log_path(&self) -> &Path {
+        T::log_path(self)
+    }
+
+    async fn is_delta_table_location(&self) -> DeltaResult<bool> {
+        T::is_delta_table_location(self).await
+    }
+
+    fn config(&self) -> &LogStoreConfig {
+        T::config(self)
+    }
+
+    #[cfg(feature = "datafusion")]
+    fn object_store_url(&self) -> ObjectStoreUrl {
+        T::object_store_url(self)
+    }
 }
 
 async fn get_engine(store: Arc<dyn ObjectStore>) -> Arc<dyn Engine> {

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -36,7 +36,7 @@ use tracing::log::*;
 use super::{CustomExecuteHandler, Operation};
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
-use crate::logstore::LogStoreRef;
+use crate::logstore::{LogStore, LogStoreRef};
 use crate::protocol::DeltaOperation;
 use crate::table::state::DeltaTableState;
 use crate::DeltaTable;
@@ -242,7 +242,7 @@ impl VacuumBuilder {
             &self.snapshot,
             retention_period,
             now_millis,
-            self.log_store.object_store(None).clone(),
+            &self.log_store,
         )
         .await?;
         let valid_files = self.snapshot.file_paths_iter().collect::<HashSet<Path>>();
@@ -452,7 +452,7 @@ async fn get_stale_files(
     snapshot: &DeltaTableState,
     retention_period: Duration,
     now_timestamp_millis: i64,
-    store: Arc<dyn ObjectStore>,
+    store: &dyn LogStore,
 ) -> DeltaResult<HashSet<String>> {
     let tombstone_retention_timestamp = now_timestamp_millis - retention_period.num_milliseconds();
     Ok(snapshot

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -178,7 +178,7 @@ pub async fn create_checkpoint_for(
 
     debug!("Writing parquet bytes to checkpoint buffer.");
     let tombstones = state
-        .unexpired_tombstones(log_store.object_store(None).clone())
+        .unexpired_tombstones(log_store)
         .await
         .map_err(|_| ProtocolError::Generic("filed to get tombstones".into()))?
         .collect::<Vec<_>>();
@@ -629,7 +629,8 @@ mod tests {
         // Look at the "files" and verify that the _last_checkpoint has the right version
         let path = Path::from("_delta_log/_last_checkpoint");
         let last_checkpoint = table
-            .object_store()
+            .log_store()
+            .object_store(None)
             .get(&path)
             .await
             .expect("Failed to get the _last_checkpoint")
@@ -715,7 +716,8 @@ mod tests {
         // Look at the "files" and verify that the _last_checkpoint has the right version
         let path = Path::from("_delta_log/_last_checkpoint");
         let last_checkpoint = table
-            .object_store()
+            .log_store()
+            .object_store(None)
             .get(&path)
             .await
             .expect("Failed to get the _last_checkpoint")

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -210,15 +210,11 @@ impl DeltaTable {
         max_version: Option<i64>,
     ) -> Result<(), DeltaTableError> {
         match self.state.as_mut() {
-            Some(state) => state.update(self.log_store.clone(), max_version).await,
+            Some(state) => state.update(&self.log_store, max_version).await,
             _ => {
-                let state = DeltaTableState::try_new(
-                    &Path::default(),
-                    self.log_store.object_store(None),
-                    self.config.clone(),
-                    max_version,
-                )
-                .await?;
+                let state =
+                    DeltaTableState::try_new(&self.log_store, self.config.clone(), max_version)
+                        .await?;
                 self.state = Some(state);
                 Ok(())
             }
@@ -262,7 +258,7 @@ impl DeltaTable {
             .snapshot()?
             .snapshot
             .snapshot()
-            .commit_infos(self.object_store(), limit)
+            .commit_infos(&self.log_store(), limit)
             .await?
             .try_collect::<Vec<_>>()
             .await?;

--- a/crates/core/tests/checkpoint_writer.rs
+++ b/crates/core/tests/checkpoint_writer.rs
@@ -360,7 +360,7 @@ mod checkpoints_with_tombstones {
             table
                 .snapshot()
                 .unwrap()
-                .all_tombstones(table.object_store().clone())
+                .all_tombstones(&table.log_store())
                 .await
                 .unwrap()
                 .collect::<HashSet<_>>(),
@@ -377,7 +377,7 @@ mod checkpoints_with_tombstones {
             table
                 .snapshot()
                 .unwrap()
-                .all_tombstones(table.object_store().clone())
+                .all_tombstones(&table.log_store())
                 .await
                 .unwrap()
                 .count(),

--- a/crates/core/tests/command_filesystem_check.rs
+++ b/crates/core/tests/command_filesystem_check.rs
@@ -41,7 +41,7 @@ async fn test_filesystem_check(context: &IntegrationContext) -> TestResult {
 
     let remove = table
         .snapshot()?
-        .all_tombstones(table.object_store().clone())
+        .all_tombstones(&table.log_store())
         .await?
         .collect::<HashSet<_>>();
     let remove = remove.get(file).unwrap();
@@ -88,7 +88,7 @@ async fn test_filesystem_check_partitioned() -> TestResult {
 
     let remove = table
         .snapshot()?
-        .all_tombstones(table.object_store().clone())
+        .all_tombstones(&table.log_store())
         .await?
         .collect::<HashSet<_>>();
     let remove = remove.get(file).unwrap();

--- a/crates/core/tests/command_restore.rs
+++ b/crates/core/tests/command_restore.rs
@@ -179,7 +179,7 @@ async fn test_restore_file_missing() -> Result<(), Box<dyn Error>> {
     for file in context
         .table
         .snapshot()?
-        .all_tombstones(context.table.object_store().clone())
+        .all_tombstones(&context.table.log_store())
         .await?
     {
         let p = tmp_dir.path().join(file.clone().path);
@@ -208,7 +208,7 @@ async fn test_restore_allow_file_missing() -> Result<(), Box<dyn Error>> {
     for file in context
         .table
         .snapshot()?
-        .all_tombstones(context.table.object_store().clone())
+        .all_tombstones(&context.table.log_store())
         .await?
     {
         let p = tmp_dir.path().join(file.clone().path);

--- a/crates/core/tests/eager_snapshot.rs
+++ b/crates/core/tests/eager_snapshot.rs
@@ -7,20 +7,15 @@ use deltalake_core::{
 };
 use deltalake_test::utils::*;
 use itertools::Itertools;
-use object_store::path::Path;
 
 #[tokio::test]
 async fn test_eager_snapshot_advance() -> TestResult {
     let context = IntegrationContext::new(Box::<LocalStorageIntegration>::default())?;
     context.load_table(TestTables::Simple).await?;
 
-    let store = context
-        .table_builder(TestTables::Simple)
-        .build_storage()?
-        .object_store(None);
+    let log_store = context.table_builder(TestTables::Simple).build_storage()?;
 
-    let mut snapshot =
-        EagerSnapshot::try_new(&Path::default(), store.clone(), Default::default(), None).await?;
+    let mut snapshot = EagerSnapshot::try_new(&log_store, Default::default(), None).await?;
 
     let version = snapshot.version();
 

--- a/crates/core/tests/integration.rs
+++ b/crates/core/tests/integration.rs
@@ -66,7 +66,7 @@ async fn test_action_reconciliation() {
         table
             .snapshot()
             .unwrap()
-            .all_tombstones(table.object_store().clone())
+            .all_tombstones(&table.log_store())
             .await
             .unwrap()
             .map(|r| r.path.clone())

--- a/crates/core/tests/integration_checkpoint.rs
+++ b/crates/core/tests/integration_checkpoint.rs
@@ -115,7 +115,8 @@ async fn test_issue_1420_cleanup_expired_logs_for() -> DeltaResult<()> {
 
     assert!(
         table
-            .object_store()
+            .log_store()
+            .object_store(None)
             .head(&Path::from(format!("_delta_log/{:020}.json", 1)))
             .await
             .is_err(),
@@ -124,7 +125,8 @@ async fn test_issue_1420_cleanup_expired_logs_for() -> DeltaResult<()> {
 
     assert!(
         table
-            .object_store()
+            .log_store()
+            .object_store(None)
             .head(&Path::from(format!("_delta_log/{:020}.json", 2)))
             .await
             .is_ok(),
@@ -133,7 +135,8 @@ async fn test_issue_1420_cleanup_expired_logs_for() -> DeltaResult<()> {
 
     assert!(
         table
-            .object_store()
+            .log_store()
+            .object_store(None)
             .head(&Path::from(format!(
                 "_delta_log/{:020}.checkpoint.parquet",
                 2
@@ -158,7 +161,8 @@ async fn test_issue_1420_cleanup_expired_logs_for() -> DeltaResult<()> {
 
     assert!(
         table
-            .object_store()
+            .log_store()
+            .object_store(None)
             .head(&Path::from(format!("_delta_log/{:020}.json", 2)))
             .await
             .is_ok(),
@@ -167,7 +171,8 @@ async fn test_issue_1420_cleanup_expired_logs_for() -> DeltaResult<()> {
 
     assert!(
         table
-            .object_store()
+            .log_store()
+            .object_store(None)
             .head(&Path::from(format!(
                 "_delta_log/{:020}.checkpoint.parquet",
                 2

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -113,7 +113,7 @@ pub async fn add_file(
     create_time: i64,
     commit_to_log: bool,
 ) {
-    let backend = table.object_store();
+    let backend = table.log_store().object_store(None);
     backend.put(path, data.clone().into()).await.unwrap();
 
     if commit_to_log {

--- a/crates/test/src/read.rs
+++ b/crates/test/src/read.rs
@@ -55,7 +55,7 @@ async fn read_simple_table(integration: &IntegrationContext) -> TestResult {
     );
     let tombstones = table
         .snapshot()?
-        .all_tombstones(table.object_store().clone())
+        .all_tombstones(&table.log_store())
         .await?
         .collect::<Vec<_>>();
     assert_eq!(tombstones.len(), 31);
@@ -100,7 +100,7 @@ async fn read_simple_table_with_version(integration: &IntegrationContext) -> Tes
     );
     let tombstones = table
         .snapshot()?
-        .all_tombstones(table.object_store().clone())
+        .all_tombstones(&table.log_store())
         .await?
         .collect::<Vec<_>>();
     assert_eq!(tombstones.len(), 29);

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -142,7 +142,7 @@ impl RawDeltaTable {
     }
 
     fn object_store(&self) -> PyResult<ObjectStoreRef> {
-        self.with_table(|t| Ok(t.object_store().clone()))
+        self.with_table(|t| Ok(t.log_store().object_store(None).clone()))
     }
 
     fn cloned_state(&self) -> PyResult<DeltaTableState> {
@@ -1403,8 +1403,7 @@ impl RawDeltaTable {
                         let new_state = if result > 0 {
                             Some(
                                 DeltaTableState::try_new(
-                                    &table.state.clone().unwrap().snapshot().table_root(),
-                                    table.object_store(),
+                                    &table.log_store(),
                                     table.config.clone(),
                                     Some(table.version()),
                                 )


### PR DESCRIPTION
# Description

Moving to kernel also means a significant change in our path handling. THus far we rely on object store's `Path`, often relative to the delta table root. In parctical terms this right now also hinders us from processing tables where data files are in different locations. More importantly though, kernel handles all path references as fully qualified URLs. As a pre-factor to further kernel adoption, we change the APIs for the internal `Snapshots` and `LogSegement` to use `LogStore`. `LogStore` carries a reference to the full table location and exposes a prefixed (to table root) as well as a non-prefixed `ObjectStore` along with kernels `Engine`. Tjis will allow us to have chanegs in functionality much more isolated in future PRs.

This PR does not change an processing logic, and just defers the decision which store to use further into the stack.