### PR TITLE
ci: run integration tests against next branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, "rust-v*"]
   pull_request:
-    branches: [main, "rust-v*"]
+    branches: [main, "rust-v*", next, next/*]
   merge_group:
 
 env:

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, next, next/*]
 
 defaults:
   run:


### PR DESCRIPTION
# Description

As we want to work more with topic branches, extending the ci triggers to run more meaningful CI when targeting topic branches.

Limiting to branches `next`, `next/*`.