### PR TITLE
fix: scan time was always 0 for merge metrics

### DIFF
--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1382,8 +1382,7 @@ async fn execute(
             .map(|v| v.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
     );
 
-    let rewrite_start = Instant::now();
-    let mut actions: Vec<Action> = write_execution_plan_v2(
+    let (mut actions, write_plan_metrics) = write_execution_plan_v2(
         Some(&snapshot),
         state.clone(),
         write,
@@ -1401,7 +1400,8 @@ async fn execute(
         actions.push(schema_metadata);
     }
 
-    metrics.rewrite_time_ms = Instant::now().duration_since(rewrite_start).as_millis() as u64;
+    metrics.rewrite_time_ms = write_plan_metrics.write_time_ms;
+    metrics.scan_time_ms = write_plan_metrics.scan_time_ms;
     metrics.num_target_files_added = actions.len();
 
     let survivors = barrier

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -690,7 +690,7 @@ impl std::future::IntoFuture for WriteBuilder {
             let source_plan = source.clone().create_physical_plan().await?;
 
             // Here we need to validate if the new data conforms to a predicate if one is provided
-            let add_actions = write_execution_plan_v2(
+            let (add_actions, _) = write_execution_plan_v2(
                 this.snapshot.as_ref(),
                 state.clone(),
                 source_plan.clone(),


### PR DESCRIPTION
# Description
Calculates scanning time and write time separately in write_execution_plan_v2 and make available to MergeMetrics

# Related Issue(s)
n/a

# Documentation
n/a