### PR TITLE
fix: remove forced table update from python writer

### DIFF
--- a/python/deltalake/writer/writer.py
+++ b/python/deltalake/writer/writer.py
@@ -107,7 +107,6 @@ def write_deltalake(
     if table is not None:
         storage_options = table._storage_options or {}
         storage_options.update(storage_options or {})
-        table.update_incremental()
 
     if isinstance(partition_by, str):
         partition_by = [partition_by]


### PR DESCRIPTION
# Description
Performing (concurrent) idempotent blind-appends by comparing transaction identifiers from python is not possible. The reason for this is the internal table state is updated automatically before the actual write is performed. To perform idempotent blind appends (adapted from Spark's strategy for the same) one must load a table snapshot and compare their App ID + version to what they find in the snapshot, if the "local" version is > the one in the snapshot then the write can proceed, and any race conditions for that specific app+version are handled by the conflict checker and atomic commits. However when the table state is updated, the snapshot the app logic used for the comparison is replaced so the [conflict check for updated transactions](https://github.com/delta-io/delta-rs/blob/2ffaacc9e1d892aa2a9a0d773efb416d9adb8bf5/crates/core/src/kernel/transaction/conflict_checker.rs#L575-L594) will always pass and the write will always be attempted.

This PR simply removes the automatic snapshot update from the python writer.

Running the following example script at the same time in two different windows (but same directory) should illustrate the issue:

```python
import sys
import time
from datetime import datetime
from pathlib import Path

import pyarrow as pa

from deltalake import CommitProperties, DeltaTable, Transaction, write_deltalake

TABLE = "concurrency"
data = pa.Table.from_pylist([{"example": 1}])

if not Path(TABLE).exists():
    write_deltalake(TABLE, data)

def write(table: DeltaTable, version: int, wait: int, skip: bool) -> None:
    txn = Transaction(app_id="demo", version=version)
    props = CommitProperties(app_transactions=[txn], max_commit_retries=0)
    table.update_incremental()
    print(f"{datetime.now()}> table updated to {table.version()=}, sleeping {wait}")
    time.sleep(wait)
    rtx = table.transaction_version("demo")
    if skip and rtx and rtx >= version:
        print(f"{datetime.now()}> skipping since version already written")
        return

    write_deltalake(table, data, mode="append", commit_properties=props)
    
    print(f"{datetime.now()}> wrote {version=}, {table.version()=}")


if __name__ == "__main__":
    wait = int(sys.argv[1])
    skip = False
    if len(sys.argv) > 2:
        skip = True
    table = DeltaTable(TABLE)
    for v in range(5):
        write(table, v, wait, skip)
        print("loop", v)
```

screenshot from running against main
![concurrent writers main demo](https://github.com/user-attachments/assets/c7b3b717-d7ab-4780-803a-2a077d82a65b)

and against this branch
![concurrent writers fixed demo](https://github.com/user-attachments/assets/1b82435e-e97e-4836-bff1-81f1332cb7b9)

This should probably be considered a bug fix, but for some it may be "breaking" as writes were previously always attempted and now they may be aborted. However the scope is relatively small as the impact is for writes that included `Transaction` properties, if we remove the commit properties from the demo script we will see warnings on write that there is a mismatch in expected and written version, but no hard failures:
> WARN  deltalake_core::kernel::transaction] Attempting to write a transaction 3 but the underlying table has been updated to 4


# Related Issue(s)
- #2580 

# Documentation