### PR TITLE
chore(cargo): add cargo-machete to detect and remove unused dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Format
         run: cargo fmt -- --check
 
+      - name: Run Machete to check for unused dependencies
+        uses: bnjbvr/cargo-machete@main
+
       - name: Default build
         run: (cd crates/deltalake && cargo build --tests)
 

--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -36,10 +36,7 @@ aws-config = { version = "1.5", default-features = false, features = [
     "behavior-version-latest",
     "rt-tokio",
     "credentials-process",
-    "sso",
 ] }
-aws-sdk-sso = { version = "=1.72.0"}
-aws-sdk-ssooidc = { version = "=1.73.0"}
 aws-sdk-dynamodb = { version = "=1.79.0", default-features = false, features = [
     "behavior-version-latest",
     "rt-tokio",

--- a/crates/azure/Cargo.toml
+++ b/crates/azure/Cargo.toml
@@ -15,14 +15,10 @@ rust-version.workspace = true
 deltalake-core = { version = "0.28.0", path = "../core", features = ["cloud"] }
 
 # workspace depenndecies
-async-trait = { workspace = true }
 bytes = { workspace = true }
-futures = { workspace = true }
-tracing = { workspace = true }
 object_store = { workspace = true, features = ["azure"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-regex = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -12,24 +12,12 @@ edition = "2021"
 clap = { version = "4", features = [ "derive" ] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 tokio = { version = "1", features = ["fs", "macros", "rt", "io-util"] }
-env_logger = "0"
 
 # arrow
 arrow = { workspace = true }
 arrow-array = { workspace = true }
-arrow-buffer = { workspace = true }
-arrow-cast = { workspace = true }
-arrow-ord = { workspace = true }
-arrow-row = { workspace = true }
-arrow-schema = { workspace = true, features = ["serde"] }
-arrow-select = { workspace = true }
-parquet = { workspace = true, features = [
-    "async",
-    "object_store",
-] }
 
 # serde
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 # datafusion

--- a/crates/catalog-glue/Cargo.toml
+++ b/crates/catalog-glue/Cargo.toml
@@ -13,7 +13,11 @@ rust-version.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
-aws-config = "1"
+aws-config = { version = "1.5", default-features = false, features = [
+    "behavior-version-latest",
+    "rt-tokio",
+    "credentials-process",
+] }
 aws-sdk-glue = "=1.78.0"
 deltalake-core = { version = "0.28.0", path = "../core" }
 thiserror = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -166,3 +166,6 @@ required-features = ["datafusion"]
 [[test]]
 name = "read_delta_partitions_test"
 required-features = ["datafusion"]
+
+[package.metadata.cargo-machete]
+ignored = ["foyer"]

--- a/crates/deltalake/Cargo.toml
+++ b/crates/deltalake/Cargo.toml
@@ -70,3 +70,6 @@ required-features = ["datafusion"]
 
 [[example]]
 name = "recordbatch-writer"
+
+[package.metadata.cargo-machete]
+ignored = ["deltalake-catalog-glue"]

--- a/crates/gcp/Cargo.toml
+++ b/crates/gcp/Cargo.toml
@@ -22,7 +22,6 @@ tracing = { workspace = true }
 object_store = { workspace = true, features = ["gcp"]}
 thiserror = { workspace = true }
 tokio = { workspace = true }
-regex = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -16,7 +16,6 @@ deltalake-core = { version = "0.28.0", path = "../core"}
 hdfs-native-object-store = "0.15"
 
 # workspace dependecies
-object_store = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 

--- a/crates/lakefs/Cargo.toml
+++ b/crates/lakefs/Cargo.toml
@@ -16,13 +16,10 @@ deltalake-core = { version = "0.28.0", path = "../core", features = ["cloud"]}
 # workspace dependencies
 async-trait = { workspace = true }
 bytes = { workspace = true }
-chrono = { workspace = true }
-futures = { workspace = true }
 tracing = { workspace = true }
 object_store = { workspace = true, features = ["aws"]}
 thiserror = { workspace = true }
 tokio = { workspace = true }
-regex = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 url = { workspace = true }
 dashmap = "6"
@@ -30,7 +27,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 reqwest = {version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls-native-roots"]}
 http = "1.0"
-delta_kernel = { workspace = true, features = [] }
 
 [dev-dependencies]
 deltalake-core = { path = "../core" }

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -19,11 +19,9 @@ errno = "0.3"
 async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
-tracing = { workspace = true }
 object_store = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-regex = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -28,7 +28,6 @@ url = { workspace = true }
 dotenvy = "0"
 fs_extra = "1.3.0"
 futures = { version = "0.3" }
-rand = "0.8"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -36,9 +36,7 @@ serde_json = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 env_logger = "0"
-regex = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 parking_lot = "0.12"
 
@@ -48,14 +46,6 @@ num_cpus = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 deltalake-mount = { path = "../crates/mount" }
-
-# catalog-unity
-deltalake-catalog-unity = { path = "../crates/catalog-unity", features = [
-    "aws",
-    "azure",
-    "gcp",
-    "r2",
-] }
 
 # Non-unix or emscripten os
 [target.'cfg(any(not(target_family = "unix"), target_os = "emscripten"))'.dependencies]


### PR DESCRIPTION
# Description
Adding `cargo machete` to find and remove unused dependencies quickly in the CI.
The cargo machete has been run to identify and remove some unused dependencies.

A review should be done to ensure that flagged dependencies are truly unused and to avoid false positives.

# Documentation
- https://github.com/bnjbvr/cargo-machete