### PR TITLE
fix: fix typo to fix CI typo check

### DIFF
--- a/crates/mount/src/lib.rs
+++ b/crates/mount/src/lib.rs
@@ -42,11 +42,11 @@ impl ObjectStoreFactory for MountFactory {
         url: &Url,
         config: &StorageConfig,
     ) -> DeltaResult<(ObjectStoreRef, Path)> {
-        let moutn_config =
+        let mount_config =
             config::MountConfigHelper::try_new(config.raw.as_mount_options())?.build()?;
 
         let allow_unsafe_rename = str_is_truthy(
-            moutn_config
+            mount_config
                 .get(&crate::config::MountConfigKey::AllowUnsafeRename)
                 .unwrap_or(&String::new()),
         );


### PR DESCRIPTION
# Description
Fix a typo that is failing on CI on my PR: https://github.com/delta-io/delta-rs/pull/3603

Here is an example failure
- https://github.com/delta-io/delta-rs/actions/runs/16379294197/job/46286870241?pr=3603

```
Warning: "moutn" should be "mount".
Warning: "moutn" should be "mount".
error: `moutn` should be `mount`
  --> ./crates/mount/src/lib.rs:45:13
   |
45 |         let moutn_config =
   |             ^^^^^
   |
error: `moutn` should be `mount`
  --> ./crates/mount/src/lib.rs:49:13
   |
49 |             moutn_config
   |             ^^^^^
```


# Related Issue(s)
- https://github.com/delta-io/delta-rs/pull/3603

# Documentation

<!---
Share links to useful documentation
--->
