### PR TITLE
feat: get the delta table row count based on the table history

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -530,15 +530,24 @@ class DeltaTable:
 
     def count(self) -> int:
         """
-        Get the row count based on the history of the DeltaTable.
+        Get the approximate row count based on file statistics added to the Delta table.
+
+        This requires that add actions have been added to the Delta table with
+        per-file statistics enabled. Because this is an optional field this
+        "count" will be less than or equal to the true row count of the table.
+        In order to get an exact number of rows a full table scan must happen
 
         Returns:
-            The number of rows for this specific table
+            The approximate number of rows for this specific table
         """
         total_rows = 0
 
         for value in self.get_add_actions().column("num_records").to_pylist():
-            total_rows += value
+            # Add action file statistics are optional and so while most modern
+            # tables are _likely_ to have this information it is not
+            # guaranteed.
+            if value is not None:
+                total_rows += value
 
         return total_rows
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -537,8 +537,9 @@ class DeltaTable:
         """
         total_rows = 0
 
-        for file in self.file_uris():
-            total_rows += pyarrow.parquet.ParquetFile(file).metadata.num_rows
+        for value in self.get_add_actions().column("num_records").to_pylist():
+            total_rows += value
+
         return total_rows
 
     def vacuum(

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -57,6 +57,12 @@ def test_read_simple_table_to_dict():
     ).read_all()["id"].to_pylist() == [5, 7, 9]
 
 
+def test_table_count():
+    table_path = "../crates/test/tests/data/COVID-19_NYT"
+    dt = DeltaTable(table_path)
+    assert dt.count() == 1
+
+
 class _SerializableException(BaseException):
     pass
 


### PR DESCRIPTION
# Description
Currently, delta-rs does not have an option to get the number of rows for a specific table.
I want to get the number of rows from the delta log without reading the whole table to the RAM of my application.
The idea is to handle a row counter and iterate over the log in order to get the number.

# Related Issue(s)
[- closes #3731](https://github.com/delta-io/delta-rs/issues/3731)
