### PR TITLE
[RFC] feat!: kernel based log replay - take 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,29 @@
+ci:
+  skip: [cargo-fmt]
+
 repos:
   - repo: https://github.com/crate-ci/typos
     rev: v1.32.0
     hooks:
       - id: typos
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.26.0
+    hooks:
+      - id: gitleaks
+
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --
+        language: system
+        types: [rust]
+        pass_filenames: false # This makes it a lot faster

--- a/crates/core/src/kernel/arrow/engine_ext.rs
+++ b/crates/core/src/kernel/arrow/engine_ext.rs
@@ -355,7 +355,7 @@ mod tests {
     async fn test_stats_schema() {
         let log_store = TestTables::Simple.table_builder().build_storage().unwrap();
         let table = Table::try_from_uri(log_store.table_root_url()).unwrap();
-        let engine = log_store.engine(None).await;
+        let engine = log_store.engine(None); //.await;
         let snapshot = table.snapshot(engine.as_ref(), None).unwrap();
         let stats_schema = snapshot.stats_schema().unwrap();
 

--- a/crates/core/src/kernel/mod.rs
+++ b/crates/core/src/kernel/mod.rs
@@ -11,6 +11,8 @@ pub mod models;
 pub mod scalars;
 pub mod schema;
 mod snapshot;
+#[allow(unused)]
+mod snapshot_next;
 pub mod transaction;
 
 pub use error::*;

--- a/crates/core/src/kernel/snapshot_next/arrow_ext.rs
+++ b/crates/core/src/kernel/snapshot_next/arrow_ext.rs
@@ -1,0 +1,141 @@
+//! Utilities for interacting with Kernel APIs using Arrow data structures.
+//!
+use delta_kernel::arrow::array::BooleanArray;
+use delta_kernel::arrow::compute::filter_record_batch;
+use delta_kernel::arrow::record_batch::RecordBatch;
+use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::scan::{Scan, ScanMetadata};
+use delta_kernel::{
+    DeltaResult, Engine, EngineData, ExpressionEvaluator, ExpressionRef, PredicateRef, Version,
+};
+use itertools::Itertools;
+
+/// [`ScanMetadata`] contains (1) a [`RecordBatch`] specifying data files to be scanned
+/// and (2) a vector of transforms (one transform per scan file) that must be applied to the data read
+/// from those files.
+pub struct ScanMetadataArrow {
+    /// Record batch with one row per file to scan
+    pub scan_files: RecordBatch,
+
+    /// Row-level transformations to apply to data read from files.
+    ///
+    /// Each entry in this vector corresponds to a row in the `scan_files` data. The entry is an
+    /// expression that must be applied to convert the file's data into the logical schema
+    /// expected by the scan:
+    ///
+    /// - `Some(expr)`: Apply this expression to transform the data to match [`Scan::schema()`].
+    /// - `None`: No transformation is needed; the data is already in the correct logical form.
+    ///
+    /// Note: This vector can be indexed by row number.
+    pub scan_file_transforms: Vec<Option<ExpressionRef>>,
+}
+
+pub trait ScanExt {
+    /// Get the metadata for a table scan.
+    ///
+    /// This method handles translation between `EngineData` and `RecordBatch`
+    /// and will already apply any selection vectors to the data.
+    /// See [`Scan::scan_metadata`] for details.
+    fn scan_metadata_arrow(
+        &self,
+        engine: &dyn Engine,
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanMetadataArrow>>>;
+
+    fn scan_metadata_from_arrow(
+        &self,
+        engine: &dyn Engine,
+        existing_version: Version,
+        existing_data: Box<dyn Iterator<Item = RecordBatch>>,
+        existing_predicate: Option<PredicateRef>,
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanMetadataArrow>>>;
+}
+
+impl ScanExt for Scan {
+    fn scan_metadata_arrow(
+        &self,
+        engine: &dyn Engine,
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanMetadataArrow>>> {
+        Ok(self
+            .scan_metadata(engine)?
+            .map_ok(kernel_to_arrow)
+            .flatten())
+    }
+
+    fn scan_metadata_from_arrow(
+        &self,
+        engine: &dyn Engine,
+        existing_version: Version,
+        existing_data: Box<dyn Iterator<Item = RecordBatch>>,
+        existing_predicate: Option<PredicateRef>,
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanMetadataArrow>>> {
+        let engine_iter =
+            existing_data.map(|batch| Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>);
+        Ok(self
+            .scan_metadata_from(engine, existing_version, engine_iter, existing_predicate)?
+            .map_ok(kernel_to_arrow)
+            .flatten())
+    }
+}
+
+fn kernel_to_arrow(metadata: ScanMetadata) -> DeltaResult<ScanMetadataArrow> {
+    let scan_file_transforms = metadata
+        .scan_file_transforms
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, v)| metadata.scan_files.selection_vector[i].then_some(v))
+        .collect();
+    let batch = ArrowEngineData::try_from_engine_data(metadata.scan_files.data)?.into();
+    let scan_files = filter_record_batch(
+        &batch,
+        &BooleanArray::from(metadata.scan_files.selection_vector),
+    )?;
+    Ok(ScanMetadataArrow {
+        scan_files,
+        scan_file_transforms,
+    })
+}
+
+pub trait ExpressionEvaluatorExt {
+    fn evaluate_arrow(&self, batch: RecordBatch) -> DeltaResult<RecordBatch>;
+}
+
+impl<T: ExpressionEvaluator + ?Sized> ExpressionEvaluatorExt for T {
+    fn evaluate_arrow(&self, batch: RecordBatch) -> DeltaResult<RecordBatch> {
+        let engine_data = ArrowEngineData::new(batch);
+        Ok(ArrowEngineData::try_from_engine_data(T::evaluate(self, &engine_data)?)?.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::ExpressionEvaluatorExt;
+
+    use delta_kernel::arrow::array::Int32Array;
+    use delta_kernel::arrow::datatypes::{DataType, Field, Schema};
+    use delta_kernel::arrow::record_batch::RecordBatch;
+    use delta_kernel::engine::arrow_conversion::TryIntoKernel;
+    use delta_kernel::engine::arrow_expression::ArrowEvaluationHandler;
+    use delta_kernel::expressions::*;
+    use delta_kernel::EvaluationHandler;
+
+    #[test]
+    fn test_evaluate_arrow() {
+        let handler = ArrowEvaluationHandler;
+
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let values = Int32Array::from(vec![1, 2, 3]);
+        let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(values)]).unwrap();
+
+        let expression = column_expr!("a");
+        let expr = handler.new_expression_evaluator(
+            Arc::new((&schema).try_into_kernel().unwrap()),
+            expression,
+            delta_kernel::schema::DataType::INTEGER,
+        );
+
+        let result = expr.evaluate_arrow(batch);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/core/src/kernel/snapshot_next/eager.rs
+++ b/crates/core/src/kernel/snapshot_next/eager.rs
@@ -1,0 +1,152 @@
+use std::sync::Arc;
+
+use arrow::compute::concat_batches;
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef as ArrowSchemaRef;
+use delta_kernel::actions::{Metadata, Protocol};
+use delta_kernel::engine::arrow_conversion::TryIntoArrow;
+use delta_kernel::scan::scan_row_schema;
+use delta_kernel::schema::Schema;
+use delta_kernel::table_properties::TableProperties;
+use delta_kernel::{PredicateRef, Table, Version};
+use futures::TryStreamExt;
+use itertools::Itertools;
+use object_store::ObjectStore;
+use url::Url;
+use uuid::Uuid;
+
+use super::arrow_ext::ScanExt;
+use super::lazy::LazySnapshot;
+use super::stream::SendableRBStream;
+use super::{LogStoreHandler, Snapshot};
+use crate::kernel::CommitInfo;
+use crate::logstore::LogStore;
+use crate::{DeltaResult, DeltaTableConfig};
+
+/// An eager snapshot of a Delta Table at a specific version.
+///
+/// This snapshot loads some log data eagerly and keeps it in memory.
+#[derive(Clone)]
+pub struct EagerSnapshot {
+    snapshot: LazySnapshot,
+    files: RecordBatch,
+    predicate: Option<PredicateRef>,
+}
+
+#[async_trait::async_trait]
+impl Snapshot for EagerSnapshot {
+    fn version(&self) -> Version {
+        self.snapshot.version()
+    }
+
+    fn schema(&self) -> ArrowSchemaRef {
+        self.snapshot.schema()
+    }
+
+    fn table_properties(&self) -> &TableProperties {
+        self.snapshot.table_properties()
+    }
+
+    fn logical_files(
+        &self,
+        log_store: &LogStoreHandler,
+        predicate: Option<PredicateRef>,
+    ) -> SendableRBStream {
+        if let Some(predicate) = predicate {
+            self.snapshot.logical_files(log_store, Some(predicate))
+        } else {
+            let batch = self.files.clone();
+            return Box::pin(futures::stream::once(async move { Ok(batch) }));
+        }
+    }
+
+    async fn application_transaction_version(
+        &self,
+        log_store: &LogStoreHandler,
+        app_id: String,
+    ) -> DeltaResult<Option<i64>> {
+        self.snapshot
+            .application_transaction_version(log_store, app_id)
+            .await
+    }
+
+    async fn commit_infos(
+        &self,
+        log_store: &LogStoreHandler,
+        start_version: Option<Version>,
+        limit: Option<usize>,
+    ) -> DeltaResult<Vec<(Version, CommitInfo)>> {
+        self.snapshot
+            .commit_infos(log_store, start_version, limit)
+            .await
+    }
+
+    async fn update(
+        &mut self,
+        log_store: &LogStoreHandler,
+        target_version: Option<Version>,
+    ) -> DeltaResult<bool> {
+        self.update_impl(log_store, target_version).await
+    }
+}
+
+impl EagerSnapshot {
+    /// Create a new [`EagerSnapshot`] instance
+    pub(crate) async fn try_new(
+        log_store: &LogStoreHandler,
+        config: DeltaTableConfig,
+        version: impl Into<Option<Version>>,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<Self> {
+        let snapshot = LazySnapshot::try_new(log_store, version).await?;
+        let all: Vec<_> = snapshot
+            .logical_files(log_store, predicate.clone())
+            .try_collect()
+            .await?;
+        let files = if all.is_empty() {
+            RecordBatch::new_empty(Arc::new((scan_row_schema().as_ref()).try_into_arrow()?))
+        } else {
+            concat_batches(&all[0].schema(), &all)?
+        };
+        Ok(Self {
+            snapshot,
+            files,
+            predicate,
+        })
+    }
+
+    /// Get the number of files in the current snapshot
+    pub fn files_count(&self) -> usize {
+        self.files.num_rows()
+    }
+
+    async fn update_impl(
+        &mut self,
+        log_store: &LogStoreHandler,
+        target_version: Option<Version>,
+    ) -> DeltaResult<bool> {
+        let mut snapshot = self.snapshot.clone();
+        let current = snapshot.version();
+        if !snapshot.update(log_store, target_version.clone()).await? {
+            return Ok(false);
+        }
+
+        let scan = snapshot.inner.clone().scan_builder().build()?;
+        let engine = log_store.engine();
+        // TODO: process blocking iterator
+        let files: Vec<_> = scan
+            .scan_metadata_from_arrow(
+                engine.as_ref(),
+                current,
+                Box::new(std::iter::once(self.files.clone())),
+                self.predicate.clone(),
+            )?
+            .map_ok(|s| s.scan_files)
+            .try_collect()?;
+
+        self.files = concat_batches(&files[0].schema(), &files)?;
+        self.snapshot = snapshot;
+
+        Ok(true)
+    }
+}

--- a/crates/core/src/kernel/snapshot_next/iterators.rs
+++ b/crates/core/src/kernel/snapshot_next/iterators.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use arrow_array::cast::AsArray;
+use arrow_array::types::Int64Type;
+use arrow_array::{Array, RecordBatch};
+use chrono::{DateTime, Utc};
+use delta_kernel::expressions::{Scalar, StructData};
+use delta_kernel::scan::scan_row_schema;
+
+use crate::kernel::scalars::ScalarExt;
+use crate::{DeltaResult, DeltaTableError};
+
+const FIELD_NAME_PATH: &str = "path";
+const FIELD_NAME_SIZE: &str = "size";
+const FIELD_NAME_MODIFICATION_TIME: &str = "modificationTime";
+const FIELD_NAME_STATS: &str = "stats";
+const FIELD_NAME_FILE_CONSTANT_VALUES: &str = "fileConstantValues";
+const FIELD_NAME_PARTITION_VALUES: &str = "partitionValues";
+
+static FIELD_INDICES: LazyLock<HashMap<&'static str, usize>> = LazyLock::new(|| {
+    let schema = scan_row_schema();
+    let mut indices = HashMap::new();
+
+    let path_idx = schema.index_of(FIELD_NAME_PATH).unwrap();
+    indices.insert(FIELD_NAME_PATH, path_idx);
+
+    let size_idx = schema.index_of(FIELD_NAME_SIZE).unwrap();
+    indices.insert(FIELD_NAME_SIZE, size_idx);
+
+    let modification_time_idx = schema.index_of(FIELD_NAME_MODIFICATION_TIME).unwrap();
+    indices.insert(FIELD_NAME_MODIFICATION_TIME, modification_time_idx);
+
+    let stats_idx = schema.index_of(FIELD_NAME_STATS).unwrap();
+    indices.insert(FIELD_NAME_STATS, stats_idx);
+
+    indices
+});
+
+#[derive(Clone)]
+pub struct LogicalFileView {
+    pub(super) files: RecordBatch,
+    pub(super) index: usize,
+}
+
+impl LogicalFileView {
+    /// Path of the file.
+    pub fn path(&self) -> &str {
+        self.files
+            .column(*FIELD_INDICES.get(FIELD_NAME_PATH).unwrap())
+            .as_string::<i32>()
+            .value(self.index)
+    }
+
+    /// Size of the file in bytes.
+    pub fn size(&self) -> i64 {
+        self.files
+            .column(*FIELD_INDICES.get(FIELD_NAME_SIZE).unwrap())
+            .as_primitive::<Int64Type>()
+            .value(self.index)
+    }
+
+    /// Modification time of the file in milliseconds since epoch.
+    pub fn modification_time(&self) -> i64 {
+        self.files
+            .column(*FIELD_INDICES.get(FIELD_NAME_MODIFICATION_TIME).unwrap())
+            .as_primitive::<Int64Type>()
+            .value(self.index)
+    }
+
+    /// Datetime of the last modification time of the file.
+    pub fn modification_datetime(&self) -> DeltaResult<chrono::DateTime<Utc>> {
+        DateTime::from_timestamp_millis(self.modification_time()).ok_or(
+            DeltaTableError::MetadataError(format!(
+                "invalid modification_time: {:?}",
+                self.modification_time()
+            )),
+        )
+    }
+
+    pub fn stats(&self) -> Option<&str> {
+        let col = self
+            .files
+            .column(*FIELD_INDICES.get(FIELD_NAME_STATS).unwrap())
+            .as_string::<i32>();
+        col.is_valid(self.index).then(|| col.value(self.index))
+    }
+
+    pub fn partition_values(&self) -> Option<StructData> {
+        self.files
+            .column_by_name(FIELD_NAME_FILE_CONSTANT_VALUES)
+            .and_then(|col| col.as_struct_opt())
+            .and_then(|s| s.column_by_name(FIELD_NAME_PARTITION_VALUES))
+            .and_then(|arr| {
+                arr.is_valid(self.index)
+                    .then(|| match Scalar::from_array(arr, self.index) {
+                        Some(Scalar::Struct(s)) => Some(s),
+                        _ => None,
+                    })
+                    .flatten()
+            })
+    }
+}

--- a/crates/core/src/kernel/snapshot_next/lazy.rs
+++ b/crates/core/src/kernel/snapshot_next/lazy.rs
@@ -1,0 +1,347 @@
+//! Snapshot of a Delta Table at a specific version.
+//!
+use std::io::{BufRead, BufReader, Cursor};
+use std::sync::{Arc, LazyLock};
+
+use arrow::array::AsArray;
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef as ArrowSchemaRef;
+use arrow_select::filter::filter_record_batch;
+use delta_kernel::actions::{get_log_schema, REMOVE_NAME, SIDECAR_NAME};
+use delta_kernel::actions::{Metadata, Protocol};
+use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::engine::default::executor::tokio::{
+    TokioBackgroundExecutor, TokioMultiThreadExecutor,
+};
+use delta_kernel::engine::default::DefaultEngine;
+use delta_kernel::log_segment::LogSegment;
+use delta_kernel::schema::{DataType, Schema};
+use delta_kernel::snapshot::Snapshot as SnapshotInner;
+use delta_kernel::table_properties::TableProperties;
+use delta_kernel::{
+    Engine, EvaluationHandler, Expression, ExpressionEvaluator, ExpressionRef, PredicateRef, Table,
+    Version,
+};
+use futures::{StreamExt, TryFutureExt};
+use itertools::Itertools;
+use object_store::ObjectStore;
+use tokio::task::spawn_blocking;
+use url::Url;
+use uuid::Uuid;
+
+use super::arrow_ext::{ExpressionEvaluatorExt, ScanExt};
+use super::stream::{RecordBatchReceiverStreamBuilder, SendableRBStream};
+use super::{LogStoreHandler, Snapshot};
+use crate::kernel::{Action, CommitInfo, ARROW_HANDLER};
+use crate::logstore::{LogStore, LogStoreExt};
+use crate::{DeltaResult, DeltaTableError};
+
+// TODO: avoid repetitive parsing of json stats
+
+#[derive(Clone)]
+pub struct LazySnapshot {
+    pub(super) inner: Arc<SnapshotInner>,
+    arrow_schema: ArrowSchemaRef,
+}
+
+#[async_trait::async_trait]
+impl Snapshot for LazySnapshot {
+    fn version(&self) -> Version {
+        self.inner.version()
+    }
+
+    fn schema(&self) -> ArrowSchemaRef {
+        self.arrow_schema.clone()
+    }
+
+    fn table_properties(&self) -> &TableProperties {
+        self.inner.table_properties()
+    }
+
+    fn logical_files(
+        &self,
+        log_store: &LogStoreHandler,
+        predicate: Option<PredicateRef>,
+    ) -> SendableRBStream {
+        let scan = match self
+            .inner
+            .clone()
+            .scan_builder()
+            .with_predicate(predicate)
+            .build()
+        {
+            Ok(scan) => scan,
+            Err(err) => {
+                return Box::pin(futures::stream::once(async {
+                    Err(DeltaTableError::KernelError(err))
+                }))
+            }
+        };
+
+        // TODO: which capacity to choose?
+        let mut builder = RecordBatchReceiverStreamBuilder::new(100);
+        let tx = builder.tx();
+        let engine = log_store.engine();
+
+        builder.spawn_blocking(move || {
+            let mut scan_iter = scan.scan_metadata_arrow(engine.as_ref())?;
+            for res in scan_iter {
+                let batch = res?.scan_files;
+                if tx.blocking_send(Ok(batch)).is_err() {
+                    break;
+                }
+            }
+            Ok(())
+        });
+
+        builder.build()
+    }
+
+    async fn application_transaction_version(
+        &self,
+        log_store: &LogStoreHandler,
+        app_id: String,
+    ) -> DeltaResult<Option<i64>> {
+        let engine = log_store.engine();
+        let inner = self.inner.clone();
+        let version = spawn_blocking(move || inner.get_app_id_version(&app_id, engine.as_ref()))
+            .await
+            .map_err(|e| DeltaTableError::GenericError { source: e.into() })??;
+        Ok(version)
+    }
+
+    async fn commit_infos(
+        &self,
+        log_store: &LogStoreHandler,
+        start_version: Option<Version>,
+        limit: Option<usize>,
+    ) -> DeltaResult<Vec<(Version, CommitInfo)>> {
+        // let start_version = start_version.into();
+        let storage = log_store.engine().storage_handler();
+        let end_version = start_version.unwrap_or_else(|| self.version());
+        let start_version = limit
+            .and_then(|limit| {
+                if limit == 0 {
+                    Some(end_version)
+                } else {
+                    Some(end_version.saturating_sub(limit as u64 - 1))
+                }
+            })
+            .unwrap_or(0);
+
+        let log_root = log_store.table_url()?.join("_delta_log/").unwrap();
+
+        let fs_client = storage.clone();
+        let mut log_segment = spawn_blocking(move || {
+            LogSegment::for_table_changes(fs_client.as_ref(), log_root, start_version, end_version)
+        })
+        .await
+        .map_err(|e| DeltaTableError::Generic(e.to_string()))??;
+
+        log_segment.ascending_commit_files.reverse();
+        let files = log_segment
+            .ascending_commit_files
+            .iter()
+            .map(|commit_file| (commit_file.location.location.clone(), None))
+            .collect_vec();
+
+        let res = spawn_blocking(move || {
+            Ok::<_, DeltaTableError>(
+                storage
+                    .read_files(files)?
+                    .zip(log_segment.ascending_commit_files.into_iter())
+                    .filter_map(|(data, path)| {
+                        data.ok().and_then(|d| {
+                            let reader = BufReader::new(Cursor::new(d));
+                            for line in reader.lines() {
+                                match line.and_then(|l| Ok(serde_json::from_str::<Action>(&l)?)) {
+                                    Ok(Action::CommitInfo(commit_info)) => {
+                                        return Some((path.version, commit_info))
+                                    }
+                                    Err(_) => return None,
+                                    _ => continue,
+                                };
+                            }
+                            None
+                        })
+                    })
+                    .collect_vec(),
+            )
+        })
+        .await
+        .map_err(|e| DeltaTableError::Generic(e.to_string()))??;
+
+        Ok(res)
+    }
+
+    async fn update(
+        &mut self,
+        log_store: &LogStoreHandler,
+        target_version: Option<Version>,
+    ) -> DeltaResult<bool> {
+        let current = self.inner.clone();
+        let engine = log_store.engine();
+
+        let snapshot = spawn_blocking(move || {
+            SnapshotInner::try_new_from(current, engine.as_ref(), target_version)
+        })
+        .await
+        .map_err(|e| DeltaTableError::GenericError { source: e.into() })??;
+
+        let did_update = snapshot.version() != self.inner.version();
+        self.inner = snapshot;
+
+        Ok(did_update)
+    }
+}
+
+impl LazySnapshot {
+    /// Create a new [`Snapshot`] instance.
+    pub(crate) fn new(inner: Arc<SnapshotInner>, arrow_schema: ArrowSchemaRef) -> Self {
+        Self {
+            inner,
+            arrow_schema,
+        }
+    }
+
+    /// Create a new [`Snapshot`] instance for a table.
+    pub(crate) async fn try_new(
+        log_store: &LogStoreHandler,
+        version: impl Into<Option<Version>>,
+    ) -> DeltaResult<Self> {
+        let version = version.into();
+
+        let table_url = log_store.table_url()?;
+        let engine = log_store.engine();
+
+        let table = Table::try_from_uri(table_url)?;
+        let task_engine = engine.clone();
+        let snapshot = spawn_blocking(move || table.snapshot(task_engine.as_ref(), version))
+            .await
+            .map_err(|e| DeltaTableError::GenericError { source: e.into() })??;
+
+        let arrow_schema = Arc::new(snapshot.schema().as_ref().try_into_arrow()?);
+
+        Ok(Self::new(Arc::new(snapshot), arrow_schema))
+    }
+
+    /// Get the timestamp of the given version in miliscends since epoch.
+    ///
+    /// Extracts the timestamp from the commit file of the given version
+    /// from the current log segment. If the commit file is not part of the
+    /// current log segment, `None` is returned.
+    pub fn version_timestamp(&self, version: Version) -> Option<i64> {
+        self.inner
+            .log_segment()
+            .ascending_commit_files
+            .iter()
+            .find(|f| f.version == version)
+            .map(|f| f.location.last_modified)
+    }
+
+    /// Get the tombstones of the given version.
+    ///
+    /// Extracts the tombstones from the commit file of the given version
+    /// from the current log segment. If the commit file is not part of the
+    /// current log segment, `None` is returned.
+    pub(crate) async fn tombstones(
+        &self,
+        log_store: &LogStoreHandler,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<RecordBatch>>>> {
+        // TODO: spawn blocking
+        static META_PREDICATE: LazyLock<ExpressionRef> = LazyLock::new(|| {
+            Arc::new(Expression::from_pred(
+                Expression::column([REMOVE_NAME, "path"]).is_not_null(),
+            ))
+        });
+        static EVALUATOR: LazyLock<Arc<dyn ExpressionEvaluator>> = LazyLock::new(|| {
+            ARROW_HANDLER.new_expression_evaluator(
+                get_log_schema().project(&[REMOVE_NAME]).unwrap(),
+                META_PREDICATE.as_ref().clone(),
+                DataType::BOOLEAN,
+            )
+        });
+        let read_schema = get_log_schema().project(&[REMOVE_NAME])?;
+        let read_schema2 = get_log_schema().project(&[REMOVE_NAME, SIDECAR_NAME])?;
+        let engine = log_store.engine();
+        Ok(Box::new(
+            self.inner
+                .log_segment()
+                .read_actions(engine.as_ref(), read_schema, read_schema2, None)?
+                .map_ok(|(data)| {
+                    let batch =
+                        RecordBatch::from(ArrowEngineData::try_from_engine_data(data.actions)?);
+                    let selection = EVALUATOR.evaluate_arrow(batch.clone())?;
+                    let filter = selection.column(0).as_boolean_opt().ok_or_else(|| {
+                        DeltaTableError::generic("failed to downcast to BooleanArray")
+                    })?;
+                    Ok(filter_record_batch(&batch, filter)?)
+                })
+                .flatten(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_cast::pretty::print_batches;
+    use delta_kernel::schema::StructType;
+    use futures::TryStreamExt;
+
+    use super::*;
+    use crate::test_utils::*;
+
+    async fn load_snapshot() -> TestResult<()> {
+        let log_store = TestTables::Simple.table_builder().build_storage()?;
+        let log_store = LogStoreHandler::new(log_store, None);
+        let snapshot = LazySnapshot::try_new(&log_store, None).await?;
+
+        let schema_string = r#"{"type":"struct","fields":[{"name":"id","type":"long","nullable":true,"metadata":{}}]}"#;
+        let expected: StructType = serde_json::from_str(schema_string)?;
+        let expected_arrow_schema = (&expected).try_into_arrow()?;
+        assert_eq!(snapshot.schema().as_ref(), &expected_arrow_schema);
+
+        let infos = snapshot.commit_infos(&log_store, None, None).await?;
+        assert_eq!(infos.len(), 5);
+
+        let tombstones: Vec<_> = snapshot.tombstones(&log_store).await?.try_collect()?;
+        let num_tombstones = tombstones.iter().map(|b| b.num_rows() as i64).sum::<i64>();
+        assert_eq!(num_tombstones, 31);
+
+        let expected = vec![
+            "part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet",
+            "part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet",
+            "part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet",
+            "part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet",
+            "part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet",
+        ];
+        let file_names: Vec<_> = snapshot
+            .logical_files_view(&log_store, None)
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
+            .map(|f| f.path().to_owned())
+            .collect();
+        assert_eq!(file_names, expected);
+
+        let logical_files: Vec<_> = snapshot
+            .logical_files(&log_store, None)
+            .try_collect()
+            .await?;
+
+        print_batches(&logical_files)?;
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn load_snapshot_multi() -> TestResult<()> {
+        load_snapshot().await
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn load_snapshot_current() -> TestResult<()> {
+        load_snapshot().await
+    }
+}

--- a/crates/core/src/kernel/snapshot_next/legacy.rs
+++ b/crates/core/src/kernel/snapshot_next/legacy.rs
@@ -1,0 +1,134 @@
+use std::convert::identity;
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef as ArrowSchemaRef;
+use delta_kernel::table_properties::TableProperties;
+use delta_kernel::{actions::Metadata, schema::SchemaRef, PredicateRef, Version};
+use futures::{FutureExt, TryStreamExt as _};
+use url::Url;
+
+use crate::errors::DeltaResult;
+use crate::kernel::snapshot::{EagerSnapshot, Snapshot as LegacySnapshot};
+use crate::kernel::CommitInfo;
+use crate::logstore::LogStore;
+
+use super::stream::SendableRBStream;
+use super::{LogStoreHandler, Snapshot};
+
+#[async_trait::async_trait]
+impl Snapshot for LegacySnapshot {
+    fn version(&self) -> Version {
+        self.version() as u64
+    }
+
+    fn schema(&self) -> ArrowSchemaRef {
+        todo!()
+    }
+
+    fn table_properties(&self) -> &TableProperties {
+        todo!()
+    }
+
+    fn logical_files(
+        &self,
+        log_store: &LogStoreHandler,
+        predicate: Option<PredicateRef>,
+    ) -> SendableRBStream {
+        todo!()
+    }
+
+    async fn application_transaction_version(
+        &self,
+        log_store: &LogStoreHandler,
+        app_id: String,
+    ) -> DeltaResult<Option<i64>> {
+        todo!()
+    }
+
+    async fn commit_infos(
+        &self,
+        log_store: &LogStoreHandler,
+        start_version: Option<Version>,
+        limit: Option<usize>,
+    ) -> DeltaResult<Vec<(Version, CommitInfo)>> {
+        Ok(self
+            .commit_infos(log_store.log_store(), limit)
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
+            .flat_map(identity)
+            .collect())
+    }
+
+    async fn update(
+        &mut self,
+        log_store: &LogStoreHandler,
+        target_version: Option<Version>,
+    ) -> DeltaResult<bool> {
+        let current_version = self.version();
+        self.update(log_store.log_store(), target_version.map(|v| v as i64))
+            .await?;
+        Ok(current_version != self.version())
+    }
+}
+
+#[async_trait::async_trait]
+impl Snapshot for EagerSnapshot {
+    fn version(&self) -> Version {
+        self.version() as u64
+    }
+
+    fn schema(&self) -> ArrowSchemaRef {
+        todo!()
+    }
+
+    fn table_properties(&self) -> &TableProperties {
+        todo!()
+    }
+
+    fn logical_files(
+        &self,
+        log_store: &LogStoreHandler,
+        predicate: Option<PredicateRef>,
+    ) -> SendableRBStream {
+        todo!()
+    }
+
+    async fn application_transaction_version(
+        &self,
+        log_store: &LogStoreHandler,
+        app_id: String,
+    ) -> DeltaResult<Option<i64>> {
+        self.transaction_version(app_id).await
+    }
+
+    async fn commit_infos(
+        &self,
+        log_store: &LogStoreHandler,
+        start_version: Option<Version>,
+        limit: Option<usize>,
+    ) -> DeltaResult<Vec<(Version, CommitInfo)>> {
+        Ok(self
+            .snapshot
+            .commit_infos(log_store.log_store(), limit)
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
+            .flat_map(identity)
+            .collect())
+    }
+
+    async fn update(
+        &mut self,
+        log_store: &LogStoreHandler,
+        target_version: Option<Version>,
+    ) -> DeltaResult<bool> {
+        let current_version = self.version();
+        self.update(log_store.log_store(), target_version.map(|v| v as i64))
+            .await?;
+        Ok(current_version != self.version())
+    }
+}

--- a/crates/core/src/kernel/snapshot_next/mod.rs
+++ b/crates/core/src/kernel/snapshot_next/mod.rs
@@ -1,0 +1,374 @@
+//! Snapshot of a Delta Table at a specific version.
+
+use std::sync::{Arc, LazyLock};
+
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef as ArrowSchemaRef;
+use delta_kernel::actions::{Metadata, Protocol};
+use delta_kernel::engine::arrow_conversion::TryIntoArrow;
+use delta_kernel::expressions::{Scalar, StructData};
+use delta_kernel::scan::scan_row_schema;
+use delta_kernel::schema::Schema;
+use delta_kernel::table_properties::TableProperties;
+use delta_kernel::{Engine, PredicateRef, Version};
+use futures::{StreamExt, TryStreamExt};
+use iterators::LogicalFileView;
+use itertools::Itertools;
+use object_store::ObjectStore;
+use stream::{SendableRBStream, SendableViewStream};
+use url::Url;
+use uuid::Uuid;
+
+use crate::kernel::actions::CommitInfo;
+use crate::logstore::{LogStore, LogStoreExt};
+use crate::{DeltaResult, DeltaTableError};
+
+pub use eager::EagerSnapshot;
+pub use lazy::LazySnapshot;
+
+mod arrow_ext;
+mod eager;
+mod iterators;
+mod lazy;
+mod legacy;
+mod stream;
+
+static SCAN_ROW_SCHEMA_ARROW: LazyLock<ArrowSchemaRef> =
+    LazyLock::new(|| Arc::new(scan_row_schema().as_ref().try_into_arrow().unwrap()));
+
+/// Helper trait to extract individual values from a `StructData`.
+pub trait StructDataExt {
+    fn get(&self, key: &str) -> Option<&Scalar>;
+}
+
+impl StructDataExt for StructData {
+    fn get(&self, key: &str) -> Option<&Scalar> {
+        self.fields()
+            .iter()
+            .zip(self.values().iter())
+            .find(|(k, _)| k.name() == key)
+            .map(|(_, v)| v)
+    }
+}
+
+pub(crate) struct LogStoreHandler {
+    log_store: Arc<dyn LogStore>,
+    operation_id: Option<Uuid>,
+}
+
+impl LogStoreHandler {
+    pub fn new(log_store: Arc<dyn LogStore>, operation_id: Option<Uuid>) -> Self {
+        Self {
+            log_store,
+            operation_id,
+        }
+    }
+
+    pub(crate) fn log_store(&self) -> &Arc<dyn LogStore> {
+        &self.log_store
+    }
+
+    pub(crate) fn object_store(&self) -> Arc<dyn ObjectStore> {
+        self.log_store.object_store(self.operation_id)
+    }
+
+    pub(crate) fn root_object_store(&self) -> Arc<dyn ObjectStore> {
+        self.log_store.root_object_store(self.operation_id)
+    }
+
+    pub(crate) fn engine(&self) -> Arc<dyn Engine> {
+        self.log_store.engine(self.operation_id)
+    }
+
+    pub(crate) fn table_url(&self) -> DeltaResult<Url> {
+        if let Some(op_id) = self.operation_id {
+            #[allow(deprecated)]
+            self.log_store
+                .transaction_url(op_id, &self.log_store.table_root_url())
+        } else {
+            Ok(self.log_store.table_root_url())
+        }
+    }
+}
+
+/// In-memory representation of a specific snapshot of a Delta table. While a `DeltaTable` exists
+/// throughout time, `Snapshot`s represent a view of a table at a specific point in time; they
+/// have a defined schema (which may change over time for any given table), specific version, and
+/// frozen log segment.
+#[async_trait::async_trait]
+pub trait Snapshot: Send + Sync + 'static {
+    /// Version of this `Snapshot` in the table.
+    fn version(&self) -> Version;
+
+    /// Table [`Schema`] at this `Snapshot`s version.
+    fn schema(&self) -> ArrowSchemaRef;
+
+    /// Get the [`TableProperties`] for this [`Snapshot`].
+    fn table_properties(&self) -> &TableProperties;
+
+    fn logical_file_schema(&self) -> ArrowSchemaRef {
+        SCAN_ROW_SCHEMA_ARROW.clone()
+    }
+
+    /// Get all logical files present in the current snapshot.
+    ///
+    /// # Parameters
+    /// - `predicate`: An optional predicate to filter the files based on file statistics.
+    ///
+    /// # Returns
+    /// A stream of [`RecordBatch`]es, where each batch contains logical file data.
+    fn logical_files(
+        &self,
+        log_store: &LogStoreHandler,
+        predicate: Option<PredicateRef>,
+    ) -> SendableRBStream;
+
+    fn logical_files_view(
+        &self,
+        log_store: &LogStoreHandler,
+        predicate: Option<PredicateRef>,
+    ) -> SendableViewStream {
+        self.logical_files(log_store, predicate)
+            .map_ok(|files| {
+                futures::stream::iter((0..files.num_rows()).into_iter().map(move |i| {
+                    Ok(LogicalFileView {
+                        files: files.clone(),
+                        index: i,
+                    })
+                }))
+            })
+            .try_flatten()
+            .boxed()
+    }
+
+    /// Scan the Delta Log for the latest transaction entry for a specific application.
+    ///
+    /// Initiates a log scan, but terminates as soon as the transaction
+    /// for the given application is found.
+    ///
+    /// # Parameters
+    /// - `app_id`: The application id for which to fetch the transaction.
+    ///
+    /// # Returns
+    /// The latest transaction for the given application id, if it exists.
+    async fn application_transaction_version(
+        &self,
+        log_store: &LogStoreHandler,
+        app_id: String,
+    ) -> DeltaResult<Option<i64>>;
+
+    /// Get commit info for the table.
+    ///
+    /// The [`CommitInfo`]s are returned in descending order of version
+    /// with the most recent commit first starting from the `start_version`.
+    ///
+    /// [`CommitInfo`]s are read on a best-effort basis. If the action
+    /// for a version is not available or cannot be parsed, it is skipped.
+    ///
+    /// # Parameters
+    /// - `start_version`: The version from which to start fetching commit info.
+    ///   Defaults to the latest version.
+    /// - `limit`: The maximum number of commit infos to fetch.
+    ///
+    /// # Returns
+    /// An iterator of commit info tuples. The first element of the tuple is the version
+    /// of the commit, the second element is the corresponding commit info.
+    // TODO(roeap): this is currently using our commit info, we should be using
+    // the definition form kernel, once handling over there matured.
+    async fn commit_infos(
+        &self,
+        log_store: &LogStoreHandler,
+        start_version: Option<Version>,
+        limit: Option<usize>,
+    ) -> DeltaResult<Vec<(Version, CommitInfo)>>;
+
+    /// Update the snapshot to a specific version.
+    ///
+    /// The target version must be greater then the current version of the snapshot.
+    ///
+    /// # Parameters
+    /// - `target_version`: The version to update the snapshot to. Defaults to latest.
+    ///
+    /// # Returns
+    /// A boolean indicating if the snapshot was updated.
+    async fn update(
+        &mut self,
+        log_store: &LogStoreHandler,
+        target_version: Option<Version>,
+    ) -> DeltaResult<bool>;
+}
+
+#[async_trait::async_trait]
+impl<T: Snapshot> Snapshot for Box<T> {
+    fn version(&self) -> Version {
+        self.as_ref().version()
+    }
+
+    fn schema(&self) -> ArrowSchemaRef {
+        self.as_ref().schema()
+    }
+
+    fn table_properties(&self) -> &TableProperties {
+        self.as_ref().table_properties()
+    }
+
+    fn logical_files(
+        &self,
+        log_store: &LogStoreHandler,
+        predicate: Option<PredicateRef>,
+    ) -> SendableRBStream {
+        self.as_ref().logical_files(log_store, predicate)
+    }
+
+    async fn application_transaction_version(
+        &self,
+        log_store: &LogStoreHandler,
+        app_id: String,
+    ) -> DeltaResult<Option<i64>> {
+        self.as_ref()
+            .application_transaction_version(log_store, app_id)
+            .await
+    }
+
+    async fn commit_infos(
+        &self,
+        log_store: &LogStoreHandler,
+        start_version: Option<Version>,
+        limit: Option<usize>,
+    ) -> DeltaResult<Vec<(Version, CommitInfo)>> {
+        self.as_ref()
+            .commit_infos(log_store, start_version, limit)
+            .await
+    }
+
+    async fn update(
+        &mut self,
+        log_store: &LogStoreHandler,
+        target_version: Option<Version>,
+    ) -> DeltaResult<bool> {
+        self.as_mut().update(log_store, target_version).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future::Future, pin::Pin};
+
+    use crate::test_utils::*;
+    use delta_kernel::Table;
+
+    use super::*;
+
+    fn get_lazy(
+        table: TestTables,
+        version: Option<Version>,
+    ) -> TestResult<Pin<Box<dyn Future<Output = TestResult<(Box<dyn Snapshot>, LogStoreHandler)>>>>>
+    {
+        let log_store = table.table_builder().build_storage()?;
+        let log_store = LogStoreHandler::new(log_store, None);
+        Ok(Box::pin(async move {
+            Ok((
+                Box::new(LazySnapshot::try_new(&log_store, version).await?) as Box<dyn Snapshot>,
+                log_store,
+            ))
+        }))
+    }
+
+    fn get_eager(
+        table: TestTables,
+        version: Option<Version>,
+    ) -> TestResult<Pin<Box<dyn Future<Output = TestResult<(Box<dyn Snapshot>, LogStoreHandler)>>>>>
+    {
+        let log_store = table.table_builder().build_storage()?;
+        let log_store = LogStoreHandler::new(log_store, None);
+        let config = Default::default();
+        Ok(Box::pin(async move {
+            Ok((
+                Box::new(EagerSnapshot::try_new(&log_store, config, version, None).await?)
+                    as Box<dyn Snapshot>,
+                log_store,
+            ))
+        }))
+    }
+
+    #[tokio::test]
+    async fn test_snapshots() -> TestResult {
+        test_snapshot(get_lazy).await?;
+        test_snapshot(get_eager).await?;
+
+        Ok(())
+    }
+
+    // NOTE: test needs to be async, so that we can pick up the runtime from the context
+    async fn test_snapshot<F>(get_snapshot: F) -> TestResult<()>
+    where
+        F: Fn(
+            TestTables,
+            Option<Version>,
+        ) -> TestResult<
+            Pin<Box<dyn Future<Output = TestResult<(Box<dyn Snapshot>, LogStoreHandler)>>>>,
+        >,
+    {
+        for version in 0..=12 {
+            let (snapshot, log_store) =
+                get_snapshot(TestTables::Checkpoints, Some(version))?.await?;
+            assert_eq!(snapshot.version(), version);
+
+            test_commit_infos(&log_store, snapshot.as_ref()).await?;
+            test_logical_files(&log_store, snapshot.as_ref()).await?;
+            test_logical_files_view(&log_store, snapshot.as_ref()).await?;
+        }
+
+        let (mut snapshot, log_store) = get_snapshot(TestTables::Checkpoints, Some(0))?.await?;
+        for version in 1..=12 {
+            snapshot.update(&log_store, Some(version)).await?;
+            assert_eq!(snapshot.version(), version);
+
+            test_commit_infos(&log_store, snapshot.as_ref()).await?;
+            test_logical_files(&log_store, snapshot.as_ref()).await?;
+            test_logical_files_view(&log_store, snapshot.as_ref()).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn test_logical_files(
+        log_store: &LogStoreHandler,
+        snapshot: &dyn Snapshot,
+    ) -> TestResult<()> {
+        let logical_files = snapshot
+            .logical_files(log_store, None)
+            .try_collect::<Vec<_>>()
+            .await?;
+        let num_files = logical_files
+            .iter()
+            .map(|b| b.num_rows() as i64)
+            .sum::<i64>();
+        assert_eq!((num_files as u64), snapshot.version());
+        Ok(())
+    }
+
+    async fn test_logical_files_view(
+        log_store: &LogStoreHandler,
+        snapshot: &dyn Snapshot,
+    ) -> TestResult<()> {
+        let num_files_view = snapshot
+            .logical_files_view(log_store, None)
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
+            .count() as u64;
+        assert_eq!(num_files_view, snapshot.version());
+        Ok(())
+    }
+
+    async fn test_commit_infos(
+        log_store: &LogStoreHandler,
+        snapshot: &dyn Snapshot,
+    ) -> TestResult<()> {
+        let commit_infos = snapshot.commit_infos(log_store, None, Some(100)).await?;
+        assert_eq!((commit_infos.len() as u64), snapshot.version() + 1);
+        assert_eq!(commit_infos.first().unwrap().0, snapshot.version());
+        Ok(())
+    }
+}

--- a/crates/core/src/kernel/snapshot_next/stream.rs
+++ b/crates/core/src/kernel/snapshot_next/stream.rs
@@ -1,0 +1,179 @@
+//! the code in this file is hoisted from datafusion with only slight modifications
+//!
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+
+use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use futures::stream::BoxStream;
+use futures::{Future, Stream, StreamExt};
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::task::JoinSet;
+
+use crate::errors::DeltaResult;
+use crate::DeltaTableError;
+
+use super::iterators::LogicalFileView;
+
+/// Trait for types that stream [RecordBatch]
+///
+/// See [`SendableRecordBatchStream`] for more details.
+pub trait RecordBatchStream: Stream<Item = DeltaResult<RecordBatch>> {
+    /// Returns the schema of this `RecordBatchStream`.
+    ///
+    /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
+    /// stream should have the same schema as returned from this method.
+    fn schema(&self) -> SchemaRef;
+}
+
+/// Trait for a [`Stream`] of [`RecordBatch`]es that can be passed between threads
+///
+/// This trait is used to retrieve the results of DataFusion execution plan nodes.
+///
+/// The trait is a specialized Rust Async [`Stream`] that also knows the schema
+/// of the data it will return (even if the stream has no data). Every
+/// `RecordBatch` returned by the stream should have the same schema as returned
+/// by [`schema`](`RecordBatchStream::schema`).
+///
+/// # See Also
+///
+/// * [`RecordBatchStreamAdapter`] to convert an existing [`Stream`]
+///   to [`SendableRecordBatchStream`]
+///
+/// [`RecordBatchStreamAdapter`]: https://docs.rs/datafusion/latest/datafusion/physical_plan/stream/struct.RecordBatchStreamAdapter.html
+///
+/// # Error Handling
+///
+/// Once a stream returns an error, it should not be polled again (the caller
+/// should stop calling `next`) and handle the error.
+///
+/// However, returning `Ready(None)` (end of stream) is likely the safest
+/// behavior after an error. Like [`Stream`]s, `RecordBatchStream`s should not
+/// be polled after end of stream or returning an error. However, also like
+/// [`Stream`]s there is no mechanism to prevent callers polling  so returning
+/// `Ready(None)` is recommended.
+pub type SendableRecordBatchStream = Pin<Box<dyn RecordBatchStream + Send>>;
+
+pub type SendableRBStream = Pin<Box<dyn Stream<Item = DeltaResult<RecordBatch>> + Send>>;
+
+pub type SendableViewStream = Pin<Box<dyn Stream<Item = DeltaResult<LogicalFileView>> + Send>>;
+
+/// Creates a stream from a collection of producing tasks, routing panics to the stream.
+///
+/// Note that this is similar to  [`ReceiverStream` from tokio-stream], with the differences being:
+///
+/// 1. Methods to bound and "detach"  tasks (`spawn()` and `spawn_blocking()`).
+///
+/// 2. Propagates panics, whereas the `tokio` version doesn't propagate panics to the receiver.
+///
+/// 3. Automatically cancels any outstanding tasks when the receiver stream is dropped.
+///
+/// [`ReceiverStream` from tokio-stream]: https://docs.rs/tokio-stream/latest/tokio_stream/wrappers/struct.ReceiverStream.html
+pub(crate) struct ReceiverStreamBuilder<O> {
+    tx: Sender<DeltaResult<O>>,
+    rx: Receiver<DeltaResult<O>>,
+    join_set: JoinSet<DeltaResult<()>>,
+}
+
+impl<O: Send + 'static> ReceiverStreamBuilder<O> {
+    /// Create new channels with the specified buffer size
+    pub fn new(capacity: usize) -> Self {
+        let (tx, rx) = tokio::sync::mpsc::channel(capacity);
+
+        Self {
+            tx,
+            rx,
+            join_set: JoinSet::new(),
+        }
+    }
+
+    /// Get a handle for sending data to the output
+    pub fn tx(&self) -> Sender<DeltaResult<O>> {
+        self.tx.clone()
+    }
+
+    /// Spawn task that will be aborted if this builder (or the stream
+    /// built from it) are dropped
+    pub fn spawn<F>(&mut self, task: F)
+    where
+        F: Future<Output = DeltaResult<()>>,
+        F: Send + 'static,
+    {
+        self.join_set.spawn(task);
+    }
+
+    /// Spawn a blocking task that will be aborted if this builder (or the stream
+    /// built from it) are dropped.
+    ///
+    /// This is often used to spawn tasks that write to the sender
+    /// retrieved from `Self::tx`.
+    pub fn spawn_blocking<F>(&mut self, f: F)
+    where
+        F: FnOnce() -> DeltaResult<()>,
+        F: Send + 'static,
+    {
+        self.join_set.spawn_blocking(f);
+    }
+
+    /// Create a stream of all data written to `tx`
+    pub fn build(self) -> BoxStream<'static, DeltaResult<O>> {
+        let Self {
+            tx,
+            rx,
+            mut join_set,
+        } = self;
+
+        // Doesn't need tx
+        drop(tx);
+
+        // future that checks the result of the join set, and propagates panic if seen
+        let check = async move {
+            while let Some(result) = join_set.join_next().await {
+                match result {
+                    Ok(task_result) => {
+                        match task_result {
+                            // Nothing to report
+                            Ok(_) => continue,
+                            // This means a blocking task error
+                            Err(error) => return Some(Err(error)),
+                        }
+                    }
+                    // This means a tokio task error, likely a panic
+                    Err(e) => {
+                        if e.is_panic() {
+                            // resume on the main thread
+                            std::panic::resume_unwind(e.into_panic());
+                        } else {
+                            // This should only occur if the task is
+                            // cancelled, which would only occur if
+                            // the JoinSet were aborted, which in turn
+                            // would imply that the receiver has been
+                            // dropped and this code is not running
+                            return Some(Err(DeltaTableError::Generic(format!(
+                                "Non Panic Task error: {e}"
+                            ))));
+                        }
+                    }
+                }
+            }
+            None
+        };
+
+        let check_stream = futures::stream::once(check)
+            // unwrap Option / only return the error
+            .filter_map(|item| async move { item });
+
+        // Convert the receiver into a stream
+        let rx_stream = futures::stream::unfold(rx, |mut rx| async move {
+            let next_item = rx.recv().await;
+            next_item.map(|next_item| (next_item, rx))
+        });
+
+        // Merge the streams together so whichever is ready first
+        // produces the batch
+        futures::stream::select(rx_stream, check_stream).boxed()
+    }
+}
+
+pub type RecordBatchReceiverStreamBuilder = ReceiverStreamBuilder<RecordBatch>;

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -320,9 +320,9 @@ pub trait LogStore: Send + Sync + AsAny {
 
     fn root_object_store(&self, operation_id: Option<Uuid>) -> Arc<dyn ObjectStore>;
 
-    async fn engine(&self, operation_id: Option<Uuid>) -> Arc<dyn Engine> {
+    fn engine(&self, operation_id: Option<Uuid>) -> Arc<dyn Engine> {
         let store = self.root_object_store(operation_id);
-        get_engine(store).await
+        get_engine(store)
     }
 
     /// [Path] to Delta log
@@ -469,8 +469,8 @@ impl<T: LogStore + ?Sized> LogStore for Arc<T> {
         T::root_object_store(self, operation_id)
     }
 
-    async fn engine(&self, operation_id: Option<Uuid>) -> Arc<dyn Engine> {
-        T::engine(self, operation_id).await
+    fn engine(&self, operation_id: Option<Uuid>) -> Arc<dyn Engine> {
+        T::engine(self, operation_id)
     }
 
     fn to_uri(&self, location: &Path) -> String {
@@ -499,7 +499,7 @@ impl<T: LogStore + ?Sized> LogStore for Arc<T> {
     }
 }
 
-async fn get_engine(store: Arc<dyn ObjectStore>) -> Arc<dyn Engine> {
+fn get_engine(store: Arc<dyn ObjectStore>) -> Arc<dyn Engine> {
     let handle = tokio::runtime::Handle::current();
     match handle.runtime_flavor() {
         RuntimeFlavor::MultiThread => Arc::new(DefaultEngine::new(
@@ -664,7 +664,7 @@ pub async fn get_latest_version(
         current_version
     };
 
-    let storage = log_store.engine(None).await.storage_handler();
+    let storage = log_store.engine(None).storage_handler();
     let log_root = log_store.log_root_url();
 
     let segment = spawn_blocking(move || {

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -35,7 +35,7 @@ pub(crate) async fn create_checkpoint_for(
     } else {
         log_store.table_root_url()
     };
-    let engine = log_store.engine(operation_id).await;
+    let engine = log_store.engine(operation_id);
 
     let table = Table::try_from_uri(table_root)?;
 

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -264,7 +264,7 @@ impl DeltaTable {
             .await?
             .try_collect::<Vec<_>>()
             .await?;
-        Ok(infos.into_iter().flatten().collect())
+        Ok(infos.into_iter().flat_map(|v| v.map(|vv| vv.1)).collect())
     }
 
     /// Obtain Add actions for files that match the filter

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -97,6 +97,10 @@ impl DeltaTableState {
     }
 
     /// Full list of tombstones (remove actions) representing files removed from table state).
+    #[deprecated(
+        since = "0.27.0",
+        note = "Tombstones are no longer exposed via public APIs. If you require access to tombstones, please file an issue."
+    )]
     pub async fn all_tombstones(
         &self,
         log_store: &dyn LogStore,
@@ -113,6 +117,10 @@ impl DeltaTableState {
 
     /// List of unexpired tombstones (remove actions) representing files removed from table state.
     /// The retention period is set by `deletedFileRetentionDuration` with default value of 1 week.
+    #[deprecated(
+        since = "0.27.0",
+        note = "Tombstones are no longer exposed via public APIs. If you require access to tombstones, please file an issue."
+    )]
     pub async fn unexpired_tombstones(
         &self,
         log_store: &dyn LogStore,
@@ -122,6 +130,7 @@ impl DeltaTableState {
                 .table_config()
                 .deleted_file_retention_duration()
                 .as_millis() as i64;
+        #[allow(deprecated)]
         let tombstones = self.all_tombstones(log_store).await?.collect::<Vec<_>>();
         Ok(tombstones
             .into_iter()


### PR DESCRIPTION
# Description

This is a redo of #3137.

Since the first attempt, kernel has evolved quite a bit, as has our codebase. We also learned a lot, particularly around some of the complexities of "nested" async evaluation that comes with kernels engine concepts.

A few things that could guide designs: 

* Use `Engine`: Anything we can do using kernels `Engine` abstractions, we can do without the need to have datafusion enabled. Potentially significantly extending what we can offer to arrow-only users.
* Expose idiomatic `async`: kernel exposes blocking iterators that only "appear to be sync". We need to figure out how to best handle these. Kernel may one day also expose apis or utilities to more seamlessly integrate with rust `async` so we should hide these complexities from end users.

Since this will (and should) have a significant impact on large parts of the codebase, we should not even try to do a once-off switch. Rather we propose the following migration strategy.

1. Define a new trait `Snapshot` that exposes a minimal API we require in operations planning etc.
2. Implement this trait for the current snapshot implementations as well as the newly introduced kernel-backed snapshots.
3. Refactor individual operations / code-paths to accept this new trait

This should allow us to incrementally "kernelize" our codebase and give us the opportunity to properly test the new snapshots. Opt-in to using new snapshots should for now be done via either feature flags or (maybe even better) runtime configuration.

Still figuring out some basics, but putting it up anyway for feedback.

## Major breaking changes

A lot of APIs will be broken eventually, but listing some of the more fundamental changes.

### No more tombstones

Currently we expose tombstones as part of our state / snapshots. Since Checkpoint writing uses kernel now, we really only need that to plan vacuums, which is a "special" or at least table format specific maintenance operation. As such, we internalise the logic how a vacuum is planned.