### PR TITLE
refactor!: use kernel TableProperties

### DIFF
--- a/crates/benchmarks/src/bin/merge.rs
+++ b/crates/benchmarks/src/bin/merge.rs
@@ -194,7 +194,6 @@ async fn benchmark_merge_tpcds(
     merge: fn(DataFrame, DeltaTable) -> Result<MergeBuilder, DeltaTableError>,
 ) -> Result<(core::time::Duration, MergeMetrics), DataFusionError> {
     let table = DeltaTableBuilder::from_uri(path).load().await?;
-    let file_count = table.snapshot()?.files_count();
 
     let provider = DeltaTableProvider::try_new(
         table.snapshot()?.clone(),
@@ -247,7 +246,6 @@ async fn benchmark_merge_tpcds(
 
     let duration = end.duration_since(start);
 
-    println!("Total File count: {file_count}");
     println!("File sample count: {file_sample_count}");
     println!("{metrics:?}");
     println!("Seconds: {}", duration.as_secs_f32());
@@ -596,7 +594,7 @@ async fn main() {
                 .sql(&format!(
                     "
                 select name as before_name,
-                 avg(cast(duration_ms as float)) as before_duration_avg 
+                 avg(cast(duration_ms as float)) as before_duration_avg
                 from before where group_id = {before_group_id}
                 group by name
             ",
@@ -608,7 +606,7 @@ async fn main() {
                 .sql(&format!(
                     "
                 select name as after_name,
-                 avg(cast(duration_ms as float)) as after_duration_avg 
+                 avg(cast(duration_ms as float)) as after_duration_avg
                 from after where group_id = {after_group_id}
                 group by name
             ",

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -95,6 +95,7 @@ use crate::kernel::{
 };
 use crate::logstore::LogStoreRef;
 use crate::table::builder::ensure_table_uri;
+use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 use crate::table::{Constraint, GeneratedColumn};
 use crate::{open_table, open_table_with_storage_options, DeltaTable};

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -97,10 +97,6 @@ pub enum DeltaTableError {
     #[error("Not a Delta table: {0}")]
     NotATable(String),
 
-    /// Error returned when no metadata was found in the DeltaTable.
-    #[error("No metadata found, please make sure table is loaded.")]
-    NoMetadata,
-
     /// Error returned when no schema was found in the DeltaTable.
     #[error("No schema found, please make sure table is loaded.")]
     NoSchema,

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -82,8 +82,6 @@ impl Snapshot {
         let table_root = log_store.table_root_url();
         let version = version.map(|v| v as u64);
 
-        println!("Reading table from {}", table_root);
-
         let snapshot = match spawn_blocking(move || {
             KernelSnapshot::try_new(table_root, engine.as_ref(), version)
         })
@@ -526,6 +524,7 @@ impl EagerSnapshot {
     }
 
     /// Get the number of files in the snapshot
+    #[deprecated = "Count any of the file-like iterators instead."]
     pub fn files_count(&self) -> usize {
         self.files.num_rows()
     }

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -26,6 +26,7 @@ use delta_kernel::path::{LogPathFileType, ParsedLogPath};
 use delta_kernel::scan::scan_row_schema;
 use delta_kernel::schema::SchemaRef;
 use delta_kernel::snapshot::Snapshot as KernelSnapshot;
+use delta_kernel::table_properties::TableProperties;
 use delta_kernel::{PredicateRef, Version};
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
@@ -42,7 +43,6 @@ use crate::kernel::parse::read_removes;
 use crate::kernel::transaction::CommitData;
 use crate::kernel::{ActionType, Add, StructType};
 use crate::logstore::{LogStore, LogStoreExt};
-use crate::table::config::TableConfig;
 use crate::{DeltaResult, DeltaTableConfig, DeltaTableError};
 
 pub use self::log_data::*;
@@ -208,8 +208,8 @@ impl Snapshot {
     }
 
     /// Well known table configuration
-    pub fn table_config(&self) -> TableConfig<'_> {
-        TableConfig(self.inner.metadata().configuration())
+    pub fn table_config(&self) -> &TableProperties {
+        self.inner.table_properties()
     }
 
     /// Get the active files for the current snapshot.
@@ -514,7 +514,7 @@ impl EagerSnapshot {
     }
 
     /// Well known table configuration
-    pub fn table_config(&self) -> TableConfig<'_> {
+    pub fn table_config(&self) -> &TableProperties {
         self.snapshot.table_config()
     }
 

--- a/crates/core/src/kernel/transaction/application.rs
+++ b/crates/core/src/kernel/transaction/application.rs
@@ -31,7 +31,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let app_txn = table
             .snapshot()

--- a/crates/core/src/kernel/transaction/conflict_checker.rs
+++ b/crates/core/src/kernel/transaction/conflict_checker.rs
@@ -1,6 +1,8 @@
 //! Helper module to check if a transaction can be committed in case of conflicting commits.
 use std::collections::HashSet;
 
+use delta_kernel::table_properties::IsolationLevel;
+
 use super::CommitInfo;
 #[cfg(feature = "datafusion")]
 use crate::delta_datafusion::DataFusionMixins;
@@ -10,7 +12,7 @@ use crate::kernel::Transaction;
 use crate::kernel::{Action, Add, Metadata, Protocol, Remove};
 use crate::logstore::{get_actions, LogStore};
 use crate::protocol::DeltaOperation;
-use crate::table::config::IsolationLevel;
+use crate::table::config::TablePropertiesExt as _;
 use crate::DeltaTableError;
 
 #[cfg(feature = "datafusion")]

--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -79,6 +79,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use chrono::Utc;
 use conflict_checker::ConflictChecker;
+use delta_kernel::table_properties::TableProperties;
 use futures::future::BoxFuture;
 use object_store::path::Path;
 use object_store::Error as ObjectStoreError;
@@ -97,7 +98,7 @@ use crate::logstore::{CommitOrBytes, LogStoreRef};
 use crate::operations::CustomExecuteHandler;
 use crate::protocol::DeltaOperation;
 use crate::protocol::{cleanup_expired_logs_for, create_checkpoint_for};
-use crate::table::config::TableConfig;
+use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 use crate::{crate_version, DeltaResult};
 
@@ -235,7 +236,7 @@ impl From<CommitBuilderError> for DeltaTableError {
 /// Reference to some structure that contains mandatory attributes for performing a commit.
 pub trait TableReference: Send + Sync {
     /// Well known table configuration
-    fn config(&self) -> TableConfig;
+    fn config(&self) -> &TableProperties;
 
     /// Get the table protocol of the snapshot
     fn protocol(&self) -> &Protocol;
@@ -256,7 +257,7 @@ impl TableReference for EagerSnapshot {
         EagerSnapshot::metadata(self)
     }
 
-    fn config(&self) -> TableConfig {
+    fn config(&self) -> &TableProperties {
         self.table_config()
     }
 
@@ -266,7 +267,7 @@ impl TableReference for EagerSnapshot {
 }
 
 impl TableReference for DeltaTableState {
-    fn config(&self) -> TableConfig {
+    fn config(&self) -> &TableProperties {
         self.snapshot.config()
     }
 
@@ -857,7 +858,7 @@ impl PostCommit {
             return Ok(false);
         }
 
-        let checkpoint_interval = table_state.config().checkpoint_interval() as i64;
+        let checkpoint_interval = table_state.config().checkpoint_interval().get() as i64;
         if ((version + 1) % checkpoint_interval) == 0 {
             create_checkpoint_for(version as u64, log_store.as_ref(), Some(operation_id)).await?;
             Ok(true)

--- a/crates/core/src/kernel/transaction/protocol.rs
+++ b/crates/core/src/kernel/transaction/protocol.rs
@@ -8,6 +8,7 @@ use crate::kernel::{
     contains_timestampntz, Action, EagerSnapshot, Protocol, ProtocolExt as _, Schema,
 };
 use crate::protocol::DeltaOperation;
+use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 
 static READER_V2: LazyLock<HashSet<ReaderFeature>> =

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -237,8 +237,16 @@ mod tests {
         table_to_update.update().await.unwrap();
 
         assert_eq!(
-            table_newest_version.get_files_iter().unwrap().collect_vec(),
-            table_to_update.get_files_iter().unwrap().collect_vec()
+            table_newest_version
+                .snapshot()
+                .unwrap()
+                .file_paths_iter()
+                .collect_vec(),
+            table_to_update
+                .snapshot()
+                .unwrap()
+                .file_paths_iter()
+                .collect_vec()
         );
     }
     #[tokio::test]
@@ -306,7 +314,7 @@ mod tests {
                 Path::from("part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet"),
             ]
         );
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let stats = table.snapshot().unwrap().add_actions_table(true).unwrap();
 
@@ -486,7 +494,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            table.get_files_iter().unwrap().collect_vec(),
+            table.snapshot().unwrap().file_paths_iter().collect_vec(),
             vec![
                 Path::parse(
                     "x=A%2FA/part-00007-b350e235-2832-45df-9918-6cab4f7578f7.c000.snappy.parquet"
@@ -577,7 +585,7 @@ mod tests {
 
         if let PeekCommit::New(version, actions) = peek {
             assert_eq!(table.version(), Some(9));
-            assert!(!table.get_files_iter().unwrap().any(|f| f
+            assert!(!table.snapshot().unwrap().file_paths_iter().any(|f| f
                 == Path::from(
                     "part-00000-f0e955c5-a1e3-4eec-834e-dcc098fc9005-c000.snappy.parquet"
                 )));
@@ -588,7 +596,7 @@ mod tests {
             table.update_incremental(None).await.unwrap();
 
             assert_eq!(table.version(), Some(10));
-            assert!(table.get_files_iter().unwrap().any(|f| f
+            assert!(table.snapshot().unwrap().file_paths_iter().any(|f| f
                 == Path::from(
                     "part-00000-f0e955c5-a1e3-4eec-834e-dcc098fc9005-c000.snappy.parquet"
                 )));
@@ -661,7 +669,7 @@ mod tests {
             .unwrap();
         assert_eq!(table.version(), Some(2));
         assert_eq!(
-            table.get_files_iter().unwrap().collect_vec(),
+            table.snapshot().unwrap().file_paths_iter().collect_vec(),
             vec![Path::from(
                 "part-00000-7444aec4-710a-4a4c-8abe-3323499043e9.c000.snappy.parquet"
             ),]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -192,11 +192,12 @@ mod tests {
         let table = crate::open_table("../test/tests/data/delta-0.2.0")
             .await
             .unwrap();
-        assert_eq!(table.version(), Some(3));
-        assert_eq!(table.protocol().unwrap().min_writer_version(), 2);
-        assert_eq!(table.protocol().unwrap().min_reader_version(), 1);
+        let snapshot = table.snapshot().unwrap();
+        assert_eq!(snapshot.version(), 3);
+        assert_eq!(snapshot.protocol().min_writer_version(), 2);
+        assert_eq!(snapshot.protocol().min_reader_version(), 1);
         assert_eq!(
-            table.get_files_iter().unwrap().collect_vec(),
+            snapshot.file_paths_iter().collect_vec(),
             vec![
                 Path::from("part-00000-cb6b150b-30b8-4662-ad28-ff32ddab96d2-c000.snappy.parquet"),
                 Path::from("part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet"),
@@ -245,11 +246,12 @@ mod tests {
         let mut table = crate::open_table_with_version("../test/tests/data/delta-0.2.0", 0)
             .await
             .unwrap();
-        assert_eq!(table.version(), Some(0));
-        assert_eq!(table.protocol().unwrap().min_writer_version(), 2);
-        assert_eq!(table.protocol().unwrap().min_reader_version(), 1);
+        let snapshot = table.snapshot().unwrap();
+        assert_eq!(snapshot.version(), 0);
+        assert_eq!(snapshot.protocol().min_writer_version(), 2);
+        assert_eq!(snapshot.protocol().min_reader_version(), 1);
         assert_eq!(
-            table.get_files_iter().unwrap().collect_vec(),
+            snapshot.file_paths_iter().collect_vec(),
             vec![
                 Path::from("part-00000-b44fcdb0-8b06-4f3a-8606-f8311a96f6dc-c000.snappy.parquet"),
                 Path::from("part-00001-185eca06-e017-4dea-ae49-fc48b973e37e-c000.snappy.parquet"),
@@ -259,11 +261,12 @@ mod tests {
         table = crate::open_table_with_version("../test/tests/data/delta-0.2.0", 2)
             .await
             .unwrap();
-        assert_eq!(table.version(), Some(2));
-        assert_eq!(table.protocol().unwrap().min_writer_version(), 2);
-        assert_eq!(table.protocol().unwrap().min_reader_version(), 1);
+        let snapshot = table.snapshot().unwrap();
+        assert_eq!(snapshot.version(), 2);
+        assert_eq!(snapshot.protocol().min_writer_version(), 2);
+        assert_eq!(snapshot.protocol().min_reader_version(), 1);
         assert_eq!(
-            table.get_files_iter().unwrap().collect_vec(),
+            snapshot.file_paths_iter().collect_vec(),
             vec![
                 Path::from("part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet"),
                 Path::from("part-00001-c373a5bd-85f0-4758-815e-7eb62007a15c-c000.snappy.parquet"),
@@ -273,11 +276,12 @@ mod tests {
         table = crate::open_table_with_version("../test/tests/data/delta-0.2.0", 3)
             .await
             .unwrap();
-        assert_eq!(table.version(), Some(3));
-        assert_eq!(table.protocol().unwrap().min_writer_version(), 2);
-        assert_eq!(table.protocol().unwrap().min_reader_version(), 1);
+        let snapshot = table.snapshot().unwrap();
+        assert_eq!(snapshot.version(), 3);
+        assert_eq!(snapshot.protocol().min_writer_version(), 2);
+        assert_eq!(snapshot.protocol().min_reader_version(), 1);
         assert_eq!(
-            table.get_files_iter().unwrap().collect_vec(),
+            snapshot.file_paths_iter().collect_vec(),
             vec![
                 Path::from("part-00000-cb6b150b-30b8-4662-ad28-ff32ddab96d2-c000.snappy.parquet"),
                 Path::from("part-00000-7c2deba3-1994-4fb8-bc07-d46c948aa415-c000.snappy.parquet"),
@@ -291,11 +295,12 @@ mod tests {
         let table = crate::open_table("../test/tests/data/delta-0.8.0")
             .await
             .unwrap();
-        assert_eq!(table.version(), Some(1));
-        assert_eq!(table.protocol().unwrap().min_writer_version(), 2);
-        assert_eq!(table.protocol().unwrap().min_reader_version(), 1);
+        let snapshot = table.snapshot().unwrap();
+        assert_eq!(snapshot.version(), 1);
+        assert_eq!(snapshot.protocol().min_writer_version(), 2);
+        assert_eq!(snapshot.protocol().min_reader_version(), 1);
         assert_eq!(
-            table.get_files_iter().unwrap().collect_vec(),
+            snapshot.file_paths_iter().collect_vec(),
             vec![
                 Path::from("part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet"),
                 Path::from("part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet"),
@@ -347,22 +352,24 @@ mod tests {
         let mut table = crate::open_table("../test/tests/data/delta-0.8.0")
             .await
             .unwrap();
-        assert_eq!(table.version(), Some(1));
-        assert_eq!(table.protocol().unwrap().min_writer_version(), 2);
-        assert_eq!(table.protocol().unwrap().min_reader_version(), 1);
+        let snapshot = table.snapshot().unwrap();
+        assert_eq!(snapshot.version(), 1);
+        assert_eq!(snapshot.protocol().min_writer_version(), 2);
+        assert_eq!(snapshot.protocol().min_reader_version(), 1);
         assert_eq!(
-            table.get_files_iter().unwrap().collect_vec(),
+            snapshot.file_paths_iter().collect_vec(),
             vec![
                 Path::from("part-00000-04ec9591-0b73-459e-8d18-ba5711d6cbe1-c000.snappy.parquet"),
                 Path::from("part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet"),
             ]
         );
         table.load_version(0).await.unwrap();
-        assert_eq!(table.version(), Some(0));
-        assert_eq!(table.protocol().unwrap().min_writer_version(), 2);
-        assert_eq!(table.protocol().unwrap().min_reader_version(), 1);
+        let snapshot = table.snapshot().unwrap();
+        assert_eq!(snapshot.version(), 0);
+        assert_eq!(snapshot.protocol().min_writer_version(), 2);
+        assert_eq!(snapshot.protocol().min_reader_version(), 1);
         assert_eq!(
-            table.get_files_iter().unwrap().collect_vec(),
+            snapshot.file_paths_iter().collect_vec(),
             vec![
                 Path::from("part-00000-c9b90f86-73e6-46c8-93ba-ff6bfaf892a1-c000.snappy.parquet"),
                 Path::from("part-00001-911a94a2-43f6-4acb-8620-5e68c2654989-c000.snappy.parquet"),

--- a/crates/core/src/operations/add_feature.rs
+++ b/crates/core/src/operations/add_feature.rs
@@ -176,9 +176,9 @@ mod tests {
             .unwrap();
 
         assert!(&result
-            .protocol()
-            .cloned()
+            .snapshot()
             .unwrap()
+            .protocol()
             .writer_features()
             .unwrap_or_default()
             .contains(&WriterFeature::ChangeDataFeed));
@@ -190,7 +190,7 @@ mod tests {
             .await
             .unwrap();
 
-        let current_protocol = &result.protocol().cloned().unwrap();
+        let current_protocol = &result.snapshot().unwrap().protocol().clone();
         assert!(&current_protocol
             .writer_features()
             .unwrap_or_default()

--- a/crates/core/src/operations/cdc.rs
+++ b/crates/core/src/operations/cdc.rs
@@ -2,6 +2,7 @@
 //! The CDC module contains private tools for managing CDC files
 //!
 
+use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 use crate::DeltaResult;
 

--- a/crates/core/src/operations/constraints.rs
+++ b/crates/core/src/operations/constraints.rs
@@ -242,6 +242,7 @@ mod tests {
     use arrow_schema::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
     use datafusion::logical_expr::{col, lit};
 
+    use crate::table::config::TablePropertiesExt as _;
     use crate::writer::test_utils::{create_bare_table, get_arrow_schema, get_record_batch};
     use crate::{DeltaOps, DeltaResult, DeltaTable};
 

--- a/crates/core/src/operations/constraints.rs
+++ b/crates/core/src/operations/constraints.rs
@@ -247,8 +247,9 @@ mod tests {
 
     fn get_constraint(table: &DeltaTable, name: &str) -> String {
         table
-            .metadata()
+            .snapshot()
             .unwrap()
+            .metadata()
             .configuration()
             .get(name)
             .cloned()

--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -625,7 +625,7 @@ mod tests {
             "Testing location: {test_data_from:?}"
         );
 
-        let mut files = table.get_files_iter().unwrap().collect_vec();
+        let mut files = table.snapshot().unwrap().file_paths_iter().collect_vec();
         files.sort();
         assert_eq!(
             files, expected_paths,

--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -633,8 +633,9 @@ mod tests {
         );
 
         let mut schema_fields = table
-            .get_schema()
-            .expect("Failed to get schema")
+            .snapshot()
+            .expect("Failed to get snapshot")
+            .schema()
             .fields()
             .cloned()
             .collect_vec();

--- a/crates/core/src/operations/create.rs
+++ b/crates/core/src/operations/create.rs
@@ -566,7 +566,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let mut table = DeltaOps(table)
             .create()
@@ -577,7 +577,7 @@ mod tests {
         table.load().await.unwrap();
         assert_eq!(table.version(), Some(1));
         // Checks if files got removed after overwrite
-        assert_eq!(table.get_files_count(), 0);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
     }
 
     #[tokio::test]
@@ -591,7 +591,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let mut table = DeltaOps(table)
             .create()
@@ -603,7 +603,7 @@ mod tests {
         table.load().await.unwrap();
         assert_eq!(table.version(), Some(1));
         // Checks if files got removed after overwrite
-        assert_eq!(table.get_files_count(), 0);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
     }
 
     #[tokio::test]

--- a/crates/core/src/operations/create.rs
+++ b/crates/core/src/operations/create.rs
@@ -418,7 +418,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_schema().unwrap(), &table_schema)
+        assert_eq!(table.snapshot().unwrap().schema(), &table_schema)
     }
 
     #[tokio::test]
@@ -438,7 +438,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_schema().unwrap(), &table_schema)
+        assert_eq!(table.snapshot().unwrap().schema(), &table_schema)
     }
 
     #[tokio::test]
@@ -465,16 +465,17 @@ mod tests {
             .with_columns(schema.fields().cloned())
             .await
             .unwrap();
-        assert_eq!(table.version(), Some(0));
+        let snapshot = table.snapshot().unwrap();
+        assert_eq!(snapshot.version(), 0);
         assert_eq!(
-            table.protocol().unwrap().min_reader_version(),
+            snapshot.protocol().min_reader_version(),
             PROTOCOL.default_reader_version()
         );
         assert_eq!(
-            table.protocol().unwrap().min_writer_version(),
+            snapshot.protocol().min_writer_version(),
             PROTOCOL.default_writer_version()
         );
-        assert_eq!(table.get_schema().unwrap(), &schema);
+        assert_eq!(snapshot.schema(), &schema);
 
         // check we can overwrite default settings via adding actions
         let protocol = ProtocolInner {
@@ -490,8 +491,9 @@ mod tests {
             .with_actions(vec![Action::Protocol(protocol)])
             .await
             .unwrap();
-        assert_eq!(table.protocol().unwrap().min_reader_version(), 1);
-        assert_eq!(table.protocol().unwrap().min_writer_version(), 2);
+        let snapshot = table.snapshot().unwrap();
+        assert_eq!(snapshot.protocol().min_reader_version(), 1);
+        assert_eq!(snapshot.protocol().min_writer_version(), 2);
 
         let table = CreateBuilder::new()
             .with_location("memory:///")
@@ -500,8 +502,9 @@ mod tests {
             .await
             .unwrap();
         let append = table
-            .metadata()
+            .snapshot()
             .unwrap()
+            .metadata()
             .configuration()
             .get(TableProperty::AppendOnly.as_ref())
             .unwrap()
@@ -521,7 +524,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        let first_id = table.metadata().unwrap().id().to_string();
+        let first_id = table.snapshot().unwrap().metadata().id().to_string();
 
         let log_store = table.log_store;
 
@@ -540,7 +543,7 @@ mod tests {
             .with_save_mode(SaveMode::Ignore)
             .await
             .unwrap();
-        assert_eq!(table.metadata().unwrap().id(), first_id);
+        assert_eq!(table.snapshot().unwrap().metadata().id(), first_id);
 
         // Check table is overwritten
         let table = CreateBuilder::new()
@@ -549,7 +552,7 @@ mod tests {
             .with_save_mode(SaveMode::Overwrite)
             .await
             .unwrap();
-        assert_ne!(table.metadata().unwrap().id(), first_id)
+        assert_ne!(table.snapshot().unwrap().metadata().id(), first_id)
     }
 
     #[cfg(feature = "datafusion")]
@@ -631,8 +634,9 @@ mod tests {
         // Ensure the non-Delta key was set correctly
         let value = table
             .unwrap()
-            .metadata()
+            .snapshot()
             .unwrap()
+            .metadata()
             .configuration()
             .get("key")
             .unwrap()

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -536,12 +536,12 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let (table, metrics) = DeltaOps(table).delete().await.unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert_eq!(table.get_files_count(), 0);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
         assert_eq!(metrics.num_added_files, 0);
         assert_eq!(metrics.num_removed_files, 1);
         assert_eq!(metrics.num_deleted_rows, 0);
@@ -595,7 +595,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
@@ -619,7 +619,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(2));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let (table, metrics) = DeltaOps(table)
             .delete()
@@ -627,7 +627,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(3));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
@@ -775,7 +775,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let (table, metrics) = DeltaOps(table)
             .delete()
@@ -783,7 +783,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(2));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         assert_eq!(metrics.num_added_files, 0);
         assert_eq!(metrics.num_removed_files, 1);
@@ -832,7 +832,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 3);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 3);
 
         let (table, metrics) = DeltaOps(table)
             .delete()
@@ -844,7 +844,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(2));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         assert_eq!(metrics.num_added_files, 0);
         assert_eq!(metrics.num_removed_files, 1);

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -59,6 +59,7 @@ use crate::operations::write::execution::{write_execution_plan, write_execution_
 use crate::operations::write::WriterStatsConfig;
 use crate::operations::CustomExecuteHandler;
 use crate::protocol::DeltaOperation;
+use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 use crate::{DeltaTable, DeltaTableError};
 
@@ -237,7 +238,8 @@ async fn execute_non_empty_expr(
         snapshot.table_config().num_indexed_cols(),
         snapshot
             .table_config()
-            .stats_columns()
+            .data_skipping_stats_columns
+            .as_ref()
             .map(|v| v.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
     );
 
@@ -257,7 +259,7 @@ async fn execute_non_empty_expr(
             filter.clone(),
             table_partition_cols.clone(),
             log_store.object_store(Some(operation_id)),
-            Some(snapshot.table_config().target_file_size() as usize),
+            Some(snapshot.table_config().target_file_size().get() as usize),
             None,
             writer_properties.clone(),
             writer_stats_config.clone(),
@@ -293,7 +295,7 @@ async fn execute_non_empty_expr(
             cdc_filter,
             table_partition_cols.clone(),
             log_store.object_store(Some(operation_id)),
-            Some(snapshot.table_config().target_file_size() as usize),
+            Some(snapshot.table_config().target_file_size().get() as usize),
             None,
             writer_properties,
             writer_stats_config,

--- a/crates/core/src/operations/drop_constraints.rs
+++ b/crates/core/src/operations/drop_constraints.rs
@@ -167,7 +167,15 @@ mod tests {
 
         let expected_name = "id";
         assert_eq!(get_constraint_op_params(&mut table).await, expected_name);
-        assert_eq!(table.metadata().unwrap().configuration().get("id"), None);
+        assert_eq!(
+            table
+                .snapshot()
+                .unwrap()
+                .metadata()
+                .configuration()
+                .get("id"),
+            None
+        );
         Ok(())
     }
 

--- a/crates/core/src/operations/filesystem_check.rs
+++ b/crates/core/src/operations/filesystem_check.rs
@@ -138,8 +138,7 @@ impl FileSystemCheckBuilder {
     }
 
     async fn create_fsck_plan(&self) -> DeltaResult<FileSystemCheckPlan> {
-        let mut files_relative: HashMap<String, Add> =
-            HashMap::with_capacity(self.snapshot.files_count());
+        let mut files_relative: HashMap<String, Add> = HashMap::new();
         let log_store = self.log_store.clone();
 
         for active in self.snapshot.file_actions_iter()? {

--- a/crates/core/src/operations/merge/filter.rs
+++ b/crates/core/src/operations/merge/filter.rs
@@ -423,7 +423,7 @@ mod tests {
         let table = setup_table(Some(vec!["id"])).await;
 
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 0);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -515,7 +515,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 0);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -570,7 +570,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 0);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -630,7 +630,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 0);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -696,7 +696,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 0);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -768,7 +768,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 0);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1880,7 +1880,10 @@ mod tests {
             json!(r#"[{"actionType":"update","predicate":"target.value = 1"}]"#)
         );
 
-        assert_eq!(table.schema(), after_table.schema());
+        assert_eq!(
+            table.snapshot().unwrap().schema(),
+            after_table.snapshot().unwrap().schema()
+        );
 
         let snapshot_bytes = after_table
             .log_store
@@ -2161,7 +2164,7 @@ mod tests {
         ];
         let actual = get_data(&table).await;
         let expected_schema_struct: StructType = Arc::clone(&schema).try_into_kernel().unwrap();
-        assert_eq!(&expected_schema_struct, table.schema().unwrap());
+        assert_eq!(&expected_schema_struct, table.snapshot().unwrap().schema());
         assert_batches_sorted_eq!(&expected, &actual);
     }
 
@@ -2229,7 +2232,7 @@ mod tests {
         ];
         let actual = get_data(&table).await;
         let expected_schema_struct: StructType = Arc::clone(&schema).try_into_kernel().unwrap();
-        assert_eq!(&expected_schema_struct, table.schema().unwrap());
+        assert_eq!(&expected_schema_struct, table.snapshot().unwrap().schema());
         assert_batches_sorted_eq!(&expected, &actual);
     }
 
@@ -3316,7 +3319,7 @@ mod tests {
         ];
         let actual = get_data(&table).await;
         let expected_schema_struct: StructType = schema.as_ref().try_into_kernel().unwrap();
-        assert_eq!(&expected_schema_struct, table.schema().unwrap());
+        assert_eq!(&expected_schema_struct, table.snapshot().unwrap().schema());
         assert_batches_sorted_eq!(&expected, &actual);
     }
 
@@ -4150,7 +4153,7 @@ mod tests {
         ];
         let actual = get_data(&table).await;
         let expected_schema_struct: StructType = source_schema.try_into_kernel().unwrap();
-        assert_eq!(&expected_schema_struct, table.schema().unwrap());
+        assert_eq!(&expected_schema_struct, table.snapshot().unwrap().schema());
         assert_batches_sorted_eq!(&expected, &actual);
 
         let ctx = SessionContext::new();

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1722,14 +1722,14 @@ mod tests {
 
         let table = write_data(table, &schema).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         (table, merge_source(schema))
     }
 
     async fn assert_merge(table: DeltaTable, metrics: MergeMetrics) {
         assert_eq!(table.version(), Some(2));
-        assert!(table.get_files_count() >= 1);
+        assert!(table.snapshot().unwrap().file_paths_iter().count() >= 1);
         assert!(metrics.num_target_files_added >= 1);
         assert_eq!(metrics.num_target_files_removed, 1);
         assert_eq!(metrics.num_target_rows_copied, 1);
@@ -2410,7 +2410,7 @@ mod tests {
 
         let table = write_data(table, &schema).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -2466,7 +2466,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert!(table.get_files_count() >= 3);
+        assert!(table.snapshot().unwrap().file_paths_iter().count() >= 3);
         assert!(metrics.num_target_files_added >= 3);
         assert_eq!(metrics.num_target_files_removed, 2);
         assert_eq!(metrics.num_target_rows_copied, 1);
@@ -2567,7 +2567,7 @@ mod tests {
 
         let table = write_data(table, &schema).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 4);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 4);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -2606,7 +2606,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert!(table.get_files_count() >= 3);
+        assert!(table.snapshot().unwrap().file_paths_iter().count() >= 3);
         assert_eq!(metrics.num_target_files_added, 3);
         assert_eq!(metrics.num_target_files_removed, 2);
         assert_eq!(metrics.num_target_rows_copied, 0);
@@ -2646,7 +2646,7 @@ mod tests {
 
         let table = write_data(table, &schema).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -2710,7 +2710,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert!(table.get_files_count() >= 3);
+        assert!(table.snapshot().unwrap().file_paths_iter().count() >= 3);
         assert!(metrics.num_target_files_added >= 3);
         assert_eq!(metrics.num_target_files_removed, 2);
         assert_eq!(metrics.num_target_rows_copied, 1);
@@ -2756,7 +2756,7 @@ mod tests {
 
         let table = write_data(table, &schema).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -2784,7 +2784,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert!(table.get_files_count() >= 2);
+        assert!(table.snapshot().unwrap().file_paths_iter().count() >= 2);
         assert_eq!(metrics.num_target_files_added, 2);
         assert_eq!(metrics.num_target_files_removed, 2);
         assert_eq!(metrics.num_target_rows_copied, 2);
@@ -2826,7 +2826,7 @@ mod tests {
 
         let table = write_data(table, &schema).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -2854,7 +2854,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert!(table.get_files_count() >= 2);
+        assert!(table.snapshot().unwrap().file_paths_iter().count() >= 2);
         assert_eq!(metrics.num_target_files_added, 1);
         assert_eq!(metrics.num_target_files_removed, 1);
         assert_eq!(metrics.num_target_rows_copied, 1);
@@ -2895,7 +2895,7 @@ mod tests {
 
         let table = write_data(table, &schema).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -2923,7 +2923,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
         assert_eq!(metrics.num_target_files_added, 2);
         assert_eq!(metrics.num_target_files_removed, 2);
         assert_eq!(metrics.num_target_rows_copied, 2);
@@ -2959,7 +2959,7 @@ mod tests {
 
         let table = write_data(table, &schema).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -3029,7 +3029,7 @@ mod tests {
 
         let table = write_data(table, &schema).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -3058,7 +3058,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
         assert_eq!(metrics.num_target_files_added, 2);
         assert_eq!(metrics.num_target_files_removed, 2);
         assert_eq!(metrics.num_target_rows_copied, 2);
@@ -3094,7 +3094,7 @@ mod tests {
 
         let table = write_data(table, &schema).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -3161,7 +3161,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 0);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -3205,7 +3205,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(1));
-        assert!(table.get_files_count() >= 2);
+        assert!(table.snapshot().unwrap().file_paths_iter().count() >= 2);
         assert!(metrics.num_target_files_added >= 2);
         assert_eq!(metrics.num_target_files_removed, 0);
         assert_eq!(metrics.num_target_rows_copied, 0);
@@ -3248,7 +3248,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
 
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 0);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
 
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -3289,7 +3289,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(1));
-        assert!(table.get_files_count() >= 2);
+        assert!(table.snapshot().unwrap().file_paths_iter().count() >= 2);
         assert!(metrics.num_target_files_added >= 2);
         assert_eq!(metrics.num_target_files_removed, 0);
         assert_eq!(metrics.num_target_rows_copied, 0);
@@ -3373,7 +3373,7 @@ mod tests {
 
         let table = write_data(table, &arrow_schema).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let (table, _metrics) = DeltaOps(table)
             .merge(source, "target.Id = source.Id")
@@ -3669,7 +3669,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let batch = RecordBatch::try_new(
             Arc::clone(&arrow_schema.clone()),
@@ -3784,7 +3784,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let batch = RecordBatch::try_new(
             Arc::clone(&arrow_schema.clone()),
@@ -3894,7 +3894,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let batch = RecordBatch::try_new(
             Arc::clone(&arrow_schema.clone()),
@@ -4008,7 +4008,7 @@ mod tests {
         let table = write_data(table, &schema).await;
 
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
         let source = merge_source(schema);
 
         let (table, metrics) = DeltaOps(table)
@@ -4108,7 +4108,7 @@ mod tests {
         let table = write_data(table, &schema).await;
 
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
         let source = merge_source(schema);
         let source = source.with_column("inserted_by", lit("new_value")).unwrap();
 
@@ -4218,7 +4218,7 @@ mod tests {
         let table = write_data(table, &schema).await;
 
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
         let source = merge_source(schema);
 
         let (table, _metrics) = DeltaOps(table)

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -91,6 +91,7 @@ use crate::operations::write::generated_columns::{
 };
 use crate::operations::write::WriterStatsConfig;
 use crate::protocol::{DeltaOperation, MergePredicate};
+use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 use crate::{DeltaResult, DeltaTable, DeltaTableError};
 
@@ -1378,7 +1379,8 @@ async fn execute(
         snapshot.table_config().num_indexed_cols(),
         snapshot
             .table_config()
-            .stats_columns()
+            .data_skipping_stats_columns
+            .as_ref()
             .map(|v| v.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
     );
 
@@ -1388,7 +1390,7 @@ async fn execute(
         write,
         table_partition_cols.clone(),
         log_store.object_store(Some(operation_id)),
-        Some(snapshot.table_config().target_file_size() as usize),
+        Some(snapshot.table_config().target_file_size().get() as usize),
         None,
         writer_properties.clone(),
         writer_stats_config.clone(),

--- a/crates/core/src/operations/mod.rs
+++ b/crates/core/src/operations/mod.rs
@@ -7,6 +7,7 @@
 //! with a [data stream][datafusion::physical_plan::SendableRecordBatchStream],
 //! if the operation returns data as well.
 use async_trait::async_trait;
+use delta_kernel::table_properties::{DataSkippingNumIndexedCols, TableProperties};
 use std::collections::HashMap;
 use std::sync::Arc;
 use update_field_metadata::UpdateFieldMetadataBuilder;
@@ -36,6 +37,7 @@ use self::{
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::logstore::LogStoreRef;
 use crate::table::builder::DeltaTableBuilder;
+use crate::table::config::{TablePropertiesExt as _, DEFAULT_NUM_INDEX_COLS};
 use crate::DeltaTable;
 
 pub mod add_column;
@@ -333,19 +335,33 @@ impl AsRef<DeltaTable> for DeltaOps {
 /// If table_config does not exist (only can occur in the first write action) it takes
 /// the configuration that was passed to the writerBuilder.
 pub fn get_num_idx_cols_and_stats_columns(
-    config: Option<crate::table::config::TableConfig<'_>>,
+    config: Option<&TableProperties>,
     configuration: HashMap<String, Option<String>>,
-) -> (i32, Option<Vec<String>>) {
+) -> (DataSkippingNumIndexedCols, Option<Vec<String>>) {
     let (num_index_cols, stats_columns) = match &config {
-        Some(conf) => (conf.num_indexed_cols(), conf.stats_columns()),
+        Some(conf) => (
+            conf.num_indexed_cols(),
+            conf.data_skipping_stats_columns
+                .clone()
+                .map(|v| v.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
+        ),
         _ => (
             configuration
                 .get("delta.dataSkippingNumIndexedCols")
-                .and_then(|v| v.clone().map(|v| v.parse::<i32>().unwrap()))
-                .unwrap_or(crate::table::config::DEFAULT_NUM_INDEX_COLS),
+                .and_then(|v| {
+                    v.as_ref()
+                        .and_then(|vv| vv.parse::<u64>().ok())
+                        .map(DataSkippingNumIndexedCols::NumColumns)
+                })
+                .unwrap_or(DataSkippingNumIndexedCols::NumColumns(
+                    DEFAULT_NUM_INDEX_COLS,
+                )),
             configuration
                 .get("delta.dataSkippingStatsColumns")
-                .and_then(|v| v.as_ref().map(|v| v.split(',').collect::<Vec<&str>>())),
+                .and_then(|v| {
+                    v.as_ref()
+                        .map(|v| v.split(',').map(|s| s.to_string()).collect::<Vec<String>>())
+                }),
         ),
     };
     (
@@ -360,14 +376,14 @@ pub fn get_num_idx_cols_and_stats_columns(
 /// If table_config does not exist (only can occur in the first write action) it takes
 /// the configuration that was passed to the writerBuilder.
 pub(crate) fn get_target_file_size(
-    config: &Option<crate::table::config::TableConfig<'_>>,
+    config: Option<&TableProperties>,
     configuration: &HashMap<String, Option<String>>,
-) -> i64 {
+) -> u64 {
     match &config {
-        Some(conf) => conf.target_file_size(),
+        Some(conf) => conf.target_file_size().get(),
         _ => configuration
             .get("delta.targetFileSize")
-            .and_then(|v| v.clone().map(|v| v.parse::<i64>().unwrap()))
+            .and_then(|v| v.clone().map(|v| v.parse::<u64>().unwrap()))
             .unwrap_or(crate::table::config::DEFAULT_TARGET_FILE_SIZE),
     }
 }

--- a/crates/core/src/operations/restore.rs
+++ b/crates/core/src/operations/restore.rs
@@ -382,6 +382,8 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "datafusion")]
     async fn test_simple_restore_constraints() -> DeltaResult<()> {
+        use crate::table::config::TablePropertiesExt as _;
+
         let batch = get_record_batch(None, false);
         let table = DeltaOps(create_bare_table())
             .write(vec![batch.clone()])

--- a/crates/core/src/operations/restore.rs
+++ b/crates/core/src/operations/restore.rs
@@ -195,9 +195,10 @@ async fn execute(
         )));
     }
 
-    let metadata_restored_version = table.metadata()?;
+    let snapshot_restored = table.snapshot()?;
+    let metadata_restored_version = snapshot_restored.metadata();
 
-    let state_to_restore_files = table.snapshot()?.file_actions()?;
+    let state_to_restore_files = snapshot_restored.file_actions()?;
     let latest_state_files = snapshot.file_actions()?;
     let state_to_restore_files_set =
         HashSet::<Add>::from_iter(state_to_restore_files.iter().cloned());
@@ -247,27 +248,27 @@ async fn execute(
     let mut actions = vec![];
     let protocol = if protocol_downgrade_allowed {
         ProtocolInner {
-            min_reader_version: table.protocol()?.min_reader_version(),
-            min_writer_version: table.protocol()?.min_writer_version(),
+            min_reader_version: snapshot_restored.protocol().min_reader_version(),
+            min_writer_version: snapshot_restored.protocol().min_writer_version(),
             writer_features: if snapshot.protocol().min_writer_version() < 7 {
                 None
             } else {
-                table.protocol()?.writer_features_set()
+                snapshot_restored.protocol().writer_features_set()
             },
             reader_features: if snapshot.protocol().min_reader_version() < 3 {
                 None
             } else {
-                table.protocol()?.reader_features_set()
+                snapshot_restored.protocol().reader_features_set()
             },
         }
     } else {
         ProtocolInner {
             min_reader_version: max(
-                table.protocol()?.min_reader_version(),
+                snapshot_restored.protocol().min_reader_version(),
                 snapshot.protocol().min_reader_version(),
             ),
             min_writer_version: max(
-                table.protocol()?.min_writer_version(),
+                snapshot_restored.protocol().min_writer_version(),
                 snapshot.protocol().min_writer_version(),
             ),
             writer_features: snapshot.protocol().writer_features_set(),

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -634,7 +634,7 @@ mod tests {
         use parquet::arrow::async_reader::ParquetObjectReader;
         use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
 
-        for pq in table.get_files_iter()? {
+        for pq in table.snapshot()?.file_paths_iter() {
             let store = table.log_store().object_store(None);
             let reader = ParquetObjectReader::new(store, pq);
             let builder = ParquetRecordBatchStreamBuilder::new(reader).await?;
@@ -673,7 +673,7 @@ mod tests {
 
         let table = write_batch(table, batch).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let (table, metrics) = DeltaOps(table)
             .update()
@@ -682,7 +682,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
         assert_eq!(metrics.num_updated_rows, 4);
@@ -727,7 +727,7 @@ mod tests {
 
         let table = write_batch(table, batch).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let (table, metrics) = DeltaOps(table)
             .update()
@@ -737,7 +737,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
         assert_eq!(metrics.num_updated_rows, 2);
@@ -784,7 +784,7 @@ mod tests {
 
         let table = write_batch(table, batch.clone()).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let (table, metrics) = DeltaOps(table)
             .update()
@@ -795,7 +795,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
         assert_eq!(metrics.num_updated_rows, 2);
@@ -819,7 +819,7 @@ mod tests {
         let table = setup_table(Some(vec!["modified"])).await;
         let table = write_batch(table, batch).await;
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
 
         let (table, metrics) = DeltaOps(table)
             .update()
@@ -834,7 +834,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(table.version(), Some(2));
-        assert_eq!(table.get_files_count(), 3);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 3);
         assert_eq!(metrics.num_added_files, 2);
         assert_eq!(metrics.num_removed_files, 1);
         assert_eq!(metrics.num_updated_rows, 1);
@@ -930,7 +930,7 @@ mod tests {
     async fn test_update_null() {
         let table = prepare_values_table().await;
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let (table, metrics) = DeltaOps(table)
             .update()
@@ -938,7 +938,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
         assert_eq!(metrics.num_updated_rows, 5);
@@ -968,7 +968,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
         assert_eq!(metrics.num_updated_rows, 2);
@@ -1004,7 +1004,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
         assert_eq!(metrics.num_updated_rows, 2);
@@ -1214,7 +1214,7 @@ mod tests {
     async fn test_no_cdc_on_older_tables() {
         let table = prepare_values_table().await;
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             "value",

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -38,6 +38,7 @@ use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::logstore::{LogStore, LogStoreRef};
 use crate::protocol::DeltaOperation;
+use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 use crate::{DeltaTable, DeltaTableConfig};
 

--- a/crates/core/src/operations/write/configs.rs
+++ b/crates/core/src/operations/write/configs.rs
@@ -1,15 +1,20 @@
+use delta_kernel::table_properties::DataSkippingNumIndexedCols;
+
 /// Configuration for the writer on how to collect stats
 #[derive(Clone)]
 pub struct WriterStatsConfig {
     /// Number of columns to collect stats for, idx based
-    pub num_indexed_cols: i32,
+    pub num_indexed_cols: DataSkippingNumIndexedCols,
     /// Optional list of columns which to collect stats for, takes precedende over num_index_cols
     pub stats_columns: Option<Vec<String>>,
 }
 
 impl WriterStatsConfig {
     /// Create new writer stats config
-    pub fn new(num_indexed_cols: i32, stats_columns: Option<Vec<String>>) -> Self {
+    pub fn new(
+        num_indexed_cols: DataSkippingNumIndexedCols,
+        stats_columns: Option<Vec<String>>,
+    ) -> Self {
         Self {
             num_indexed_cols,
             stats_columns,

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -22,6 +22,7 @@ use crate::errors::DeltaResult;
 use crate::kernel::{Action, Add, AddCDCFile, Remove, StructType, StructTypeExt};
 use crate::logstore::{LogStoreRef, ObjectStoreRef};
 use crate::operations::cdc::should_write_cdc;
+use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 use crate::table::Constraint as DeltaConstraint;
 use crate::DeltaTableError;
@@ -168,7 +169,7 @@ pub(crate) async fn execute_non_empty_expr(
             filter,
             partition_columns.clone(),
             log_store.object_store(Some(operation_id)),
-            Some(snapshot.table_config().target_file_size() as usize),
+            Some(snapshot.table_config().target_file_size().get() as usize),
             None,
             writer_properties.clone(),
             writer_stats_config.clone(),

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -833,11 +833,14 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(1));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
 
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, batch.num_rows());
-        assert_eq!(write_metrics.num_added_files, table.get_files_count());
+        assert_eq!(
+            write_metrics.num_added_files,
+            table.snapshot().unwrap().file_paths_iter().count()
+        );
         assert_common_write_metrics(write_metrics);
 
         table.load().await.unwrap();
@@ -862,7 +865,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(2));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, batch.num_rows());
         assert_eq!(write_metrics.num_added_files, 1);
@@ -890,7 +893,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(3));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_rows, batch.num_rows());
         assert!(write_metrics.num_removed_files > 0);
@@ -1029,7 +1032,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 1);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 1);
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_common_write_metrics(write_metrics);
     }
@@ -1044,7 +1047,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 2);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 2);
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_files, 2);
         assert_common_write_metrics(write_metrics);
@@ -1056,7 +1059,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_files_count(), 4);
+        assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 4);
 
         let write_metrics: WriteMetrics = get_write_metrics(table.clone()).await;
         assert_eq!(write_metrics.num_added_files, 4);

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -599,13 +599,13 @@ impl std::future::IntoFuture for WriteBuilder {
                 _ => (None, None),
             };
 
-            let config: Option<crate::table::config::TableConfig<'_>> = this
+            let config = this
                 .snapshot
                 .as_ref()
                 .map(|snapshot| snapshot.table_config());
 
             let target_file_size = this.target_file_size.or_else(|| {
-                Some(super::get_target_file_size(&config, &this.configuration) as usize)
+                Some(super::get_target_file_size(config, &this.configuration) as usize)
             });
             let (num_indexed_cols, stats_columns) =
                 super::get_num_idx_cols_and_stats_columns(config, this.configuration);

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -20,6 +20,7 @@ use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use crate::logstore::{LogStore, LogStoreExt};
+use crate::table::config::TablePropertiesExt as _;
 use crate::{open_table_with_version, DeltaTable};
 use crate::{DeltaResult, DeltaTableError};
 

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -289,7 +289,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_schema().unwrap(), &table_schema);
+        assert_eq!(table.snapshot().unwrap().schema(), &table_schema);
         let res = create_checkpoint_for(0, table.log_store.as_ref(), None).await;
         assert!(res.is_ok());
 
@@ -319,7 +319,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_schema().unwrap(), &table_schema);
+        assert_eq!(table.snapshot().unwrap().schema(), &table_schema);
 
         let part_cols: Vec<String> = vec![];
         let metadata =
@@ -407,7 +407,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.get_schema().unwrap(), &table_schema);
+        assert_eq!(table.snapshot().unwrap().schema(), &table_schema);
         match create_checkpoint_for(1, table.log_store.as_ref(), None).await {
             Ok(_) => {
                 /*

--- a/crates/core/src/table/config.rs
+++ b/crates/core/src/table/config.rs
@@ -1,12 +1,10 @@
 //! Delta Table configuration
+use std::num::NonZero;
+use std::str::FromStr;
 use std::sync::LazyLock;
 use std::time::Duration;
-use std::{collections::HashMap, str::FromStr};
 
-use delta_kernel::expressions::ColumnName;
-use delta_kernel::table_features::ColumnMappingMode;
-use delta_kernel::table_properties::DataSkippingNumIndexedCols;
-use serde::{Deserialize, Serialize};
+use delta_kernel::table_properties::{DataSkippingNumIndexedCols, IsolationLevel, TableProperties};
 
 use super::Constraint;
 use crate::errors::DeltaTableError;
@@ -200,168 +198,101 @@ pub enum DeltaConfigError {
     Validation(String),
 }
 
-macro_rules! table_config {
-    ($(($docs:literal, $key:expr, $name:ident, $ret:ty, $default:literal),)*) => {
-        $(
-            #[doc = $docs]
-            pub fn $name(&self) -> $ret {
-                self.0
-                    .get($key.as_ref())
-                    .and_then(|value| value.parse().ok())
-                    .unwrap_or($default)
-            }
-        )*
-    }
-}
-
-/// Well known delta table configuration
-#[derive(Debug)]
-pub struct TableConfig<'a>(pub(crate) &'a HashMap<String, String>);
-
 /// Default num index cols
-pub const DEFAULT_NUM_INDEX_COLS: i32 = 32;
+pub const DEFAULT_NUM_INDEX_COLS: u64 = 32;
 /// Default target file size
-pub const DEFAULT_TARGET_FILE_SIZE: i64 = 104857600;
+pub const DEFAULT_TARGET_FILE_SIZE: u64 = 100 * 1024 * 1024;
 
-impl TableConfig<'_> {
-    table_config!(
-        (
-            "true for this Delta table to be append-only",
-            TableProperty::AppendOnly,
-            append_only,
-            bool,
-            false
-        ),
-        (
-            "true for Delta Lake to write file statistics in checkpoints in JSON format for the stats column.",
-            TableProperty::CheckpointWriteStatsAsJson,
-            write_stats_as_json,
-            bool,
-            true
-        ),
-        (
-            "true for Delta Lake to write file statistics to checkpoints in struct format",
-            TableProperty::CheckpointWriteStatsAsStruct,
-            write_stats_as_struct,
-            bool,
-            false
-        ),
-        (
-            "true for Delta Lake to write checkpoint files using run length encoding (RLE)",
-            TableProperty::CheckpointUseRunLengthEncoding,
-            use_checkpoint_rle,
-            bool,
-            true
-        ),
-        (
-            "The target file size in bytes or higher units for file tuning",
-            TableProperty::TargetFileSize,
-            target_file_size,
-            i64,
-            // Databricks / spark defaults to 104857600 (bytes) or 100mb
-            104857600
-        ),
-        (
-            "true to enable change data feed.",
-            TableProperty::EnableChangeDataFeed,
-            enable_change_data_feed,
-            bool,
-            false
-        ),
-        (
-            "true to enable deletion vectors and predictive I/O for updates.",
-            TableProperty::EnableDeletionVectors,
-            enable_deletion_vectors,
-            bool,
-            // in databricks the default is dependent on the workspace settings and runtime version
-            // https://learn.microsoft.com/en-us/azure/databricks/administration-guide/workspace-settings/deletion-vectors
-            false
-        ),
-        (
-            "The number of columns for Delta Lake to collect statistics about for data skipping.",
-            TableProperty::DataSkippingNumIndexedCols,
-            num_indexed_cols,
-            i32,
-            32
-        ),
-        (
-            "whether to cleanup expired logs",
-            TableProperty::EnableExpiredLogCleanup,
-            enable_expired_log_cleanup,
-            bool,
-            true
-        ),
-        (
-            "Interval (number of commits) after which a new checkpoint should be created",
-            TableProperty::CheckpointInterval,
-            checkpoint_interval,
-            i32,
-            100
-        ),
-    );
-
-    /// The shortest duration for Delta Lake to keep logically deleted data files before deleting
-    /// them physically. This is to prevent failures in stale readers after compactions or partition overwrites.
+pub trait TablePropertiesExt {
+    /// true for this Delta table to be append-only. If append-only, existing records cannot be
+    /// deleted, and existing values cannot be updated. See [append-only tables] in the protocol.
     ///
-    /// This value should be large enough to ensure that:
-    ///
-    /// * It is larger than the longest possible duration of a job if you run VACUUM when there are
-    ///   concurrent readers or writers accessing the Delta table.
-    /// * If you run a streaming query that reads from the table, that query does not stop for longer
-    ///   than this value. Otherwise, the query may not be able to restart, as it must still read old files.
-    pub fn deleted_file_retention_duration(&self) -> Duration {
-        static DEFAULT_DURATION: LazyLock<Duration> =
-            LazyLock::new(|| parse_interval("interval 1 weeks").unwrap());
-        self.0
-            .get(TableProperty::DeletedFileRetentionDuration.as_ref())
-            .and_then(|v| parse_interval(v).ok())
-            .unwrap_or_else(|| DEFAULT_DURATION.to_owned())
-    }
+    /// [append-only tables]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#append-only-tables
+    fn append_only(&self) -> bool;
 
     /// How long the history for a Delta table is kept.
     ///
     /// Each time a checkpoint is written, Delta Lake automatically cleans up log entries older
     /// than the retention interval. If you set this property to a large enough value, many log
     /// entries are retained. This should not impact performance as operations against the log are
-    /// constant time. Operations on history are parallel but will become more expensive as the log size increases.
-    pub fn log_retention_duration(&self) -> Duration {
+    /// constant time. Operations on history are parallel but will become more expensive as the log
+    /// size increases.
+    fn log_retention_duration(&self) -> Duration;
+
+    /// Whether to clean up expired checkpoints/commits in the delta log.
+    fn enable_expired_log_cleanup(&self) -> bool;
+
+    /// Interval (expressed as number of commits) after which a new checkpoint should be created.
+    /// E.g. if checkpoint interval = 10, then a checkpoint should be written every 10 commits.
+    fn checkpoint_interval(&self) -> NonZero<u64>;
+
+    /// Number of columns to be indexed.
+    fn num_indexed_cols(&self) -> DataSkippingNumIndexedCols;
+
+    fn target_file_size(&self) -> NonZero<u64>;
+
+    fn enable_change_data_feed(&self) -> bool;
+
+    fn deleted_file_retention_duration(&self) -> Duration;
+
+    fn isolation_level(&self) -> IsolationLevel;
+
+    fn get_constraints(&self) -> Vec<Constraint>;
+}
+
+impl TablePropertiesExt for TableProperties {
+    fn append_only(&self) -> bool {
+        self.append_only.unwrap_or(false)
+    }
+
+    fn log_retention_duration(&self) -> Duration {
         static DEFAULT_DURATION: LazyLock<Duration> =
             LazyLock::new(|| parse_interval("interval 30 days").unwrap());
-        self.0
-            .get(TableProperty::LogRetentionDuration.as_ref())
-            .and_then(|v| parse_interval(v).ok())
-            .unwrap_or_else(|| DEFAULT_DURATION.to_owned())
+        self.log_retention_duration
+            .unwrap_or(DEFAULT_DURATION.to_owned())
     }
 
-    /// The degree to which a transaction must be isolated from modifications made by concurrent transactions.
-    ///
-    /// Valid values are `Serializable` and `WriteSerializable`.
-    pub fn isolation_level(&self) -> IsolationLevel {
-        self.0
-            .get(TableProperty::IsolationLevel.as_ref())
-            .and_then(|v| v.parse().ok())
-            .unwrap_or_default()
+    fn enable_expired_log_cleanup(&self) -> bool {
+        self.enable_expired_log_cleanup.unwrap_or(true)
     }
 
-    /// Policy applied during chepoint creation
-    pub fn checkpoint_policy(&self) -> CheckpointPolicy {
-        self.0
-            .get(TableProperty::CheckpointPolicy.as_ref())
-            .and_then(|v| v.parse().ok())
-            .unwrap_or_default()
+    fn checkpoint_interval(&self) -> NonZero<u64> {
+        static DEFAULT_INTERVAL: LazyLock<NonZero<u64>> =
+            LazyLock::new(|| NonZero::new(10).unwrap());
+        self.checkpoint_interval
+            .unwrap_or(DEFAULT_INTERVAL.to_owned())
     }
 
-    /// Return the column mapping mode according to delta.columnMapping.mode
-    pub fn column_mapping_mode(&self) -> ColumnMappingMode {
-        self.0
-            .get(TableProperty::ColumnMappingMode.as_ref())
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(ColumnMappingMode::None)
+    fn num_indexed_cols(&self) -> DataSkippingNumIndexedCols {
+        self.data_skipping_num_indexed_cols
+            .unwrap_or(DataSkippingNumIndexedCols::NumColumns(32))
+    }
+
+    fn target_file_size(&self) -> NonZero<u64> {
+        static DEFAULT_SIZE: LazyLock<NonZero<u64>> =
+            LazyLock::new(|| NonZero::new(100 * 1024 * 1024).unwrap());
+        self.target_file_size.unwrap_or(DEFAULT_SIZE.to_owned())
+    }
+
+    fn enable_change_data_feed(&self) -> bool {
+        self.enable_change_data_feed.unwrap_or(false)
+    }
+
+    fn deleted_file_retention_duration(&self) -> Duration {
+        static DEFAULT_DURATION: LazyLock<Duration> =
+            LazyLock::new(|| parse_interval("interval 1 weeks").unwrap());
+        self.deleted_file_retention_duration
+            .unwrap_or(DEFAULT_DURATION.to_owned())
+    }
+
+    fn isolation_level(&self) -> IsolationLevel {
+        self.isolation_level.unwrap_or_default()
     }
 
     /// Return the check constraints on the current table
-    pub fn get_constraints(&self) -> Vec<Constraint> {
-        self.0
+    fn get_constraints(&self) -> Vec<Constraint> {
+        // TODO: upstream parsing of constraints to delta-kernel
+        self.unknown_properties
             .iter()
             .filter_map(|(field, value)| {
                 if field.starts_with("delta.constraints") {
@@ -372,128 +303,6 @@ impl TableConfig<'_> {
                 }
             })
             .collect()
-    }
-
-    /// Column names on which Delta Lake collects statistics to enhance data skipping functionality.
-    /// This property takes precedence over [num_indexed_cols](Self::num_indexed_cols).
-    pub fn stats_columns(&self) -> Option<Vec<&str>> {
-        self.0
-            .get(TableProperty::DataSkippingStatsColumns.as_ref())
-            .map(|v| v.split(',').collect())
-    }
-
-    pub fn stats_columns_kernel(&self) -> Option<Vec<ColumnName>> {
-        self.0
-            .get(TableProperty::DataSkippingStatsColumns.as_ref())
-            .and_then(|v| {
-                ColumnName::parse_column_name_list(v)
-                    .inspect_err(|e| println!("{e:?}"))
-                    .ok()
-            })
-    }
-
-    pub fn num_indexed_cols_kernel(&self) -> Option<DataSkippingNumIndexedCols> {
-        self.0
-            .get(TableProperty::DataSkippingNumIndexedCols.as_ref())
-            .and_then(|v| DataSkippingNumIndexedCols::try_from(v.as_str()).ok())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq)]
-/// The isolation level applied during transaction
-pub enum IsolationLevel {
-    /// The strongest isolation level. It ensures that committed write operations
-    /// and all reads are Serializable. Operations are allowed as long as there
-    /// exists a serial sequence of executing them one-at-a-time that generates
-    /// the same outcome as that seen in the table. For the write operations,
-    /// the serial sequence is exactly the same as that seen in the table’s history.
-    Serializable,
-
-    /// A weaker isolation level than Serializable. It ensures only that the write
-    /// operations (that is, not reads) are serializable. However, this is still stronger
-    /// than Snapshot isolation. WriteSerializable is the default isolation level because
-    /// it provides great balance of data consistency and availability for most common operations.
-    WriteSerializable,
-
-    /// SnapshotIsolation is a guarantee that all reads made in a transaction will see a consistent
-    /// snapshot of the database (in practice it reads the last committed values that existed at the
-    /// time it started), and the transaction itself will successfully commit only if no updates
-    /// it has made conflict with any concurrent updates made since that snapshot.
-    SnapshotIsolation,
-}
-
-// Spark assumes Serializable as default isolation level
-// https://github.com/delta-io/delta/blob/abb171c8401200e7772b27e3be6ea8682528ac72/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala#L1023
-impl Default for IsolationLevel {
-    fn default() -> Self {
-        Self::Serializable
-    }
-}
-
-impl AsRef<str> for IsolationLevel {
-    fn as_ref(&self) -> &str {
-        match self {
-            Self::Serializable => "Serializable",
-            Self::WriteSerializable => "WriteSerializable",
-            Self::SnapshotIsolation => "SnapshotIsolation",
-        }
-    }
-}
-
-impl FromStr for IsolationLevel {
-    type Err = DeltaTableError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
-            "serializable" => Ok(Self::Serializable),
-            "writeserializable" | "write_serializable" => Ok(Self::WriteSerializable),
-            "snapshotisolation" | "snapshot_isolation" => Ok(Self::SnapshotIsolation),
-            _ => Err(DeltaTableError::Generic(
-                "Invalid string for IsolationLevel".into(),
-            )),
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-/// The checkpoint policy applied when writing checkpoints
-#[serde(rename_all = "camelCase")]
-pub enum CheckpointPolicy {
-    /// classic Delta Lake checkpoints
-    Classic,
-    /// v2 checkpoints
-    V2,
-    /// unknown checkpoint policy
-    Other(String),
-}
-
-impl Default for CheckpointPolicy {
-    fn default() -> Self {
-        Self::Classic
-    }
-}
-
-impl AsRef<str> for CheckpointPolicy {
-    fn as_ref(&self) -> &str {
-        match self {
-            Self::Classic => "classic",
-            Self::V2 => "v2",
-            Self::Other(s) => s,
-        }
-    }
-}
-
-impl FromStr for CheckpointPolicy {
-    type Err = DeltaTableError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
-            "classic" => Ok(Self::Classic),
-            "v2" => Ok(Self::V2),
-            _ => Err(DeltaTableError::Generic(
-                "Invalid string for CheckpointPolicy".into(),
-            )),
-        }
     }
 }
 
@@ -546,69 +355,6 @@ fn parse_int(value: &str) -> Result<i64, DeltaConfigError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::kernel::{new_metadata, Metadata, StructType};
-    use std::collections::HashMap;
-
-    fn dummy_metadata() -> Metadata {
-        let schema = StructType::new(Vec::new());
-        new_metadata(
-            &schema,
-            Vec::<String>::new(),
-            std::iter::empty::<(&str, &str)>(),
-        )
-        .unwrap()
-    }
-
-    #[test]
-    fn get_interval_from_metadata_test() {
-        let md = dummy_metadata();
-        let config = TableConfig(md.configuration());
-
-        // default 1 week
-        assert_eq!(
-            config.deleted_file_retention_duration().as_secs(),
-            SECONDS_PER_WEEK,
-        );
-
-        // change to 2 day
-        let raw = HashMap::from([(
-            TableProperty::DeletedFileRetentionDuration
-                .as_ref()
-                .to_string(),
-            "interval 2 day".to_string(),
-        )]);
-        let config = TableConfig(&raw);
-
-        assert_eq!(
-            config.deleted_file_retention_duration().as_secs(),
-            2 * SECONDS_PER_DAY,
-        );
-    }
-
-    #[test]
-    fn get_long_from_metadata_test() {
-        let md = dummy_metadata();
-        let config = TableConfig(md.configuration());
-        assert_eq!(config.checkpoint_interval(), 100,)
-    }
-
-    #[test]
-    fn get_boolean_from_metadata_test() {
-        let md = dummy_metadata();
-        let config = TableConfig(md.configuration());
-
-        // default value is true
-        assert!(config.enable_expired_log_cleanup());
-
-        // change to false
-        let raw = HashMap::from([(
-            TableProperty::EnableExpiredLogCleanup.as_ref().to_string(),
-            "false".to_string(),
-        )]);
-        let config = TableConfig(&raw);
-
-        assert!(!config.enable_expired_log_cleanup());
-    }
 
     #[test]
     fn parse_interval_test() {

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -321,6 +321,7 @@ impl DeltaTable {
     }
 
     /// Get the number of files in the table - returns 0 if no metadata is loaded
+    #[cfg(test)]
     pub fn get_files_count(&self) -> usize {
         self.state.as_ref().map(|s| s.files_count()).unwrap_or(0)
     }
@@ -331,6 +332,7 @@ impl DeltaTable {
     }
 
     /// Returns current table protocol
+    #[deprecated(since = "0.27.1", note = "Use `snapshot()?.protocol()` instead")]
     pub fn protocol(&self) -> DeltaResult<&Protocol> {
         Ok(self
             .state
@@ -340,18 +342,21 @@ impl DeltaTable {
     }
 
     /// Returns the metadata associated with the loaded state.
+    #[deprecated(since = "0.27.1", note = "Use `snapshot()?.metadata()` instead")]
     pub fn metadata(&self) -> Result<&Metadata, DeltaTableError> {
         Ok(self.snapshot()?.metadata())
     }
 
     /// Return table schema parsed from transaction log. Return None if table hasn't been loaded or
     /// no metadata was found in the log.
+    #[deprecated(since = "0.27.1", note = "Use `snapshot()?.schema()` instead")]
     pub fn schema(&self) -> Option<&StructType> {
         Some(self.snapshot().ok()?.schema())
     }
 
     /// Return table schema parsed from transaction log. Return `DeltaTableError` if table hasn't
     /// been loaded or no metadata was found in the log.
+    #[deprecated(since = "0.27.1", note = "Use `snapshot()?.schema()` instead")]
     pub fn get_schema(&self) -> Result<&StructType, DeltaTableError> {
         Ok(self.snapshot()?.schema())
     }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -302,6 +302,7 @@ impl DeltaTable {
 
     /// Returns an iterator of file names present in the loaded state
     #[inline]
+    #[deprecated = "Use `snapshot()?.file_paths_iter()` instead"]
     pub fn get_files_iter(&self) -> DeltaResult<impl Iterator<Item = Path> + '_> {
         Ok(self
             .state
@@ -321,7 +322,7 @@ impl DeltaTable {
     }
 
     /// Get the number of files in the table - returns 0 if no metadata is loaded
-    #[cfg(test)]
+    #[deprecated = "Count any of the file-like iterators on `snapshot()` instead."]
     pub fn get_files_count(&self) -> usize {
         self.state.as_ref().map(|s| s.files_count()).unwrap_or(0)
     }

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -270,7 +270,7 @@ impl DeltaTable {
     ) -> Result<impl Iterator<Item = DeltaResult<LogicalFile<'a>>>, DeltaTableError> {
         self.state
             .as_ref()
-            .ok_or(DeltaTableError::NoMetadata)?
+            .ok_or(DeltaTableError::NotInitialized)?
             .get_active_add_actions_by_partitions(filters)
     }
 
@@ -307,7 +307,7 @@ impl DeltaTable {
         Ok(self
             .state
             .as_ref()
-            .ok_or(DeltaTableError::NoMetadata)?
+            .ok_or(DeltaTableError::NotInitialized)?
             .file_paths_iter())
     }
 
@@ -316,7 +316,7 @@ impl DeltaTable {
         Ok(self
             .state
             .as_ref()
-            .ok_or(DeltaTableError::NoMetadata)?
+            .ok_or(DeltaTableError::NotInitialized)?
             .file_paths_iter()
             .map(|path| self.log_store.to_uri(&path)))
     }
@@ -328,6 +328,16 @@ impl DeltaTable {
     }
 
     /// Returns the currently loaded state snapshot.
+    ///
+    /// This method provides access to the currently loaded state of the Delta table.
+    ///
+    /// ## Returns
+    ///
+    /// A reference to the current state of the Delta table.
+    ///
+    /// ## Errors
+    ///
+    /// Returns [`NotInitialized`](DeltaTableError::NotInitialized) if the table has not been initialized.
     pub fn snapshot(&self) -> DeltaResult<&DeltaTableState> {
         self.state.as_ref().ok_or(DeltaTableError::NotInitialized)
     }
@@ -338,7 +348,7 @@ impl DeltaTable {
         Ok(self
             .state
             .as_ref()
-            .ok_or(DeltaTableError::NoMetadata)?
+            .ok_or(DeltaTableError::NotInitialized)?
             .protocol())
     }
 

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -143,6 +143,7 @@ impl DeltaTableState {
     }
 
     /// Get the number of files in the current table state
+    #[deprecated = "Count any of the file-like iterators instead."]
     pub fn files_count(&self) -> usize {
         self.snapshot.files_count()
     }

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -7,12 +7,13 @@ use chrono::Utc;
 use delta_kernel::engine::arrow_conversion::TryIntoKernel;
 use delta_kernel::expressions::column_expr;
 use delta_kernel::schema::StructField;
+use delta_kernel::table_properties::TableProperties;
 use delta_kernel::{EvaluationHandler, Expression};
 use futures::TryStreamExt;
 use object_store::path::Path;
 use serde::{Deserialize, Serialize};
 
-use super::{config::TableConfig, get_partition_col_data_types, DeltaTableConfig};
+use super::{get_partition_col_data_types, DeltaTableConfig};
 use crate::kernel::arrow::engine_ext::{ExpressionEvaluatorExt, SnapshotExt};
 #[cfg(test)]
 use crate::kernel::Action;
@@ -22,6 +23,7 @@ use crate::kernel::{
 };
 use crate::logstore::LogStore;
 use crate::partitions::{DeltaTablePartition, PartitionFilter};
+use crate::table::config::TablePropertiesExt;
 use crate::{DeltaResult, DeltaTableError};
 
 /// State snapshot currently held by the Delta Table instance.
@@ -188,7 +190,7 @@ impl DeltaTableState {
     }
 
     /// Well known table configuration
-    pub fn table_config(&self) -> TableConfig<'_> {
+    pub fn table_config(&self) -> &TableProperties {
         self.snapshot.table_config()
     }
 

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -74,9 +74,9 @@ impl RecordBatchWriter {
             .build();
 
         // if metadata fails to load, use an empty hashmap and default values for num_indexed_cols and stats_columns
-        let configuration = delta_table.metadata().map_or_else(
+        let configuration = delta_table.snapshot().map_or_else(
             |_| HashMap::new(),
-            |metadata| metadata.configuration().clone(),
+            |snapshot| snapshot.metadata().configuration().clone(),
         );
 
         Ok(Self {
@@ -100,7 +100,7 @@ impl RecordBatchWriter {
     /// Creates a [`RecordBatchWriter`] to write data to provided Delta Table
     pub fn for_table(table: &DeltaTable) -> Result<Self, DeltaTableError> {
         // Initialize an arrow schema ref from the delta table schema
-        let metadata = table.metadata()?;
+        let metadata = table.snapshot()?.metadata();
         let arrow_schema: ArrowSchema = (&metadata.parse_schema()?).try_into_arrow()?;
         let arrow_schema_ref = Arc::new(arrow_schema);
         let partition_columns = metadata.partition_columns().clone();
@@ -110,7 +110,7 @@ impl RecordBatchWriter {
             // NOTE: Consider extracting config for writer properties and setting more than just compression
             .set_compression(Compression::SNAPPY)
             .build();
-        let configuration = table.metadata()?.configuration().clone();
+        let configuration = table.snapshot()?.metadata().configuration().clone();
 
         Ok(Self {
             storage: table.object_store(),
@@ -279,7 +279,7 @@ impl DeltaWriter<RecordBatch> for RecordBatchWriter {
             // TODO: we are using the metadata from the passed table, but actually have no guarantee that this is
             // the same table that was used to create the writer instance. Previously we were erasing current config
             // assigning a new table ID, which we should not be doing when evolving the schema.
-            let current_meta = table.metadata()?.clone();
+            let current_meta = table.snapshot()?.metadata().clone();
             let metadata = current_meta.with_schema(&schema)?;
             adds.push(Action::Metadata(metadata));
         }
@@ -826,7 +826,7 @@ mod tests {
             table.load().await.expect("Failed to load table");
             assert_eq!(table.version(), Some(2));
 
-            let new_schema = table.metadata().unwrap().parse_schema().unwrap();
+            let new_schema = table.snapshot().unwrap().metadata().parse_schema().unwrap();
             let expected_columns = vec!["id", "value", "modified", "vid", "name"];
             let found_columns: Vec<&String> = new_schema.fields().map(|f| f.name()).collect();
             assert_eq!(

--- a/crates/core/tests/command_optimize.rs
+++ b/crates/core/tests/command_optimize.rs
@@ -169,7 +169,7 @@ async fn test_optimize_non_partitioned_table() -> Result<(), Box<dyn Error>> {
     .await?;
 
     let version = dt.version().unwrap();
-    assert_eq!(dt.snapshot().unwrap().files_count(), 5);
+    assert_eq!(dt.snapshot().unwrap().file_paths_iter().count(), 5);
 
     let optimize = DeltaOps(dt).optimize().with_target_size(2_000_000);
     let (dt, metrics) = optimize.await?;
@@ -179,7 +179,7 @@ async fn test_optimize_non_partitioned_table() -> Result<(), Box<dyn Error>> {
     assert_eq!(metrics.num_files_removed, 4);
     assert_eq!(metrics.total_considered_files, 5);
     assert_eq!(metrics.partitions_optimized, 1);
-    assert_eq!(dt.snapshot().unwrap().files_count(), 2);
+    assert_eq!(dt.snapshot().unwrap().file_paths_iter().count(), 2);
 
     let commit_info = dt.history(None).await?;
     let last_commit = &commit_info[0];
@@ -241,7 +241,7 @@ async fn test_optimize_with_partitions() -> Result<(), Box<dyn Error>> {
     assert_eq!(version + 1, dt.version().unwrap());
     assert_eq!(metrics.num_files_added, 1);
     assert_eq!(metrics.num_files_removed, 2);
-    assert_eq!(dt.snapshot().unwrap().files_count(), 3);
+    assert_eq!(dt.snapshot().unwrap().file_paths_iter().count(), 3);
 
     let partition_adds = dt
         .get_active_add_actions_by_partitions(&filter)?
@@ -734,7 +734,7 @@ async fn test_zorder_unpartitioned() -> Result<(), Box<dyn Error>> {
     assert_eq!(metrics.total_considered_files, 2);
 
     // Check data
-    let files = dt.get_files_iter()?.collect::<Vec<_>>();
+    let files = dt.snapshot()?.file_paths_iter().collect::<Vec<_>>();
     assert_eq!(files.len(), 1);
 
     let actual = read_parquet_file(&files[0], dt.object_store()).await?;

--- a/crates/core/tests/command_optimize.rs
+++ b/crates/core/tests/command_optimize.rs
@@ -169,7 +169,7 @@ async fn test_optimize_non_partitioned_table() -> Result<(), Box<dyn Error>> {
     .await?;
 
     let version = dt.version().unwrap();
-    assert_eq!(dt.get_files_count(), 5);
+    assert_eq!(dt.snapshot().unwrap().files_count(), 5);
 
     let optimize = DeltaOps(dt).optimize().with_target_size(2_000_000);
     let (dt, metrics) = optimize.await?;
@@ -179,7 +179,7 @@ async fn test_optimize_non_partitioned_table() -> Result<(), Box<dyn Error>> {
     assert_eq!(metrics.num_files_removed, 4);
     assert_eq!(metrics.total_considered_files, 5);
     assert_eq!(metrics.partitions_optimized, 1);
-    assert_eq!(dt.get_files_count(), 2);
+    assert_eq!(dt.snapshot().unwrap().files_count(), 2);
 
     let commit_info = dt.history(None).await?;
     let last_commit = &commit_info[0];
@@ -241,7 +241,7 @@ async fn test_optimize_with_partitions() -> Result<(), Box<dyn Error>> {
     assert_eq!(version + 1, dt.version().unwrap());
     assert_eq!(metrics.num_files_added, 1);
     assert_eq!(metrics.num_files_removed, 2);
-    assert_eq!(dt.get_files_count(), 3);
+    assert_eq!(dt.snapshot().unwrap().files_count(), 3);
 
     let partition_adds = dt
         .get_active_add_actions_by_partitions(&filter)?

--- a/crates/core/tests/command_restore.rs
+++ b/crates/core/tests/command_restore.rs
@@ -110,7 +110,7 @@ async fn test_restore_by_version() -> Result<(), Box<dyn Error>> {
         .restore()
         .with_version_to_restore(0)
         .await?;
-    assert_eq!(result.0.snapshot().unwrap().files_count(), 0);
+    assert_eq!(result.0.snapshot().unwrap().file_paths_iter().count(), 0);
     Ok(())
 }
 

--- a/crates/core/tests/command_restore.rs
+++ b/crates/core/tests/command_restore.rs
@@ -110,7 +110,7 @@ async fn test_restore_by_version() -> Result<(), Box<dyn Error>> {
         .restore()
         .with_version_to_restore(0)
         .await?;
-    assert_eq!(result.0.get_files_count(), 0);
+    assert_eq!(result.0.snapshot().unwrap().files_count(), 0);
     Ok(())
 }
 

--- a/crates/core/tests/command_update_table_metadata.rs
+++ b/crates/core/tests/command_update_table_metadata.rs
@@ -36,7 +36,7 @@ async fn test_update_table_name_valid() {
         .await
         .unwrap();
 
-    let metadata = updated_table.metadata().unwrap();
+    let metadata = updated_table.snapshot().unwrap().metadata();
     assert_eq!(metadata.name().unwrap(), name);
     assert_eq!(updated_table.version(), Some(1));
 }
@@ -60,7 +60,7 @@ async fn test_update_table_description_valid() {
         .await
         .unwrap();
 
-    let metadata = updated_table.metadata().unwrap();
+    let metadata = updated_table.snapshot().unwrap().metadata();
     assert_eq!(metadata.description().unwrap(), description);
     assert_eq!(updated_table.version(), Some(1));
 }
@@ -84,7 +84,7 @@ async fn test_update_table_name_character_limit_valid() {
         .await
         .unwrap();
 
-    let metadata = updated_table.metadata().unwrap();
+    let metadata = updated_table.snapshot().unwrap().metadata();
     assert_eq!(metadata.name().unwrap(), &name_255_chars);
     assert_eq!(updated_table.version(), Some(1));
 }
@@ -131,7 +131,7 @@ async fn test_update_table_description_character_limit_valid() {
         .await
         .unwrap();
 
-    let metadata = updated_table.metadata().unwrap();
+    let metadata = updated_table.snapshot().unwrap().metadata();
     assert_eq!(metadata.description().unwrap(), &description_4000_chars);
     assert_eq!(updated_table.version(), Some(1));
 }
@@ -180,7 +180,7 @@ async fn test_update_existing_table_name() {
 
     assert_eq!(updated_table.version(), Some(1));
     assert_eq!(
-        updated_table.metadata().unwrap().name().unwrap(),
+        updated_table.snapshot().unwrap().metadata().name().unwrap(),
         initial_name
     );
 
@@ -196,7 +196,10 @@ async fn test_update_existing_table_name() {
         .unwrap();
 
     assert_eq!(final_table.version(), Some(2));
-    assert_eq!(final_table.metadata().unwrap().name().unwrap(), new_name);
+    assert_eq!(
+        final_table.snapshot().unwrap().metadata().name().unwrap(),
+        new_name
+    );
 }
 
 #[tokio::test]
@@ -220,7 +223,12 @@ async fn test_update_existing_table_description() {
 
     assert_eq!(updated_table.version(), Some(1));
     assert_eq!(
-        updated_table.metadata().unwrap().description().unwrap(),
+        updated_table
+            .snapshot()
+            .unwrap()
+            .metadata()
+            .description()
+            .unwrap(),
         initial_description
     );
 
@@ -237,7 +245,12 @@ async fn test_update_existing_table_description() {
 
     assert_eq!(final_table.version(), Some(2));
     assert_eq!(
-        final_table.metadata().unwrap().description().unwrap(),
+        final_table
+            .snapshot()
+            .unwrap()
+            .metadata()
+            .description()
+            .unwrap(),
         new_description
     );
 }
@@ -282,7 +295,7 @@ async fn test_empty_table_description() {
         .await
         .unwrap();
 
-    let metadata = updated_table.metadata().unwrap();
+    let metadata = updated_table.snapshot().unwrap().metadata();
     assert_eq!(metadata.description().unwrap(), "");
     assert_eq!(updated_table.version(), Some(1));
 }
@@ -327,7 +340,7 @@ async fn test_with_commit_properties() {
         .await
         .unwrap();
 
-    let metadata = updated_table.metadata().unwrap();
+    let metadata = updated_table.snapshot().unwrap().metadata();
     assert_eq!(metadata.name().unwrap(), name);
     assert_eq!(updated_table.version(), Some(1));
 }
@@ -410,7 +423,7 @@ async fn test_with_custom_execute_handler() {
         .await
         .unwrap();
 
-    let metadata = updated_table.metadata().unwrap();
+    let metadata = updated_table.snapshot().unwrap().metadata();
     assert_eq!(metadata.name().unwrap(), name);
     assert_eq!(updated_table.version(), Some(1));
 

--- a/crates/core/tests/dat.rs
+++ b/crates/core/tests/dat.rs
@@ -35,7 +35,7 @@ fn reader_test_eager(path: &Path) -> datatest_stable::Result<()> {
                 .expect("table");
             let table_info = case.table_summary().expect("load summary");
             let snapshot = table.snapshot().expect("Failed to load snapshot");
-            let protocol = table.protocol().expect("Failed to load protocol");
+            let protocol = snapshot.protocol();
             assert_eq!(snapshot.version() as u64, table_info.version);
             assert_eq!(
                 (protocol.min_reader_version(), protocol.min_writer_version()),

--- a/crates/core/tests/integration.rs
+++ b/crates/core/tests/integration.rs
@@ -42,7 +42,11 @@ async fn test_action_reconciliation() {
     let a = fs_common::add(3 * 60 * 1000);
     assert_eq!(1, fs_common::commit_add(&mut table, &a).await);
     assert_eq!(
-        table.get_files_iter().unwrap().collect::<Vec<_>>(),
+        table
+            .snapshot()
+            .unwrap()
+            .file_paths_iter()
+            .collect::<Vec<_>>(),
         vec![Path::from(a.path.clone())]
     );
 
@@ -61,7 +65,7 @@ async fn test_action_reconciliation() {
     };
 
     assert_eq!(2, fs_common::commit_removes(&mut table, vec![&r]).await);
-    assert_eq!(table.get_files_iter().unwrap().count(), 0);
+    assert_eq!(table.snapshot().unwrap().file_paths_iter().count(), 0);
     assert_eq!(
         table
             .snapshot()

--- a/crates/core/tests/read_delta_log_test.rs
+++ b/crates/core/tests/read_delta_log_test.rs
@@ -149,8 +149,8 @@ async fn test_read_liquid_table() -> DeltaResult<()> {
 #[ignore = "not implemented"]
 async fn test_read_table_features() -> DeltaResult<()> {
     let mut _table = deltalake_core::open_table("../test/tests/data/simple_table_features").await?;
-    let rf = _table.protocol()?.reader_features();
-    let wf = _table.protocol()?.writer_features();
+    let rf = _table.snapshot()?.protocol().reader_features();
+    let wf = _table.snapshot()?.protocol().writer_features();
 
     assert!(rf.is_some());
     assert!(wf.is_some());
@@ -167,7 +167,7 @@ async fn read_delta_table_from_dlt() {
         .await
         .unwrap();
     assert_eq!(table.version(), Some(1));
-    assert!(table.get_schema().is_ok());
+    assert!(table.snapshot().is_ok());
 }
 
 #[tokio::test]
@@ -177,7 +177,7 @@ async fn read_delta_table_with_null_stats_in_notnull_struct() {
             .await
             .unwrap();
     assert_eq!(table.version(), Some(1));
-    assert!(table.get_schema().is_ok());
+    assert!(table.snapshot().is_ok());
 }
 
 #[tokio::test]
@@ -187,5 +187,5 @@ async fn read_delta_table_with_renamed_partitioning_column() {
         .await
         .unwrap();
     assert_eq!(table.version(), Some(4));
-    assert!(table.get_schema().is_ok());
+    assert!(table.snapshot().is_ok());
 }

--- a/crates/deltalake/examples/recordbatch-writer.rs
+++ b/crates/deltalake/examples/recordbatch-writer.rs
@@ -160,8 +160,9 @@ fn fetch_readings() -> Vec<WeatherRecord> {
  */
 fn convert_to_batch(table: &DeltaTable, records: &Vec<WeatherRecord>) -> RecordBatch {
     let metadata = table
-        .metadata()
-        .expect("Failed to get metadata for the table");
+        .snapshot()
+        .expect("Failed to get snapshot for the table")
+        .metadata();
     let arrow_schema: deltalake::arrow::datatypes::Schema =
         (&(metadata.parse_schema().expect("failed to get schema")))
             .try_into_arrow()

--- a/crates/test/src/concurrent.rs
+++ b/crates/test/src/concurrent.rs
@@ -36,10 +36,10 @@ async fn prepare_table(
         .create()
         .with_columns(schema.fields().cloned())
         .await?;
-
-    assert_eq!(Some(0), table.version());
-    assert_eq!(1, table.protocol()?.min_reader_version());
-    assert_eq!(2, table.protocol()?.min_writer_version());
+    let snapshot = table.snapshot()?;
+    assert_eq!(snapshot.version(), 0);
+    assert_eq!(snapshot.protocol().min_reader_version(), 1);
+    assert_eq!(snapshot.protocol().min_writer_version(), 2);
     // assert_eq!(0, table.get_files_iter().count());
 
     Ok((table, table_uri))

--- a/crates/test/src/read.rs
+++ b/crates/test/src/read.rs
@@ -39,12 +39,12 @@ async fn read_simple_table(integration: &IntegrationContext) -> TestResult {
         .with_allow_http(true)
         .load()
         .await?;
-
-    assert_eq!(table.version(), Some(4));
-    assert_eq!(table.protocol()?.min_writer_version(), 2);
-    assert_eq!(table.protocol()?.min_reader_version(), 1);
+    let snapshot = table.snapshot()?;
+    assert_eq!(snapshot.version(), 4);
+    assert_eq!(snapshot.protocol().min_writer_version(), 2);
+    assert_eq!(snapshot.protocol().min_reader_version(), 1);
     assert_eq!(
-        table.get_files_iter()?.collect::<Vec<_>>(),
+        snapshot.file_paths_iter().collect::<Vec<_>>(),
         vec![
             Path::from("part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet"),
             Path::from("part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet"),
@@ -53,8 +53,7 @@ async fn read_simple_table(integration: &IntegrationContext) -> TestResult {
             Path::from("part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet"),
         ]
     );
-    let tombstones = table
-        .snapshot()?
+    let tombstones = snapshot
         .all_tombstones(&table.log_store())
         .await?
         .collect::<Vec<_>>();
@@ -83,12 +82,12 @@ async fn read_simple_table_with_version(integration: &IntegrationContext) -> Tes
         .with_version(3)
         .load()
         .await?;
-
-    assert_eq!(table.version(), Some(3));
-    assert_eq!(table.protocol()?.min_writer_version(), 2);
-    assert_eq!(table.protocol()?.min_reader_version(), 1);
+    let snapshot = table.snapshot()?;
+    assert_eq!(snapshot.version(), 3);
+    assert_eq!(snapshot.protocol().min_writer_version(), 2);
+    assert_eq!(snapshot.protocol().min_reader_version(), 1);
     assert_eq!(
-        table.get_files_iter()?.collect::<Vec<_>>(),
+        snapshot.file_paths_iter().collect::<Vec<_>>(),
         vec![
             Path::from("part-00000-f17fcbf5-e0dc-40ba-adae-ce66d1fcaef6-c000.snappy.parquet"),
             Path::from("part-00001-bb70d2ba-c196-4df2-9c85-f34969ad3aa9-c000.snappy.parquet"),
@@ -98,8 +97,7 @@ async fn read_simple_table_with_version(integration: &IntegrationContext) -> Tes
             Path::from("part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet"),
         ]
     );
-    let tombstones = table
-        .snapshot()?
+    let tombstones = snapshot
         .all_tombstones(&table.log_store())
         .await?
         .collect::<Vec<_>>();
@@ -128,10 +126,10 @@ pub async fn read_golden(integration: &IntegrationContext) -> TestResult {
         .load()
         .await
         .unwrap();
-
-    assert_eq!(table.version(), Some(0));
-    assert_eq!(table.protocol()?.min_writer_version(), 2);
-    assert_eq!(table.protocol()?.min_reader_version(), 1);
+    let snapshot = table.snapshot()?;
+    assert_eq!(snapshot.version(), 0);
+    assert_eq!(snapshot.protocol().min_writer_version(), 2);
+    assert_eq!(snapshot.protocol().min_reader_version(), 1);
 
     Ok(())
 }
@@ -164,9 +162,9 @@ async fn read_encoded_table(integration: &IntegrationContext, root_path: &str) -
         .with_allow_http(true)
         .load()
         .await?;
-
-    assert_eq!(table.version(), Some(0));
-    assert_eq!(table.get_files_iter()?.count(), 2);
+    let snapshot = table.snapshot()?;
+    assert_eq!(snapshot.version(), 0);
+    assert_eq!(snapshot.file_paths_iter().count(), 2);
 
     Ok(())
 }

--- a/delta-inspect/src/main.rs
+++ b/delta-inspect/src/main.rs
@@ -69,7 +69,10 @@ async fn main() -> anyhow::Result<()> {
             if files_matches.is_present("full_uri") {
                 table.get_file_uris()?.for_each(|f| println!("{f}"));
             } else {
-                table.get_files_iter()?.for_each(|f| println!("{f}"));
+                table
+                    .snapshot()?
+                    .file_paths_iter()
+                    .for_each(|f| println!("{f}"));
             };
         }
         Some(("info", info_matches)) => {

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -407,8 +407,9 @@ impl RawDeltaTable {
             } else {
                 match self._table.lock() {
                     Ok(table) => Ok(table
-                        .get_files_iter()
+                        .snapshot()
                         .map_err(PythonError::from)?
+                        .file_paths_iter()
                         .map(|f| f.to_string())
                         .collect()),
                     Err(e) => Err(PyRuntimeError::new_err(e.to_string())),


### PR DESCRIPTION
# Description

This PR is stacked on #3646

Replaces usage of our internal `TableConfig` with kernels `TableProperties`.