### PR TITLE
fix: use RFC3896 percent encoding with delta protocol correctness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ tracing = { version = "0.1", features = ["log"] }
 regex = { version = "1" }
 thiserror = { version = "2" }
 url = { version = "2" }
-urlencoding = "2.1.3"
+percent-encoding-rfc3986 = { version = "0.1.3" }
 uuid = { version = "1" }
 
 # runtime / async

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -51,7 +51,7 @@ regex = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 url = { workspace = true, features = ["serde"] }
-urlencoding = { workspace = true }
+percent-encoding-rfc3986 = {workspace = true}
 
 # runtime
 async-trait = { workspace = true }

--- a/crates/core/src/kernel/scalars.rs
+++ b/crates/core/src/kernel/scalars.rs
@@ -13,7 +13,8 @@ use percent_encoding_rfc3986::{utf8_percent_encode, AsciiSet, CONTROLS};
 #[cfg(any(test, feature = "integration_test"))]
 use serde_json::Value;
 
-// ASCII set that needs to be encoded
+// ASCII set that needs to be encoded, derived from
+// PROTOCOL DOCS: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#how-to-url-encode-keys-and-string-values
 const RFC3986_PART: &AsciiSet = &CONTROLS
     .add(b' ') // space
     .add(b'!')

--- a/crates/core/src/kernel/scalars.rs
+++ b/crates/core/src/kernel/scalars.rs
@@ -121,7 +121,7 @@ impl ScalarExt for Scalar {
         if self.is_null() {
             return NULL_PARTITION_VALUE_DATA_PATH.to_string();
         }
-        encode_partition_value(self.serialize().as_str()).to_string()
+        encode_partition_value(self.serialize().as_str())
     }
 
     /// Create a [`Scalar`] from a row in an arrow array.

--- a/crates/core/src/kernel/scalars.rs
+++ b/crates/core/src/kernel/scalars.rs
@@ -9,7 +9,6 @@ use delta_kernel::{
     expressions::{Scalar, StructData},
     schema::StructField,
 };
-
 use percent_encoding_rfc3986::{utf8_percent_encode, AsciiSet, CONTROLS};
 #[cfg(any(test, feature = "integration_test"))]
 use serde_json::Value;

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -102,7 +102,7 @@ dev = [
     "ruff>=0.11.2,<0.11.12",
     "types-deprecated>=1.2.15.20250304",
 ]
-polars = ["polars==1.17.1"]
+polars = ["polars==1.32"]
 lakefs = ["lakefs==0.8.0"]
 pyspark = [
     "pyspark",

--- a/python/tests/test_partition_encoding_rfc3896.py
+++ b/python/tests/test_partition_encoding_rfc3896.py
@@ -1,0 +1,31 @@
+import pytest
+
+from deltalake import DeltaTable
+
+
+@pytest.mark.polars
+def test_partition_encoding_rfc3896(tmp_path):
+    import polars as pl
+    from polars.testing import assert_frame_equal
+
+    (start, stop) = (32, 127)
+    df = pl.DataFrame(
+        {
+            "a": list(i for i in range(start, stop)),
+            "strings": list("a" + chr(i) for i in range(start, stop)),
+        }
+    )
+    print(f"df:\n{df}")
+
+    # write:
+    df.write_delta(tmp_path, delta_write_options={"partition_by": "strings"})
+
+    # read:
+    partitioned_tbl = DeltaTable(tmp_path)
+    pl_df_partitioned = pl.read_delta(partitioned_tbl).sort("a")
+    print(f"pl_df_partitioned:\n{pl_df_partitioned}")
+
+    assert_frame_equal(
+        df,
+        pl_df_partitioned,
+    )

--- a/python/tests/test_partition_encoding_rfc3896.py
+++ b/python/tests/test_partition_encoding_rfc3896.py
@@ -23,7 +23,6 @@ def test_partition_encoding_rfc3896(tmp_path):
     # read:
     partitioned_tbl = DeltaTable(tmp_path)
     pl_df_partitioned = pl.read_delta(partitioned_tbl).sort("a")
-    print(f"pl_df_partitioned:\n{pl_df_partitioned}")
 
     assert_frame_equal(
         df,

--- a/python/tests/test_partition_encoding_rfc3896.py
+++ b/python/tests/test_partition_encoding_rfc3896.py
@@ -8,7 +8,7 @@ def test_partition_encoding_rfc3896(tmp_path):
     import polars as pl
     from polars.testing import assert_frame_equal
 
-    (start, stop) = (32, 127)
+    (start, stop) = (32, 255)
     df = pl.DataFrame(
         {
             "a": list(i for i in range(start, stop)),


### PR DESCRIPTION
# Description
Before when I addressed partition encoding I was using the URL encoding, where I naively assumed this was URI encoding compatible, but protocol states to use RFC3896 with additional stricter rules. I have used the percent-encoding-rfc3896 crate for this which forks the percent-encoding crate but adds some extra things to make it it RFC3896 compatible.

The ASCII set contains all reserved characters that need to be encoded according to the protocol

- fixes: #3577

@kdn36
