### PR TITLE
feat: if the user asks not to load files, make EagerSnapshot _never_ load files

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -721,7 +721,8 @@ impl<'a> DeltaScanBuilder<'a> {
         //  Should we update datafusion_table_statistics to optionally take the mask?
         let stats = if let Some(mask) = pruning_mask {
             let es = self.snapshot.snapshot();
-            let pruned_stats = prune_file_statistics(&es.files, mask);
+            let empty = vec![];
+            let pruned_stats = prune_file_statistics(es.files.as_ref().unwrap_or(&empty), mask);
             LogDataHandler::new(&pruned_stats, es.metadata(), es.schema()).statistics()
         } else {
             self.snapshot.datafusion_table_statistics()

--- a/crates/core/src/kernel/snapshot/serde.rs
+++ b/crates/core/src/kernel/snapshot/serde.rs
@@ -128,7 +128,7 @@ impl Serialize for EagerSnapshot {
         seq.serialize_element(&self.snapshot)?;
         seq.serialize_element(&self.tracked_actions)?;
         seq.serialize_element(&self.transactions)?;
-        for batch in self.files.iter() {
+        for batch in self.files_iter() {
             let mut buffer = vec![];
             let mut writer = FileWriter::try_new(&mut buffer, batch.schema().as_ref())
                 .map_err(serde::ser::Error::custom)?;
@@ -176,7 +176,7 @@ impl<'de> Visitor<'de> for EagerSnapshotVisitor {
         }
         Ok(EagerSnapshot {
             snapshot,
-            files,
+            files: Some(files),
             tracked_actions,
             transactions,
         })

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -231,9 +231,11 @@ mod tests {
         let table_newest_version = crate::open_table(path).await.unwrap();
         let mut table_to_update = crate::open_table_with_version(path, 0).await.unwrap();
         // calling update several times should not produce any duplicates
-        table_to_update.update().await.unwrap();
-        table_to_update.update().await.unwrap();
-        table_to_update.update().await.unwrap();
+        // The first call should have read some data
+        assert_eq!(true, table_to_update.update().await.unwrap());
+        // Subsequent calls should not
+        assert_eq!(false, table_to_update.update().await.unwrap());
+        assert_eq!(false, table_to_update.update().await.unwrap());
 
         assert_eq!(
             table_newest_version.get_files_iter().unwrap().collect_vec(),

--- a/crates/core/src/table/builder.rs
+++ b/crates/core/src/table/builder.rs
@@ -290,7 +290,7 @@ impl DeltaTableBuilder {
             DeltaVersion::Newest => table.load().await?,
             DeltaVersion::Version(v) => table.load_version(v).await?,
             DeltaVersion::Timestamp(ts) => table.load_with_datetime(ts).await?,
-        }
+        };
         Ok(table)
     }
 }

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -204,9 +204,8 @@ impl DeltaTableState {
         &mut self,
         log_store: &dyn LogStore,
         version: Option<i64>,
-    ) -> Result<(), DeltaTableError> {
-        self.snapshot.update(log_store, version).await?;
-        Ok(())
+    ) -> Result<bool, DeltaTableError> {
+        self.snapshot.update(log_store, version).await
     }
 
     /// Obtain Add actions for files that match the filter

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -306,7 +306,7 @@ impl RawDeltaTable {
     /// Load the internal [RawDeltaTable] with the table state from the specified `version`
     ///
     /// This will acquire the internal lock since it is a mutating operation!
-    pub fn load_version(&self, py: Python, version: i64) -> PyResult<()> {
+    pub fn load_version(&self, py: Python, version: i64) -> PyResult<bool> {
         py.allow_threads(|| {
             #[allow(clippy::await_holding_lock)]
             rt().block_on(async {
@@ -359,7 +359,7 @@ impl RawDeltaTable {
         })
     }
 
-    pub fn load_with_datetime(&self, py: Python, ds: &str) -> PyResult<()> {
+    pub fn load_with_datetime(&self, py: Python, ds: &str) -> PyResult<bool> {
         py.allow_threads(|| {
             let datetime =
                 DateTime::<Utc>::from(DateTime::<FixedOffset>::parse_from_rfc3339(ds).map_err(
@@ -1014,7 +1014,7 @@ impl RawDeltaTable {
             .collect())
     }
 
-    pub fn update_incremental(&self) -> PyResult<()> {
+    pub fn update_incremental(&self) -> PyResult<bool> {
         #[allow(clippy::await_holding_lock)]
         #[allow(deprecated)]
         Ok(rt()


### PR DESCRIPTION
Previously the files would be loaded on a conflict even if the user requested they not be loaded, now they're never loaded.

This is a optimization, reducing the performance for loading unneeded files when in append mode.

For my reproducer benchmark (see #3528), this speeds things up by about 30%.

**IMPORTANT:** It is not clear to me if this is semantically correct! On the one hand, if you're doing append only, I don't see why you'd need to load the files, this shouldn't be any different than e.g. restarting from scratch by reopening the database. On the other hand, maybe this code path is used in other situations beyond appends?

Are there other tests I should write?

# Related Issue(s)
Fixes #3528 

