### PR TITLE
fix: reintroduce the 100 commit checkpoint interval

### DIFF
--- a/crates/core/src/table/config.rs
+++ b/crates/core/src/table/config.rs
@@ -258,7 +258,7 @@ impl TablePropertiesExt for TableProperties {
 
     fn checkpoint_interval(&self) -> NonZero<u64> {
         static DEFAULT_INTERVAL: LazyLock<NonZero<u64>> =
-            LazyLock::new(|| NonZero::new(10).unwrap());
+            LazyLock::new(|| NonZero::new(100).unwrap());
         self.checkpoint_interval
             .unwrap_or(DEFAULT_INTERVAL.to_owned())
     }


### PR DESCRIPTION
@ion-elgreco and I originally bumped the delta-rs checkpoint interval to every 100 commits rather than every 10. The Delta/Spark implementation uses 10, but since this is not specified by the protocol, we should adopt the setting for good performance by delta-rs users (100) :smile:
