### PR TITLE
feat: add per column Parquet Encoding support for Delta Table column

### DIFF
--- a/python/deltalake/writer/properties.py
+++ b/python/deltalake/writer/properties.py
@@ -58,6 +58,32 @@ class Compression(Enum):
             return True
 
 
+class Encoding(Enum):
+    """
+    Encoding types for Parquet columns.
+    https://parquet.apache.org/docs/file-format/data-pages/encodings/
+    """
+
+    PLAIN = "PLAIN"
+    PLAIN_DICTIONARY = "PLAIN_DICTIONARY"  # Deprecated
+    RLE_DICTIONARY = "RLE_DICTIONARY"
+    RLE = "RLE"
+    BIT_PACKED = "BIT_PACKED"  # Deprecated
+    DELTA_BINARY_PACKED = "DELTA_BINARY_PACKED"
+    DELTA_LENGTH_BYTE_ARRAY = "DELTA_LENGTH_BYTE_ARRAY"
+    DELTA_BYTE_ARRAY = "DELTA_BYTE_ARRAY"
+    BYTE_STREAM_SPLIT = "BYTE_STREAM_SPLIT"
+
+    @classmethod
+    def from_str(cls, value: str) -> "Encoding":
+        try:
+            return cls(value.upper())
+        except ValueError:
+            raise ValueError(
+                f"{value} is not a valid Encoding. Valid values are: {[item.value for item in Encoding]}"
+            )
+
+
 @dataclass(init=True)
 class BloomFilterProperties:
     """The Bloom Filter Properties instance for the Rust parquet writer."""
@@ -94,6 +120,16 @@ class ColumnProperties:
         dictionary_enabled: bool | None = None,
         statistics_enabled: Literal["NONE", "CHUNK", "PAGE"] | None = None,
         bloom_filter_properties: BloomFilterProperties | None = None,
+        encoding: Literal[
+            "PLAIN",
+            "RLE",
+            "BIT_PACKED",
+            "DELTA_BINARY_PACKED",
+            "DELTA_LENGTH_BYTE_ARRAY",
+            "DELTA_BYTE_ARRAY",
+            "BYTE_STREAM_SPLIT",
+        ]
+        | None = None,
     ) -> None:
         """Create a Column Properties instance for the Rust parquet writer:
 
@@ -101,15 +137,32 @@ class ColumnProperties:
             dictionary_enabled: Enable dictionary encoding for the column.
             statistics_enabled: Statistics level for the column.
             bloom_filter_properties: Bloom Filter Properties for the column.
+            encoding: Encoding for the column if *NOT* using dictionary encoding.
         """
         self.dictionary_enabled = dictionary_enabled
         self.statistics_enabled = statistics_enabled
         self.bloom_filter_properties = bloom_filter_properties
+        if isinstance(encoding, str):
+            if self.dictionary_enabled:
+                raise ValueError("Can not specify dictionary_enabled=True AND encoding")
+
+            encoding_enum = Encoding.from_str(encoding)
+            if encoding_enum in [
+                Encoding.PLAIN_DICTIONARY,
+                Encoding.RLE_DICTIONARY,
+            ]:
+                raise ValueError(
+                    f"Can not specify dictionary encoding {encoding}, use dictionary_enabled=True instead"
+                )
+            else:
+                self.encoding = encoding
+        else:
+            self.encoding = encoding
 
     def __str__(self) -> str:
         return (
             f"dictionary_enabled: {self.dictionary_enabled}, statistics_enabled: {self.statistics_enabled}, "
-            f"bloom_filter_properties: {self.bloom_filter_properties}"
+            f"bloom_filter_properties: {self.bloom_filter_properties}, encoding: {self.encoding}"
         )
 
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -51,7 +51,7 @@ use deltalake::operations::update_table_metadata::{
 use deltalake::operations::vacuum::{VacuumBuilder, VacuumMode};
 use deltalake::operations::write::WriteBuilder;
 use deltalake::operations::CustomExecuteHandler;
-use deltalake::parquet::basic::Compression;
+use deltalake::parquet::basic::{Compression, Encoding};
 use deltalake::parquet::errors::ParquetError;
 use deltalake::parquet::file::properties::{EnabledStatistics, WriterProperties};
 use deltalake::partitions::PartitionFilter;
@@ -1868,6 +1868,14 @@ fn set_writer_properties(writer_properties: PyWriterProperties) -> DeltaResult<W
                         enabled_statistics,
                     );
                 }
+                if let Some(encoding) = column_prop.encoding {
+                    properties = properties.set_column_encoding(
+                        column_name.clone().into(),
+                        Encoding::from_str(&encoding).map_err(|err| DeltaTableError::from(err))?,
+                    );
+                    properties =
+                        properties.set_column_dictionary_enabled(column_name.clone().into(), false);
+                }
                 if let Some(bloom_filter_properties) = column_prop.bloom_filter_properties {
                     if let Some(set_bloom_filter_enabled) =
                         bloom_filter_properties.set_bloom_filter_enabled
@@ -2200,6 +2208,7 @@ pub struct ColumnProperties {
     pub dictionary_enabled: Option<bool>,
     pub statistics_enabled: Option<String>,
     pub bloom_filter_properties: Option<BloomFilterProperties>,
+    pub encoding: Option<String>,
 }
 
 #[derive(FromPyObject)]

--- a/python/tests/test_writerproperties.py
+++ b/python/tests/test_writerproperties.py
@@ -1,5 +1,7 @@
 import pathlib
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from arro3.core import Table
 
@@ -33,11 +35,12 @@ def test_writer_properties_all_filled():
                 ),
             ),
             "b": ColumnProperties(
-                dictionary_enabled=True,
+                dictionary_enabled=False,
                 statistics_enabled="PAGE",
                 bloom_filter_properties=BloomFilterProperties(
                     set_bloom_filter_enabled=False, fpp=0.2, ndv=30
                 ),
+                encoding="RLE",
             ),
         },
     )
@@ -48,7 +51,6 @@ def test_writer_properties_all_filled():
 
 def test_writer_properties_lower_case_compression():
     wp = WriterProperties(compression="snappy")  # type: ignore
-
     assert wp.compression == "SNAPPY"
 
 
@@ -100,3 +102,94 @@ def test_write_with_writerproperties(
     metadata = pq.read_metadata(parquet_path)
 
     assert metadata.to_dict()["row_groups"][0]["columns"][0]["compression"] == "GZIP"
+
+
+def test_write_with_writerproperties_encoding(
+    tmp_path: pathlib.Path, sample_table: pa.Table
+):
+    writer_properties = WriterProperties(
+        compression="ZSTD",
+        column_properties={"price": ColumnProperties(encoding="DELTA_BINARY_PACKED")},
+    )
+    write_deltalake(tmp_path, sample_table, writer_properties=writer_properties)
+
+    parquet_path = DeltaTable(tmp_path).file_uris()[0]
+    metadata = pq.read_metadata(parquet_path)
+    price_metadata = next(
+        c
+        for c in metadata.to_dict()["row_groups"][0]["columns"]
+        if c["path_in_schema"] == "price"
+    )
+    assert "DELTA_BINARY_PACKED" in price_metadata["encodings"]
+
+    sold_metadata = next(
+        c
+        for c in metadata.to_dict()["row_groups"][0]["columns"]
+        if c["path_in_schema"] == "sold"
+    )
+    assert "RLE_DICTIONARY" in sold_metadata["encodings"]
+
+
+@pytest.mark.parametrize("placement", ["per_column", "default"])
+@pytest.mark.parametrize(
+    "col_props",
+    [
+        ColumnProperties(),
+        ColumnProperties(dictionary_enabled=True),
+        ColumnProperties(encoding=None),
+        ColumnProperties(encoding=None, dictionary_enabled=True),
+    ],
+    ids=[
+        "empty",
+        "dict_only_true",
+        "encoding_none",
+        "encoding_none_and_dict_true",
+    ],
+)
+def test_column_properties_omitted_encoding_paths(
+    tmp_path: pathlib.Path,
+    sample_table: pa.Table,
+    placement: str,
+    col_props: ColumnProperties,
+):
+    """
+    Supreme Overkill
+    Test for the edge cases where encoding is throwing AttributeError due to missing else.
+    which lead to nothing being passed to the Rust writer instead of `None`.
+    Kept it this to catch it in the future if something changes.
+    """
+    if placement == "per_column":
+        writer_props = WriterProperties(
+            compression="ZSTD",
+            column_properties={"price": col_props},
+        )
+    else:
+        writer_props = WriterProperties(
+            compression="ZSTD",
+            default_column_properties=col_props,
+        )
+
+    write_deltalake(tmp_path, sample_table, writer_properties=writer_props)
+
+    dt = DeltaTable(tmp_path)
+    read = dt.to_pyarrow_table()
+    # Just check if we was created or not with the column name existing
+    assert DeltaTable(tmp_path).version() >= 0
+    assert len(DeltaTable(tmp_path).file_uris()) > 0
+    assert "price" in read.column_names
+
+
+def test_write_invalid_encoding_configuration():
+    with pytest.raises(ValueError):
+        WriterProperties(
+            compression="ZSTD",
+            column_properties={
+                "price": ColumnProperties(encoding="RLE", dictionary_enabled=True)
+            },
+        )
+
+    with pytest.raises(ValueError):
+        WriterProperties(
+            compression="ZSTD",
+            column_properties={"price": ColumnProperties(encoding="RLE_DICTIONARY")},
+        )


### PR DESCRIPTION
# Description
This PR aims to add per column parquet encoding support similar to what pyarrow has right now. Since pyarrow engine is being deprecated this is the best way to resolve the issue. It adds encoding spec same as what parquet spec has defined.

https://parquet.apache.org/docs/file-format/data-pages/encodings/

Thanks to ghost or deleted-user who has carried out most of the work but it never got merged in.

# Related Issue(s)

- closes #3319


# Documentation

This is implementing 

https://parquet.apache.org/docs/file-format/data-pages/encodings/

into ColumnProperties, as part of this it has also added Encoding enum.
It will the same format as the other ColumnProperties arguments, PLAIN_DICTIONARY and RLE_DICTIONARY could not be implemented due to some issues, will be looked into later on.

Here is a code snippet on how you can how use the delta tables and how you can compare against existing implementation

```python
import os
import pandas as pd
import numpy as np

from deltalake import write_deltalake, WriterProperties, ColumnProperties,DeltaTable
from pathlib import Path

import pyarrow.parquet as pq
import pyarrow as pa

# Make some fake time series data
TOTAL_ROWS = 100_000_00
timestamps = pd.date_range(start=pd.Timestamp.now(), periods=TOTAL_ROWS, freq="5ms")
timeline = np.linspace(0, len(timestamps), len(timestamps))
print("Generating data...")
pat = pa.Table.from_pandas(
    pd.DataFrame(
        {
            # timestamp (auto-generated)
            "timestamp": timestamps,
            # Timeseries data as float32
            "timeseries_data": (10 * np.sin(2 * np.pi * 50 * timeline)).astype(
                np.float32
            ),
            "timeseries_int_data": (1000 * np.sin(2 * np.pi * 50 * timeline)).astype(
                np.int32
            ),
            # 1 minute partitions
            "partition_label": timestamps.strftime("%H%M"),
        }
    )
)
print("Data generated.")
output_path_normal = "example_deltalake"
write_deltalake(
    output_path_normal,
    data=pat,
    partition_by=["partition_label"],
    # Enabled compression for equivalent comparison, dictionary enabled leads to a larger file size
    writer_properties=WriterProperties(
        compression="ZSTD",
        compression_level=1,
        default_column_properties=ColumnProperties(dictionary_enabled=True),
    ),
    mode="overwrite",
    # Can't specify per-column encoding
)
print("Wrote normal delta table.")



output_path_encoded = "encoded_example_deltalake"
write_deltalake(
    output_path_encoded,
    data=pat,
    partition_by=["partition_label"],
    # Enabled compression for equivalent comparison, dictionary enabled leads to a larger file size
    writer_properties=WriterProperties(
        compression="ZSTD",
        compression_level=1,
        column_properties={
            "timestamp": ColumnProperties(dictionary_enabled=False,encoding="DELTA_BINARY_PACKED"),
            "timeseries_data": ColumnProperties(dictionary_enabled=False,encoding="BYTE_STREAM_SPLIT"),
            "timeseries_int_data": ColumnProperties(dictionary_enabled=False,encoding="DELTA_BINARY_PACKED"),
            "partition_label": ColumnProperties(dictionary_enabled=False,encoding="DELTA_BINARY_PACKED"),
        },
    ),
    mode="overwrite",
    # Can't specify per-column encoding
)
print("Wrote encoded delta table.")

output_path_default_encoded = "example_pyarrow_delta_default_encoding"
pq.write_to_dataset(
    pat,
    output_path_default_encoded,
    partition_cols=["partition_label"],
    use_dictionary=False,
    use_byte_stream_split=True,
    compression="ZSTD",
    compression_level=1,
)


output_path_delta_specifc_encoded = "example_pyarrow_delta_specifc_col_encoding"
pq.write_to_dataset(
    pat,
    output_path_delta_specifc_encoded,
    partition_cols=["partition_label"],
    # Ability to specify column encodings here
    use_dictionary=False,
    use_byte_stream_split=False,
    column_encoding={
        "timestamp": "DELTA_BINARY_PACKED",
        "timeseries_data": "BYTE_STREAM_SPLIT",
        "timeseries_int_data": "DELTA_BINARY_PACKED",
        "partition_label": "DELTA_BINARY_PACKED",
    },
    compression="ZSTD",
    compression_level=1,
)
print("Wrote delta table with pyarrow column encodings.")


def get_folder_size(folder):
    return ByteSize(
        sum(file.stat().st_size for file in Path(folder).rglob("*"))
    ).megabytes


class ByteSize(int):
    _KB = 1024
    _suffixes = "B", "KB", "MB", "GB", "PB"

    def __new__(cls, *args, **kwargs):
        return super().__new__(cls, *args, **kwargs)

    def __init__(self, *args, **kwargs):
        self.bytes = self.B = int(self)
        self.kilobytes = self.KB = self / self._KB**1
        self.megabytes = self.MB = self / self._KB**2
        self.gigabytes = self.GB = self / self._KB**3
        self.petabytes = self.PB = self / self._KB**4
        *suffixes, last = self._suffixes
        suffix = next(
            (suffix for suffix in suffixes if 1 < getattr(self, suffix) < self._KB),
            last,
        )
        self.readable = suffix, getattr(self, suffix)

        super().__init__()

    def __str__(self):
        return self.__format__(".2f")

print(DeltaTable(output_path_encoded).to_pandas())

print(f"The File size of delta table is {get_folder_size(output_path_normal)} MB")
print(f"The File size of delta table with parquet encoding is {get_folder_size(output_path_default_encoded)} MB")
print(
    f"The File size of delta table with pyarrow default column encodings is {get_folder_size(output_path_default_encoded)} MB"
)
print(
    f"The File size of delta table with pyarrow specific column encodings is {get_folder_size(output_path_delta_specifc_encoded)} MB"
)


print("Deleting the folders now...")
import shutil

shutil.rmtree(output_path_normal)
shutil.rmtree(output_path_encoded)
shutil.rmtree(output_path_default_encoded)
shutil.rmtree(output_path_delta_specifc_encoded)
print("Deleted the folders.")


``` 


I have ran this script on my dev environment of Ubuntu 24.04 WSL2 and python 3.12.3

The outputs came to 

The File size of delta table is 122.21567821502686 MB
The File size of delta table with parquet encoding is 25.041666984558105 MB
The File size of delta table with pyarrow default column encodings is 25.041666984558105 MB
The File size of delta table with pyarrow specific column encodings is 20.985719680786133 MB

Which is roughly 75% improvement with mixed data. If you decide to further optimisations you can go down to 95%-98% (if all INT data)