### PR TITLE
refactor: make match_partitions and new_metadata public

### DIFF
--- a/crates/core/src/kernel/schema/partitions.rs
+++ b/crates/core/src/kernel/schema/partitions.rs
@@ -158,6 +158,7 @@ impl PartitionFilter {
 
     /// Indicates if one of the DeltaTable partition among the list
     /// matches with the partition filter.
+    #[deprecated(since = "0.27.0", note = "stop-gap for adopting kernel actions")]
     pub fn match_partitions(
         &self,
         partitions: &[DeltaTablePartition],

--- a/crates/core/src/kernel/schema/partitions.rs
+++ b/crates/core/src/kernel/schema/partitions.rs
@@ -158,7 +158,7 @@ impl PartitionFilter {
 
     /// Indicates if one of the DeltaTable partition among the list
     /// matches with the partition filter.
-    pub(crate) fn match_partitions(
+    pub fn match_partitions(
         &self,
         partitions: &[DeltaTablePartition],
         partition_col_data_types: &HashMap<&String, &DataType>,


### PR DESCRIPTION
# Description
make match_partitions and new_metadata public.

We're writing Metadata "actions" and use match_partitions to do column mapping partition filtering (at least until delta-rs fully supports column mapping)
