### PR TITLE
refactor: compute stats schema with kernel types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,5 @@ Arro = "Arro"
 arro3 = "arro3"
 Arro3 = "Arro3"
 AKS = "AKS"
+# to avoid using 'type' as a field name.
+tpe = "tpe"

--- a/crates/core/src/kernel/arrow/engine_ext.rs
+++ b/crates/core/src/kernel/arrow/engine_ext.rs
@@ -1,14 +1,25 @@
 //! Utilities for interacting with Kernel APIs using Arrow data structures.
 //!
+use std::borrow::Cow;
+use std::sync::Arc;
+
 use delta_kernel::arrow::array::BooleanArray;
 use delta_kernel::arrow::compute::filter_record_batch;
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::expressions::ColumnName;
 use delta_kernel::scan::{Scan, ScanMetadata};
+use delta_kernel::schema::{
+    DataType, PrimitiveType, SchemaRef, SchemaTransform, StructField, StructType,
+};
+use delta_kernel::snapshot::Snapshot;
+use delta_kernel::table_properties::{DataSkippingNumIndexedCols, TableProperties};
 use delta_kernel::{
     DeltaResult, Engine, EngineData, ExpressionEvaluator, ExpressionRef, PredicateRef, Version,
 };
 use itertools::Itertools;
+
+use crate::table::config::TableConfig;
 
 /// [`ScanMetadata`] contains (1) a [`RecordBatch`] specifying data files to be scanned
 /// and (2) a vector of transforms (one transform per scan file) that must be applied to the data read
@@ -77,6 +88,189 @@ impl ScanExt for Scan {
     }
 }
 
+pub(crate) trait SnapshotExt {
+    /// Returns the expected file statistics schema for the snapshot.
+    fn stats_schema(&self) -> DeltaResult<SchemaRef>;
+}
+
+impl SnapshotExt for Snapshot {
+    fn stats_schema(&self) -> DeltaResult<SchemaRef> {
+        let physical_schema =
+            StructType::new(self.schema().fields().map(|field| field.make_physical()));
+        let min_max_transform = MinMaxStatsTransform::new(self.table_properties());
+        stats_schema(&physical_schema, min_max_transform)
+    }
+}
+
+// create a stats schema from our internal representation of the table config.
+pub(crate) fn stats_schema_from_config(
+    logical_schema: &StructType,
+    table_conf: TableConfig<'_>,
+) -> DeltaResult<SchemaRef> {
+    let physical_schema =
+        StructType::new(logical_schema.fields().map(|field| field.make_physical()));
+    let min_max_transform = MinMaxStatsTransform::new_from_config(table_conf);
+    stats_schema(&physical_schema, min_max_transform)
+}
+
+fn stats_schema(
+    physical_schema: &StructType,
+    mut min_max_transform: MinMaxStatsTransform,
+) -> DeltaResult<SchemaRef> {
+    let min_max_schema =
+        if let Some(min_max_schema) = min_max_transform.transform_struct(&physical_schema) {
+            min_max_schema.into_owned()
+        } else {
+            StructType::new(vec![])
+        };
+    let nullcount_schema =
+        if let Some(nullcount_schema) = NullCountStatsTransform.transform_struct(&min_max_schema) {
+            nullcount_schema.into_owned()
+        } else {
+            StructType::new(vec![])
+        };
+    Ok(Arc::new(StructType::new([
+        StructField::nullable("numRecords", DataType::LONG),
+        StructField::nullable("nullCount", nullcount_schema),
+        StructField::nullable("minValues", min_max_schema.clone()),
+        StructField::nullable("maxValues", min_max_schema),
+    ])))
+}
+
+struct MinMaxStatsTransform {
+    n_columns: Option<DataSkippingNumIndexedCols>,
+    added_columns: u64,
+    column_names: Option<Vec<ColumnName>>,
+    path: Vec<String>,
+}
+
+impl MinMaxStatsTransform {
+    fn new(props: &TableProperties) -> Self {
+        if let Some(columns_names) = &props.data_skipping_stats_columns {
+            Self {
+                n_columns: None,
+                added_columns: 0,
+                column_names: Some(columns_names.clone()),
+                path: Vec::new(),
+            }
+        } else {
+            Self {
+                n_columns: Some(
+                    props
+                        .data_skipping_num_indexed_cols
+                        .unwrap_or(DataSkippingNumIndexedCols::NumColumns(32)),
+                ),
+                added_columns: 0,
+                column_names: None,
+                path: Vec::new(),
+            }
+        }
+    }
+
+    fn new_from_config(props: TableConfig<'_>) -> Self {
+        if let Some(columns_names) = props.stats_columns_kernel() {
+            Self {
+                n_columns: None,
+                added_columns: 0,
+                column_names: Some(columns_names.clone()),
+                path: Vec::new(),
+            }
+        } else {
+            Self {
+                n_columns: Some(
+                    props
+                        .num_indexed_cols_kernel()
+                        .unwrap_or(DataSkippingNumIndexedCols::NumColumns(32)),
+                ),
+                added_columns: 0,
+                column_names: None,
+                path: Vec::new(),
+            }
+        }
+    }
+}
+
+// Convert a min/max stats schema into a nullcount schema (all leaf fields are LONG)
+struct NullCountStatsTransform;
+impl<'a> SchemaTransform<'a> for NullCountStatsTransform {
+    fn transform_primitive(&mut self, _ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
+        Some(Cow::Owned(PrimitiveType::Long))
+    }
+}
+
+fn should_include_column(column_name: &ColumnName, column_names: &[ColumnName]) -> bool {
+    column_names
+        .iter()
+        .any(|name| name.as_ref().starts_with(column_name))
+}
+
+impl<'a> SchemaTransform<'a> for MinMaxStatsTransform {
+    fn transform_struct_field(&mut self, field: &'a StructField) -> Option<Cow<'a, StructField>> {
+        use Cow::*;
+
+        if let Some(DataSkippingNumIndexedCols::NumColumns(n_cols)) = self.n_columns {
+            if self.added_columns >= n_cols {
+                return None;
+            }
+        }
+
+        self.path.push(field.name.clone());
+        let data_type = field.data_type();
+
+        let should_include = self
+            .column_names
+            .as_ref()
+            .map(|column_names| {
+                let col_name = ColumnName::new(&self.path);
+                should_include_column(&col_name, column_names)
+                    || matches!(data_type, DataType::Struct(_))
+            })
+            .unwrap_or_else(|| is_skipping_eligeble_datatype(data_type))
+            || matches!(data_type, DataType::Struct(_));
+
+        if !should_include {
+            self.path.pop();
+            return None;
+        }
+
+        if is_skipping_eligeble_datatype(data_type) {
+            self.added_columns += 1;
+        }
+
+        let field = match self.transform(&field.data_type)? {
+            Borrowed(_) if field.is_nullable() => Borrowed(field),
+            data_type => Owned(StructField {
+                name: field.name.clone(),
+                data_type: data_type.into_owned(),
+                nullable: true,
+                metadata: field.metadata.clone(),
+            }),
+        };
+
+        self.path.pop();
+        Some(field)
+    }
+}
+
+// https://github.com/delta-io/delta/blob/143ab3337121248d2ca6a7d5bc31deae7c8fe4be/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java#L61
+fn is_skipping_eligeble_datatype(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        &DataType::BYTE
+            | &DataType::SHORT
+            | &DataType::INTEGER
+            | &DataType::LONG
+            | &DataType::FLOAT
+            | &DataType::DOUBLE
+            | &DataType::DATE
+            | &DataType::TIMESTAMP
+            | &DataType::TIMESTAMP_NTZ
+            | &DataType::STRING
+            | &DataType::BOOLEAN
+            | DataType::Primitive(PrimitiveType::Decimal(_))
+    )
+}
+
 fn kernel_to_arrow(metadata: ScanMetadata) -> DeltaResult<ScanMetadataArrow> {
     let scan_file_transforms = metadata
         .scan_file_transforms
@@ -108,17 +302,23 @@ impl<T: ExpressionEvaluator + ?Sized> ExpressionEvaluatorExt for T {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
-    use super::ExpressionEvaluatorExt as _;
+    use crate::logstore::LogStoreExt;
+    use crate::test_utils::TestTables;
+
+    use super::*;
 
     use delta_kernel::arrow::array::Int32Array;
     use delta_kernel::arrow::datatypes::{DataType, Field, Schema};
     use delta_kernel::arrow::record_batch::RecordBatch;
     use delta_kernel::engine::arrow_conversion::TryIntoKernel;
     use delta_kernel::engine::arrow_expression::ArrowEvaluationHandler;
-    use delta_kernel::expressions::*;
+    use delta_kernel::schema::{ArrayType, DataType as KernelDataType};
     use delta_kernel::EvaluationHandler;
+    use delta_kernel::{expressions::*, Table};
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_evaluate_arrow() {
@@ -132,10 +332,246 @@ mod tests {
         let expr = handler.new_expression_evaluator(
             Arc::new((&schema).try_into_kernel().unwrap()),
             expression,
-            delta_kernel::schema::DataType::INTEGER,
+            KernelDataType::INTEGER,
         );
 
         let result = expr.evaluate_arrow(batch);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_should_include_column() {
+        let full_name = vec![ColumnName::new(["lvl1", "lvl2", "lvl3", "lvl4"])];
+        let parent = ColumnName::new(["lvl1", "lvl2", "lvl3"]);
+        assert!(should_include_column(&parent, &full_name));
+        assert!(should_include_column(&full_name[0], &full_name));
+        let not_parent = ColumnName::new(["lvl1", "lvl2", "lvl3", "lvl5"]);
+        assert!(!should_include_column(&not_parent, &full_name));
+        let not_parent = ColumnName::new(["lvl1", "lvl3", "lvl4"]);
+        assert!(!should_include_column(&not_parent, &full_name));
+    }
+
+    #[tokio::test]
+    async fn test_stats_schema() {
+        let log_store = TestTables::Simple.table_builder().build_storage().unwrap();
+        let table = Table::try_from_uri(log_store.table_root_url()).unwrap();
+        let engine = log_store.engine(None).await;
+        let snapshot = table.snapshot(engine.as_ref(), None).unwrap();
+        let stats_schema = snapshot.stats_schema().unwrap();
+
+        let id_field = StructType::new([StructField::nullable("id", KernelDataType::LONG)]);
+        let expected = Arc::new(StructType::new([
+            StructField::nullable("numRecords", KernelDataType::LONG),
+            StructField::nullable("nullCount", id_field.clone()),
+            StructField::nullable("minValues", id_field.clone()),
+            StructField::nullable("maxValues", id_field.clone()),
+        ]));
+
+        assert_eq!(&expected, &stats_schema);
+    }
+
+    #[test]
+    fn test_stats_schema_old() {
+        let raw = HashMap::from([("key".to_string(), Some("value".to_string()))]);
+        let config = TableConfig(&raw);
+        let logical_schema = StructType::new([StructField::nullable("id", KernelDataType::LONG)]);
+
+        let stats_schema = stats_schema_from_config(&logical_schema, config).unwrap();
+
+        let expected = Arc::new(StructType::new([
+            StructField::nullable("numRecords", KernelDataType::LONG),
+            StructField::nullable("nullCount", logical_schema.clone()),
+            StructField::nullable("minValues", logical_schema.clone()),
+            StructField::nullable("maxValues", logical_schema.clone()),
+        ]));
+
+        assert_eq!(&expected, &stats_schema);
+    }
+
+    #[test]
+    fn test_stats_schema_old_nested() {
+        let raw = HashMap::from([("key".to_string(), Some("value".to_string()))]);
+        let config = TableConfig(&raw);
+
+        // Create a nested logical schema with:
+        // - top-level field "id" (LONG)
+        // - nested struct "user" containing fields "name" (STRING) and "age" (INTEGER)
+        let user_struct = StructType::new([
+            StructField::nullable("name", KernelDataType::STRING),
+            StructField::nullable("age", KernelDataType::INTEGER),
+        ]);
+
+        let logical_schema = StructType::new([
+            StructField::nullable("id", KernelDataType::LONG),
+            StructField::nullable(
+                "user",
+                KernelDataType::Struct(Box::new(user_struct.clone())),
+            ),
+        ]);
+
+        let stats_schema = stats_schema_from_config(&logical_schema, config).unwrap();
+
+        // Expected result: The stats schema should maintain the nested structure
+        // but make all fields nullable
+        let expected_nested = StructType::new([
+            StructField::nullable("name", KernelDataType::STRING),
+            StructField::nullable("age", KernelDataType::INTEGER),
+        ]);
+
+        let expected_fields = StructType::new([
+            StructField::nullable("id", KernelDataType::LONG),
+            StructField::nullable("user", KernelDataType::Struct(Box::new(expected_nested))),
+        ]);
+        let null_count = NullCountStatsTransform
+            .transform_struct(&expected_fields)
+            .unwrap()
+            .into_owned();
+
+        let expected = Arc::new(StructType::new([
+            StructField::nullable("numRecords", KernelDataType::LONG),
+            StructField::nullable("nullCount", null_count),
+            StructField::nullable("minValues", expected_fields.clone()),
+            StructField::nullable("maxValues", expected_fields.clone()),
+        ]));
+
+        assert_eq!(&expected, &stats_schema);
+    }
+
+    #[test]
+    fn test_stats_schema_old_with_nonskippable_field() {
+        let raw = HashMap::from([("key".to_string(), Some("value".to_string()))]);
+        let config = TableConfig(&raw);
+
+        // Create a nested logical schema with:
+        // - top-level field "id" (LONG) - eligible for data skipping
+        // - nested struct "metadata" containing:
+        //   - "name" (STRING) - eligible for data skipping
+        //   - "tags" (ARRAY) - NOT eligible for data skipping
+        //   - "score" (DOUBLE) - eligible for data skipping
+
+        // Create array type for a field that's not eligible for data skipping
+        let array_type =
+            KernelDataType::Array(Box::new(ArrayType::new(KernelDataType::STRING, false)));
+
+        let metadata_struct = StructType::new([
+            StructField::nullable("name", KernelDataType::STRING),
+            StructField::nullable("tags", array_type),
+            StructField::nullable("score", KernelDataType::DOUBLE),
+        ]);
+
+        let logical_schema = StructType::new([
+            StructField::nullable("id", KernelDataType::LONG),
+            StructField::nullable(
+                "metadata",
+                KernelDataType::Struct(Box::new(metadata_struct.clone())),
+            ),
+        ]);
+
+        let stats_schema = stats_schema_from_config(&logical_schema, config).unwrap();
+
+        // Expected result: The stats schema should maintain the structure
+        // but exclude fields not eligible for data skipping (array type)
+        let expected_nested = StructType::new([
+            StructField::nullable("name", KernelDataType::STRING),
+            // "tags" field should be excluded as it's an array type
+            StructField::nullable("score", KernelDataType::DOUBLE),
+        ]);
+
+        let expected_fields = StructType::new([
+            StructField::nullable("id", KernelDataType::LONG),
+            StructField::nullable(
+                "metadata",
+                KernelDataType::Struct(Box::new(expected_nested)),
+            ),
+        ]);
+
+        let null_count = NullCountStatsTransform
+            .transform_struct(&expected_fields)
+            .unwrap()
+            .into_owned();
+
+        let expected = Arc::new(StructType::new([
+            StructField::nullable("numRecords", KernelDataType::LONG),
+            StructField::nullable("nullCount", null_count),
+            StructField::nullable("minValues", expected_fields.clone()),
+            StructField::nullable("maxValues", expected_fields.clone()),
+        ]));
+
+        assert_eq!(&expected, &stats_schema);
+    }
+
+    #[test]
+    fn test_stats_schema_old_col_names() {
+        let raw = HashMap::from([(
+            "delta.dataSkippingStatsColumns".to_string(),
+            Some("`user.info`.name".to_string()),
+        )]);
+        let config = TableConfig(&raw);
+
+        let user_struct = StructType::new([
+            StructField::nullable("name", KernelDataType::STRING),
+            StructField::nullable("age", KernelDataType::INTEGER),
+        ]);
+        let logical_schema = StructType::new([
+            StructField::nullable("id", KernelDataType::LONG),
+            StructField::nullable(
+                "user.info",
+                KernelDataType::Struct(Box::new(user_struct.clone())),
+            ),
+        ]);
+
+        let stats_schema = stats_schema_from_config(&logical_schema, config).unwrap();
+
+        let expected_nested =
+            StructType::new([StructField::nullable("name", KernelDataType::STRING)]);
+        let expected_fields = StructType::new([StructField::nullable(
+            "user.info",
+            KernelDataType::Struct(Box::new(expected_nested)),
+        )]);
+        let null_count = NullCountStatsTransform
+            .transform_struct(&expected_fields)
+            .unwrap()
+            .into_owned();
+
+        let expected = Arc::new(StructType::new([
+            StructField::nullable("numRecords", KernelDataType::LONG),
+            StructField::nullable("nullCount", null_count),
+            StructField::nullable("minValues", expected_fields.clone()),
+            StructField::nullable("maxValues", expected_fields.clone()),
+        ]));
+
+        assert_eq!(&expected, &stats_schema);
+    }
+
+    #[test]
+    fn test_stats_schema_old_n_cols() {
+        let raw = HashMap::from([(
+            "delta.dataSkippingNumIndexedCols".to_string(),
+            Some("1".to_string()),
+        )]);
+        let config = TableConfig(&raw);
+
+        let logical_schema = StructType::new([
+            StructField::nullable("name", KernelDataType::STRING),
+            StructField::nullable("age", KernelDataType::INTEGER),
+        ]);
+
+        let stats_schema = stats_schema_from_config(&logical_schema, config).unwrap();
+
+        let expected_fields =
+            StructType::new([StructField::nullable("name", KernelDataType::STRING)]);
+        let null_count = NullCountStatsTransform
+            .transform_struct(&expected_fields)
+            .unwrap()
+            .into_owned();
+
+        let expected = Arc::new(StructType::new([
+            StructField::nullable("numRecords", KernelDataType::LONG),
+            StructField::nullable("nullCount", null_count),
+            StructField::nullable("minValues", expected_fields.clone()),
+            StructField::nullable("maxValues", expected_fields.clone()),
+        ]));
+
+        assert_eq!(&expected, &stats_schema);
     }
 }

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -25,17 +25,14 @@ use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::ObjectStore;
-use tracing::warn;
 use url::Url;
 
 use self::log_segment::LogSegment;
 use self::parse::{read_adds, read_removes};
 use self::replay::{LogMapper, LogReplayScanner, ReplayStream};
 use self::visitors::*;
-use super::{
-    Action, Add, AddCDCFile, CommitInfo, DataType, Metadata, Protocol, Remove, StructField,
-    Transaction,
-};
+use super::arrow::engine_ext::stats_schema_from_config;
+use super::{Action, Add, AddCDCFile, CommitInfo, Metadata, Protocol, Remove, Transaction};
 use crate::kernel::parse::read_cdf_adds;
 use crate::kernel::transaction::{CommitData, PROTOCOL};
 use crate::kernel::{ActionType, StructType};
@@ -317,7 +314,9 @@ impl Snapshot {
     /// Get the statistics schema of the snapshot
     pub fn stats_schema(&self, table_schema: Option<&StructType>) -> DeltaResult<StructType> {
         let schema = table_schema.unwrap_or_else(|| self.schema());
-        stats_schema(schema, self.table_config())
+        Ok(stats_schema_from_config(&schema, self.table_config())?
+            .as_ref()
+            .clone())
     }
 
     /// Get the partition values schema of the snapshot
@@ -658,59 +657,6 @@ impl EagerSnapshot {
     }
 }
 
-fn stats_schema(schema: &StructType, config: TableConfig<'_>) -> DeltaResult<StructType> {
-    let stats_fields = if let Some(stats_cols) = config.stats_columns() {
-        stats_cols
-            .iter()
-            .filter_map(|col| match get_stats_field(schema, col) {
-                Some(field) => {
-                    let is_binary_type = matches!(field.data_type(), &DataType::BINARY);
-                    if is_binary_type {
-                        warn!("Column {} is of binary type and excluded from loading in stats columns.", col);
-                        return None
-                    }
-                    Some(match field.data_type() {
-                        DataType::Map(_) | DataType::Array(_) => {
-                            Err(DeltaTableError::Generic(format!(
-                                "Stats column {col} has unsupported type {}",
-                                field.data_type()
-                            )))
-                        }
-                        _ => Ok(StructField::new(
-                            field.name(),
-                            field.data_type().clone(),
-                            true,
-                        )),
-                    })
-                }
-                _ => {
-                    Some(Err(DeltaTableError::Generic(format!(
-                        "Stats column {col} not found in schema"
-                    ))))
-                }
-            })
-            .collect::<Result<Vec<_>, _>>()?
-    } else {
-        let num_indexed_cols = config.num_indexed_cols();
-        schema
-            .fields
-            .values()
-            .enumerate()
-            .filter_map(|(idx, f)| stats_field(idx, num_indexed_cols, f))
-            .collect()
-    };
-    Ok(StructType::new(vec![
-        StructField::new("numRecords", DataType::LONG, true),
-        StructField::new("minValues", StructType::new(stats_fields.clone()), true),
-        StructField::new("maxValues", StructType::new(stats_fields.clone()), true),
-        StructField::new(
-            "nullCount",
-            StructType::new(stats_fields.iter().filter_map(to_count_field)),
-            true,
-        ),
-    ]))
-}
-
 pub(crate) fn partitions_schema(
     schema: &StructType,
     partition_columns: &[String],
@@ -730,41 +676,6 @@ pub(crate) fn partitions_schema(
     )))
 }
 
-fn stats_field(idx: usize, num_indexed_cols: i32, field: &StructField) -> Option<StructField> {
-    if !(num_indexed_cols < 0 || (idx as i32) < num_indexed_cols) {
-        return None;
-    }
-    match field.data_type() {
-        DataType::Map(_) | DataType::Array(_) | &DataType::BINARY => None,
-        DataType::Struct(dt_struct) => Some(StructField::new(
-            field.name(),
-            StructType::new(
-                dt_struct
-                    .fields()
-                    .flat_map(|f| stats_field(idx, num_indexed_cols, f)),
-            ),
-            true,
-        )),
-        DataType::Primitive(_) => Some(StructField::new(
-            field.name(),
-            field.data_type.clone(),
-            true,
-        )),
-    }
-}
-
-fn to_count_field(field: &StructField) -> Option<StructField> {
-    match field.data_type() {
-        DataType::Map(_) | DataType::Array(_) | &DataType::BINARY => None,
-        DataType::Struct(s) => Some(StructField::new(
-            field.name(),
-            StructType::new(s.fields().filter_map(to_count_field)),
-            true,
-        )),
-        _ => Some(StructField::new(field.name(), DataType::LONG, true)),
-    }
-}
-
 #[cfg(feature = "datafusion")]
 mod datafusion {
     use datafusion_common::stats::Statistics;
@@ -779,49 +690,11 @@ mod datafusion {
     }
 }
 
-/// Retrieves a specific field from the schema based on the provided field name.
-/// It handles cases where the field name is nested or enclosed in backticks.
-fn get_stats_field<'a>(schema: &'a StructType, stats_field_name: &str) -> Option<&'a StructField> {
-    let dialect = sqlparser::dialect::GenericDialect {};
-    match sqlparser::parser::Parser::new(&dialect).try_with_sql(stats_field_name) {
-        Ok(mut parser) => match parser.parse_multipart_identifier() {
-            Ok(parts) => find_nested_field(schema, &parts),
-            Err(_) => schema.field(stats_field_name),
-        },
-        Err(_) => schema.field(stats_field_name),
-    }
-}
-
-fn find_nested_field<'a>(
-    schema: &'a StructType,
-    parts: &[sqlparser::ast::Ident],
-) -> Option<&'a StructField> {
-    if parts.is_empty() {
-        return None;
-    }
-    let part_name = &parts[0].value;
-    match schema.field(part_name) {
-        Some(field) => {
-            if parts.len() == 1 {
-                Some(field)
-            } else {
-                match field.data_type() {
-                    DataType::Struct(struct_schema) => {
-                        find_nested_field(struct_schema, &parts[1..])
-                    }
-                    // Any part before the end must be a struct
-                    _ => None,
-                }
-            }
-        }
-        None => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
+    use delta_kernel::schema::{DataType, StructField};
     use futures::TryStreamExt;
     use itertools::Itertools;
 
@@ -884,11 +757,11 @@ mod tests {
             "+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
             "| add                                                                                                                                                                                                                                                                                                                                  |",
             "+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
-            "| {path: part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet, partitionValues: {}, size: 262, modificationTime: 1587968626000, dataChange: true, stats: , tags: , deletionVector: , baseRowId: , defaultRowCommitVersion: , clusteringProvider: , stats_parsed: {numRecords: , minValues: , maxValues: , nullCount: }} |",
-            "| {path: part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet, partitionValues: {}, size: 262, modificationTime: 1587968602000, dataChange: true, stats: , tags: , deletionVector: , baseRowId: , defaultRowCommitVersion: , clusteringProvider: , stats_parsed: {numRecords: , minValues: , maxValues: , nullCount: }} |",
-            "| {path: part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet, partitionValues: {}, size: 429, modificationTime: 1587968602000, dataChange: true, stats: , tags: , deletionVector: , baseRowId: , defaultRowCommitVersion: , clusteringProvider: , stats_parsed: {numRecords: , minValues: , maxValues: , nullCount: }} |",
-            "| {path: part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet, partitionValues: {}, size: 429, modificationTime: 1587968602000, dataChange: true, stats: , tags: , deletionVector: , baseRowId: , defaultRowCommitVersion: , clusteringProvider: , stats_parsed: {numRecords: , minValues: , maxValues: , nullCount: }} |",
-            "| {path: part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet, partitionValues: {}, size: 429, modificationTime: 1587968602000, dataChange: true, stats: , tags: , deletionVector: , baseRowId: , defaultRowCommitVersion: , clusteringProvider: , stats_parsed: {numRecords: , minValues: , maxValues: , nullCount: }} |",
+            "| {path: part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet, partitionValues: {}, size: 262, modificationTime: 1587968626000, dataChange: true, stats: , tags: , deletionVector: , baseRowId: , defaultRowCommitVersion: , clusteringProvider: , stats_parsed: {numRecords: , nullCount: , minValues: , maxValues: }} |",
+            "| {path: part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet, partitionValues: {}, size: 262, modificationTime: 1587968602000, dataChange: true, stats: , tags: , deletionVector: , baseRowId: , defaultRowCommitVersion: , clusteringProvider: , stats_parsed: {numRecords: , nullCount: , minValues: , maxValues: }} |",
+            "| {path: part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet, partitionValues: {}, size: 429, modificationTime: 1587968602000, dataChange: true, stats: , tags: , deletionVector: , baseRowId: , defaultRowCommitVersion: , clusteringProvider: , stats_parsed: {numRecords: , nullCount: , minValues: , maxValues: }} |",
+            "| {path: part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet, partitionValues: {}, size: 429, modificationTime: 1587968602000, dataChange: true, stats: , tags: , deletionVector: , baseRowId: , defaultRowCommitVersion: , clusteringProvider: , stats_parsed: {numRecords: , nullCount: , minValues: , maxValues: }} |",
+            "| {path: part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet, partitionValues: {}, size: 429, modificationTime: 1587968602000, dataChange: true, stats: , tags: , deletionVector: , baseRowId: , defaultRowCommitVersion: , clusteringProvider: , stats_parsed: {numRecords: , nullCount: , minValues: , maxValues: }} |",
             "+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
         ];
         assert_batches_sorted_eq!(expected, &batches);
@@ -999,101 +872,5 @@ mod tests {
         };
 
         assert_eq!(snapshot.partitions_schema(None).unwrap(), None);
-    }
-
-    #[test]
-    fn test_field_with_name() {
-        let schema = StructType::new(vec![
-            StructField::new("a", DataType::STRING, true),
-            StructField::new("b", DataType::INTEGER, true),
-        ]);
-        let field = get_stats_field(&schema, "b").unwrap();
-        assert_eq!(*field, StructField::new("b", DataType::INTEGER, true));
-    }
-
-    #[test]
-    fn test_field_with_name_escaped() {
-        let schema = StructType::new(vec![
-            StructField::new("a", DataType::STRING, true),
-            StructField::new("b.b", DataType::INTEGER, true),
-        ]);
-        let field = get_stats_field(&schema, "`b.b`").unwrap();
-        assert_eq!(*field, StructField::new("b.b", DataType::INTEGER, true));
-    }
-
-    #[test]
-    fn test_field_does_not_exist() {
-        let schema = StructType::new(vec![
-            StructField::new("a", DataType::STRING, true),
-            StructField::new("b", DataType::INTEGER, true),
-        ]);
-        let field = get_stats_field(&schema, "c");
-        assert!(field.is_none());
-    }
-
-    #[test]
-    fn test_field_part_is_not_struct() {
-        let schema = StructType::new(vec![
-            StructField::new("a", DataType::STRING, true),
-            StructField::new("b", DataType::INTEGER, true),
-        ]);
-        let field = get_stats_field(&schema, "b.c");
-        assert!(field.is_none());
-    }
-
-    #[test]
-    fn test_field_name_does_not_parse() {
-        let schema = StructType::new(vec![
-            StructField::new("a", DataType::STRING, true),
-            StructField::new("b", DataType::INTEGER, true),
-        ]);
-        let field = get_stats_field(&schema, "b.");
-        assert!(field.is_none());
-    }
-
-    #[test]
-    fn test_field_with_name_nested() {
-        let nested = StructType::new(vec![StructField::new(
-            "nested_struct",
-            DataType::BOOLEAN,
-            true,
-        )]);
-        let schema = StructType::new(vec![
-            StructField::new("a", DataType::STRING, true),
-            StructField::new("b", DataType::Struct(Box::new(nested)), true),
-        ]);
-
-        let field = get_stats_field(&schema, "b.nested_struct").unwrap();
-
-        assert_eq!(
-            *field,
-            StructField::new("nested_struct", DataType::BOOLEAN, true)
-        );
-    }
-
-    #[test]
-    fn test_field_with_last_name_nested_backticks() {
-        let nested = StructType::new(vec![StructField::new("pr!me", DataType::BOOLEAN, true)]);
-        let schema = StructType::new(vec![
-            StructField::new("a", DataType::STRING, true),
-            StructField::new("b", DataType::Struct(Box::new(nested)), true),
-        ]);
-
-        let field = get_stats_field(&schema, "b.`pr!me`").unwrap();
-
-        assert_eq!(*field, StructField::new("pr!me", DataType::BOOLEAN, true));
-    }
-
-    #[test]
-    fn test_field_with_name_nested_backticks() {
-        let nested = StructType::new(vec![StructField::new("pr", DataType::BOOLEAN, true)]);
-        let schema = StructType::new(vec![
-            StructField::new("a", DataType::STRING, true),
-            StructField::new("b&b", DataType::Struct(Box::new(nested)), true),
-        ]);
-
-        let field = get_stats_field(&schema, "`b&b`.pr").unwrap();
-
-        assert_eq!(*field, StructField::new("pr", DataType::BOOLEAN, true));
     }
 }

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -1,6 +1,6 @@
 //! Implementation for writing delta checkpoints.
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use arrow::compute::filter_record_batch;
 use arrow_array::{BooleanArray, RecordBatch};
@@ -40,9 +40,12 @@ pub(crate) async fn create_checkpoint_for(
     let table = Table::try_from_uri(table_root)?;
 
     let task_engine = engine.clone();
-    let cp_writer = spawn_blocking(move || table.checkpoint(task_engine.as_ref(), Some(version)))
+    let snapshot = spawn_blocking(move || table.snapshot(task_engine.as_ref(), Some(version)))
         .await
         .map_err(|e| DeltaTableError::Generic(e.to_string()))??;
+    let snapshot = Arc::new(snapshot);
+
+    let cp_writer = snapshot.checkpoint()?;
 
     let cp_url = cp_writer.checkpoint_path()?;
     let cp_path = Path::from_url_path(cp_url.path())?;

--- a/crates/core/src/table/config.rs
+++ b/crates/core/src/table/config.rs
@@ -3,7 +3,9 @@ use std::sync::LazyLock;
 use std::time::Duration;
 use std::{collections::HashMap, str::FromStr};
 
+use delta_kernel::expressions::ColumnName;
 use delta_kernel::table_features::ColumnMappingMode;
+use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use serde::{Deserialize, Serialize};
 
 use super::Constraint;
@@ -378,6 +380,27 @@ impl TableConfig<'_> {
         self.0
             .get(TableProperty::DataSkippingStatsColumns.as_ref())
             .and_then(|o| o.as_ref().map(|v| v.split(',').collect()))
+    }
+
+    pub fn stats_columns_kernel(&self) -> Option<Vec<ColumnName>> {
+        self.0
+            .get(TableProperty::DataSkippingStatsColumns.as_ref())
+            .and_then(|o| {
+                o.as_ref().and_then(|v| {
+                    ColumnName::parse_column_name_list(v)
+                        .inspect_err(|e| println!("{:?}", e))
+                        .ok()
+                })
+            })
+    }
+
+    pub fn num_indexed_cols_kernel(&self) -> Option<DataSkippingNumIndexedCols> {
+        self.0
+            .get(TableProperty::DataSkippingNumIndexedCols.as_ref())
+            .and_then(|o| {
+                o.as_ref()
+                    .and_then(|v| DataSkippingNumIndexedCols::try_from(v.as_str()).ok())
+            })
     }
 }
 


### PR DESCRIPTION
# Description

To simplify our stats schema computation a bit, we leverage the `SchemaTransform` pattern from kernel. This also allows us to compute the schema from our internal representation of the table configuration or the configuration exposed on kernel snapshots.

This is a pre-factor to handle stats as structs in our checkpointing.

