### PR TITLE
refactor!: have DeltaTable::version return an Option

### DIFF
--- a/crates/aws/tests/integration_s3_dynamodb.rs
+++ b/crates/aws/tests/integration_s3_dynamodb.rs
@@ -212,7 +212,7 @@ async fn test_repair_on_update() -> TestResult<()> {
     let _entry = create_incomplete_commit_entry(&table, 1, "unfinished_commit").await?;
     table.update().await?;
     // table update should find and update to newest, incomplete commit entry
-    assert_eq!(table.version(), 1);
+    assert_eq!(table.version(), Some(1));
     validate_lock_table_state(&table, 1).await?;
     Ok(())
 }
@@ -225,7 +225,7 @@ async fn test_repair_on_load() -> TestResult<()> {
     let _entry = create_incomplete_commit_entry(&table, 1, "unfinished_commit").await?;
     table.load_version(1).await?;
     // table should fix the broken entry while loading a specific version
-    assert_eq!(table.version(), 1);
+    assert_eq!(table.version(), Some(1));
     validate_lock_table_state(&table, 1).await?;
     Ok(())
 }

--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -697,7 +697,7 @@ mod test {
             .with_columns(schema.fields().cloned())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         table
     }
 

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -2545,7 +2545,7 @@ mod tests {
             .with_partition_columns(["modified", "id"])
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let batch = RecordBatch::try_new(
             schema.clone(),

--- a/crates/core/src/kernel/snapshot/log_segment.rs
+++ b/crates/core/src/kernel/snapshot/log_segment.rs
@@ -683,7 +683,7 @@ pub(super) mod tests {
             .with_storage_backend(slow_list_store, url::Url::parse("dummy:///").unwrap())
             .build_storage()?;
 
-        let version = table_to_checkpoint.version();
+        let version = table_to_checkpoint.version().unwrap();
         let load_task: JoinHandle<Result<LogSegment, DeltaTableError>> = tokio::spawn(async move {
             let segment = LogSegment::try_new(&slow_log_store, Some(version)).await?;
             Ok(segment)

--- a/crates/core/src/kernel/transaction/application.rs
+++ b/crates/core/src/kernel/transaction/application.rs
@@ -30,7 +30,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 2);
 
         let app_txns = table.get_app_transaction_version();
@@ -75,7 +75,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let app_txns = table.get_app_transaction_version();
         assert_eq!(app_txns.len(), 1);
         assert_eq!(app_txns.get("my-app").map(|t| t.version), Some(3));
@@ -88,7 +88,7 @@ mod tests {
         assert_eq!(txn_version, Some(3));
 
         table2.update_incremental(None).await.unwrap();
-        assert_eq!(table2.version(), 1);
+        assert_eq!(table2.version(), Some(1));
         let app_txns2 = table2.get_app_transaction_version();
         assert_eq!(app_txns2.len(), 1);
         assert_eq!(app_txns2.get("my-app").map(|t| t.version), Some(3));
@@ -109,7 +109,7 @@ mod tests {
         let app_txns3 = table3.get_app_transaction_version();
         assert_eq!(app_txns3.len(), 1);
         assert_eq!(app_txns3.get("my-app").map(|t| t.version), Some(3));
-        assert_eq!(table3.version(), 1);
+        assert_eq!(table3.version(), Some(1));
         let txn_version = table3
             .snapshot()
             .unwrap()

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -192,7 +192,7 @@ mod tests {
         let table = crate::open_table("../test/tests/data/delta-0.2.0")
             .await
             .unwrap();
-        assert_eq!(table.version(), 3);
+        assert_eq!(table.version(), Some(3));
         assert_eq!(table.protocol().unwrap().min_writer_version, 2);
         assert_eq!(table.protocol().unwrap().min_reader_version, 1);
         assert_eq!(
@@ -245,7 +245,7 @@ mod tests {
         let mut table = crate::open_table_with_version("../test/tests/data/delta-0.2.0", 0)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.protocol().unwrap().min_writer_version, 2);
         assert_eq!(table.protocol().unwrap().min_reader_version, 1);
         assert_eq!(
@@ -259,7 +259,7 @@ mod tests {
         table = crate::open_table_with_version("../test/tests/data/delta-0.2.0", 2)
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.protocol().unwrap().min_writer_version, 2);
         assert_eq!(table.protocol().unwrap().min_reader_version, 1);
         assert_eq!(
@@ -273,7 +273,7 @@ mod tests {
         table = crate::open_table_with_version("../test/tests/data/delta-0.2.0", 3)
             .await
             .unwrap();
-        assert_eq!(table.version(), 3);
+        assert_eq!(table.version(), Some(3));
         assert_eq!(table.protocol().unwrap().min_writer_version, 2);
         assert_eq!(table.protocol().unwrap().min_reader_version, 1);
         assert_eq!(
@@ -291,7 +291,7 @@ mod tests {
         let table = crate::open_table("../test/tests/data/delta-0.8.0")
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.protocol().unwrap().min_writer_version, 2);
         assert_eq!(table.protocol().unwrap().min_reader_version, 1);
         assert_eq!(
@@ -347,7 +347,7 @@ mod tests {
         let mut table = crate::open_table("../test/tests/data/delta-0.8.0")
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.protocol().unwrap().min_writer_version, 2);
         assert_eq!(table.protocol().unwrap().min_reader_version, 1);
         assert_eq!(
@@ -358,7 +358,7 @@ mod tests {
             ]
         );
         table.load_version(0).await.unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.protocol().unwrap().min_writer_version, 2);
         assert_eq!(table.protocol().unwrap().min_reader_version, 1);
         assert_eq!(
@@ -560,16 +560,16 @@ mod tests {
     async fn test_poll_table_commits() {
         let path = "../test/tests/data/simple_table_with_checkpoint";
         let mut table = crate::open_table_with_version(path, 9).await.unwrap();
-        assert_eq!(table.version(), 9);
+        assert_eq!(table.version(), Some(9));
         let peek = table
             .log_store()
-            .peek_next_commit(table.version())
+            .peek_next_commit(table.version().unwrap())
             .await
             .unwrap();
         assert!(matches!(peek, PeekCommit::New(..)));
 
         if let PeekCommit::New(version, actions) = peek {
-            assert_eq!(table.version(), 9);
+            assert_eq!(table.version(), Some(9));
             assert!(!table.get_files_iter().unwrap().any(|f| f
                 == Path::from(
                     "part-00000-f0e955c5-a1e3-4eec-834e-dcc098fc9005-c000.snappy.parquet"
@@ -580,7 +580,7 @@ mod tests {
 
             table.update_incremental(None).await.unwrap();
 
-            assert_eq!(table.version(), 10);
+            assert_eq!(table.version(), Some(10));
             assert!(table.get_files_iter().unwrap().any(|f| f
                 == Path::from(
                     "part-00000-f0e955c5-a1e3-4eec-834e-dcc098fc9005-c000.snappy.parquet"
@@ -589,7 +589,7 @@ mod tests {
 
         let peek = table
             .log_store()
-            .peek_next_commit(table.version())
+            .peek_next_commit(table.version().unwrap())
             .await
             .unwrap();
         assert!(matches!(peek, PeekCommit::UpToDate));
@@ -599,7 +599,7 @@ mod tests {
     async fn test_read_vacuumed_log() {
         let path = "../test/tests/data/checkpoints_vacuumed";
         let table = crate::open_table(path).await.unwrap();
-        assert_eq!(table.version(), 12);
+        assert_eq!(table.version(), Some(12));
     }
 
     #[tokio::test]
@@ -652,7 +652,7 @@ mod tests {
         let table = crate::open_table("../test/tests/data/simple_table_with_cdc")
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(
             table.get_files_iter().unwrap().collect_vec(),
             vec![Path::from(

--- a/crates/core/src/operations/add_feature.rs
+++ b/crates/core/src/operations/add_feature.rs
@@ -201,7 +201,7 @@ mod tests {
             .clone()
             .unwrap_or_default()
             .contains(&ReaderFeature::DeletionVectors));
-        assert_eq!(result.version(), 2);
+        assert_eq!(result.version(), Some(2));
         Ok(())
     }
 

--- a/crates/core/src/operations/constraints.rs
+++ b/crates/core/src/operations/constraints.rs
@@ -326,7 +326,7 @@ mod tests {
             .with_constraint("id", "value <    1000")
             .await?;
         let version = table.version();
-        assert_eq!(version, 1);
+        assert_eq!(version, Some(1));
 
         let expected_expr = "value < 1000";
         assert_eq!(get_constraint_op_params(&mut table).await, expected_expr);
@@ -351,7 +351,7 @@ mod tests {
             .with_constraint("valid_values", col("value").lt(lit(1000)))
             .await?;
         let version = table.version();
-        assert_eq!(version, 1);
+        assert_eq!(version, Some(1));
 
         let expected_expr = "value < 1000";
         assert_eq!(get_constraint_op_params(&mut table).await, expected_expr);
@@ -392,7 +392,7 @@ mod tests {
             .with_constraint("valid_values", "vAlue < 1000") // spellchecker:disable-line
             .await?;
         let version = table.version();
-        assert_eq!(version, 1);
+        assert_eq!(version, Some(1));
 
         let expected_expr = "vAlue < 1000"; // spellchecker:disable-line
         assert_eq!(get_constraint_op_params(&mut table).await, expected_expr);

--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -567,7 +567,7 @@ mod tests {
     ) {
         assert_eq!(
             table.version(),
-            expected_version,
+            Some(expected_version),
             "Testing location: {test_data_from:?}"
         );
 

--- a/crates/core/src/operations/create.rs
+++ b/crates/core/src/operations/create.rs
@@ -416,7 +416,7 @@ mod tests {
             .with_save_mode(SaveMode::Ignore)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_schema().unwrap(), &table_schema)
     }
 
@@ -436,7 +436,7 @@ mod tests {
             .with_save_mode(SaveMode::Ignore)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_schema().unwrap(), &table_schema)
     }
 
@@ -453,7 +453,7 @@ mod tests {
             .with_columns(schema.fields().cloned())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
     }
 
     #[tokio::test]
@@ -464,7 +464,7 @@ mod tests {
             .with_columns(schema.fields().cloned())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(
             table.protocol().unwrap().min_reader_version,
             PROTOCOL.default_reader_version()
@@ -520,7 +520,7 @@ mod tests {
             .with_columns(schema.fields().cloned())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         let first_id = table.metadata().unwrap().id.clone();
 
         let log_store = table.log_store;
@@ -562,7 +562,7 @@ mod tests {
             .with_save_mode(SaveMode::ErrorIfExists)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 1);
 
         let mut table = DeltaOps(table)
@@ -572,7 +572,7 @@ mod tests {
             .await
             .unwrap();
         table.load().await.unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         // Checks if files got removed after overwrite
         assert_eq!(table.get_files_count(), 0);
     }
@@ -587,7 +587,7 @@ mod tests {
             .with_save_mode(SaveMode::ErrorIfExists)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 1);
 
         let mut table = DeltaOps(table)
@@ -598,7 +598,7 @@ mod tests {
             .await
             .unwrap();
         table.load().await.unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         // Checks if files got removed after overwrite
         assert_eq!(table.get_files_count(), 0);
     }

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -491,7 +491,7 @@ mod tests {
             .with_partition_columns(partitions.unwrap_or_default())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         table
     }
 
@@ -533,12 +533,12 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
 
         let (table, metrics) = DeltaOps(table).delete().await.unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.get_files_count(), 0);
         assert_eq!(metrics.num_added_files, 0);
         assert_eq!(metrics.num_removed_files, 1);
@@ -555,7 +555,7 @@ mod tests {
 
         // Deletes with no changes to state must not commit
         let (table, metrics) = DeltaOps(table).delete().await.unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(metrics.num_added_files, 0);
         assert_eq!(metrics.num_removed_files, 0);
         assert_eq!(metrics.num_deleted_rows, 0);
@@ -592,7 +592,7 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
 
         let batch = RecordBatch::try_new(
@@ -616,7 +616,7 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.get_files_count(), 2);
 
         let (table, metrics) = DeltaOps(table)
@@ -624,7 +624,7 @@ mod tests {
             .with_predicate(col("value").eq(lit(1)))
             .await
             .unwrap();
-        assert_eq!(table.version(), 3);
+        assert_eq!(table.version(), Some(3));
         assert_eq!(table.get_files_count(), 2);
 
         assert_eq!(metrics.num_added_files, 1);
@@ -772,7 +772,7 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 2);
 
         let (table, metrics) = DeltaOps(table)
@@ -780,7 +780,7 @@ mod tests {
             .with_predicate(col("modified").eq(lit("2021-02-03")))
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.get_files_count(), 1);
 
         assert_eq!(metrics.num_added_files, 0);
@@ -829,7 +829,7 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 3);
 
         let (table, metrics) = DeltaOps(table)
@@ -841,7 +841,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.get_files_count(), 2);
 
         assert_eq!(metrics.num_added_files, 0);
@@ -944,7 +944,7 @@ mod tests {
             .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             "value",
@@ -961,14 +961,14 @@ mod tests {
             .write(vec![batch])
             .await
             .expect("Failed to write first batch");
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
 
         let (table, _metrics) = DeltaOps(table)
             .delete()
             .with_predicate(col("value").eq(lit(2)))
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
 
         let ctx = SessionContext::new();
         let table = DeltaOps(table)
@@ -1021,7 +1021,7 @@ mod tests {
             .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let schema = Arc::new(Schema::new(vec![
             Field::new("year", DataType::Utf8, true),
@@ -1045,14 +1045,14 @@ mod tests {
             .write(vec![batch])
             .await
             .expect("Failed to write first batch");
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
 
         let (table, _metrics) = DeltaOps(table)
             .delete()
             .with_predicate(col("value").eq(lit(2)))
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
 
         let ctx = SessionContext::new();
         let table = DeltaOps(table)

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -818,7 +818,7 @@ pub(crate) mod tests {
             .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let schema: Arc<Schema> = Arc::new(delta_schema.try_into_arrow()?);
 
@@ -850,14 +850,14 @@ pub(crate) mod tests {
             .write(vec![batch])
             .await
             .expect("Failed to write first batch");
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
 
         let table = DeltaOps(table)
             .write([second_batch])
             .with_save_mode(crate::protocol::SaveMode::Overwrite)
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
 
         let ctx = SessionContext::new();
         let cdf_scan = DeltaOps(table.clone())

--- a/crates/core/src/operations/merge/filter.rs
+++ b/crates/core/src/operations/merge/filter.rs
@@ -422,7 +422,7 @@ mod tests {
         let schema = get_arrow_schema(&None);
         let table = setup_table(Some(vec!["id"])).await;
 
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 0);
 
         let ctx = SessionContext::new();
@@ -514,7 +514,7 @@ mod tests {
         let schema = get_arrow_schema(&None);
         let table = setup_table(Some(vec!["modified"])).await;
 
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 0);
 
         let ctx = SessionContext::new();
@@ -569,7 +569,7 @@ mod tests {
         let schema = get_arrow_schema(&None);
         let table = setup_table(Some(vec!["modified"])).await;
 
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 0);
 
         let ctx = SessionContext::new();
@@ -629,7 +629,7 @@ mod tests {
         let schema = get_arrow_schema(&None);
         let table = setup_table(Some(vec!["modified"])).await;
 
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 0);
 
         let ctx = SessionContext::new();
@@ -695,7 +695,7 @@ mod tests {
         let schema = get_arrow_schema(&None);
         let table = setup_table(Some(vec!["modified"])).await;
 
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 0);
 
         let ctx = SessionContext::new();
@@ -767,7 +767,7 @@ mod tests {
         let schema = get_arrow_schema(&None);
         let table = setup_table(Some(vec!["modified"])).await;
 
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 0);
 
         let ctx = SessionContext::new();

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1621,7 +1621,7 @@ mod tests {
             .with_partition_columns(partitions.unwrap_or_default())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         table
     }
 
@@ -1722,14 +1722,14 @@ mod tests {
         let table = setup_table(None).await;
 
         let table = write_data(table, &schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
 
         (table, merge_source(schema))
     }
 
     async fn assert_merge(table: DeltaTable, metrics: MergeMetrics) {
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert!(table.get_files_count() >= 1);
         assert!(metrics.num_target_files_added >= 1);
         assert_eq!(metrics.num_target_files_removed, 1);
@@ -2403,7 +2403,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         let table = write_data(table, &schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 2);
 
         let ctx = SessionContext::new();
@@ -2459,7 +2459,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert!(table.get_files_count() >= 3);
         assert!(metrics.num_target_files_added >= 3);
         assert_eq!(metrics.num_target_files_removed, 2);
@@ -2500,7 +2500,7 @@ mod tests {
         let schema = get_arrow_schema(&None);
         let table = setup_table(Some(vec!["modified"])).await;
         let table = write_data(table, &schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
@@ -2539,7 +2539,7 @@ mod tests {
             .unwrap()
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         let commit_info = table.history(None).await.unwrap();
         let last_commit = &commit_info[0];
         let parameters = last_commit.operation_parameters.clone().unwrap();
@@ -2560,7 +2560,7 @@ mod tests {
         let table = setup_table(Some(vec!["id"])).await;
 
         let table = write_data(table, &schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 4);
 
         let ctx = SessionContext::new();
@@ -2599,7 +2599,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert!(table.get_files_count() >= 3);
         assert_eq!(metrics.num_target_files_added, 3);
         assert_eq!(metrics.num_target_files_removed, 2);
@@ -2639,7 +2639,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         let table = write_data(table, &schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 2);
 
         let ctx = SessionContext::new();
@@ -2703,7 +2703,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert!(table.get_files_count() >= 3);
         assert!(metrics.num_target_files_added >= 3);
         assert_eq!(metrics.num_target_files_removed, 2);
@@ -2749,7 +2749,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         let table = write_data(table, &schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 2);
 
         let ctx = SessionContext::new();
@@ -2777,7 +2777,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert!(table.get_files_count() >= 2);
         assert_eq!(metrics.num_target_files_added, 2);
         assert_eq!(metrics.num_target_files_removed, 2);
@@ -2819,7 +2819,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         let table = write_data(table, &schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 2);
 
         let ctx = SessionContext::new();
@@ -2847,7 +2847,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert!(table.get_files_count() >= 2);
         assert_eq!(metrics.num_target_files_added, 1);
         assert_eq!(metrics.num_target_files_removed, 1);
@@ -2888,7 +2888,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         let table = write_data(table, &schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 2);
 
         let ctx = SessionContext::new();
@@ -2916,7 +2916,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.get_files_count(), 2);
         assert_eq!(metrics.num_target_files_added, 2);
         assert_eq!(metrics.num_target_files_removed, 2);
@@ -2952,7 +2952,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         let table = write_data(table, &schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 2);
 
         let ctx = SessionContext::new();
@@ -2982,7 +2982,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert!(metrics.num_target_files_added == 1);
         assert_eq!(metrics.num_target_files_removed, 1);
         assert_eq!(metrics.num_target_rows_copied, 1);
@@ -3022,7 +3022,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         let table = write_data(table, &schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 2);
 
         let ctx = SessionContext::new();
@@ -3051,7 +3051,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.get_files_count(), 2);
         assert_eq!(metrics.num_target_files_added, 2);
         assert_eq!(metrics.num_target_files_removed, 2);
@@ -3087,7 +3087,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         let table = write_data(table, &schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 2);
 
         let ctx = SessionContext::new();
@@ -3117,7 +3117,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert!(metrics.num_target_files_added == 1);
         assert_eq!(metrics.num_target_files_removed, 1);
         assert_eq!(metrics.num_target_rows_copied, 1);
@@ -3154,7 +3154,7 @@ mod tests {
         let schema = get_arrow_schema(&None);
         let table = setup_table(Some(vec!["modified"])).await;
 
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 0);
 
         let ctx = SessionContext::new();
@@ -3198,7 +3198,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert!(table.get_files_count() >= 2);
         assert!(metrics.num_target_files_added >= 2);
         assert_eq!(metrics.num_target_files_removed, 0);
@@ -3241,7 +3241,7 @@ mod tests {
         ]));
         let table = setup_table(Some(vec!["modified"])).await;
 
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 0);
 
         let ctx = SessionContext::new();
@@ -3282,7 +3282,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert!(table.get_files_count() >= 2);
         assert!(metrics.num_target_files_added >= 2);
         assert_eq!(metrics.num_target_files_removed, 0);
@@ -3366,7 +3366,7 @@ mod tests {
         let source = ctx.read_batch(batch).unwrap();
 
         let table = write_data(table, &arrow_schema).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
 
         let (table, _metrics) = DeltaOps(table)
@@ -3662,7 +3662,7 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
 
         let batch = RecordBatch::try_new(
@@ -3777,7 +3777,7 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
 
         let batch = RecordBatch::try_new(
@@ -3887,7 +3887,7 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
 
         let batch = RecordBatch::try_new(
@@ -3996,12 +3996,12 @@ mod tests {
             .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let schema = get_arrow_schema(&None);
         let table = write_data(table, &schema).await;
 
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
         let source = merge_source(schema);
 
@@ -4089,7 +4089,7 @@ mod tests {
             .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let schema = get_arrow_schema(&None);
 
@@ -4101,7 +4101,7 @@ mod tests {
         ]));
         let table = write_data(table, &schema).await;
 
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
         let source = merge_source(schema);
         let source = source.with_column("inserted_by", lit("new_value")).unwrap();
@@ -4206,12 +4206,12 @@ mod tests {
             .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let schema = get_arrow_schema(&None);
         let table = write_data(table, &schema).await;
 
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
         let source = merge_source(schema);
 

--- a/crates/core/src/operations/mod.rs
+++ b/crates/core/src/operations/mod.rs
@@ -187,7 +187,7 @@ impl DeltaOps {
     /// async {
     ///     let ops = DeltaOps::try_from_uri("memory:///").await.unwrap();
     ///     let table = ops.create().with_table_name("my_table").await.unwrap();
-    ///     assert_eq!(table.version(), 0);
+    ///     assert_eq!(table.version(), Some(0));
     /// };
     /// ```
     #[must_use]

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -563,7 +563,7 @@ mod tests {
             .with_partition_columns(partitions.unwrap_or_default())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         table
     }
 
@@ -623,7 +623,7 @@ mod tests {
         )?;
 
         let table = write_batch(table, batch).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
 
         let (table, _) = DeltaOps(table)
             .update()
@@ -672,7 +672,7 @@ mod tests {
         .unwrap();
 
         let table = write_batch(table, batch).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
 
         let (table, metrics) = DeltaOps(table)
@@ -681,7 +681,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.get_files_count(), 1);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
@@ -726,7 +726,7 @@ mod tests {
         // The expectation is that a physical scan of data is not required
 
         let table = write_batch(table, batch).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
 
         let (table, metrics) = DeltaOps(table)
@@ -736,7 +736,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.get_files_count(), 1);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
@@ -783,7 +783,7 @@ mod tests {
         .unwrap();
 
         let table = write_batch(table, batch.clone()).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 2);
 
         let (table, metrics) = DeltaOps(table)
@@ -794,7 +794,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.get_files_count(), 2);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
@@ -818,7 +818,7 @@ mod tests {
         // Update a partitioned table where the predicate contains a partition column and non-partition column
         let table = setup_table(Some(vec!["modified"])).await;
         let table = write_batch(table, batch).await;
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 2);
 
         let (table, metrics) = DeltaOps(table)
@@ -833,7 +833,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.get_files_count(), 3);
         assert_eq!(metrics.num_added_files, 2);
         assert_eq!(metrics.num_removed_files, 1);
@@ -929,7 +929,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_null() {
         let table = prepare_values_table().await;
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 1);
 
         let (table, metrics) = DeltaOps(table)
@@ -937,7 +937,7 @@ mod tests {
             .with_update("value", col("value") + lit(1))
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
@@ -967,7 +967,7 @@ mod tests {
             .with_update("value", lit(10))
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
@@ -1003,7 +1003,7 @@ mod tests {
             .with_update("value", "10")
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
@@ -1031,7 +1031,7 @@ mod tests {
         let table = prepare_values_table().await;
         let (table, metrics) = DeltaOps(table).update().await.unwrap();
 
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(metrics.num_added_files, 0);
         assert_eq!(metrics.num_removed_files, 0);
         assert_eq!(metrics.num_copied_rows, 0);
@@ -1047,7 +1047,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(metrics.num_added_files, 0);
         assert_eq!(metrics.num_removed_files, 0);
         assert_eq!(metrics.num_copied_rows, 0);
@@ -1121,13 +1121,13 @@ mod tests {
             .with_columns(schema.fields().cloned())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let table = DeltaOps(table)
             .write(vec![batch])
             .await
             .expect("Failed to write first batch");
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         // Completed the first creation/write
 
         use arrow::array::{Int32Builder, ListBuilder};
@@ -1142,7 +1142,7 @@ mod tests {
             .with_update("items", lit(new_items))
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
     }
 
     /// Lists coming in from the Python bindings need to be parsed as SQL expressions by the update
@@ -1192,13 +1192,13 @@ mod tests {
             .with_columns(schema.fields().cloned())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let table = DeltaOps(table)
             .write(vec![batch])
             .await
             .expect("Failed to write first batch");
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         // Completed the first creation/write
 
         let (table, _metrics) = DeltaOps(table)
@@ -1207,13 +1207,13 @@ mod tests {
             .with_update("items", "[100]".to_string())
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
     }
 
     #[tokio::test]
     async fn test_no_cdc_on_older_tables() {
         let table = prepare_values_table().await;
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 1);
 
         let schema = Arc::new(Schema::new(vec![Field::new(
@@ -1230,7 +1230,7 @@ mod tests {
             .write(vec![batch])
             .await
             .expect("Failed to write first batch");
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
 
         let (table, _metrics) = DeltaOps(table)
             .update()
@@ -1238,7 +1238,7 @@ mod tests {
             .with_update("value", lit(12))
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
 
         // NOTE: This currently doesn't really assert anything because cdc_files() is not reading
         // actions correct
@@ -1287,7 +1287,7 @@ mod tests {
             .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             "value",
@@ -1304,7 +1304,7 @@ mod tests {
             .write(vec![batch])
             .await
             .expect("Failed to write first batch");
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
 
         let (table, _metrics) = DeltaOps(table)
             .update()
@@ -1312,7 +1312,7 @@ mod tests {
             .with_update("value", lit(12))
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
 
         let ctx = SessionContext::new();
         let table = DeltaOps(table)
@@ -1371,7 +1371,7 @@ mod tests {
             .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let schema = Arc::new(Schema::new(vec![
             Field::new("year", DataType::Utf8, true),
@@ -1394,7 +1394,7 @@ mod tests {
             .write(vec![batch])
             .await
             .expect("Failed to write first batch");
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
 
         let (table, _metrics) = DeltaOps(table)
             .update()
@@ -1402,7 +1402,7 @@ mod tests {
             .with_update("year", "2024")
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
 
         let ctx = SessionContext::new();
         let table = DeltaOps(table)

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -823,7 +823,7 @@ mod tests {
             .with_columns(table_schema.fields().cloned())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.history(None).await.unwrap().len(), 1);
 
         // write some data
@@ -834,7 +834,7 @@ mod tests {
             .with_commit_properties(CommitProperties::default().with_metadata(metadata.clone()))
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         assert_eq!(table.get_files_count(), 1);
 
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
@@ -863,7 +863,7 @@ mod tests {
             .with_commit_properties(CommitProperties::default().with_metadata(metadata.clone()))
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         assert_eq!(table.get_files_count(), 2);
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, batch.num_rows());
@@ -891,7 +891,7 @@ mod tests {
             .with_commit_properties(CommitProperties::default().with_metadata(metadata.clone()))
             .await
             .unwrap();
-        assert_eq!(table.version(), 3);
+        assert_eq!(table.version(), Some(3));
         assert_eq!(table.get_files_count(), 1);
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, batch.num_rows());
@@ -1030,7 +1030,7 @@ mod tests {
             .with_save_mode(SaveMode::ErrorIfExists)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 1);
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_common_write_metrics(write_metrics);
@@ -1045,7 +1045,7 @@ mod tests {
             .with_partition_columns(["modified"])
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 2);
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_files, 2);
@@ -1057,7 +1057,7 @@ mod tests {
             .with_partition_columns(["modified", "id"])
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         assert_eq!(table.get_files_count(), 4);
 
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
@@ -1073,7 +1073,7 @@ mod tests {
             .with_save_mode(SaveMode::ErrorIfExists)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_common_write_metrics(write_metrics);
@@ -1119,7 +1119,7 @@ mod tests {
             .await
             .unwrap();
         table.load().await.unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let new_schema = table.metadata().unwrap().schema().unwrap();
         let fields = new_schema.fields();
         let names = fields.map(|f| f.name()).collect::<Vec<_>>();
@@ -1147,7 +1147,7 @@ mod tests {
             .with_save_mode(SaveMode::ErrorIfExists)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_common_write_metrics(write_metrics);
@@ -1192,7 +1192,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let new_schema = table.metadata().unwrap().schema().unwrap();
         let fields = new_schema.fields();
         let mut names = fields.map(|f| f.name()).collect::<Vec<_>>();
@@ -1213,7 +1213,7 @@ mod tests {
             .with_save_mode(SaveMode::ErrorIfExists)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_common_write_metrics(write_metrics);
         let mut new_schema_builder = arrow_schema::SchemaBuilder::new();
@@ -1267,7 +1267,7 @@ mod tests {
             .with_save_mode(SaveMode::ErrorIfExists)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_common_write_metrics(write_metrics);
 
@@ -1321,10 +1321,10 @@ mod tests {
             .with_columns(schema.fields().cloned())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let table = DeltaOps(table).write(vec![batch.clone()]).await.unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_common_write_metrics(write_metrics);
 
@@ -1345,7 +1345,7 @@ mod tests {
             .with_columns(schema.fields().cloned())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let table = DeltaOps(table).write(vec![batch.clone()]).await;
         assert!(table.is_err());
@@ -1361,14 +1361,14 @@ mod tests {
             .with_columns(table_schema.fields().cloned())
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let table = DeltaOps(table)
             .write(vec![batch.clone()])
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_common_write_metrics(write_metrics);
 
@@ -1453,7 +1453,7 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, 4);
         assert_common_write_metrics(write_metrics);
@@ -1474,7 +1474,7 @@ mod tests {
             .with_replace_where(col("id").eq(lit("C")))
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, 1);
         assert_common_write_metrics(write_metrics);
@@ -1515,7 +1515,7 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_common_write_metrics(write_metrics);
 
@@ -1559,7 +1559,7 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_common_write_metrics(write_metrics);
 
@@ -1583,7 +1583,7 @@ mod tests {
             .with_replace_where(col("id").eq(lit("A")))
             .await
             .unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, 3);
         assert_common_write_metrics(write_metrics);
@@ -1615,7 +1615,7 @@ mod tests {
             .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let schema: Arc<ArrowSchema> = Arc::new(delta_schema.try_into_arrow()?);
 
@@ -1647,7 +1647,7 @@ mod tests {
             .write(vec![batch])
             .await
             .expect("Failed to write first batch");
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, 3);
         assert_common_write_metrics(write_metrics);
@@ -1657,7 +1657,7 @@ mod tests {
             .with_save_mode(crate::protocol::SaveMode::Overwrite)
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, 1);
         assert!(write_metrics.num_removed_files > 0);
@@ -1688,7 +1688,7 @@ mod tests {
             .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let schema: Arc<ArrowSchema> = Arc::new(delta_schema.try_into_arrow()?);
 
@@ -1720,7 +1720,7 @@ mod tests {
             .write(vec![batch])
             .await
             .expect("Failed to write first batch");
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, 3);
         assert_common_write_metrics(write_metrics);
@@ -1731,7 +1731,7 @@ mod tests {
             .with_replace_where("id='3'")
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, 1);
         assert!(write_metrics.num_removed_files > 0);
@@ -1762,7 +1762,7 @@ mod tests {
             .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let schema: Arc<ArrowSchema> = Arc::new(delta_schema.try_into_arrow()?);
 
@@ -1794,7 +1794,7 @@ mod tests {
             .write(vec![batch])
             .await
             .expect("Failed to write first batch");
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
 
         let table = DeltaOps(table)
             .write([second_batch])
@@ -1802,7 +1802,7 @@ mod tests {
             .with_replace_where("value=3")
             .await
             .unwrap();
-        assert_eq!(table.version(), 2);
+        assert_eq!(table.version(), Some(2));
 
         let ctx = SessionContext::new();
         let cdf_scan = DeltaOps(table.clone())

--- a/crates/core/src/writer/json.rs
+++ b/crates/core/src/writer/json.rs
@@ -480,7 +480,7 @@ mod tests {
             .await
             .unwrap();
         table.load().await.expect("Failed to load table");
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         table
     }
 
@@ -675,7 +675,7 @@ mod tests {
             // TODO This should fail because we haven't asked to evolve the schema
             writer.write(vec![second_data]).await.unwrap();
             writer.flush_and_commit(&mut table).await.unwrap();
-            assert_eq!(table.version(), 1);
+            assert_eq!(table.version(), Some(1));
         }
     }
 
@@ -704,7 +704,7 @@ mod tests {
             .with_configuration(config)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         let mut writer = JsonWriter::for_table(&table).unwrap();
         let data = serde_json::json!(
             {
@@ -748,7 +748,7 @@ mod tests {
             .with_configuration(config)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         let mut writer = JsonWriter::for_table(&table).unwrap();
         let data = serde_json::json!(
             {
@@ -760,7 +760,7 @@ mod tests {
 
         writer.write(vec![data]).await.unwrap();
         writer.flush_and_commit(&mut table).await.unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let add_actions = table.state.unwrap().file_actions().unwrap();
         assert_eq!(add_actions.len(), 1);
         let expected_stats = "{\"numRecords\":1,\"minValues\":{\"id\":\"A\",\"value\":42},\"maxValues\":{\"id\":\"A\",\"value\":42},\"nullCount\":{\"id\":0,\"value\":0}}";
@@ -797,7 +797,7 @@ mod tests {
             .with_configuration(config)
             .await
             .unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
         let mut writer = JsonWriter::for_table(&table).unwrap();
         let data = serde_json::json!(
             {
@@ -809,7 +809,7 @@ mod tests {
 
         writer.write(vec![data]).await.unwrap();
         writer.flush_and_commit(&mut table).await.unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let add_actions = table.state.unwrap().file_actions().unwrap();
         assert_eq!(add_actions.len(), 1);
         let expected_stats = "{\"numRecords\":1,\"minValues\":{\"id\":\"A\"},\"maxValues\":{\"id\":\"A\"},\"nullCount\":{\"id\":0}}";

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -792,7 +792,7 @@ mod tests {
                 .await
                 .unwrap();
             table.load().await.expect("Failed to load table");
-            assert_eq!(table.version(), 0);
+            assert_eq!(table.version(), Some(0));
 
             let batch = get_record_batch(None, false);
             let mut writer = RecordBatchWriter::for_table(&table).unwrap();
@@ -801,7 +801,7 @@ mod tests {
             let version = writer.flush_and_commit(&mut table).await.unwrap();
             assert_eq!(version, 1);
             table.load().await.expect("Failed to load table");
-            assert_eq!(table.version(), 1);
+            assert_eq!(table.version(), Some(1));
 
             // Create a second batch with a different schema
             let second_schema = Arc::new(ArrowSchema::new(vec![
@@ -827,7 +827,7 @@ mod tests {
             let version = writer.flush_and_commit(&mut table).await.unwrap();
             assert_eq!(version, 2);
             table.load().await.expect("Failed to load table");
-            assert_eq!(table.version(), 2);
+            assert_eq!(table.version(), Some(2));
 
             let new_schema = table.metadata().unwrap().schema().unwrap();
             let expected_columns = vec!["id", "value", "modified", "vid", "name"];
@@ -853,7 +853,7 @@ mod tests {
                 .await
                 .unwrap();
             table.load().await.expect("Failed to load table");
-            assert_eq!(table.version(), 0);
+            assert_eq!(table.version(), Some(0));
 
             let batch = get_record_batch(None, false);
             let mut writer = RecordBatchWriter::for_table(&table).unwrap();
@@ -862,7 +862,7 @@ mod tests {
             let version = writer.flush_and_commit(&mut table).await.unwrap();
             assert_eq!(version, 1);
             table.load().await.expect("Failed to load table");
-            assert_eq!(table.version(), 1);
+            assert_eq!(table.version(), Some(1));
 
             // Create a second batch with appended columns
             let second_batch = {
@@ -985,7 +985,7 @@ mod tests {
                 .await
                 .unwrap();
             table.load().await.expect("Failed to load table");
-            assert_eq!(table.version(), 0);
+            assert_eq!(table.version(), Some(0));
 
             // Hand-crafting the first RecordBatch to ensure that a write with non-nullable columns
             // works properly before attempting the second write
@@ -1066,7 +1066,7 @@ mod tests {
         assert_eq!(partitions[0].record_batch, batch);
         writer.write(batch).await.unwrap();
         writer.flush_and_commit(&mut table).await.unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let add_actions = table.state.unwrap().file_actions().unwrap();
         assert_eq!(add_actions.len(), 1);
         let expected_stats ="{\"numRecords\":11,\"minValues\":{\"value\":1,\"id\":\"A\"},\"maxValues\":{\"id\":\"B\",\"value\":11},\"nullCount\":{\"id\":0,\"value\":0}}";
@@ -1115,7 +1115,7 @@ mod tests {
         assert_eq!(partitions[0].record_batch, batch);
         writer.write(batch).await.unwrap();
         writer.flush_and_commit(&mut table).await.unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
         let add_actions = table.state.unwrap().file_actions().unwrap();
         assert_eq!(add_actions.len(), 1);
         let expected_stats = "{\"numRecords\":11,\"minValues\":{\"id\":\"A\"},\"maxValues\":{\"id\":\"B\"},\"nullCount\":{\"id\":0}}";

--- a/crates/core/tests/checkpoint_writer.rs
+++ b/crates/core/tests/checkpoint_writer.rs
@@ -101,7 +101,7 @@ mod simple_checkpoint {
 
         // _last_checkpoint should exist and point to the correct version
         let version = get_last_checkpoint_version(&log_path);
-        assert_eq!(table.version(), version);
+        assert_eq!(table.version(), Some(version));
 
         // delta table should load just fine with the checkpoint in place
         let table_result = deltalake_core::open_table(table_location).await.unwrap();
@@ -223,7 +223,7 @@ mod delete_expired_delta_log_in_checkpoint {
 
         checkpoints::create_checkpoint_from_table_uri_and_cleanup(
             &table.table_uri(),
-            table.version(),
+            table.version().unwrap(),
             None,
             None,
         )
@@ -273,7 +273,7 @@ mod delete_expired_delta_log_in_checkpoint {
 
         checkpoints::create_checkpoint_from_table_uri_and_cleanup(
             &table.table_uri(),
-            table.version(),
+            table.version().unwrap(),
             None,
             None,
         )

--- a/crates/core/tests/command_optimize.rs
+++ b/crates/core/tests/command_optimize.rs
@@ -168,13 +168,13 @@ async fn test_optimize_non_partitioned_table() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    let version = dt.version();
+    let version = dt.version().unwrap();
     assert_eq!(dt.get_files_count(), 5);
 
     let optimize = DeltaOps(dt).optimize().with_target_size(2_000_000);
     let (dt, metrics) = optimize.await?;
 
-    assert_eq!(version + 1, dt.version());
+    assert_eq!(version + 1, dt.version().unwrap());
     assert_eq!(metrics.num_files_added, 1);
     assert_eq!(metrics.num_files_removed, 4);
     assert_eq!(metrics.total_considered_files, 5);
@@ -232,13 +232,13 @@ async fn test_optimize_with_partitions() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    let version = dt.version();
+    let version = dt.version().unwrap();
     let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
 
     let optimize = DeltaOps(dt).optimize().with_filters(&filter);
     let (dt, metrics) = optimize.await?;
 
-    assert_eq!(version + 1, dt.version());
+    assert_eq!(version + 1, dt.version().unwrap());
     assert_eq!(metrics.num_files_added, 1);
     assert_eq!(metrics.num_files_removed, 2);
     assert_eq!(dt.get_files_count(), 3);
@@ -279,7 +279,7 @@ async fn test_conflict_for_remove_actions() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    let version = dt.version();
+    let version = dt.version().unwrap();
 
     //create the merge plan, remove a file, and execute the plan.
     let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
@@ -317,7 +317,7 @@ async fn test_conflict_for_remove_actions() -> Result<(), Box<dyn Error>> {
 
     assert!(maybe_metrics.is_err());
     dt.update().await?;
-    assert_eq!(dt.version(), version + 1);
+    assert_eq!(dt.version().unwrap(), version + 1);
     Ok(())
 }
 
@@ -342,7 +342,7 @@ async fn test_no_conflict_for_append_actions() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    let version = dt.version();
+    let version = dt.version().unwrap();
 
     let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
     let plan = create_merge_plan(
@@ -379,7 +379,7 @@ async fn test_no_conflict_for_append_actions() -> Result<(), Box<dyn Error>> {
     assert_eq!(metrics.num_files_removed, 2);
 
     dt.update().await.unwrap();
-    assert_eq!(dt.version(), version + 2);
+    assert_eq!(dt.version().unwrap(), version + 2);
     Ok(())
 }
 
@@ -402,7 +402,7 @@ async fn test_commit_interval() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    let version = dt.version();
+    let version = dt.version().unwrap();
 
     let plan = create_merge_plan(
         OptimizeType::Compact,
@@ -428,7 +428,7 @@ async fn test_commit_interval() -> Result<(), Box<dyn Error>> {
     assert_eq!(metrics.num_files_removed, 4);
 
     dt.update().await.unwrap();
-    assert_eq!(dt.version(), version + 2);
+    assert_eq!(dt.version().unwrap(), version + 2);
     Ok(())
 }
 
@@ -460,7 +460,7 @@ async fn test_idempotent() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    let version = dt.version();
+    let version = dt.version().unwrap();
 
     let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
 
@@ -471,7 +471,7 @@ async fn test_idempotent() -> Result<(), Box<dyn Error>> {
     let (dt, metrics) = optimize.await?;
     assert_eq!(metrics.num_files_added, 1);
     assert_eq!(metrics.num_files_removed, 2);
-    assert_eq!(dt.version(), version + 1);
+    assert_eq!(dt.version().unwrap(), version + 1);
 
     let optimize = DeltaOps(dt)
         .optimize()
@@ -481,7 +481,7 @@ async fn test_idempotent() -> Result<(), Box<dyn Error>> {
 
     assert_eq!(metrics.num_files_added, 0);
     assert_eq!(metrics.num_files_removed, 0);
-    assert_eq!(dt.version(), version + 1);
+    assert_eq!(dt.version().unwrap(), version + 1);
 
     Ok(())
 }
@@ -569,7 +569,7 @@ async fn test_idempotent_with_multiple_bins() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    let version = dt.version();
+    let version = dt.version().unwrap();
 
     let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
 
@@ -580,7 +580,7 @@ async fn test_idempotent_with_multiple_bins() -> Result<(), Box<dyn Error>> {
     let (dt, metrics) = optimize.await?;
     assert_eq!(metrics.num_files_added, 2);
     assert_eq!(metrics.num_files_removed, 4);
-    assert_eq!(dt.version(), version + 1);
+    assert_eq!(dt.version().unwrap(), version + 1);
 
     let optimize = DeltaOps(dt)
         .optimize()
@@ -589,7 +589,7 @@ async fn test_idempotent_with_multiple_bins() -> Result<(), Box<dyn Error>> {
     let (dt, metrics) = optimize.await?;
     assert_eq!(metrics.num_files_added, 0);
     assert_eq!(metrics.num_files_removed, 0);
-    assert_eq!(dt.version(), version + 1);
+    assert_eq!(dt.version().unwrap(), version + 1);
 
     Ok(())
 }
@@ -615,7 +615,7 @@ async fn test_commit_info() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    let version = dt.version();
+    let version = dt.version().unwrap();
 
     let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
 

--- a/crates/core/tests/command_update_table_metadata.rs
+++ b/crates/core/tests/command_update_table_metadata.rs
@@ -38,7 +38,7 @@ async fn test_update_table_name_valid() {
 
     let metadata = updated_table.metadata().unwrap();
     assert_eq!(metadata.name.as_ref().unwrap(), name);
-    assert_eq!(updated_table.version(), 1);
+    assert_eq!(updated_table.version(), Some(1));
 }
 
 #[tokio::test]
@@ -62,7 +62,7 @@ async fn test_update_table_description_valid() {
 
     let metadata = updated_table.metadata().unwrap();
     assert_eq!(metadata.description.as_ref().unwrap(), description);
-    assert_eq!(updated_table.version(), 1);
+    assert_eq!(updated_table.version(), Some(1));
 }
 
 #[tokio::test]
@@ -86,7 +86,7 @@ async fn test_update_table_name_character_limit_valid() {
 
     let metadata = updated_table.metadata().unwrap();
     assert_eq!(metadata.name.as_ref().unwrap(), &name_255_chars);
-    assert_eq!(updated_table.version(), 1);
+    assert_eq!(updated_table.version(), Some(1));
 }
 
 #[tokio::test]
@@ -136,7 +136,7 @@ async fn test_update_table_description_character_limit_valid() {
         metadata.description.as_ref().unwrap(),
         &description_4000_chars
     );
-    assert_eq!(updated_table.version(), 1);
+    assert_eq!(updated_table.version(), Some(1));
 }
 
 #[tokio::test]
@@ -181,7 +181,7 @@ async fn test_update_existing_table_name() {
         .await
         .unwrap();
 
-    assert_eq!(updated_table.version(), 1);
+    assert_eq!(updated_table.version(), Some(1));
     assert_eq!(
         updated_table.metadata().unwrap().name.as_ref().unwrap(),
         initial_name
@@ -198,7 +198,7 @@ async fn test_update_existing_table_name() {
         .await
         .unwrap();
 
-    assert_eq!(final_table.version(), 2);
+    assert_eq!(final_table.version(), Some(2));
     assert_eq!(
         final_table.metadata().unwrap().name.as_ref().unwrap(),
         new_name
@@ -224,7 +224,7 @@ async fn test_update_existing_table_description() {
         .await
         .unwrap();
 
-    assert_eq!(updated_table.version(), 1);
+    assert_eq!(updated_table.version(), Some(1));
     assert_eq!(
         updated_table
             .metadata()
@@ -246,7 +246,7 @@ async fn test_update_existing_table_description() {
         .await
         .unwrap();
 
-    assert_eq!(final_table.version(), 2);
+    assert_eq!(final_table.version(), Some(2));
     assert_eq!(
         final_table
             .metadata()
@@ -300,7 +300,7 @@ async fn test_empty_table_description() {
 
     let metadata = updated_table.metadata().unwrap();
     assert_eq!(metadata.description.as_ref().unwrap(), "");
-    assert_eq!(updated_table.version(), 1);
+    assert_eq!(updated_table.version(), Some(1));
 }
 
 #[tokio::test]
@@ -345,7 +345,7 @@ async fn test_with_commit_properties() {
 
     let metadata = updated_table.metadata().unwrap();
     assert_eq!(metadata.name.as_ref().unwrap(), name);
-    assert_eq!(updated_table.version(), 1);
+    assert_eq!(updated_table.version(), Some(1));
 }
 
 #[tokio::test]
@@ -428,7 +428,7 @@ async fn test_with_custom_execute_handler() {
 
     let metadata = updated_table.metadata().unwrap();
     assert_eq!(metadata.name.as_ref().unwrap(), name);
-    assert_eq!(updated_table.version(), 1);
+    assert_eq!(updated_table.version(), Some(1));
 
     assert!(handler
         .pre_execute_called

--- a/crates/core/tests/integration_checkpoint.rs
+++ b/crates/core/tests/integration_checkpoint.rs
@@ -100,13 +100,13 @@ async fn test_issue_1420_cleanup_expired_logs_for() -> DeltaResult<()> {
 
     writer.write(vec![json!({"id": 2})]).await?;
     writer.flush_and_commit(&mut table).await?; // v2
-    assert_eq!(table.version(), 2);
+    assert_eq!(table.version(), Some(2));
 
     create_checkpoint(&table, None).await.unwrap(); // v2.checkpoint.parquet
 
     // Should delete v1 but not v2 or v2.checkpoint.parquet
     cleanup_expired_logs_for(
-        table.version(),
+        table.version().unwrap(),
         table.log_store().as_ref(),
         ts.timestamp_millis(),
         None,
@@ -152,7 +152,7 @@ async fn test_issue_1420_cleanup_expired_logs_for() -> DeltaResult<()> {
     sleep(Duration::from_secs(1)).await;
 
     cleanup_expired_logs_for(
-        table.version(),
+        table.version().unwrap(),
         table.log_store().as_ref(),
         ts.timestamp_millis(),
         None,

--- a/crates/core/tests/read_delta_log_test.rs
+++ b/crates/core/tests/read_delta_log_test.rs
@@ -36,7 +36,7 @@ async fn test_log_buffering() {
             .await
             .expect("Failed to load table");
         table_seq.update_incremental(None).await.unwrap();
-        seq_version = table_seq.version();
+        seq_version = table_seq.version().unwrap();
     }
     let time_seq = t.elapsed().unwrap();
 
@@ -52,7 +52,7 @@ async fn test_log_buffering() {
             .await
             .unwrap();
         table_buf.update_incremental(None).await.unwrap();
-        buf_version = table_buf.version();
+        buf_version = table_buf.version().unwrap();
     }
     let time_buf = t2.elapsed().unwrap();
 
@@ -83,7 +83,7 @@ async fn test_log_buffering_success_explicit_version() {
             .await
             .unwrap();
         table.update_incremental(None).await.unwrap();
-        assert_eq!(table.version(), 10);
+        assert_eq!(table.version(), Some(10));
 
         let mut table = DeltaTableBuilder::from_uri(path)
             .with_version(0)
@@ -93,7 +93,7 @@ async fn test_log_buffering_success_explicit_version() {
             .await
             .unwrap();
         table.update_incremental(Some(0)).await.unwrap();
-        assert_eq!(table.version(), 0);
+        assert_eq!(table.version(), Some(0));
 
         let mut table = DeltaTableBuilder::from_uri(path)
             .with_version(0)
@@ -103,7 +103,7 @@ async fn test_log_buffering_success_explicit_version() {
             .await
             .unwrap();
         table.update_incremental(Some(1)).await.unwrap();
-        assert_eq!(table.version(), 1);
+        assert_eq!(table.version(), Some(1));
 
         let mut table = DeltaTableBuilder::from_uri(path)
             .with_version(0)
@@ -113,7 +113,7 @@ async fn test_log_buffering_success_explicit_version() {
             .await
             .unwrap();
         table.update_incremental(Some(10)).await.unwrap();
-        assert_eq!(table.version(), 10);
+        assert_eq!(table.version(), Some(10));
 
         let mut table = DeltaTableBuilder::from_uri(path)
             .with_version(0)
@@ -123,7 +123,7 @@ async fn test_log_buffering_success_explicit_version() {
             .await
             .unwrap();
         table.update_incremental(Some(20)).await.unwrap();
-        assert_eq!(table.version(), 10);
+        assert_eq!(table.version(), Some(10));
     }
 }
 
@@ -166,7 +166,7 @@ async fn read_delta_table_from_dlt() {
     let table = deltalake_core::open_table("../test/tests/data/delta-live-table")
         .await
         .unwrap();
-    assert_eq!(table.version(), 1);
+    assert_eq!(table.version(), Some(1));
     assert!(table.get_schema().is_ok());
 }
 
@@ -176,7 +176,7 @@ async fn read_delta_table_with_null_stats_in_notnull_struct() {
         deltalake_core::open_table("../test/tests/data/table_with_null_stats_in_notnull_struct")
             .await
             .unwrap();
-    assert_eq!(table.version(), 1);
+    assert_eq!(table.version(), Some(1));
     assert!(table.get_schema().is_ok());
 }
 
@@ -186,6 +186,6 @@ async fn read_delta_table_with_renamed_partitioning_column() {
     let table = deltalake_core::open_table("../test/tests/data/table_with_partitioning_mapping")
         .await
         .unwrap();
-    assert_eq!(table.version(), 4);
+    assert_eq!(table.version(), Some(4));
     assert!(table.get_schema().is_ok());
 }

--- a/crates/core/tests/read_delta_partitions_test.rs
+++ b/crates/core/tests/read_delta_partitions_test.rs
@@ -48,7 +48,7 @@ async fn read_null_partitions_from_checkpoint() {
     let table = deltalake_core::open_table(&table.table_uri())
         .await
         .unwrap();
-    assert_eq!(table.version(), 2);
+    assert_eq!(table.version(), Some(2));
 }
 
 #[cfg(feature = "datafusion")]

--- a/crates/core/tests/time_travel.rs
+++ b/crates/core/tests/time_travel.rs
@@ -36,7 +36,7 @@ async fn time_travel_by_ds() {
     .await
     .unwrap();
 
-    assert_eq!(table.version(), 0);
+    assert_eq!(table.version(), Some(0));
 
     table = deltalake_core::open_table_with_ds(
         "../test/tests/data/simple_table",
@@ -44,7 +44,7 @@ async fn time_travel_by_ds() {
     )
     .await
     .unwrap();
-    assert_eq!(table.version(), 1);
+    assert_eq!(table.version(), Some(1));
 
     table = deltalake_core::open_table_with_ds(
         "../test/tests/data/simple_table",
@@ -52,7 +52,7 @@ async fn time_travel_by_ds() {
     )
     .await
     .unwrap();
-    assert_eq!(table.version(), 1);
+    assert_eq!(table.version(), Some(1));
 
     table = deltalake_core::open_table_with_ds(
         "../test/tests/data/simple_table",
@@ -60,7 +60,7 @@ async fn time_travel_by_ds() {
     )
     .await
     .unwrap();
-    assert_eq!(table.version(), 2);
+    assert_eq!(table.version(), Some(2));
 
     table = deltalake_core::open_table_with_ds(
         "../test/tests/data/simple_table",
@@ -68,7 +68,7 @@ async fn time_travel_by_ds() {
     )
     .await
     .unwrap();
-    assert_eq!(table.version(), 3);
+    assert_eq!(table.version(), Some(3));
 
     table = deltalake_core::open_table_with_ds(
         "../test/tests/data/simple_table",
@@ -76,7 +76,7 @@ async fn time_travel_by_ds() {
     )
     .await
     .unwrap();
-    assert_eq!(table.version(), 3);
+    assert_eq!(table.version(), Some(3));
 
     table = deltalake_core::open_table_with_ds(
         "../test/tests/data/simple_table",
@@ -84,7 +84,7 @@ async fn time_travel_by_ds() {
     )
     .await
     .unwrap();
-    assert_eq!(table.version(), 4);
+    assert_eq!(table.version(), Some(4));
 
     // Final append in .tmp subdir is uncommitted and should be ignored
     table = deltalake_core::open_table_with_ds(
@@ -93,7 +93,7 @@ async fn time_travel_by_ds() {
     )
     .await
     .unwrap();
-    assert_eq!(table.version(), 4);
+    assert_eq!(table.version(), Some(4));
 }
 
 fn ds_to_ts(ds: &str) -> DateTime<Utc> {

--- a/crates/deltalake/examples/basic_operations.rs
+++ b/crates/deltalake/examples/basic_operations.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<(), deltalake::errors::DeltaTableError> {
         .with_comment("A table to show how delta-rs works")
         .await?;
 
-    assert_eq!(table.version(), 0);
+    assert_eq!(table.version(), Some(0));
 
     let writer_properties = WriterProperties::builder()
         .set_compression(Compression::ZSTD(ZstdLevel::try_new(3).unwrap()))
@@ -93,7 +93,7 @@ async fn main() -> Result<(), deltalake::errors::DeltaTableError> {
         .with_writer_properties(writer_properties)
         .await?;
 
-    assert_eq!(table.version(), 1);
+    assert_eq!(table.version(), Some(1));
 
     let writer_properties = WriterProperties::builder()
         .set_compression(Compression::ZSTD(ZstdLevel::try_new(3).unwrap()))
@@ -106,7 +106,7 @@ async fn main() -> Result<(), deltalake::errors::DeltaTableError> {
         .with_writer_properties(writer_properties)
         .await?;
 
-    assert_eq!(table.version(), 2);
+    assert_eq!(table.version(), Some(2));
 
     let (_table, stream) = DeltaOps(table).load().await?;
     let data: Vec<RecordBatch> = collect_sendable_stream(stream).await?;

--- a/crates/test/src/concurrent.rs
+++ b/crates/test/src/concurrent.rs
@@ -37,7 +37,7 @@ async fn prepare_table(
         .with_columns(schema.fields().cloned())
         .await?;
 
-    assert_eq!(0, table.version());
+    assert_eq!(Some(0), table.version());
     assert_eq!(1, table.protocol()?.min_reader_version);
     assert_eq!(2, table.protocol()?.min_writer_version);
     // assert_eq!(0, table.get_files_iter().count());

--- a/crates/test/src/read.rs
+++ b/crates/test/src/read.rs
@@ -40,7 +40,7 @@ async fn read_simple_table(integration: &IntegrationContext) -> TestResult {
         .load()
         .await?;
 
-    assert_eq!(table.version(), 4);
+    assert_eq!(table.version(), Some(4));
     assert_eq!(table.protocol()?.min_writer_version, 2);
     assert_eq!(table.protocol()?.min_reader_version, 1);
     assert_eq!(
@@ -84,7 +84,7 @@ async fn read_simple_table_with_version(integration: &IntegrationContext) -> Tes
         .load()
         .await?;
 
-    assert_eq!(table.version(), 3);
+    assert_eq!(table.version(), Some(3));
     assert_eq!(table.protocol()?.min_writer_version, 2);
     assert_eq!(table.protocol()?.min_reader_version, 1);
     assert_eq!(
@@ -129,7 +129,7 @@ pub async fn read_golden(integration: &IntegrationContext) -> TestResult {
         .await
         .unwrap();
 
-    assert_eq!(table.version(), 0);
+    assert_eq!(table.version(), Some(0));
     assert_eq!(table.protocol()?.min_writer_version, 2);
     assert_eq!(table.protocol()?.min_reader_version, 1);
 
@@ -165,7 +165,7 @@ async fn read_encoded_table(integration: &IntegrationContext, root_path: &str) -
         .load()
         .await?;
 
-    assert_eq!(table.version(), 0);
+    assert_eq!(table.version(), Some(0));
     assert_eq!(table.get_files_iter()?.count(), 2);
 
     Ok(())

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -237,7 +237,7 @@ impl RawDeltaTable {
         self.with_table(|t| Ok(t.table_uri()))
     }
 
-    pub fn version(&self) -> PyResult<i64> {
+    pub fn version(&self) -> PyResult<Option<i64>> {
         self.with_table(|t| Ok(t.version()))
     }
 
@@ -1379,7 +1379,7 @@ impl RawDeltaTable {
                                 DeltaTableState::try_new(
                                     &table.log_store(),
                                     table.config.clone(),
-                                    Some(table.version()),
+                                    table.version(),
                                 )
                                 .await
                                 .map_err(PythonError::from)?,


### PR DESCRIPTION
# Description

Right now `DeltaTable:;version` defaults to a negative number if the state in the table is not yet initialised. I feel the idiomatic way in rust so express that something may exist is an `Option`. Turn out though we are using that in A LOT of tests, so changing the version return type needed its own PR to maintain review-able :)