### PR TITLE
fix: switch the url schemes for Azure integration tests

### DIFF
--- a/crates/azure/tests/context.rs
+++ b/crates/azure/tests/context.rs
@@ -56,7 +56,7 @@ impl StorageIntegration for MsftIntegration {
     }
 
     fn root_uri(&self) -> String {
-        format!("az://{}", self.bucket_name())
+        format!("abfs://{}", self.bucket_name())
     }
 
     fn copy_directory(&self, source: &str, destination: &str) -> std::io::Result<ExitStatus> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: "3.9"
+---
 services:
   localstack:
-    image: localstack/localstack:0.14
+    image: localstack/localstack:4
     ports:
       - 4566:4566
       - 8080:8080
@@ -25,6 +25,6 @@ services:
       - 4443:4443
 
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite
+    image: mcr.microsoft.com/azure-storage/azurite:3.34.0
     ports:
       - 10000:10000

--- a/python/tests/test_fs.py
+++ b/python/tests/test_fs.py
@@ -179,7 +179,7 @@ def test_roundtrip_s3_direct(s3_localstack_creds, sample_data_pyarrow: "pa.Table
 @pytest.mark.integration
 @pytest.mark.timeout(timeout=60, method="thread")
 def test_roundtrip_azure_env(azurite_env_vars, sample_data_pyarrow: "pa.Table"):
-    table_path = "az://deltars/roundtrip"
+    table_path = "abfs://deltars/roundtrip"
 
     # Create new table with path
     write_deltalake(table_path, sample_data_pyarrow)
@@ -202,7 +202,7 @@ def test_roundtrip_azure_env(azurite_env_vars, sample_data_pyarrow: "pa.Table"):
 @pytest.mark.integration
 @pytest.mark.timeout(timeout=60, method="thread")
 def test_roundtrip_azure_direct(azurite_creds, sample_data_pyarrow: "pa.Table"):
-    table_path = "az://deltars/roundtrip2"
+    table_path = "abfs://deltars/roundtrip2"
 
     # Can pass storage_options in directly
     write_deltalake(table_path, sample_data_pyarrow, storage_options=azurite_creds)
@@ -225,7 +225,7 @@ def test_roundtrip_azure_direct(azurite_creds, sample_data_pyarrow: "pa.Table"):
 @pytest.mark.integration
 @pytest.mark.timeout(timeout=60, method="thread")
 def test_roundtrip_azure_sas(azurite_sas_creds, sample_data_pyarrow: "pa.Table"):
-    table_path = "az://deltars/roundtrip3"
+    table_path = "abfs://deltars/roundtrip3"
     write_deltalake(table_path, sample_data_pyarrow, storage_options=azurite_sas_creds)
     dt = DeltaTable(table_path, storage_options=azurite_sas_creds)
     table = dt.to_pyarrow_table()
@@ -240,7 +240,7 @@ def test_roundtrip_azure_sas(azurite_sas_creds, sample_data_pyarrow: "pa.Table")
 def test_roundtrip_azure_decoded_sas(
     azurite_sas_creds, sample_data_pyarrow: "pa.Table"
 ):
-    table_path = "az://deltars/roundtrip4"
+    table_path = "abfs://deltars/roundtrip4"
     azurite_sas_creds["SAS_TOKEN"] = urllib.parse.unquote(
         azurite_sas_creds["SAS_TOKEN"]
     )


### PR DESCRIPTION
The azure integration tests have been failing and the best I can tell is
that it happened around the upgrade to object_store 0.12.0? Perhaps?
It's a little confusing.

Either way I could not find documentation on what ebhaviors are
supported for different Azure URL schemes, but noticed that `az://` was
changed in object_store 0.12. It's not clear to me _how_ the changes in
object_store would affect behavior but based on the logs I have observed
it seems like something about the az:// handling was dropping the
container name in the URLs.

rust-v0.25.0 (object_store 0.11.x):

```
azurite-1     | 172.19.0.1 - - [22/Jul/2025:18:15:19 +0000] "GET /devstoreaccount1/test-delta-table-1753208110/simple/_delta_log/_last_checkpoint HTTP/1.1" 404 -
azurite-1     | 172.19.0.1 - - [22/Jul/2025:18:15:19 +0000] "GET /devstoreaccount1/test-delta-table-1753208110?restype=container&comp=list&prefix=simple%2F_delta_log%2F HTTP/1.1" 200 -
```

`main` (object_store 0.12.x):

```
azurite-1     | 172.19.0.1 - - [22/Jul/2025:18:23:31 +0000] "GET /devstoreaccount1/test-delta-table-1753208600/_delta_log/_last_checkpoint HTTP/1.1" 404 -
azurite-1     | 172.19.0.1 - - [22/Jul/2025:18:23:31 +0000] "GET /devstoreaccount1/test-delta-table-1753208600?restype=container&comp=list&prefix=_delta_log%2F HTTP/1.1" 200 -
```

Not that the table name `simple` is being dropped in the latter GET
requests from `main`.

Switching the URL scheme that our tests are using to `abfs://` or
`azure://` seems to fix the behavior. Which makes me think there is a
problem in the `az://` URL scheme handling in object_store but I
couldn't find the issue _or_ documentation for what constitutes a valid
`az://` URL

Fixes #3612
