### PR TITLE
fix: version binary search

### DIFF
--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -644,7 +644,7 @@ impl<'de> Deserialize<'de> for LogStoreConfig {
 }
 
 static DELTA_LOG_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(\d{20})\.(json|checkpoint).*$").unwrap());
+    LazyLock::new(|| Regex::new(r"(\d{20})\.(json|checkpoint(\.\d+)?\.parquet)$").unwrap());
 
 /// Extract version from a file name in the delta log
 pub fn extract_version_from_filename(name: &str) -> Option<i64> {

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -411,7 +411,11 @@ impl DeltaTable {
                 break;
             }
         }
-        let mut max_version = match self.get_latest_version().await {
+        let mut max_version = match self
+            .log_store
+            .get_latest_version(self.version().unwrap_or(min_version))
+            .await
+        {
             Ok(version) => version,
             Err(DeltaTableError::InvalidVersion(_)) => {
                 return Err(DeltaTableError::NotATable(

--- a/crates/core/tests/time_travel.rs
+++ b/crates/core/tests/time_travel.rs
@@ -96,6 +96,73 @@ async fn time_travel_by_ds() {
     assert_eq!(table.version(), Some(4));
 }
 
+#[tokio::test]
+async fn time_travel_by_ds_checkpoint_vacuumed() {
+    // git does not preserve mtime, so we need to manually set it in the test
+    let log_dir = "../test/tests/data/checkpoints_vacuumed/_delta_log";
+    let log_mtime_pair = vec![
+        (
+            "00000000000000000005.checkpoint.parquet",
+            "2020-05-01T22:47:31-07:00",
+        ),
+        ("00000000000000000005.json", "2020-05-02T22:47:31-07:00"),
+        ("00000000000000000006.json", "2020-05-03T22:47:31-07:00"),
+        ("00000000000000000007.json", "2020-05-04T22:47:31-07:00"),
+        ("00000000000000000008.json", "2020-05-05T22:47:31-07:00"),
+        ("00000000000000000009.json", "2020-05-06T22:47:31-07:00"),
+        (
+            "00000000000000000010.checkpoint.parquet",
+            "2020-05-06T22:47:31-07:00",
+        ),
+        ("00000000000000000010.json", "2020-05-08T22:47:31-07:00"),
+        ("00000000000000000011.json", "2020-05-09T22:47:31-07:00"),
+        ("00000000000000000012.json", "2020-05-10T22:47:31-07:00"),
+    ];
+    for (fname, ds) in log_mtime_pair {
+        let ts: SystemTime = ds_to_ts(ds).into();
+        let full_path = Path::new(log_dir).join(fname);
+        let file = OpenOptions::new().write(true).open(full_path).unwrap();
+        let times = FileTimes::new().set_accessed(ts).set_modified(ts);
+        file.set_times(times).unwrap()
+    }
+
+    let table = deltalake_core::open_table_with_ds(
+        "../test/tests/data/checkpoints_vacuumed",
+        "2020-05-02T00:47:31-07:00",
+    )
+    .await
+    .unwrap();
+    assert_eq!(table.version(), Some(5));
+
+    let table = deltalake_core::open_table_with_ds(
+        "../test/tests/data/checkpoints_vacuumed",
+        "2020-05-09T00:47:31-07:00",
+    )
+    .await
+    .unwrap();
+    assert_eq!(table.version(), Some(10));
+
+    let latest_version = table.get_latest_version().await.unwrap();
+    assert_eq!(latest_version, 12);
+
+    // Test that a temporary checkpoint file breaks binary search
+    let existing_dir = "../test/tests/data/checkpoints_vacuumed/_delta_log";
+    let temp_checkpoint = tempfile::NamedTempFile::with_prefix_in(
+        "00000000000000000000.checkpoint.parquet.tmp",
+        existing_dir,
+    )
+    .unwrap();
+    assert!(temp_checkpoint.path().exists());
+
+    let table = deltalake_core::open_table_with_ds(
+        "../test/tests/data/checkpoints_vacuumed",
+        "2020-05-09T00:47:31-07:00",
+    )
+    .await
+    .unwrap();
+    assert_eq!(table.version(), Some(10));
+}
+
 fn ds_to_ts(ds: &str) -> DateTime<Utc> {
     let fixed_dt = DateTime::<FixedOffset>::parse_from_rfc3339(ds).unwrap();
     DateTime::<Utc>::from(fixed_dt)


### PR DESCRIPTION
# Description

Version search does not work if there are temporary parquet checkpoint files in the `_delta_log` folder.

The 2nd commit fixes a regression introduced in a recent commit that uses the kernel to look for max_version, which fails if the version doesn't start at 0 (rarely the case on an older table).