### PR TITLE
feat: support converting parquet with non-microsecond timestamps to d…

### DIFF
--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -71,8 +71,10 @@ fn convert_field_timestamps(field: &ArrowField) -> Result<ArrowField, ArrowError
     };
 
     if let Some(data_type) = converted_data_type {
-        Ok(ArrowField::new(field.name(), data_type, field.is_nullable())
-            .with_metadata(field.metadata().clone()))
+        Ok(
+            ArrowField::new(field.name(), data_type, field.is_nullable())
+                .with_metadata(field.metadata().clone()),
+        )
     } else {
         Ok(field.clone())
     }

--- a/crates/core/src/operations/convert_to_delta.rs
+++ b/crates/core/src/operations/convert_to_delta.rs
@@ -5,7 +5,10 @@ use std::num::TryFromIntError;
 use std::str::{FromStr, Utf8Error};
 use std::sync::Arc;
 
-use arrow_schema::{ArrowError, Schema as ArrowSchema};
+use arrow_schema::{
+    ArrowError, DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
+    TimeUnit,
+};
 use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
 use delta_kernel::schema::StructType;
 use futures::future::{self, BoxFuture};
@@ -32,6 +35,75 @@ use crate::{
     writer::stats::stats_from_parquet_metadata,
     DeltaResult, DeltaTable, DeltaTableError, ObjectStoreError, NULL_PARTITION_VALUE_DATA_PATH,
 };
+
+fn convert_timestamps_to_microseconds(schema: ArrowSchema) -> Result<ArrowSchema, ArrowError> {
+    let mut any_changed = false;
+    let mut converted_fields = Vec::with_capacity(schema.fields().len());
+
+    for field in schema.fields() {
+        if let Some(converted_field) = convert_field_timestamps(field)? {
+            any_changed = true;
+            converted_fields.push(converted_field);
+        } else {
+            converted_fields.push(field.as_ref().clone());
+        }
+    }
+
+    if any_changed {
+        Ok(ArrowSchema::new(converted_fields))
+    } else {
+        Ok(schema)
+    }
+}
+
+/// Recursively convert timestamp fields to microseconds
+fn convert_field_timestamps(field: &ArrowField) -> Result<Option<ArrowField>, ArrowError> {
+    let converted_data_type = match field.data_type() {
+        ArrowDataType::Timestamp(TimeUnit::Nanosecond, tz)
+        | ArrowDataType::Timestamp(TimeUnit::Millisecond, tz)
+        | ArrowDataType::Timestamp(TimeUnit::Second, tz) => {
+            Some(ArrowDataType::Timestamp(TimeUnit::Microsecond, tz.clone()))
+        }
+        // Recursively handle nested structures
+        ArrowDataType::Struct(fields) => {
+            let mut any_changed = false;
+            let mut converted_fields = Vec::with_capacity(fields.len());
+
+            for field in fields {
+                if let Some(converted_field) = convert_field_timestamps(field)? {
+                    any_changed = true;
+                    converted_fields.push(converted_field);
+                } else {
+                    converted_fields.push(field.as_ref().clone());
+                }
+            }
+
+            if any_changed {
+                Some(ArrowDataType::Struct(Fields::from(converted_fields)))
+            } else {
+                None
+            }
+        }
+        // Handle lists that might contain timestamps
+        ArrowDataType::List(field_ref) => {
+            if let Some(converted_field) = convert_field_timestamps(field_ref)? {
+                Some(ArrowDataType::List(Arc::new(converted_field)))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+
+    if let Some(data_type) = converted_data_type {
+        Ok(Some(
+            ArrowField::new(field.name(), data_type, field.is_nullable())
+                .with_metadata(field.metadata().clone()),
+        ))
+    } else {
+        Ok(None)
+    }
+}
 
 /// Error converting a Parquet table to a Delta table
 #[derive(Debug, thiserror::Error)]
@@ -415,8 +487,11 @@ impl ConvertToDeltaBuilder {
         }
 
         // Merge parquet file schemas
-        // This step is needed because timestamp will not be preserved when copying files in S3. We can't use the schema of the latest parqeut file as Delta table's schema
-        let schema: StructType = (&ArrowSchema::try_merge(arrow_schemas)?).try_into_kernel()?;
+        // This step is needed because timestamp will not be preserved when copying files in S3. We can't use the schema of the latest parquet file as Delta table's schema
+        let merged_schema = ArrowSchema::try_merge(arrow_schemas)?;
+        let converted_schema = convert_timestamps_to_microseconds(merged_schema)?;
+        let schema: StructType = (&converted_schema).try_into_kernel()?;
+
         let mut schema_fields = schema.fields().collect_vec();
         schema_fields.append(&mut partition_schema_fields.values().collect::<Vec<_>>());
 
@@ -469,9 +544,13 @@ impl std::future::IntoFuture for ConvertToDeltaBuilder {
 mod tests {
     use std::fs;
 
+    use arrow::array::{Int32Array, TimestampMicrosecondArray, TimestampMillisecondArray};
+    use arrow::record_batch::RecordBatch;
     use delta_kernel::expressions::Scalar;
     use itertools::Itertools;
+    use parquet::arrow::ArrowWriter;
     use pretty_assertions::assert_eq;
+    use std::fs::File;
     use tempfile::tempdir;
 
     use super::*;
@@ -955,5 +1034,260 @@ mod tests {
             .with_location("../test/tests/data/delta-0.2.0")
             .await
             .expect_err("The given location is already a delta table location. Should error");
+    }
+
+    #[test]
+    fn test_convert_timestamps_to_microseconds_no_change() {
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, false),
+            ArrowField::new("name", ArrowDataType::Utf8, true),
+            ArrowField::new(
+                "timestamp_micro",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+                true,
+            ),
+        ]);
+
+        let result = convert_timestamps_to_microseconds(schema.clone()).unwrap();
+
+        // Should return the same schema instance when no conversion needed
+        assert_eq!(result.fields().len(), 3);
+        assert_eq!(result.field(0).data_type(), &ArrowDataType::Int32);
+        assert_eq!(result.field(1).data_type(), &ArrowDataType::Utf8);
+        assert_eq!(
+            result.field(2).data_type(),
+            &ArrowDataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+    }
+
+    #[test]
+    fn test_convert_timestamps_to_microseconds_conversions() {
+        let inner_struct = ArrowDataType::Struct(Fields::from(vec![
+            ArrowField::new(
+                "ts_nano",
+                ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+            ArrowField::new(
+                "ts_milli",
+                ArrowDataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+                true,
+            ),
+            ArrowField::new("value", ArrowDataType::Int32, false),
+        ]));
+
+        let list_element = ArrowField::new(
+            "element",
+            ArrowDataType::Timestamp(TimeUnit::Second, Some("UTC".into())),
+            true,
+        );
+        let list_type = ArrowDataType::List(Arc::new(list_element));
+
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new(
+                "ts_nano",
+                ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+            ArrowField::new(
+                "ts_milli",
+                ArrowDataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+                true,
+            ),
+            ArrowField::new(
+                "ts_sec",
+                ArrowDataType::Timestamp(TimeUnit::Second, Some("UTC".into())),
+                true,
+            ),
+            ArrowField::new(
+                "ts_micro",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+                true,
+            ),
+            ArrowField::new("nested_struct", inner_struct, true),
+            ArrowField::new("timestamp_list", list_type, true),
+            ArrowField::new("regular_field", ArrowDataType::Utf8, true),
+        ]);
+
+        let result = convert_timestamps_to_microseconds(schema).unwrap();
+
+        assert_eq!(
+            result.field(0).data_type(),
+            &ArrowDataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+        assert_eq!(
+            result.field(1).data_type(),
+            &ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+        );
+        assert_eq!(
+            result.field(2).data_type(),
+            &ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+        );
+        assert_eq!(
+            result.field(3).data_type(),
+            &ArrowDataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+
+        if let ArrowDataType::Struct(fields) = result.field(4).data_type() {
+            assert_eq!(
+                fields[0].data_type(),
+                &ArrowDataType::Timestamp(TimeUnit::Microsecond, None)
+            );
+            assert_eq!(
+                fields[1].data_type(),
+                &ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+            );
+            assert_eq!(fields[2].data_type(), &ArrowDataType::Int32);
+        } else {
+            panic!("Expected struct type");
+        }
+
+        if let ArrowDataType::List(element) = result.field(5).data_type() {
+            assert_eq!(
+                element.data_type(),
+                &ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+            );
+        } else {
+            panic!("Expected list type");
+        }
+
+        assert_eq!(result.field(6).data_type(), &ArrowDataType::Utf8);
+    }
+
+    #[test]
+    fn test_convert_field_timestamps_no_conversion() {
+        let field = ArrowField::new("test", ArrowDataType::Int32, false);
+        let result = convert_field_timestamps(&field).unwrap();
+        assert!(
+            result.is_none(),
+            "Should return None for non-timestamp fields"
+        );
+
+        let micro_field = ArrowField::new(
+            "test",
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            true,
+        );
+        let result = convert_field_timestamps(&micro_field).unwrap();
+        assert!(
+            result.is_none(),
+            "Should return None for already-microsecond timestamps"
+        );
+    }
+
+    #[test]
+    fn test_convert_field_timestamps_with_conversion() {
+        let field = ArrowField::new(
+            "test",
+            ArrowDataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+            true,
+        );
+        let result = convert_field_timestamps(&field).unwrap();
+
+        assert!(result.is_some(), "Should return Some for converted field");
+        let converted = result.unwrap();
+        assert_eq!(converted.name(), "test");
+        assert_eq!(
+            converted.data_type(),
+            &ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+        );
+        assert_eq!(converted.is_nullable(), true);
+    }
+
+    #[tokio::test]
+    async fn test_convert_to_delta_with_timestamp_conversion() {
+        let temp_dir = tempdir().expect("Failed to create temp directory");
+        let parquet_path = temp_dir.path().join("test_timestamps.parquet");
+
+        // Create schema with mixed timestamp precisions
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, false),
+            ArrowField::new(
+                "timestamp_milli",
+                ArrowDataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+                true,
+            ),
+            ArrowField::new(
+                "timestamp_nano",
+                ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+            ArrowField::new(
+                "timestamp_micro",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                true,
+            ),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(
+                    TimestampMillisecondArray::from(vec![
+                        Some(1609459200000),
+                        Some(1609545600000),
+                        Some(1609632000000),
+                    ])
+                    .with_timezone("UTC"),
+                ),
+                Arc::new(arrow::array::TimestampNanosecondArray::from(vec![
+                    Some(1609459200000000000),
+                    Some(1609545600000000000),
+                    Some(1609632000000000000),
+                ])),
+                Arc::new(
+                    arrow::array::TimestampMicrosecondArray::from(vec![
+                        Some(1609459200000000),
+                        Some(1609545600000000),
+                        Some(1609632000000000),
+                    ])
+                    .with_timezone("UTC"),
+                ),
+            ],
+        )
+        .expect("Failed to create record batch");
+
+        let file = File::create(&parquet_path).expect("Failed to create parquet file");
+        let mut writer =
+            ArrowWriter::try_new(file, schema, None).expect("Failed to create parquet writer");
+        writer.write(&batch).expect("Failed to write batch");
+        writer.close().expect("Failed to close writer");
+
+        let table = ConvertToDeltaBuilder::new()
+            .with_location(temp_dir.path().to_str().unwrap())
+            .await
+            .expect("Failed to convert to Delta table");
+
+        assert_eq!(table.version(), Some(0));
+
+        let delta_schema = table.get_schema().expect("Failed to get schema");
+        let fields: Vec<_> = delta_schema.fields().collect();
+        let timestamp_fields: Vec<_> = fields
+            .iter()
+            .filter(|f| {
+                matches!(
+                    f.data_type(),
+                    crate::kernel::DataType::Primitive(crate::kernel::PrimitiveType::Timestamp)
+                        | crate::kernel::DataType::Primitive(
+                            crate::kernel::PrimitiveType::TimestampNtz
+                        )
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            timestamp_fields.len(),
+            3,
+            "Should have 3 timestamp fields (Timestamp + TimestampNtz)"
+        );
+
+        // Verify table can be read
+        let files: Vec<_> = table.get_files_iter().unwrap().collect();
+        assert_eq!(files.len(), 1, "Should have one data file");
+
+        // Verify can get file metadata
+        let snapshot = table.snapshot().unwrap();
+        assert_eq!(snapshot.files_count(), 1);
     }
 }


### PR DESCRIPTION
…eltalake

# Description
Delta Lake only supports microsecond timestamp precision. Previously when attempting to convert a parquet table with non-microsecond precision to a delta table `SchemaMismatchError: Invalid data type for Delta Lake: Timestamp(...)` would be raised.

Now this can be done successfully and the timestamp is converted to microseconds:
```
>>> import pandas as pd
>>> import deltalake
>>> df = pd.DataFrame({"column1": [0]*2, "column2": [pd.to_datetime("2020-01-01T00:00:00Z"), pd.to_datetime("2020-01-02T00:00:00Z")]})
>>> df["column2"] = df["column2"].dt.as_unit("ms")
>>> df.to_parquet("test", partition_cols=["column1"], index=False, engine="pyarrow", compression="zstd", compression_level=3)
>>> deltalake.convert_to_deltalake(uri="test", partition_by=deltalake.Schema(fields=[deltalake.Field("column1", "integer")]), partition_strategy="hive")
>>> dt = deltalake.DeltaTable("test")
>>> df_converted = dt.to_pandas()
>>> print(df_converted)
                    column2  column1
0 2020-01-01 00:00:00+00:00        0
1 2020-01-02 00:00:00+00:00        0
>>> print(dt.schema())
Schema([Field(column2, PrimitiveType("timestamp"), nullable=True), Field(column1, PrimitiveType("integer"), nullable=True)])
```

# Related Issue(s)
- closes #3535 

# Documentation
- N/A
