### PR TITLE
fix: make DeltaTable pickleable

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -158,12 +158,29 @@ class DeltaTable:
 
         """
         self._storage_options = storage_options
+        self._without_files = without_files
+        self._log_buffer_size = log_buffer_size
         self._table = RawDeltaTable(
             str(table_uri),
             version=version,
             storage_options=storage_options,
             without_files=without_files,
             log_buffer_size=log_buffer_size,
+        )
+
+    def __reduce__(self) -> tuple:
+        """
+        This allows DeltaTable to be pickled.
+        """
+        return (
+            self.__class__,
+            (
+                self.table_uri,
+                self.version(),
+                self._storage_options,
+                self._without_files,
+                self._log_buffer_size,
+            ),
         )
 
     @staticmethod

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -168,7 +168,7 @@ class DeltaTable:
             log_buffer_size=log_buffer_size,
         )
 
-    def __reduce__(self) -> tuple:
+    def __reduce__(self) -> tuple[type, tuple[Any, ...]]:
         """
         This allows DeltaTable to be pickled.
         """

--- a/python/tests/test_table.py
+++ b/python/tests/test_table.py
@@ -1,0 +1,14 @@
+import pickle
+
+from deltalake import DeltaTable
+
+
+def test_table_serialization():
+    table_path = "../crates/test/tests/data/simple_table"
+    dt = DeltaTable(table_path)
+
+    dt2 = pickle.loads(pickle.dumps(dt))
+
+    # Do some sanity checks
+    assert dt2.version() == dt.version()
+    assert dt2.table_uri == dt.table_uri


### PR DESCRIPTION
# Description
This PR adds `__reduce__` method to DeltaTable to make an object of this class pickleable.

# Related Issue(s)
This will fix https://github.com/dask-contrib/dask-deltatable/issues/87 and potentially other distributed system that have to serialize a DeltaTable object and send it over to workers.

# Documentation
N/A
