### PR TITLE
fix: use more accurate log path parsing

### DIFF
--- a/crates/core/src/kernel/snapshot/log_segment.rs
+++ b/crates/core/src/kernel/snapshot/log_segment.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, LazyLock};
 
 use arrow_array::RecordBatch;
 use chrono::Utc;
+use delta_kernel::path::{LogPathFileType, ParsedLogPath};
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use object_store::path::Path;
@@ -11,9 +12,9 @@ use object_store::{Error as ObjectStoreError, ObjectMeta, ObjectStore};
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 use parquet::arrow::ProjectionMask;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
+use url::Url;
 
 use super::parse;
 use crate::kernel::transaction::CommitData;
@@ -22,81 +23,8 @@ use crate::logstore::{LogStore, LogStoreExt};
 use crate::{DeltaResult, DeltaTableConfig, DeltaTableError};
 
 const LAST_CHECKPOINT_FILE_NAME: &str = "_last_checkpoint";
-
-static CHECKPOINT_FILE_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\d+\.checkpoint(\.\d+\.\d+)?\.parquet").unwrap());
-static DELTA_FILE_PATTERN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\d+\.json$").unwrap());
-static CRC_FILE_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\.\d+(\.crc|\.json)|\d+)\.crc$").unwrap());
-static LAST_CHECKPOINT_FILE_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^_last_checkpoint$").unwrap());
-static LAST_VACUUM_INFO_FILE_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^_last_vacuum_info$").unwrap());
-static DELETION_VECTOR_FILE_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r".*\.bin$").unwrap());
 pub(super) static TOMBSTONE_SCHEMA: LazyLock<StructType> =
     LazyLock::new(|| StructType::new(vec![ActionType::Remove.schema_field().clone()]));
-
-/// Trait to extend a file path representation with delta specific functionality
-///
-/// specifically, this trait adds the ability to recognize valid log files and
-/// parse the version number from a log file path
-// TODO handle compaction files
-pub(crate) trait PathExt {
-    /// Returns the last path segment if not terminated with a "/"
-    fn filename(&self) -> Option<&str>;
-
-    /// Parse the version number assuming a commit json or checkpoint parquet file
-    fn commit_version(&self) -> Option<i64> {
-        self.filename()
-            .and_then(|f| f.split_once('.'))
-            .and_then(|(name, _)| name.parse().ok())
-    }
-
-    /// Returns true if the file is a checkpoint parquet file
-    fn is_checkpoint_file(&self) -> bool {
-        self.filename()
-            .map(|name| CHECKPOINT_FILE_PATTERN.captures(name).is_some())
-            .unwrap_or(false)
-    }
-
-    /// Returns true if the file is a commit json file
-    fn is_commit_file(&self) -> bool {
-        self.filename()
-            .map(|name| DELTA_FILE_PATTERN.captures(name).is_some())
-            .unwrap_or(false)
-    }
-
-    fn is_crc_file(&self) -> bool {
-        self.filename()
-            .map(|name| CRC_FILE_PATTERN.captures(name).is_some())
-            .unwrap()
-    }
-
-    fn is_last_checkpoint_file(&self) -> bool {
-        self.filename()
-            .map(|name| LAST_CHECKPOINT_FILE_PATTERN.captures(name).is_some())
-            .unwrap_or(false)
-    }
-
-    fn is_last_vacuum_info_file(&self) -> bool {
-        self.filename()
-            .map(|name| LAST_VACUUM_INFO_FILE_PATTERN.captures(name).is_some())
-            .unwrap_or(false)
-    }
-
-    fn is_deletion_vector_file(&self) -> bool {
-        self.filename()
-            .map(|name| DELETION_VECTOR_FILE_PATTERN.captures(name).is_some())
-            .unwrap_or(false)
-    }
-}
-
-impl PathExt for Path {
-    fn filename(&self) -> Option<&str> {
-        self.filename()
-    }
-}
 
 #[derive(Debug, Clone, PartialEq)]
 pub(super) struct LogSegment {
@@ -111,6 +39,11 @@ impl LogSegment {
     /// This will list the entire log directory and find all relevant files for the given table version.
     pub async fn try_new(log_store: &dyn LogStore, version: Option<i64>) -> DeltaResult<Self> {
         let root_store = log_store.root_object_store(None);
+
+        let root_url = log_store.table_root_url();
+        let mut store_root = root_url.clone();
+        store_root.set_path("");
+
         let log_url = log_store.log_root_url();
         let log_path = crate::logstore::object_store_path(&log_url)?;
 
@@ -118,22 +51,26 @@ impl LogSegment {
 
         // List relevant files from log
         let (mut commit_files, checkpoint_files) = match (maybe_cp, version) {
-            (Some(cp), None) => list_log_files_with_checkpoint(&cp, &root_store, &log_path).await?,
-            (Some(cp), Some(v)) if cp.version <= v => {
-                list_log_files_with_checkpoint(&cp, &root_store, &log_path).await?
+            (Some(cp), None) => {
+                list_log_files_with_checkpoint(&cp, &root_store, &log_path, &store_root).await?
             }
-            _ => list_log_files(&root_store, &log_path, version, None).await?,
+            (Some(cp), Some(v)) if cp.version <= v => {
+                list_log_files_with_checkpoint(&cp, &root_store, &log_path, &store_root).await?
+            }
+            _ => list_log_files(&root_store, &log_path, version, None, &store_root).await?,
         };
 
         // remove all files above requested version
         if let Some(version) = version {
-            commit_files.retain(|meta| meta.location.commit_version() <= Some(version));
+            commit_files.retain(|meta| meta.1.version <= version as u64);
         }
+
+        validate(&commit_files, &checkpoint_files)?;
 
         let mut segment = Self {
             version: 0,
-            commit_files: commit_files.into(),
-            checkpoint_files,
+            commit_files: commit_files.into_iter().map(|(meta, _)| meta).collect(),
+            checkpoint_files: checkpoint_files.into_iter().map(|(meta, _)| meta).collect(),
         };
         if segment.commit_files.is_empty() && segment.checkpoint_files.is_empty() {
             return Err(DeltaTableError::NotATable("no log files".into()));
@@ -141,13 +78,11 @@ impl LogSegment {
         // get the effective version from chosen files
         let version_eff = segment.file_version().ok_or(DeltaTableError::Generic(
             "failed to get effective version".into(),
-        ))?; // TODO: A more descriptive error
+        ))?;
         segment.version = version_eff;
-        segment.validate()?;
 
         if let Some(v) = version {
             if version_eff != v {
-                // TODO more descriptive error
                 return Err(DeltaTableError::Generic("missing version".into()));
             }
         }
@@ -167,6 +102,8 @@ impl LogSegment {
         debug!("try_new_slice: start_version: {start_version}, end_version: {end_version:?}",);
         log_store.refresh().await?;
         let log_url = log_store.log_root_url();
+        let mut store_root = log_url.clone();
+        store_root.set_path("");
         let log_path = crate::logstore::object_store_path(&log_url)?;
 
         let (mut commit_files, checkpoint_files) = list_log_files(
@@ -174,69 +111,44 @@ impl LogSegment {
             &log_path,
             end_version,
             Some(start_version),
+            &store_root,
         )
         .await?;
+
         // remove all files above requested version
         if let Some(version) = end_version {
-            commit_files.retain(|meta| meta.location.commit_version() <= Some(version));
+            commit_files.retain(|meta| meta.1.version <= version as u64);
         }
+
+        validate(&commit_files, &checkpoint_files)?;
+
         let mut segment = Self {
             version: start_version,
-            commit_files: commit_files.into(),
-            checkpoint_files,
+            commit_files: commit_files.into_iter().map(|(meta, _)| meta).collect(),
+            checkpoint_files: checkpoint_files.into_iter().map(|(meta, _)| meta).collect(),
         };
         segment.version = segment
             .file_version()
             .unwrap_or(end_version.unwrap_or(start_version));
 
-        segment.validate()?;
-
         Ok(segment)
-    }
-
-    pub fn validate(&self) -> DeltaResult<()> {
-        let is_contiguous = self
-            .commit_files
-            .iter()
-            .collect_vec()
-            .windows(2)
-            .all(|cfs| {
-                cfs[0].location.commit_version().unwrap() - 1
-                    == cfs[1].location.commit_version().unwrap()
-            });
-        if !is_contiguous {
-            return Err(DeltaTableError::Generic(
-                "non-contiguous log segment".into(),
-            ));
-        }
-
-        let checkpoint_version = self
-            .checkpoint_files
-            .iter()
-            .filter_map(|f| f.location.commit_version())
-            .max();
-        if let Some(v) = checkpoint_version {
-            if !self
-                .commit_files
-                .iter()
-                .all(|f| f.location.commit_version() > Some(v))
-            {
-                return Err(DeltaTableError::Generic("inconsistent log segment".into()));
-            }
-        }
-        Ok(())
     }
 
     /// Returns the highest commit version number in the log segment
     pub fn file_version(&self) -> Option<i64> {
+        let dummy_url = Url::parse("dummy:///").unwrap();
         self.commit_files
-            .iter()
-            .filter_map(|f| f.location.commit_version())
-            .max()
-            .or(self
-                .checkpoint_files
-                .first()
-                .and_then(|f| f.location.commit_version()))
+            .front()
+            .and_then(|f| {
+                let file_url = dummy_url.join(f.location.as_ref()).ok()?;
+                let parsed = ParsedLogPath::try_from(file_url).ok()?;
+                parsed.map(|p| p.version as i64)
+            })
+            .or(self.checkpoint_files.first().and_then(|f| {
+                let file_url = dummy_url.join(f.location.as_ref()).ok()?;
+                let parsed = ParsedLogPath::try_from(file_url).ok()?;
+                parsed.map(|p| p.version as i64)
+            }))
     }
 
     #[cfg(test)]
@@ -266,9 +178,17 @@ impl LogSegment {
 
     /// Returns the last modified timestamp for a commit file with the given version
     pub fn version_timestamp(&self, version: i64) -> Option<chrono::DateTime<Utc>> {
+        let dummy_url = Url::parse("dummy:///").unwrap();
         self.commit_files
             .iter()
-            .find(|f| f.location.commit_version() == Some(version))
+            .find(|f| {
+                let parsed = dummy_url
+                    .join(f.location.as_ref())
+                    .ok()
+                    .and_then(|p| ParsedLogPath::try_from(p).ok())
+                    .flatten();
+                parsed.map(|p| p.version == version as u64).unwrap_or(false)
+            })
             .map(|f| f.last_modified)
     }
 
@@ -438,6 +358,30 @@ impl LogSegment {
     }
 }
 
+fn validate(
+    commit_files: &[(ObjectMeta, ParsedLogPath<Url>)],
+    checkpoint_files: &[(ObjectMeta, ParsedLogPath<Url>)],
+) -> DeltaResult<()> {
+    let is_contiguous = commit_files
+        .iter()
+        .collect_vec()
+        .windows(2)
+        .all(|cfs| cfs[0].1.version - 1 == cfs[1].1.version);
+    if !is_contiguous {
+        return Err(DeltaTableError::Generic(
+            "non-contiguous log segment".into(),
+        ));
+    }
+
+    let checkpoint_version = checkpoint_files.iter().map(|f| f.1.version).max();
+    if let Some(v) = checkpoint_version {
+        if !commit_files.iter().all(|f| f.1.version > v) {
+            return Err(DeltaTableError::Generic("inconsistent log segment".into()));
+        }
+    }
+    Ok(())
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct CheckpointMetadata {
@@ -481,7 +425,11 @@ async fn list_log_files_with_checkpoint(
     cp: &CheckpointMetadata,
     root_store: &dyn ObjectStore,
     log_root: &Path,
-) -> DeltaResult<(Vec<ObjectMeta>, Vec<ObjectMeta>)> {
+    store_root: &Url,
+) -> DeltaResult<(
+    Vec<(ObjectMeta, ParsedLogPath<Url>)>,
+    Vec<(ObjectMeta, ParsedLogPath<Url>)>,
+)> {
     let version_prefix = format!("{:020}", cp.version);
     let start_from = log_root.child(version_prefix.as_str());
 
@@ -490,14 +438,17 @@ async fn list_log_files_with_checkpoint(
         .try_collect::<Vec<_>>()
         .await?
         .into_iter()
-        // TODO this filters out .crc files etc which start with "." - how do we want to use these kind of files?
-        .filter(|f| f.location.commit_version().is_some())
+        .filter_map(|f| {
+            let file_url = store_root.join(f.location.as_ref()).ok()?;
+            let path = ParsedLogPath::try_from(file_url).ok()??;
+            Some((f, path))
+        })
         .collect::<Vec<_>>();
 
     let mut commit_files = files
         .iter()
         .filter_map(|f| {
-            if f.location.is_commit_file() && f.location.commit_version() > Some(cp.version) {
+            if matches!(f.1.file_type, LogPathFileType::Commit) && f.1.version > cp.version as u64 {
                 Some(f.clone())
             } else {
                 None
@@ -506,12 +457,19 @@ async fn list_log_files_with_checkpoint(
         .collect_vec();
 
     // NOTE: this will sort in reverse order
-    commit_files.sort_unstable_by(|a, b| b.location.cmp(&a.location));
+    commit_files.sort_unstable_by(|a, b| b.0.location.cmp(&a.0.location));
 
     let checkpoint_files = files
         .iter()
         .filter_map(|f| {
-            if f.location.is_checkpoint_file() && f.location.commit_version() == Some(cp.version) {
+            if matches!(
+                f.1.file_type,
+                // UUID named checkpoints are part of the v2 spec and can currently not be parsed.
+                // This will be supported once we do kernel log replay.
+                // | LogPathFileType::UuidCheckpoint(_)
+                LogPathFileType::SinglePartCheckpoint | LogPathFileType::MultiPartCheckpoint { .. }
+            ) && f.1.version == cp.version as u64
+            {
                 Some(f.clone())
             } else {
                 None
@@ -539,7 +497,11 @@ pub(super) async fn list_log_files(
     log_root: &Path,
     max_version: Option<i64>,
     start_version: Option<i64>,
-) -> DeltaResult<(Vec<ObjectMeta>, Vec<ObjectMeta>)> {
+    store_root: &Url,
+) -> DeltaResult<(
+    Vec<(ObjectMeta, ParsedLogPath<Url>)>,
+    Vec<(ObjectMeta, ParsedLogPath<Url>)>,
+)> {
     let max_version = max_version.unwrap_or(i64::MAX - 1);
     let start_from = log_root.child(format!("{:020}", start_version.unwrap_or(0)).as_str());
 
@@ -551,15 +513,24 @@ pub(super) async fn list_log_files(
         .list_with_offset(Some(log_root), &start_from)
         .try_collect::<Vec<_>>()
         .await?
+        .into_iter()
+        .filter_map(|f| {
+            let file_url = store_root.join(f.location.as_ref()).ok()?;
+            let path = ParsedLogPath::try_from(file_url).ok()??;
+            Some((f, path))
+        })
     {
-        if meta.location.commit_version().unwrap_or(i64::MAX) <= max_version
-            && meta.location.commit_version() >= start_version
-        {
-            if meta.location.is_checkpoint_file() {
-                let version = meta.location.commit_version().unwrap_or(0);
-                match version.cmp(&max_checkpoint_version) {
+        if meta.1.version <= max_version as u64 && Some(meta.1.version as i64) >= start_version {
+            if matches!(
+                meta.1.file_type,
+                // UUID named checkpoints are part of the v2 spec and can currently not be parsed.
+                // This will be supported once we do kernel log replay.
+                // | LogPathFileType::UuidCheckpoint(_)
+                LogPathFileType::SinglePartCheckpoint | LogPathFileType::MultiPartCheckpoint { .. }
+            ) {
+                match (meta.1.version as i64).cmp(&max_checkpoint_version) {
                     Ordering::Greater => {
-                        max_checkpoint_version = version;
+                        max_checkpoint_version = meta.1.version as i64;
                         checkpoint_files.clear();
                         checkpoint_files.push(meta);
                     }
@@ -568,15 +539,15 @@ pub(super) async fn list_log_files(
                     }
                     _ => {}
                 }
-            } else if meta.location.is_commit_file() {
+            } else if matches!(meta.1.file_type, LogPathFileType::Commit) {
                 commit_files.push(meta);
             }
         }
     }
 
-    commit_files.retain(|f| f.location.commit_version().unwrap_or(0) > max_checkpoint_version);
+    commit_files.retain(|f| f.1.version as i64 > max_checkpoint_version);
     // NOTE this will sort in reverse order
-    commit_files.sort_unstable_by(|a, b| b.location.cmp(&a.location));
+    commit_files.sort_unstable_by(|a, b| b.0.location.cmp(&a.0.location));
 
     Ok((commit_files, checkpoint_files))
 }
@@ -629,19 +600,23 @@ pub(super) mod tests {
         let root_store = log_store.root_object_store(None);
         let log_url = log_store.table_root_url().join("_delta_log/")?;
         let log_path = Path::from_url_path(log_url.path())?;
+        let mut store_url = log_url.clone();
+        store_url.set_path("");
 
         let cp = read_last_checkpoint(&root_store, &log_path).await?.unwrap();
         assert_eq!(cp.version, 10);
 
-        let (log, check) = list_log_files_with_checkpoint(&cp, &root_store, &log_path).await?;
+        let (log, check) =
+            list_log_files_with_checkpoint(&cp, &root_store, &log_path, &store_url).await?;
         assert_eq!(log.len(), 0);
         assert_eq!(check.len(), 1);
 
-        let (log, check) = list_log_files(&root_store, &log_path, None, None).await?;
+        let (log, check) = list_log_files(&root_store, &log_path, None, None, &store_url).await?;
         assert_eq!(log.len(), 0);
         assert_eq!(check.len(), 1);
 
-        let (log, check) = list_log_files(&root_store, &log_path, Some(8), None).await?;
+        let (log, check) =
+            list_log_files(&root_store, &log_path, Some(8), None, &store_url).await?;
         assert_eq!(log.len(), 9);
         assert_eq!(check.len(), 0);
 
@@ -658,13 +633,16 @@ pub(super) mod tests {
         let log_store = TestTables::Simple.table_builder().build_storage()?;
         let root_store = log_store.root_object_store(None);
         let log_url = log_store.log_root_url();
+        let mut store_url = log_url.clone();
+        store_url.set_path("");
         let log_path = Path::from_url_path(log_url.path())?;
 
-        let (log, check) = list_log_files(&root_store, &log_path, None, None).await?;
+        let (log, check) = list_log_files(&root_store, &log_path, None, None, &store_url).await?;
         assert_eq!(log.len(), 5);
         assert_eq!(check.len(), 0);
 
-        let (log, check) = list_log_files(&root_store, &log_path, Some(2), None).await?;
+        let (log, check) =
+            list_log_files(&root_store, &log_path, Some(2), None, &store_url).await?;
         assert_eq!(log.len(), 3);
         assert_eq!(check.len(), 0);
 
@@ -789,23 +767,6 @@ pub(super) mod tests {
             async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
                 self.store.copy_if_not_exists(from, to).await
             }
-        }
-    }
-
-    #[test]
-    pub fn is_commit_file_only_matches_commits() {
-        for path in [0, 1, 5, 10, 100, i64::MAX]
-            .into_iter()
-            .map(crate::logstore::commit_uri_from_version)
-        {
-            assert!(path.is_commit_file());
-        }
-
-        let not_commits = ["_delta_log/_commit_2132c4fe-4077-476c-b8f5-e77fea04f170.json.tmp"];
-
-        for not_commit in not_commits {
-            let path = Path::from(not_commit);
-            assert!(!path.is_commit_file());
         }
     }
 

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -59,6 +59,7 @@ use delta_kernel::engine::default::executor::tokio::{
     TokioBackgroundExecutor, TokioMultiThreadExecutor,
 };
 use delta_kernel::engine::default::DefaultEngine;
+use delta_kernel::path::{LogPathFileType, ParsedLogPath};
 use delta_kernel::{AsAny, Engine};
 use futures::{StreamExt, TryStreamExt};
 use object_store::ObjectStoreScheme;
@@ -68,11 +69,10 @@ use serde::de::{Error, SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 use tokio::runtime::RuntimeFlavor;
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 use url::Url;
 use uuid::Uuid;
 
-use crate::kernel::log_segment::PathExt;
 use crate::kernel::transaction::TransactionError;
 use crate::kernel::Action;
 use crate::protocol::{get_last_checkpoint, ProtocolError};
@@ -347,27 +347,27 @@ pub trait LogStore: Send + Sync + AsAny {
     /// Check if the location is a delta table location
     async fn is_delta_table_location(&self) -> DeltaResult<bool> {
         let object_store = self.object_store(None);
-        let mut stream = object_store.list(Some(self.log_path()));
+        let dummy_url = Url::parse("http://example.com").unwrap();
+        let log_path = Path::from("_delta_log");
+
+        let mut stream = object_store.list(Some(&log_path));
         while let Some(res) = stream.next().await {
             match res {
                 Ok(meta) => {
-                    // Valid but optional files.
-                    if meta.location.is_crc_file()
-                        || meta.location.is_last_checkpoint_file()
-                        || meta.location.is_last_vacuum_info_file()
-                        || meta.location.is_deletion_vector_file()
-                    {
-                        continue;
+                    let file_url = dummy_url.join(meta.location.as_ref()).unwrap();
+                    if let Ok(Some(parsed_path)) = ParsedLogPath::try_from(file_url) {
+                        if matches!(
+                            parsed_path.file_type,
+                            LogPathFileType::Commit
+                                | LogPathFileType::SinglePartCheckpoint
+                                | LogPathFileType::UuidCheckpoint(_)
+                                | LogPathFileType::MultiPartCheckpoint { .. }
+                                | LogPathFileType::CompactedCommit { .. }
+                        ) {
+                            return Ok(true);
+                        }
                     }
-                    let is_valid =
-                        meta.location.is_commit_file() || meta.location.is_checkpoint_file();
-                    if !is_valid {
-                        warn!(
-                            "Expected a valid delta file. Found {}",
-                            meta.location.filename().unwrap_or("<empty>")
-                        )
-                    }
-                    return Ok(is_valid);
+                    continue;
                 }
                 Err(ObjectStoreError::NotFound { .. }) => return Ok(false),
                 Err(err) => return Err(err.into()),
@@ -898,7 +898,7 @@ pub(crate) mod tests {
         let _put = store
             .object_store(None)
             .put_opts(
-                &Path::from("_delta_log/0.json"),
+                &Path::from("_delta_log/00000000000000000000.json"),
                 payload,
                 PutOptions::default(),
             )
@@ -928,7 +928,7 @@ pub(crate) mod tests {
         let _put = store
             .object_store(None)
             .put_opts(
-                &Path::from("_delta_log/0.checkpoint.parquet"),
+                &Path::from("_delta_log/00000000000000000000.checkpoint.parquet"),
                 payload,
                 PutOptions::default(),
             )
@@ -959,7 +959,7 @@ pub(crate) mod tests {
         let _put = store
             .object_store(None)
             .put_opts(
-                &Path::from("_delta_log/.0.crc.crc"),
+                &Path::from("_delta_log/.00000000000000000000.crc.crc"),
                 payload.clone(),
                 PutOptions::default(),
             )
@@ -969,7 +969,7 @@ pub(crate) mod tests {
         let _put = store
             .object_store(None)
             .put_opts(
-                &Path::from("_delta_log/.0.json.crc"),
+                &Path::from("_delta_log/.00000000000000000000.json.crc"),
                 payload.clone(),
                 PutOptions::default(),
             )
@@ -979,7 +979,7 @@ pub(crate) mod tests {
         let _put = store
             .object_store(None)
             .put_opts(
-                &Path::from("_delta_log/0.crc"),
+                &Path::from("_delta_log/00000000000000000000.crc"),
                 payload.clone(),
                 PutOptions::default(),
             )
@@ -990,7 +990,7 @@ pub(crate) mod tests {
         let _put = store
             .object_store(None)
             .put_opts(
-                &Path::from("_delta_log/0.json"),
+                &Path::from("_delta_log/00000000000000000000.json"),
                 payload.clone(),
                 PutOptions::default(),
             )


### PR DESCRIPTION
# Description

stacked on: #3456

With more features we see more and more different file types in the delta log. Our parsing logic to identify specific types files may not have been fine granular enough. In this PR we use the log file parsing from delta kernel to handle more recent addition to the spec.