### PR TITLE
docs: ensure create_checkpoint() is visible in the Python API docs

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -963,6 +963,9 @@ class DeltaTable:
         self._table.update_incremental()
 
     def create_checkpoint(self) -> None:
+        """
+        Create a checkpoint at the current table version.
+        """
         self._table.create_checkpoint()
 
     def cleanup_metadata(self) -> None:


### PR DESCRIPTION
# Description
The Python library already exposes `create_checkpoint()`, but users don't know that since it isn't documented. This ensures the method shows up in the API docs.