### PR TITLE
fix: re-export the DecimalType for consumers

### DIFF
--- a/crates/core/src/kernel/schema/schema.rs
+++ b/crates/core/src/kernel/schema/schema.rs
@@ -4,8 +4,8 @@ use std::any::Any;
 use std::sync::Arc;
 
 pub use delta_kernel::schema::{
-    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, PrimitiveType, StructField,
-    StructType,
+    ArrayType, ColumnMetadataKey, DataType, DecimalType, MapType, MetadataValue, PrimitiveType,
+    StructField, StructType,
 };
 use serde_json::Value;
 


### PR DESCRIPTION
This seems a reasonable thing to export.

Fixes #3279

