### PR TITLE
fix: handle checking partition filters in array/list when converting …

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -883,11 +883,7 @@ class DeltaTable:
                 self.schema().to_arrow(as_large_types=as_large_types)
             )
 
-        if partitions:
-            partitions = [
-                (column, operator, encode_partition_value(value))
-                for column, operator, value in partitions
-            ]
+        partitions = self._stringify_partition_values(partitions)
 
         fragments = [
             format.make_fragment(

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -302,7 +302,9 @@ def test_read_partitioned_table_with_primitive_type_partition_filters():
     assert all(year == "2020" for year in result_year_in["year"])
 
     partitions_bool_true_only = [("is_active", "in", [True])]
-    result_bool_true_only = dt.to_pyarrow_dataset(partitions_bool_true_only).to_table().to_pydict()
+    result_bool_true_only = (
+        dt.to_pyarrow_dataset(partitions_bool_true_only).to_table().to_pydict()
+    )
     assert len(result_bool_true_only["id"]) == 8
     assert all(is_active == "true" for is_active in result_bool_true_only["is_active"])
 

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -291,6 +291,29 @@ def test_read_partitioned_table_with_primitive_type_partition_filters():
     assert len(result_string["id"]) == 8
     assert all(category == "A" for category in result_string["category"])
 
+    partitions_bool_in = [("is_active", "in", [True, False])]
+    result_bool_in = dt.to_pyarrow_dataset(partitions_bool_in).to_table().to_pydict()
+    total_rows = len(dt.to_pyarrow_dataset().to_table().to_pydict()["id"])
+    assert len(result_bool_in["id"]) == total_rows
+
+    partitions_year_in = [("year", "in", [2020, 2022.0])]
+    result_year_in = dt.to_pyarrow_dataset(partitions_year_in).to_table().to_pydict()
+    assert len(result_year_in["id"]) == 8
+    assert all(year == "2020" for year in result_year_in["year"])
+
+    partitions_bool_true_only = [("is_active", "in", [True])]
+    result_bool_true_only = dt.to_pyarrow_dataset(partitions_bool_true_only).to_table().to_pydict()
+    assert len(result_bool_true_only["id"]) == 8
+    assert all(is_active == "true" for is_active in result_bool_true_only["is_active"])
+
+    with pytest.raises(ValueError, match="Could not encode partition value for type"):
+        partitions_invalid = [("category", "=", {"invalid": "dict"})]
+        dt.to_pyarrow_dataset(partitions_invalid)
+
+    with pytest.raises(ValueError, match="Could not encode partition value for type"):
+        partitions_invalid_list = [("category", "in", [{"invalid": "dict"}, "A"])]
+        dt.to_pyarrow_dataset(partitions_invalid_list)
+
 
 @pytest.mark.pyarrow
 def test_read_empty_delta_table_after_delete():


### PR DESCRIPTION
…to pyarrow dataset

# Description
A bug was introduced where we didn't handle encoding partition filters in an array/list. This fixes the issue:
```
>>> from deltalake import DeltaTable
>>> dt = DeltaTable("../crates/test/tests/data/partition-type-primitives")
>>> result_int = dt.to_pyarrow_dataset(partitions=[("year", "in", [2020, 2022.0])])
>>> print(result_int.to_table().to_pydict())
{'id': [8, 2, 1, 5, 7, 4, 3, 6], 'value': ['record_8', 'record_2', 'record_1', 'record_5', 'record_7', 'record_4', 'record_3', 'record_6'], 'year': ['2020', '2020', '2020', '2020', '2020', '2020', '2020', '2020'], 'is_active': ['false', 'true', 'true', 'false', 'false', 'true', 'true', 'false'], 'event_date': ['2023-01-02', '2023-01-01', '2023-01-01', '2023-01-01', '2023-01-02', '2023-01-02', '2023-01-02', '2023-01-01'], 'category': ['B', 'B', 'A', 'A', 'A', 'B', 'A', 'B']}
```

# Related Issue(s)
- closes #3648 

# Documentation
N/A