### PR TITLE
chore: bump minor version for rust crate

### DIFF
--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-aws"
-version = "0.9.1"
+version = "0.10.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 # path dependencies
-deltalake-core = { version = "0.26.0", path = "../core" }
+deltalake-core = { version = "0.27.0", path = "../core" }
 
 # workspace dependencies
 async-trait = { workspace = true }

--- a/crates/azure/Cargo.toml
+++ b/crates/azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-azure"
-version = "0.9.1"
+version = "0.10.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.26.0", path = "../core" }
+deltalake-core = { version = "0.27.0", path = "../core" }
 
 # workspace depenndecies
 async-trait = { workspace = true }
@@ -26,7 +26,7 @@ regex = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-deltalake-core = { version = "0.26.0", path = "../core", features = [
+deltalake-core = { version = "0.27.0", path = "../core", features = [
     "datafusion",
 ] }
 chrono = { workspace = true }

--- a/crates/catalog-glue/Cargo.toml
+++ b/crates/catalog-glue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-catalog-glue"
-version = "0.10.0"
+version = "0.11.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -15,7 +15,7 @@ rust-version.workspace = true
 async-trait = { workspace = true }
 aws-config = "1"
 aws-sdk-glue = "=1.78.0"
-deltalake-core = { version = "0.26.0", path = "../core" }
+deltalake-core = { version = "0.27.0", path = "../core" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/catalog-unity/Cargo.toml
+++ b/crates/catalog-unity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-catalog-unity"
-version = "0.10.1"
+version = "0.11.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -20,10 +20,10 @@ thiserror.workspace = true
 futures.workspace = true
 chrono.workspace = true
 tracing.workspace = true
-deltalake-core = { version = "0.26.0", path = "../core" }
-deltalake-aws = { version = "0.9.0", path = "../aws", optional = true }
-deltalake-azure = { version = "0.9.0", path = "../azure", optional = true }
-deltalake-gcp = { version = "0.10.0", path = "../gcp", optional = true }
+deltalake-core = { version = "0.27.0", path = "../core" }
+deltalake-aws = { version = "0.10.0", path = "../aws", optional = true }
+deltalake-azure = { version = "0.10.0", path = "../azure", optional = true }
+deltalake-gcp = { version = "0.11.0", path = "../gcp", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "http2"] }
 reqwest-retry = "0.7"
 reqwest-middleware = { version = "0.4.0", features = ["json"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-core"
-version = "0.26.3"
+version = "0.27.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -15,7 +15,7 @@ rust-version.workspace = true
 features = ["datafusion", "json"]
 
 [dependencies]
-deltalake-derive = { version = "0.26.0", path = "../derive" }
+deltalake-derive = { version = "0.27.0", path = "../derive" }
 
 delta_kernel.workspace = true
 

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake"
-version = "0.26.3"
+version = "0.27.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -25,14 +25,14 @@ features = [
 ]
 
 [dependencies]
-deltalake-core = { version = "0.26.0", path = "../core", default-features = false }
-deltalake-aws = { version = "0.9.0", path = "../aws", default-features = false, optional = true }
-deltalake-azure = { version = "0.9.0", path = "../azure", optional = true }
-deltalake-gcp = { version = "0.10.0", path = "../gcp", optional = true }
-deltalake-hdfs = { version = "0.10.0", path = "../hdfs", optional = true }
-deltalake-lakefs = { version = "0.9.0", path = "../lakefs", optional = true }
-deltalake-catalog-glue = { version = "0.10.0", path = "../catalog-glue", optional = true }
-deltalake-catalog-unity = { version = "0.10.0", path = "../catalog-unity", optional = true }
+deltalake-core = { version = "0.27.0", path = "../core", default-features = false }
+deltalake-aws = { version = "0.10.0", path = "../aws", default-features = false, optional = true }
+deltalake-azure = { version = "0.10.0", path = "../azure", optional = true }
+deltalake-gcp = { version = "0.11.0", path = "../gcp", optional = true }
+deltalake-hdfs = { version = "0.11.0", path = "../hdfs", optional = true }
+deltalake-lakefs = { version = "0.10.0", path = "../lakefs", optional = true }
+deltalake-catalog-glue = { version = "0.11.0", path = "../catalog-glue", optional = true }
+deltalake-catalog-unity = { version = "0.11.0", path = "../catalog-unity", optional = true }
 delta_kernel = { workspace = true }
 
 

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-derive"
-version = "0.26.0"
+version = "0.27.0"
 description = "Dervice macros for use in delta ecosystem crates"
 authors.workspace = true
 rust-version.workspace = true

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-gcp"
-version = "0.10.1"
+version = "0.11.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.26.0", path = "../core" }
+deltalake-core = { version = "0.27.0", path = "../core" }
 
 # workspace depenndecies
 async-trait = { workspace = true }

--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-hdfs"
-version = "0.10.1"
+version = "0.11.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.26.0", path = "../core"}
+deltalake-core = { version = "0.27.0", path = "../core"}
 hdfs-native-object-store = "0.14"
 
 # workspace dependecies

--- a/crates/lakefs/Cargo.toml
+++ b/crates/lakefs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-lakefs"
-version = "0.9.2"
+version = "0.10.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.26.0", path = "../core" }
+deltalake-core = { version = "0.27.0", path = "../core" }
 # workspace dependencies
 async-trait = { workspace = true }
 bytes = { workspace = true }

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-mount"
-version = "0.10.0"
+version = "0.11.0"
 authors.workspace = true
 keywords.workspace = true
 readme.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-deltalake-core = { version = "0.26.0", path = "../core" }
+deltalake-core = { version = "0.27.0", path = "../core" }
 errno = "0.3"
 
 # workspace depenndecies

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "deltalake-test"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 publish = false
 
 [dependencies]
-deltalake-core = { version = "0.26.0", path = "../core", features = [
+deltalake-core = { version = "0.27.0", path = "../core", features = [
     "integration_test",
 ] }
 


### PR DESCRIPTION
Turns out we removed some APIs and changed default_logstore() since
0.26.2

