### PR TITLE
fix: aws special paths encoding

### DIFF
--- a/crates/aws/tests/integration_read.rs
+++ b/crates/aws/tests/integration_read.rs
@@ -18,8 +18,8 @@ async fn test_read_tables_aws() -> TestResult {
 
     test_read_tables(&context).await?;
 
-    for (prefix, prefix_encoded) in TEST_PREFIXES.iter().zip(TEST_PREFIXES_ENCODED.iter()) {
-        read_table_paths(&context, prefix, prefix_encoded).await?;
+    for (prefix, _prefix_encoded) in TEST_PREFIXES.iter().zip(TEST_PREFIXES_ENCODED.iter()) {
+        read_table_paths(&context, prefix, prefix).await?;
     }
 
     Ok(())

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -525,7 +525,6 @@ fn object_store_url(location: &Url) -> ObjectStoreUrl {
 // TODO: find out why this is necessary
 pub(crate) fn object_store_path(table_root: &Url) -> DeltaResult<Path> {
     Ok(match ObjectStoreScheme::parse(table_root) {
-        Ok((ObjectStoreScheme::AmazonS3, _)) => Path::parse(table_root.path())?,
         Ok((_, path)) => path,
         _ => Path::parse(table_root.path())?,
     })


### PR DESCRIPTION
# Description

Removes special casing for handling some AWS paths. The fix in the PR is trivial, since we just remove the special casing and do the test setup the same way we do for azure and gcp.

However I am more than sure that we did try this before to no avail. So why is it working now? My best guess is that the source was somewhere in the test setup when uploading the files to localstack, and has been removed when @rtyler recently updated the localstack version in our test setup.

In any case I am happy we got rid of it 😆.
