### PR TITLE
chore: ensuring default builds work without datafusion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Default build
-        run: (cd crates/deltalake && cargo build)
+        run: (cd crates/deltalake && cargo build --tests)
 
       - name: build and lint with clippy
         run: cargo clippy --features ${{ env.DEFAULT_FEATURES }} --tests

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -138,3 +138,15 @@ integration_test = []
 [[test]]
 name = "dat"
 harness = false
+
+[[test]]
+name = "command_optimize"
+required-features = ["datafusion"]
+
+[[test]]
+name = "command_merge"
+required-features = ["datafusion"]
+
+[[test]]
+name = "command_restore"
+required-features = ["datafusion"]

--- a/crates/core/src/kernel/transaction/application.rs
+++ b/crates/core/src/kernel/transaction/application.rs
@@ -5,6 +5,7 @@ mod tests {
         protocol::SaveMode, writer::test_utils::get_record_batch, DeltaOps, DeltaTableBuilder,
     };
 
+    #[cfg(feature = "datafusion")]
     #[tokio::test]
     async fn test_app_txn_workload() {
         // Test that the transaction ids can be read from different scenarios

--- a/crates/core/src/operations/create.rs
+++ b/crates/core/src/operations/create.rs
@@ -551,6 +551,7 @@ mod tests {
         assert_ne!(table.metadata().unwrap().id, first_id)
     }
 
+    #[cfg(feature = "datafusion")]
     #[tokio::test]
     async fn test_create_or_replace_existing_table() {
         let batch = get_record_batch(None, false);
@@ -576,6 +577,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "datafusion")]
     async fn test_create_or_replace_existing_table_partitioned() {
         let batch = get_record_batch(None, false);
         let schema = get_delta_schema();

--- a/crates/core/src/operations/restore.rs
+++ b/crates/core/src/operations/restore.rs
@@ -375,6 +375,7 @@ mod tests {
     /// Verify that restore respects constraints that were added/removed in previous version_to_restore
     /// <https://github.com/delta-io/delta-rs/issues/3352>
     #[tokio::test]
+    #[cfg(feature = "datafusion")]
     async fn test_simple_restore_constraints() -> DeltaResult<()> {
         let batch = get_record_batch(None, false);
         let table = DeltaOps(create_bare_table())

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -899,6 +899,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "datafusion")]
     async fn setup_table() -> DeltaTable {
         use arrow_schema::{DataType, Field};
         let schema = Arc::new(ArrowSchema::new(vec![Field::new(
@@ -923,6 +924,7 @@ mod tests {
             .unwrap()
     }
 
+    #[cfg(feature = "datafusion")]
     #[tokio::test]
     async fn test_cleanup_no_checkpoints() {
         // Test that metadata clean up does not corrupt the table when no checkpoints exist
@@ -952,6 +954,7 @@ mod tests {
         assert!(res.is_ok());
     }
 
+    #[cfg(feature = "datafusion")]
     #[tokio::test]
     async fn test_cleanup_with_checkpoints() {
         let table = setup_table().await;
@@ -1081,6 +1084,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "datafusion")]
     #[tokio::test]
     async fn test_struct_with_single_list_field() {
         // you need another column otherwise the entire stats struct is empty
@@ -1167,6 +1171,7 @@ mod tests {
     });
 
     #[ignore = "This test is only useful if the batch size has been made small"]
+    #[cfg(feature = "datafusion")]
     #[tokio::test]
     async fn test_checkpoint_large_table() -> DeltaResult<()> {
         use crate::writer::test_utils::get_arrow_schema;


### PR DESCRIPTION
turns out our CI shouldn't have let some things through since it wasn't running a default build of tests too