### PR TITLE
fix: setting wrong schema in table provider for `merge`

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Qingping Hou <dave2008713@gmail.com>", "Will Jones <willjones127@gmail.com>"]
 homepage = "https://github.com/delta-io/delta-rs"
 license = "Apache-2.0"

--- a/python/src/merge.rs
+++ b/python/src/merge.rs
@@ -55,15 +55,13 @@ impl PyMergeBuilder {
         custom_execute_handler: Option<Arc<dyn CustomExecuteHandler>>,
     ) -> DeltaResult<Self> {
         let ctx = SessionContext::new();
-        let schema = source
-            .schema_ref()
-            .map_err(|e| DeltaTableError::generic(e.to_string()))?;
 
         let source = source
             .into_reader()
             .map_err(|e| DeltaTableError::generic(e.to_string()))?;
 
         let source = maybe_lazy_cast_reader(source, batch_schema.into_inner());
+        let schema = source.schema();
 
         let source_df = if streamed_exec {
             let arrow_stream_batch_generator: Arc<RwLock<dyn LazyBatchGenerator>> =


### PR DESCRIPTION
# Description
The pre-casted schema was set in the table provider, but should be post casting. Als updating py for quick python release.


- closes https://github.com/delta-io/delta-rs/issues/3507