### PR TITLE
chore: update arrow/parquet to 55.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,19 +29,19 @@ debug = "line-tables-only"
 delta_kernel = { version = "0.11.0", features = ["arrow-55", "internal-api"] }
 
 # arrow
-arrow = { version = "=55.0.0" }
-arrow-arith = { version = "=55.0.0" }
-arrow-array = { version = "=55.0.0", features = ["chrono-tz"] }
-arrow-buffer = { version = "=55.0.0" }
-arrow-cast = { version = "=55.0.0" }
-arrow-ipc = { version = "=55.0.0" }
-arrow-json = { version = "=55.0.0" }
-arrow-ord = { version = "=55.0.0" }
-arrow-row = { version = "=55.0.0" }
-arrow-schema = { version = "=55.0.0" }
-arrow-select = { version = "=55.0.0" }
+arrow = { version = "55.2.0" }
+arrow-arith = { version = "55.2.0" }
+arrow-array = { version = "55.2.0", features = ["chrono-tz"] }
+arrow-buffer = { version = "55.2.0" }
+arrow-cast = { version = "55.2.0" }
+arrow-ipc = { version = "55.2.0" }
+arrow-json = { version = "55.2.0" }
+arrow-ord = { version = "55.2.0" }
+arrow-row = { version = "55.2.0" }
+arrow-schema = { version = "55.2.0" }
+arrow-select = { version = "55.2.0" }
 object_store = { version = "0.12.1" }
-parquet = { version = "=55.0.0" }
+parquet = { version = "55.2.0" }
 
 # datafusion
 datafusion = "47.0.0"

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -3059,8 +3059,8 @@ mod tests {
         assert_eq!("a", small.iter().next().unwrap().unwrap());
 
         let expected = vec![
-            ObjectStoreOperation::GetRange(LocationType::Data, 4920..4928),
-            ObjectStoreOperation::GetRange(LocationType::Data, 2399..4920),
+            ObjectStoreOperation::GetRange(LocationType::Data, 4952..4960),
+            ObjectStoreOperation::GetRange(LocationType::Data, 2399..4952),
             #[expect(clippy::single_range_in_vec_init)]
             ObjectStoreOperation::GetRanges(LocationType::Data, vec![4..58]),
         ];

--- a/crates/core/src/operations/cast/mod.rs
+++ b/crates/core/src/operations/cast/mod.rs
@@ -19,7 +19,8 @@ fn cast_struct(
     cast_options: &CastOptions,
     add_missing: bool,
 ) -> Result<StructArray, ArrowError> {
-    StructArray::try_new(
+    let num_rows = struct_array.len();
+    StructArray::try_new_with_length(
         fields.to_owned(),
         fields
             .iter()
@@ -41,6 +42,7 @@ fn cast_struct(
             })
             .collect::<Result<Vec<_>, _>>()?,
         struct_array.nulls().map(ToOwned::to_owned),
+        num_rows,
     )
 }
 

--- a/crates/core/src/table/state_arrow.rs
+++ b/crates/core/src/table/state_arrow.rs
@@ -244,13 +244,16 @@ impl DeltaTableState {
                 .map(|(datatype, name)| arrow::datatypes::Field::new(name, datatype, true))
                 .collect::<Vec<_>>();
 
+            let num_rows = partition_columns.first().map(|arr| arr.len()).unwrap_or(0);
+
             if fields.is_empty() {
                 vec![]
             } else {
-                let arr = Arc::new(arrow::array::StructArray::try_new(
+                let arr = Arc::new(StructArray::try_new_with_length(
                     Fields::from(fields),
                     partition_columns,
                     None,
+                    num_rows,
                 )?);
                 vec![(Cow::Borrowed("partition_values"), arr)]
             }


### PR DESCRIPTION
# Description
This is part of updating DataFusion:
- https://github.com/delta-io/delta-rs/pull/3520

Let's first upgrade the arrow and parquet libraries independently

# Related Issue(s)
Brings in the fix for
- https://github.com/apache/arrow-rs/pull/7539


