### PR TITLE
fix(pandas): implement-automatic-conversion-for-pandas-null-types

### DIFF
--- a/python/deltalake/writer/_conversion.py
+++ b/python/deltalake/writer/_conversion.py
@@ -23,14 +23,15 @@ def _convert_arro3_schema_to_delta(
     def dtype_to_delta_dtype(
         dtype: DataType, field_name: str | None = None
     ) -> DataType:
-        if DataType.is_null(dtype) and existing_schema and field_name:
-            for existing_field in existing_schema:  # type: ignore[attr-defined]
-                if existing_field.name == field_name:
-                    # Prevent infinite recursion: if existing field is also null, keep as null
-                    if DataType.is_null(existing_field.type):
-                        return dtype
-                    return dtype_to_delta_dtype(existing_field.type, None)
-            return dtype
+        if DataType.is_null(dtype) and existing_schema is not None and field_name is not None:
+            try:
+                existing_field = existing_schema.field(field_name)
+                # Prevent infinite recursion: if existing field is also null, keep as null
+                if DataType.is_null(existing_field.type):
+                    return dtype
+                return dtype_to_delta_dtype(existing_field.type, None)
+            except (KeyError, IndexError):
+                return dtype
 
         # Handle nested types
         if (

--- a/python/deltalake/writer/_conversion.py
+++ b/python/deltalake/writer/_conversion.py
@@ -6,14 +6,32 @@ from arro3.core import Schema as Arro3Schema
 
 def _convert_arro3_schema_to_delta(
     schema: Arro3Schema,
+    existing_schema: Arro3Schema | None = None,
 ) -> Arro3Schema:
     """Convert a arro3 schema to a schema compatible with Delta Lake. Converts unsigned to signed equivalent, and
-    converts all timestamps to `us` timestamps.
-    Args
-        schema: Source schema
+    converts all timestamps to `us` timestamps. Also handles null column types by converting them to match
+    corresponding fields in the existing table schema.
+
+    Args:
+        schema (Arro3Schema): Source schema.
+        existing_schema (Arro3Schema, optional): Existing table schema to match null types against. Defaults to None.
+
+    Returns:
+        Arro3Schema: Delta-compatible schema with converted types.
     """
 
-    def dtype_to_delta_dtype(dtype: DataType) -> DataType:
+    def dtype_to_delta_dtype(
+        dtype: DataType, field_name: str | None = None
+    ) -> DataType:
+        if DataType.is_null(dtype) and existing_schema and field_name:
+            for existing_field in existing_schema:  # type: ignore[attr-defined]
+                if existing_field.name == field_name:
+                    # Prevent infinite recursion: if existing field is also null, keep as null
+                    if DataType.is_null(existing_field.type):
+                        return dtype
+                    return dtype_to_delta_dtype(existing_field.type, None)
+            return dtype
+
         # Handle nested types
         if (
             DataType.is_list(dtype)
@@ -55,7 +73,9 @@ def _convert_arro3_schema_to_delta(
         assert nested_dtype is not None
         assert inner_field is not None
 
-        inner_field_casted = inner_field.with_type(dtype_to_delta_dtype(nested_dtype))
+        inner_field_casted = inner_field.with_type(
+            dtype_to_delta_dtype(nested_dtype, None)
+        )
 
         if DataType.is_large_list(dtype):
             return DataType.large_list(inner_field_casted)
@@ -80,7 +100,11 @@ def _convert_arro3_schema_to_delta(
             raise NotImplementedError
 
     def struct_to_delta_dtype(dtype: DataType) -> DataType:
-        fields_cast = [f.with_type(dtype_to_delta_dtype(f.type)) for f in dtype.fields]
+        fields_cast = [
+            f.with_type(dtype_to_delta_dtype(f.type, f.name)) for f in dtype.fields
+        ]
         return DataType.struct(fields_cast)
 
-    return Arro3Schema([f.with_type(dtype_to_delta_dtype(f.type)) for f in schema])  # type: ignore[attr-defined]
+    return Arro3Schema(
+        [f.with_type(dtype_to_delta_dtype(f.type, f.name)) for f in schema]  # type: ignore[attr-defined]
+    )

--- a/python/deltalake/writer/writer.py
+++ b/python/deltalake/writer/writer.py
@@ -119,7 +119,13 @@ def write_deltalake(
     else:
         data = RecordBatchReader.from_arrow(data)
 
-    compatible_delta_schema = _convert_arro3_schema_to_delta(data.schema)
+    existing_schema = None
+    if table is not None:
+        existing_schema = table.schema().to_arrow()
+
+    compatible_delta_schema = _convert_arro3_schema_to_delta(
+        data.schema, existing_schema
+    )
 
     if table:
         table._table.write(

--- a/python/tests/test_conversion.py
+++ b/python/tests/test_conversion.py
@@ -495,8 +495,8 @@ def test_null_conversion_prevents_infinite_recursion():
 
     converted = _convert_arro3_schema_to_delta(source_schema, existing_schema)
 
-    assert converted.field(0).type == DataType.int64()
-    assert DataType.is_null(converted.field(1).type)
+    assert converted.field("id").type == DataType.int64()
+    assert DataType.is_null(converted.field("problematic_field").type)
 
 
 @pytest.mark.pandas
@@ -521,9 +521,9 @@ def test_null_conversion_with_mixed_types():
 
     converted = _convert_arro3_schema_to_delta(source_schema, existing_schema)
 
-    assert converted.field(0).type == DataType.int64()
-    assert converted.field(1).type == DataType.string()
-    assert converted.field(2).type == DataType.string()
+    assert converted.field("concrete_field").type == DataType.int64()
+    assert converted.field("null_field").type == DataType.string()
+    assert converted.field("missing_field").type == DataType.string()
 
 
 @pytest.mark.pandas
@@ -541,9 +541,9 @@ def test_null_conversion_without_existing_schema():
 
     converted = _convert_arro3_schema_to_delta(source_schema)
 
-    assert converted.field(0).type == DataType.int64()
-    assert DataType.is_null(converted.field(1).type)
-    assert converted.field(2).type == DataType.timestamp("us")
+    assert converted.field("id").type == DataType.int64()
+    assert DataType.is_null(converted.field("null_field").type)
+    assert converted.field("timestamp_field").type == DataType.timestamp("us")
 
 
 @pytest.mark.pandas
@@ -565,7 +565,7 @@ def test_null_conversion_field_not_found():
 
     converted = _convert_arro3_schema_to_delta(source_schema, existing_schema)
 
-    assert DataType.is_null(converted.field(0).type)
+    assert DataType.is_null(converted.field("missing_field").type)
 
 
 @pytest.mark.pandas
@@ -587,7 +587,7 @@ def test_null_conversion_no_field_name():
 
     converted = _convert_arro3_schema_to_delta(source_schema, existing_schema)
 
-    list_field = converted.field(0)
+    list_field = converted.field("list_field")
     assert DataType.is_list(list_field.type)
 
 
@@ -626,7 +626,7 @@ def test_null_conversion_with_struct_types():
 
     converted = _convert_arro3_schema_to_delta(source_schema, existing_schema)
 
-    struct_field = converted.field(0)
+    struct_field = converted.field("struct_field")
     assert DataType.is_struct(struct_field.type)
     inner_fields = struct_field.type.fields
     assert DataType.is_null(inner_fields[0].type)


### PR DESCRIPTION
# Description
This PR fixes type inconsistencies in Pandas DataFrames by implementing automatic conversion of `object` dtype columns containing null values into their correct schema-defined types (when available).

Previously, `object` dtype columns with `null` values could remain untyped, leading to mismatches with schema-defined types and causing validation or serialization errors.

Now, these columns are automatically converted, ensuring consistency between DataFrame values and the schema while reducing type-related issues.

# Related Issue(s)
- closes #3691