### PR TITLE
refactor: avoid explicit mutex in MergeBarrier

### DIFF
--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1413,9 +1413,8 @@ async fn execute(
         .survivors();
 
     {
-        let lock = survivors.lock().unwrap();
         for action in snapshot.log_data() {
-            if lock.contains(action.path().as_ref()) {
+            if survivors.contains(action.path().as_ref()) {
                 metrics.num_target_files_removed += 1;
                 actions.push(action.remove_action(true).into());
             }


### PR DESCRIPTION
# Description

Just a quick drive-by refactor. We were using `Mutex<HashSet<String>>` inside the merge barrier implementation. Since we already depend on `dashmap`, we might as well use `DashSet`, which simplifies the code a little bit by avoiding explicit locks.