### PR TITLE
chore: bump version for release

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "1.1.2"
+version = "1.1.3"
 authors = [
     "Qingping Hou <dave2008713@gmail.com>",
     "Will Jones <willjones127@gmail.com>",


### PR DESCRIPTION
This commit was released as python-v1.1.3
