### PR TITLE
chore: upgrade to delta_kernel 0.12.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ debug = true
 debug = "line-tables-only"
 
 [workspace.dependencies]
-delta_kernel = { version = "0.11.0", features = ["arrow-55", "internal-api"] }
+delta_kernel = { version = "0.12.1", features = ["arrow-55", "internal-api"] }
 
 # arrow
 arrow = { version = "55.2.0" }


### PR DESCRIPTION
With the latest arrow upgrade we can jump up a version now
