### PR TITLE
chore: bump patch versions for another relaese

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-core"
-version = "0.26.2"
+version = "0.26.3"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake"
-version = "0.26.2"
+version = "0.26.3"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true


### PR DESCRIPTION
There is a major datafusion change in this upcoming release, but I don't
believe we're treating that as our public API because we're
re-exporting. The arrow APis are still on 55.x so I think we're safe to
semantically version this as a patch release
