### PR TITLE
refactor: remove protocol error

### DIFF
--- a/crates/core/src/delta_datafusion/cdf/mod.rs
+++ b/crates/core/src/delta_datafusion/cdf/mod.rs
@@ -103,11 +103,9 @@ impl FileAction for Remove {
         } else {
             match self.partition_values {
                 Some(ref part_map) => Ok(part_map),
-                _ => Err(crate::DeltaTableError::Protocol {
-                    source: crate::protocol::ProtocolError::InvalidField(
-                        "partition_values".to_string(),
-                    ),
-                }),
+                _ => Err(crate::DeltaTableError::MetadataError(
+                    "Remove action is missing required field: 'partition_values'".to_string(),
+                )),
             }
         }
     }
@@ -123,9 +121,9 @@ impl FileAction for Remove {
         } else {
             match self.size {
                 Some(size) => Ok(size as usize),
-                _ => Err(crate::DeltaTableError::Protocol {
-                    source: crate::protocol::ProtocolError::InvalidField("size".to_string()),
-                }),
+                _ => Err(crate::DeltaTableError::MetadataError(
+                    "Remove action is missing required field: 'size'".to_string(),
+                )),
             }
         }
     }

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -3,7 +3,6 @@ use chrono::{DateTime, Utc};
 use object_store::Error as ObjectStoreError;
 
 use crate::kernel::transaction::{CommitBuilderError, TransactionError};
-use crate::protocol::ProtocolError;
 
 /// A result returned by delta-rs
 pub type DeltaResult<T, E = DeltaTableError> = Result<T, E>;
@@ -14,9 +13,6 @@ pub type DeltaResult<T, E = DeltaTableError> = Result<T, E>;
 pub enum DeltaTableError {
     #[error("Kernel error: {0}")]
     KernelError(#[from] delta_kernel::error::Error),
-
-    #[error("Delta protocol violation: {source}")]
-    Protocol { source: ProtocolError },
 
     /// Error returned when reading the delta log object failed.
     #[error("Failed to read delta log object: {}", .source)]
@@ -245,18 +241,6 @@ impl From<object_store::path::Error> for DeltaTableError {
     fn from(err: object_store::path::Error) -> Self {
         Self::GenericError {
             source: Box::new(err),
-        }
-    }
-}
-
-impl From<ProtocolError> for DeltaTableError {
-    fn from(value: ProtocolError) -> Self {
-        match value {
-            ProtocolError::Arrow { source } => DeltaTableError::Arrow { source },
-            ProtocolError::IO { source } => DeltaTableError::Io { source },
-            ProtocolError::ObjectStore { source } => DeltaTableError::ObjectStore { source },
-            ProtocolError::ParquetParseError { source } => DeltaTableError::Parquet { source },
-            _ => DeltaTableError::Protocol { source: value },
         }
     }
 }

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -180,12 +180,12 @@ impl LogicalFile<'_> {
 
     /// Datetime of the last modification time of the file.
     pub fn modification_datetime(&self) -> DeltaResult<chrono::DateTime<Utc>> {
-        DateTime::from_timestamp_millis(self.modification_time()).ok_or(DeltaTableError::from(
-            crate::protocol::ProtocolError::InvalidField(format!(
+        DateTime::from_timestamp_millis(self.modification_time()).ok_or(
+            DeltaTableError::MetadataError(format!(
                 "invalid modification_time: {:?}",
                 self.modification_time()
             )),
-        ))
+        )
     }
 
     /// The partition values for this logical file.

--- a/crates/core/src/logstore/storage/utils.rs
+++ b/crates/core/src/logstore/storage/utils.rs
@@ -33,10 +33,10 @@ impl TryFrom<&Add> for ObjectMeta {
 
     fn try_from(value: &Add) -> DeltaResult<Self> {
         let last_modified = DateTime::from_timestamp_millis(value.modification_time).ok_or(
-            DeltaTableError::from(crate::protocol::ProtocolError::InvalidField(format!(
+            DeltaTableError::MetadataError(format!(
                 "invalid modification_time: {:?}",
                 value.modification_time
-            ))),
+            )),
         )?;
 
         Ok(Self {

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -58,9 +58,6 @@ enum VacuumError {
     /// Error returned
     #[error(transparent)]
     DeltaTable(#[from] DeltaTableError),
-
-    #[error(transparent)]
-    Protocol(#[from] crate::protocol::ProtocolError),
 }
 
 impl From<VacuumError> for DeltaTableError {

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -1,6 +1,5 @@
 use arrow_schema::ArrowError;
 use deltalake::datafusion::error::DataFusionError;
-use deltalake::protocol::ProtocolError;
 use deltalake::{errors::DeltaTableError, ObjectStoreError};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::{
@@ -123,24 +122,6 @@ fn arrow_to_py(err: ArrowError) -> PyErr {
     }
 }
 
-fn checkpoint_to_py(err: ProtocolError) -> PyErr {
-    match err {
-        ProtocolError::Arrow { source } => arrow_to_py(source),
-        ProtocolError::ObjectStore { source } => object_store_to_py(source),
-        ProtocolError::EndOfLog => DeltaProtocolError::new_err("End of log"),
-        ProtocolError::NoMetaData => DeltaProtocolError::new_err("Table metadata missing"),
-        ProtocolError::CheckpointNotFound => DeltaProtocolError::new_err(err.to_string()),
-        ProtocolError::InvalidField(err) => PyValueError::new_err(err),
-        ProtocolError::InvalidRow(err) => PyValueError::new_err(err),
-        ProtocolError::InvalidDeletionVectorStorageType(err) => PyValueError::new_err(err),
-        ProtocolError::SerializeOperation { source } => PyValueError::new_err(source.to_string()),
-        ProtocolError::ParquetParseError { source } => PyIOError::new_err(source.to_string()),
-        ProtocolError::IO { source } => PyIOError::new_err(source.to_string()),
-        ProtocolError::Generic(msg) => DeltaError::new_err(msg),
-        ProtocolError::Kernel { source } => DeltaError::new_err(source.to_string()),
-    }
-}
-
 fn datafusion_to_py(err: DataFusionError) -> PyErr {
     DeltaError::new_err(err.to_string())
 }
@@ -153,8 +134,6 @@ pub enum PythonError {
     ObjectStore(#[from] ObjectStoreError),
     #[error("Error in arrow")]
     Arrow(#[from] ArrowError),
-    #[error("Error in checkpoint")]
-    Protocol(#[from] ProtocolError),
     #[error("Error in data fusion")]
     DataFusion(#[from] DataFusionError),
     #[error("Lock acquisition error")]
@@ -173,7 +152,6 @@ impl From<PythonError> for pyo3::PyErr {
             PythonError::DeltaTable(err) => inner_to_py_err(err),
             PythonError::ObjectStore(err) => object_store_to_py(err),
             PythonError::Arrow(err) => arrow_to_py(err),
-            PythonError::Protocol(err) => checkpoint_to_py(err),
             PythonError::DataFusion(err) => datafusion_to_py(err),
             PythonError::ThreadingError(err) => PyRuntimeError::new_err(err),
         }


### PR DESCRIPTION
# Description

When adopting Kernel checkpoint writes, we also removed the need to fine granular errors in the `protocol` module. Consequently this PR removes the last call sites so we can fully get rid of `ProtocolError`.
