### PR TITLE
chore(ci): cache rust dependencies in the CI

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -36,3 +36,5 @@ runs:
         components: rustfmt, clippy
 
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,13 @@ jobs:
           toolchain: "1.85"
           override: true
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: "rust-cache-${{ matrix.os }}"
+          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
+          cache-all-crates: true
+          cache-targets: false
+
       - name: Format
         run: cargo fmt -- --check
 
@@ -87,6 +94,13 @@ jobs:
           toolchain: "1.85"
           override: true
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: "rust-cache-${{ matrix.os }}"
+          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
+          cache-all-crates: true
+          cache-targets: false
+
       - name: Run tests
         run: |
           make setup-dat
@@ -120,6 +134,13 @@ jobs:
           profile: default
           toolchain: "1.85"
           override: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-cache-integration-tests"
+          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
+          cache-all-crates: true
+          cache-targets: false
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -176,6 +197,13 @@ jobs:
           toolchain: "1.85"
           override: true
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-cache-integration-tests"
+          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
+          cache-all-crates: true
+          cache-targets: false
+
       # Install Java and Hadoop for HDFS integration tests
       - uses: actions/setup-java@v4
         with:
@@ -215,6 +243,13 @@ jobs:
           profile: default
           toolchain: "1.85"
           override: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-cache-integration-tests-hdfs"
+          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
+          cache-all-crates: true
+          cache-targets: false
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -267,6 +302,13 @@ jobs:
           profile: default
           toolchain: "1.85"
           override: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-cache-integration-tests-lakefs"
+          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
+          cache-all-crates: true
+          cache-targets: false
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-cache-python-builds"
+          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
+          cache-all-crates: true
+          cache-targets: false
+
       - name: Setup Environment
         uses: ./.github/actions/setup-env
         with:
@@ -57,8 +64,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-cache-python-builds"
+          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
+          cache-all-crates: true
+          cache-targets: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+
       - name: Publish to pypi (without sdist)
         uses: messense/maturin-action@v1
         env:
@@ -49,6 +53,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
 
       - name: Publish to pypi (without sdist)
         uses: messense/maturin-action@v1
@@ -66,6 +74,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+
       - name: Publish manylinux to pypi x86_64 (with sdist)
         uses: messense/maturin-action@v1
         env:
@@ -82,6 +94,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
 
       - name: Publish manylinux to pypi aarch64 (without sdist)
         uses: messense/maturin-action@v1
@@ -103,6 +119,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+
       - name: Publish manylinux to pypi aarch64 manylinux-2_28 (without sdist)
         uses: messense/maturin-action@v1
         env:
@@ -119,6 +139,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
 
       - name: Publish manylinux to pypi x86_64 (with sdist)
         uses: messense/maturin-action@v1

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -38,6 +38,10 @@ jobs:
           toolchain: stable
           override: true
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+
       - name: cargo publish
         uses: actions-rs/cargo@v1
         env:


### PR DESCRIPTION
# Description
Integrate `rust-cache` to persist Rust build artifacts and dependencies across CI runs, removing the need for repeated downloads and recompilations of unchanged dependencies.

# Documentation
- https://github.com/Swatinem/rust-cache
