### PR TITLE
refactor: use full paths in log processing

### DIFF
--- a/crates/azure/Cargo.toml
+++ b/crates/azure/Cargo.toml
@@ -26,6 +26,9 @@ regex = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+deltalake-core = { version = "0.26.0", path = "../core", features = [
+    "datafusion",
+] }
 chrono = { workspace = true }
 serial_test = "3"
 deltalake-test = { path = "../test" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -57,7 +57,7 @@ chrono = { workspace = true, default-features = false, features = ["clock"] }
 regex = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
-url = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 urlencoding = { workspace = true }
 
 # runtime

--- a/crates/core/src/kernel/snapshot/replay.rs
+++ b/crates/core/src/kernel/snapshot/replay.rs
@@ -604,6 +604,7 @@ pub(super) mod tests {
     use arrow_select::concat::concat_batches;
     use delta_kernel::schema::DataType;
     use futures::TryStreamExt;
+    use object_store::path::Path;
 
     use super::super::{log_segment::LogSegment, partitions_schema, stats_schema};
     use super::*;
@@ -680,7 +681,7 @@ pub(super) mod tests {
             app_metadata: Default::default(),
             app_transactions: Default::default(),
         };
-        let (_, maybe_batches) = LogSegment::new_test(&[commit_data])?;
+        let (_, maybe_batches) = LogSegment::new_test(&[commit_data], &Path::default())?;
 
         let batches = maybe_batches.into_iter().collect::<Result<Vec<_>, _>>()?;
         let batch = concat_batches(&batches[0].schema(), &batches)?;
@@ -743,7 +744,7 @@ pub(super) mod tests {
             app_metadata: Default::default(),
             app_transactions: Default::default(),
         };
-        let (_, maybe_batches) = LogSegment::new_test(&[commit_data])?;
+        let (_, maybe_batches) = LogSegment::new_test(&[commit_data], &Path::default())?;
 
         let batches = maybe_batches.into_iter().collect::<Result<Vec<_>, _>>()?;
         let batch = concat_batches(&batches[0].schema(), &batches)?;

--- a/crates/core/src/kernel/transaction/conflict_checker.rs
+++ b/crates/core/src/kernel/transaction/conflict_checker.rs
@@ -698,10 +698,12 @@ mod tests {
         actions: Vec<Action>,
         read_whole_table: bool,
     ) -> Result<(), CommitConflictError> {
+        use object_store::path::Path;
+
         use crate::table::state::DeltaTableState;
 
         let setup_actions = setup.unwrap_or_else(init_table_actions);
-        let state = DeltaTableState::from_actions(setup_actions).unwrap();
+        let state = DeltaTableState::from_actions(setup_actions, &Path::default()).unwrap();
         let snapshot = state.snapshot();
         let transaction_info = TransactionInfo::new(snapshot, reads, &actions, read_whole_table);
         let summary = WinningCommitSummary {

--- a/crates/core/src/kernel/transaction/protocol.rs
+++ b/crates/core/src/kernel/transaction/protocol.rs
@@ -235,6 +235,8 @@ pub static INSTANCE: LazyLock<ProtocolChecker> = LazyLock::new(|| {
 mod tests {
     use std::collections::HashMap;
 
+    use object_store::path::Path;
+
     use super::*;
     use crate::kernel::DataType as DeltaDataType;
     use crate::kernel::{Action, Add, Metadata, PrimitiveType, Protocol, Remove};
@@ -307,7 +309,7 @@ mod tests {
         let checker = ProtocolChecker::new(HashSet::new(), WRITER_V2.clone());
 
         let actions = create_actions(1, "true", vec![]);
-        let snapshot = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager = snapshot.snapshot();
         assert!(checker
             .can_commit(eager, &append_actions, &append_op)
@@ -320,7 +322,7 @@ mod tests {
             .is_ok());
 
         let actions = create_actions(2, "true", vec![]);
-        let snapshot = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager = snapshot.snapshot();
         assert!(checker
             .can_commit(eager, &append_actions, &append_op)
@@ -333,7 +335,7 @@ mod tests {
             .is_ok());
 
         let actions = create_actions(2, "false", vec![]);
-        let snapshot = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager = snapshot.snapshot();
         assert!(checker
             .can_commit(eager, &append_actions, &append_op)
@@ -346,7 +348,7 @@ mod tests {
             .is_ok());
 
         let actions = create_actions(7, "true", vec![WriterFeature::AppendOnly]);
-        let snapshot = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager = snapshot.snapshot();
         assert!(checker
             .can_commit(eager, &append_actions, &append_op)
@@ -359,7 +361,7 @@ mod tests {
             .is_ok());
 
         let actions = create_actions(7, "false", vec![WriterFeature::AppendOnly]);
-        let snapshot = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager = snapshot.snapshot();
         assert!(checker
             .can_commit(eager, &append_actions, &append_op)
@@ -372,7 +374,7 @@ mod tests {
             .is_ok());
 
         let actions = create_actions(7, "true", vec![]);
-        let snapshot = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager = snapshot.snapshot();
         assert!(checker
             .can_commit(eager, &append_actions, &append_op)
@@ -396,7 +398,7 @@ mod tests {
             }),
             metadata_action(None).into(),
         ];
-        let snapshot_1 = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot_1 = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager_1 = snapshot_1.snapshot();
         assert!(checker_1.can_read_from(eager_1).is_ok());
         assert!(checker_1.can_write_to(eager_1).is_ok());
@@ -410,7 +412,7 @@ mod tests {
             }),
             metadata_action(None).into(),
         ];
-        let snapshot_2 = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot_2 = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager_2 = snapshot_2.snapshot();
         assert!(checker_1.can_read_from(eager_2).is_err());
         assert!(checker_1.can_write_to(eager_2).is_err());
@@ -427,7 +429,7 @@ mod tests {
             }),
             metadata_action(None).into(),
         ];
-        let snapshot_3 = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot_3 = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager_3 = snapshot_3.snapshot();
         assert!(checker_1.can_read_from(eager_3).is_err());
         assert!(checker_1.can_write_to(eager_3).is_err());
@@ -447,7 +449,7 @@ mod tests {
             }),
             metadata_action(None).into(),
         ];
-        let snapshot_4 = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot_4 = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager_4 = snapshot_4.snapshot();
         assert!(checker_1.can_read_from(eager_4).is_err());
         assert!(checker_1.can_write_to(eager_4).is_err());
@@ -470,7 +472,7 @@ mod tests {
             }),
             metadata_action(None).into(),
         ];
-        let snapshot_5 = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot_5 = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager_5 = snapshot_5.snapshot();
         assert!(checker_1.can_read_from(eager_5).is_err());
         assert!(checker_1.can_write_to(eager_5).is_err());
@@ -496,7 +498,7 @@ mod tests {
             }),
             metadata_action(None).into(),
         ];
-        let snapshot_6 = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot_6 = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager_6 = snapshot_6.snapshot();
         assert!(checker_1.can_read_from(eager_6).is_err());
         assert!(checker_1.can_write_to(eager_6).is_err());
@@ -525,7 +527,7 @@ mod tests {
             }),
             metadata_action(None).into(),
         ];
-        let snapshot_7 = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot_7 = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager_7 = snapshot_7.snapshot();
         assert!(checker_1.can_read_from(eager_7).is_err());
         assert!(checker_1.can_write_to(eager_7).is_err());
@@ -558,7 +560,7 @@ mod tests {
             ),
             metadata_action(None).into(),
         ];
-        let snapshot_5 = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot_5 = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager_5 = snapshot_5.snapshot();
         assert!(checker_5.can_write_to(eager_5).is_ok());
     }
@@ -575,7 +577,7 @@ mod tests {
             ),
             metadata_action(None).into(),
         ];
-        let snapshot_5 = DeltaTableState::from_actions(actions).unwrap();
+        let snapshot_5 = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let eager_5 = snapshot_5.snapshot();
         assert!(checker_5.can_write_to(eager_5).is_ok());
     }

--- a/crates/core/src/kernel/transaction/state.rs
+++ b/crates/core/src/kernel/transaction/state.rs
@@ -254,6 +254,7 @@ mod tests {
 
     use datafusion::prelude::SessionContext;
     use datafusion_expr::{col, lit};
+    use object_store::path::Path;
 
     use super::*;
     use crate::delta_datafusion::{files_matching_predicate, DataFusionMixins};
@@ -269,7 +270,8 @@ mod tests {
 
     #[test]
     fn test_parse_predicate_expression() {
-        let snapshot = DeltaTableState::from_actions(init_table_actions()).unwrap();
+        let snapshot =
+            DeltaTableState::from_actions(init_table_actions(), &Path::default()).unwrap();
         let session = SessionContext::new();
         let state = session.state();
 
@@ -317,7 +319,7 @@ mod tests {
             true,
         )));
 
-        let state = DeltaTableState::from_actions(actions).unwrap();
+        let state = DeltaTableState::from_actions(actions, &Path::default()).unwrap();
         let files = files_matching_predicate(&state.snapshot, &[])
             .unwrap()
             .collect::<Vec<_>>();

--- a/crates/core/src/logstore/config.rs
+++ b/crates/core/src/logstore/config.rs
@@ -9,7 +9,7 @@
 use std::collections::HashMap;
 
 use ::object_store::RetryConfig;
-use object_store::{path::Path, prefix::PrefixStore, ObjectStore, ObjectStoreScheme};
+use object_store::{path::Path, prefix::PrefixStore, ObjectStore};
 
 use super::storage::LimitConfig;
 use super::{storage::runtime::RuntimeConfig, IORuntime};
@@ -132,11 +132,7 @@ impl StorageConfig {
         store: T,
         table_root: &url::Url,
     ) -> DeltaResult<Box<dyn ObjectStore>> {
-        let prefix = match ObjectStoreScheme::parse(table_root) {
-            Ok((ObjectStoreScheme::AmazonS3, _)) => Path::parse(table_root.path())?,
-            Ok((_, path)) => path,
-            _ => Path::parse(table_root.path())?,
-        };
+        let prefix = super::object_store_path(table_root)?;
         Ok(if prefix != Path::from("/") {
             Box::new(PrefixStore::new(store, prefix)) as Box<dyn ObjectStore>
         } else {

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -56,7 +56,7 @@ impl DeltaTableState {
 
     /// Construct a delta table state object from a list of actions
     #[cfg(test)]
-    pub fn from_actions(actions: Vec<Action>) -> DeltaResult<Self> {
+    pub fn from_actions(actions: Vec<Action>, table_root: &Path) -> DeltaResult<Self> {
         use crate::kernel::transaction::CommitData;
         use crate::protocol::{DeltaOperation, SaveMode};
 
@@ -87,7 +87,7 @@ impl DeltaTableState {
             Vec::new(),
         )];
 
-        let snapshot = EagerSnapshot::new_test(&commit_data).unwrap();
+        let snapshot = EagerSnapshot::new_test(&commit_data, table_root).unwrap();
         Ok(Self { snapshot })
     }
 


### PR DESCRIPTION
# Description

Delta kernel handles all paths as fully qualified URLs. As another step towards adopting kernel, we move the internal log processing to handle full paths, rather than paths relative to the table root.