### PR TITLE
fix: use regex replace in expression backticking

### DIFF
--- a/python/tests/test_constraints.py
+++ b/python/tests/test_constraints.py
@@ -1,0 +1,34 @@
+from arro3.core import Array, DataType, Table
+
+from deltalake import write_deltalake
+
+
+def test_not_corrupting_expression(tmp_path):
+    data = Table.from_pydict(
+        {
+            "b": Array([1], DataType.int64()),
+            "color_column": Array(["red"], DataType.string()),
+        },
+    )
+
+    data2 = Table.from_pydict(
+        {
+            "b": Array([1], DataType.int64()),
+            "color_column": Array(["blue"], DataType.string()),
+        },
+    )
+
+    write_deltalake(
+        tmp_path,
+        data,
+        mode="overwrite",
+        partition_by=["color_column"],
+        predicate="color_column = 'red'",
+    )
+    write_deltalake(
+        tmp_path,
+        data2,
+        mode="overwrite",
+        partition_by=["color_column"],
+        predicate="color_column = 'blue'",
+    )


### PR DESCRIPTION
# Description
The fix was naively replacing values in the whole expression, so if you had a single letter as a column `b`, it would replace `b` in any part of the expression.

This makes it slightly better using regex word boundaries and checking if a column name has a whitespace before trying to backtick it, but it's still not fail proof. You could still have a col as `foo is bar`, and then some where in your value of the expression `foo is bar but not so baz` becoming "\`foo is bar\` but not so baz"