### PR TITLE
chore: use pytest-xdist for speeding up python tests

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -70,17 +70,17 @@ jobs:
         run: make develop
 
       - name: Run tests
-        run: uv run --no-sync pytest -m '((s3 or azure) and integration) or not integration and not benchmark and not no_pyarrow' --doctest-modules
+        run: uv run --no-sync pytest -n auto -m '((s3 or azure) and integration) or not integration and not benchmark and not no_pyarrow' --doctest-modules
 
       - name: Test without pandas
         run: |
           uv pip uninstall pandas
-          uv run --no-sync pytest -m "not pandas and not integration and not benchmark and not no_pyarrow"
+          uv run --no-sync pytest -n auto -m "not pandas and not integration and not benchmark and not no_pyarrow"
 
       - name: Test without pyarrow and without pandas
         run: |
           uv pip uninstall pyarrow
-          uv run --no-sync pytest -m "not pyarrow and not pandas and not integration and not benchmark"
+          uv run --no-sync pytest -n auto -m "not pyarrow and not pandas and not integration and not benchmark"
 
   test-lakefs:
     name: Python Build (Python 3.10 LakeFS Integration tests)

--- a/python/Makefile
+++ b/python/Makefile
@@ -58,7 +58,7 @@ check-python: ## Run check on Python
 .PHONY: unit-test
 unit-test: ## Run unit test
 	$(info --- Run Python unit-test ---)
-	uv run --no-sync pytest --doctest-modules
+	uv run --no-sync pytest -q -n auto --doctest-modules
 
 .PHONY: test-cov
 test-cov: ## Create coverage report

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -93,10 +93,11 @@ source = ["deltalake"]
 [dependency-groups]
 dev = [
     "pytest",
-    "pytest-mock",
-    "pytest-cov",
-    "pytest-timeout",
     "pytest-benchmark",
+    "pytest-cov",
+    "pytest-mock",
+    "pytest-timeout",
+    "pytest-xdist",
     "mypy==1.10.1",
     "ruff>=0.11.2,<0.11.12",
     "types-deprecated>=1.2.15.20250304",

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -52,9 +52,9 @@ def test_read_table_with_edge_timestamps():
 def test_read_simple_table_to_dict():
     table_path = "../crates/test/tests/data/simple_table"
     dt = DeltaTable(table_path)
-    assert QueryBuilder().register("tbl", dt).execute("select * from tbl").read_all()[
-        "id"
-    ].to_pylist() == [5, 7, 9]
+    assert QueryBuilder().register("tbl", dt).execute(
+        "select * from tbl ORDER BY id"
+    ).read_all()["id"].to_pylist() == [5, 7, 9]
 
 
 class _SerializableException(BaseException):

--- a/python/tests/test_threaded.py
+++ b/python/tests/test_threaded.py
@@ -77,5 +77,10 @@ def test_multithreaded_write_using_path(tmp_path: pathlib.Path):
 
     with ThreadPoolExecutor() as exe:
         list(
-            exe.map(lambda _: write_deltalake(tmp_path, table, mode="append"), range(5))
+            exe.map(
+                lambda _: write_deltalake(
+                    tmp_path, pl.DataFrame({"a": [1, 2, 3]}), mode="append"
+                ),
+                range(5),
+            )
         )


### PR DESCRIPTION
The additional benefit of running these tests in parallel is that more
racey/timing related test failures are cropping up for me.

