### PR TITLE
feat(datafusion): add insert_into operation with DataFusion

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -3,6 +3,9 @@ use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use futures::StreamExt;
+
 use arrow::compute::filter_record_batch;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::error::ArrowError;
@@ -18,10 +21,13 @@ use datafusion::datasource::physical_plan::{
     wrap_partition_type_in_dict, wrap_partition_value_in_dict, FileGroup, FileSource,
 };
 use datafusion::datasource::physical_plan::{FileScanConfigBuilder, ParquetSource};
+use datafusion::datasource::sink::{DataSink, DataSinkExec};
 use datafusion::datasource::TableType;
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::ExecutionProps;
+use datafusion::execution::context::SessionState;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::dml::InsertOp;
 use datafusion::logical_expr::simplify::SimplifyContext;
 use datafusion::logical_expr::utils::split_conjunction;
 use datafusion::logical_expr::{BinaryExpr, LogicalPlan, Operator};
@@ -29,7 +35,8 @@ use datafusion::optimizer::simplify_expressions::ExprSimplifier;
 use datafusion::physical_optimizer::pruning::PruningPredicate;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, PlanProperties,
+    stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr,
+    PlanProperties,
 };
 use datafusion::{
     catalog::Session,
@@ -41,18 +48,225 @@ use datafusion::{
 };
 use futures::TryStreamExt;
 use object_store::ObjectMeta;
+
 use serde::{Deserialize, Serialize};
 
 use crate::delta_datafusion::schema_adapter::DeltaSchemaAdapterFactory;
 use crate::delta_datafusion::{
     get_null_of_arrow_type, register_store, to_correct_scalar_value, DataFusionMixins as _,
+    LogDataHandler,
 };
-use crate::kernel::{Add, LogDataHandler};
-use crate::table::builder::ensure_table_uri;
-use crate::DeltaTable;
+use crate::kernel::schema::cast::cast_record_batch;
+use crate::kernel::transaction::CommitBuilder;
+use crate::kernel::{Action, Add, Remove};
+use crate::operations::write::writer::{DeltaWriter, WriterConfig};
+use crate::operations::write::WriterStatsConfig;
+use crate::protocol::{DeltaOperation, SaveMode};
+use crate::{ensure_table_uri, DeltaTable};
 use crate::{logstore::LogStoreRef, table::state::DeltaTableState, DeltaResult, DeltaTableError};
+use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 
 const PATH_COLUMN: &str = "__delta_rs_path";
+
+/// Get the session state from the session
+fn session_state_from_session(session: &dyn Session) -> Result<&SessionState> {
+    session
+        .as_any()
+        .downcast_ref::<SessionState>()
+        .ok_or_else(|| {
+            DataFusionError::Plan("Failed to downcast Session to SessionState".to_string())
+        })
+}
+
+/// DataSink implementation for delta lake
+/// This uses DataSinkExec to handle the insert operation
+/// Implements writing streams of RecordBatches to delta.
+#[derive(Debug)]
+pub struct DeltaDataSink {
+    /// The log store
+    log_store: LogStoreRef,
+    /// The snapshot
+    snapshot: DeltaTableState,
+    /// The save mode
+    save_mode: SaveMode,
+    /// The schema
+    schema: SchemaRef,
+    /// Metrics for monitoring throughput
+    metrics: ExecutionPlanMetricsSet,
+}
+
+/// A [`DataSink`] implementation for writing to Delta Lake.
+///
+/// `DeltaDataSink` is used by [`DataSinkExec`] during query execution to
+/// stream [`RecordBatch`]es into a Delta table. It encapsulates everything
+/// needed to perform an insert/append/overwrite operation, including
+/// transaction log access, snapshot state, and session configuration.
+impl DeltaDataSink {
+    /// Create a new `DeltaDataSink`
+    pub fn new(
+        log_store: LogStoreRef,
+        snapshot: DeltaTableState,
+        save_mode: SaveMode,
+        session_state: Arc<SessionState>,
+    ) -> datafusion::common::Result<Self> {
+        let schema = snapshot
+            .arrow_schema()
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        Ok(Self {
+            log_store,
+            snapshot,
+            save_mode,
+            schema,
+            metrics: ExecutionPlanMetricsSet::new(),
+        })
+    }
+
+    /// Create a streaming transformed version of the input that converts dictionary columns
+    /// This is used to convert dictionary columns to their native types
+    fn create_converted_stream(
+        &self,
+        input: SendableRecordBatchStream,
+        target_schema: SchemaRef,
+    ) -> SendableRecordBatchStream {
+        use futures::StreamExt;
+
+        let schema_for_closure = Arc::clone(&target_schema);
+        let converted_stream = input.map(move |batch_result| {
+            batch_result.and_then(|batch| {
+                cast_record_batch(&batch, Arc::clone(&schema_for_closure), false, true)
+                    .map_err(|e| DataFusionError::External(Box::new(e)))
+            })
+        });
+
+        Box::pin(RecordBatchStreamAdapter::new(
+            target_schema,
+            converted_stream,
+        ))
+    }
+}
+
+/// Implementation of the `DataSink` trait for `DeltaDataSink`
+/// This is used to write the data to the delta table
+/// It implements the `DataSink` trait and is used by the `DataSinkExec` node
+/// to write the data to the delta table
+#[async_trait]
+impl DataSink for DeltaDataSink {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    /// Write the data to the delta table
+    /// This is used for insert into operation
+    async fn write_all(
+        &self,
+        data: SendableRecordBatchStream,
+        _context: &Arc<TaskContext>,
+    ) -> datafusion::common::Result<u64> {
+        let target_schema = self
+            .snapshot
+            .input_schema()
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        let mut stream = self.create_converted_stream(data, target_schema.clone());
+        let partition_columns = self.snapshot.metadata().partition_columns();
+        let object_store = self.log_store.object_store(None);
+        let total_rows_metric = MetricBuilder::new(&self.metrics).counter("total_rows", 0);
+        let stats_config = WriterStatsConfig::new(DataSkippingNumIndexedCols::AllColumns, None);
+        let config = WriterConfig::new(
+            self.snapshot
+                .arrow_schema()
+                .map_err(|e| DataFusionError::External(Box::new(e)))?,
+            partition_columns.clone(),
+            None,
+            None,
+            None,
+            stats_config.num_indexed_cols,
+            stats_config.stats_columns,
+        );
+
+        let mut writer = DeltaWriter::new(object_store, config);
+        let mut total_rows = 0u64;
+
+        while let Some(batch_result) = stream.next().await {
+            let batch = batch_result?;
+            let batch_rows = batch.num_rows() as u64;
+            total_rows += batch_rows;
+            total_rows_metric.add(batch_rows as usize);
+            writer
+                .write(&batch)
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        }
+
+        let add_actions = writer
+            .close()
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        let mut actions = if self.save_mode == SaveMode::Overwrite {
+            let current_files = self
+                .snapshot
+                .file_actions(&*self.log_store)
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+            current_files
+                .into_iter()
+                .map(|add| {
+                    Action::Remove(Remove {
+                        path: add.path,
+                        deletion_timestamp: Some(chrono::Utc::now().timestamp_millis()),
+                        data_change: true,
+                        extended_file_metadata: Some(true),
+                        partition_values: Some(add.partition_values),
+                        size: Some(add.size),
+                        tags: add.tags,
+                        base_row_id: None,
+                        default_row_commit_version: None,
+                        deletion_vector: None,
+                    })
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        actions.extend(add_actions.into_iter().map(Action::Add));
+
+        let operation = DeltaOperation::Write {
+            mode: self.save_mode,
+            partition_by: if partition_columns.is_empty() {
+                None
+            } else {
+                Some(partition_columns.clone())
+            },
+            predicate: None,
+        };
+
+        CommitBuilder::default()
+            .with_actions(actions)
+            .build(Some(&self.snapshot), self.log_store.clone(), operation)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        Ok(total_rows)
+    }
+}
+
+/// Implementation of the `DisplayAs` trait for `DeltaDataSink`
+impl DisplayAs for DeltaDataSink {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "DeltaDataSink")
+    }
+}
 
 #[derive(Debug, Clone)]
 /// Used to specify if additional metadata columns are exposed to the user
@@ -643,6 +857,42 @@ impl TableProvider for DeltaTableProvider {
     fn statistics(&self) -> Option<Statistics> {
         self.snapshot.datafusion_table_statistics()
     }
+
+    /// Insert the data into the delta table
+    /// Insert operation is only supported for Append and Overwrite
+    /// Return the execution plan
+    async fn insert_into(
+        &self,
+        state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        insert_op: InsertOp,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let session_state = session_state_from_session(state)?.clone();
+        register_store(self.log_store.clone(), session_state.runtime_env().clone());
+
+        let save_mode = match insert_op {
+            InsertOp::Append => SaveMode::Append,
+            InsertOp::Overwrite => SaveMode::Overwrite,
+            InsertOp::Replace => {
+                return Err(DataFusionError::Plan(format!(
+                    "Replace operation is not supported for DeltaTableProvider"
+                )))
+            }
+        };
+
+        let data_sink = DeltaDataSink::new(
+            self.log_store.clone(),
+            self.snapshot.clone(),
+            save_mode,
+            Arc::new(session_state),
+        )?;
+
+        Ok(Arc::new(DataSinkExec::new(
+            input,
+            Arc::new(data_sink),
+            None,
+        )))
+    }
 }
 
 // TODO: this will likely also need to perform column mapping later when we support reader protocol v2
@@ -918,11 +1168,104 @@ fn partitioned_file_from_action(
 
 #[cfg(test)]
 mod tests {
-    use arrow::datatypes::{Field, Schema};
+    use crate::kernel::{DataType, PrimitiveType, StructField, StructType};
+    use crate::operations::create::CreateBuilder;
+    use crate::protocol::SaveMode;
+    use crate::{DeltaTable, DeltaTableError};
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
     use chrono::{TimeZone, Utc};
+    use datafusion::common::ScalarValue;
+    use datafusion::datasource::listing::PartitionedFile;
+    use datafusion::datasource::MemTable;
+    use datafusion::execution::context::SessionState;
+    use datafusion::logical_expr::dml::InsertOp;
     use object_store::path::Path;
+    use std::sync::Arc;
 
     use super::*;
+
+    async fn create_test_table() -> Result<DeltaTable, DeltaTableError> {
+        use tempfile::TempDir;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let table_path = tmp_dir.path().to_str().unwrap();
+
+        let schema = StructType::new(vec![
+            StructField::new(
+                "id".to_string(),
+                DataType::Primitive(PrimitiveType::Long),
+                false,
+            ),
+            StructField::new(
+                "value".to_string(),
+                DataType::Primitive(PrimitiveType::String),
+                false,
+            ),
+        ]);
+
+        CreateBuilder::new()
+            .with_location(table_path)
+            .with_columns(schema.fields().cloned())
+            .await
+    }
+
+    fn create_test_session_state() -> Arc<SessionState> {
+        use datafusion::execution::SessionStateBuilder;
+        use datafusion::prelude::SessionConfig;
+        let config = SessionConfig::new();
+        Arc::new(SessionStateBuilder::new().with_config(config).build())
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_simple() {
+        let table = create_test_table().await.unwrap();
+        let session_state = create_test_session_state();
+
+        let scan_config = DeltaScanConfigBuilder::new()
+            .build(table.snapshot().unwrap())
+            .unwrap();
+        let table_provider = DeltaTableProvider::try_new(
+            table.snapshot().unwrap().clone(),
+            table.log_store(),
+            scan_config,
+        )
+        .unwrap();
+
+        let schema = table_provider.schema();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["test1", "test2"])),
+            ],
+        )
+        .unwrap();
+
+        let mem_table = Arc::new(MemTable::try_new(schema.clone(), vec![vec![batch]]).unwrap());
+        let logical_plan = mem_table
+            .scan(&*session_state, None, &[], None)
+            .await
+            .unwrap();
+
+        let result_plan = table_provider
+            .insert_into(&*session_state, logical_plan, InsertOp::Append)
+            .await
+            .unwrap();
+
+        assert!(!result_plan.schema().fields().is_empty());
+
+        let result_schema = result_plan.schema();
+        assert_eq!(result_schema.fields().len(), 1);
+        assert_eq!(result_schema.field(0).name(), "count");
+        assert_eq!(
+            result_schema.field(0).data_type(),
+            &arrow::datatypes::DataType::UInt64
+        );
+        assert_eq!(result_plan.children().len(), 1);
+        assert!(result_plan.metrics().is_some());
+    }
 
     #[test]
     fn test_partitioned_file_from_action() {
@@ -943,8 +1286,8 @@ mod tests {
             clustering_provider: None,
         };
         let schema = Schema::new(vec![
-            Field::new("year", DataType::Int64, true),
-            Field::new("month", DataType::Int64, true),
+            Field::new("year", ArrowDataType::Int64, true),
+            Field::new("month", ArrowDataType::Int64, true),
         ]);
 
         let part_columns = vec!["year".to_string(), "month".to_string()];

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -24,7 +24,9 @@ use datafusion::physical_plan::{visit_execution_plan, ExecutionPlan, ExecutionPl
 use datafusion_proto::bytes::{
     logical_plan_from_bytes_with_extension_codec, logical_plan_to_bytes_with_extension_codec,
 };
-use deltalake_core::delta_datafusion::{DeltaScan, DeltaTableFactory};
+use deltalake_core::delta_datafusion::{
+    DeltaScan, DeltaScanConfigBuilder, DeltaTableFactory, DeltaTableProvider,
+};
 use deltalake_core::kernel::{DataType, MapType, PrimitiveType, StructField, StructType};
 use deltalake_core::operations::create::CreateBuilder;
 use deltalake_core::operations::write::SchemaMode;
@@ -1633,6 +1635,537 @@ mod date_partitions {
         ];
 
         assert_batches_sorted_eq!(&expected, &batches);
+
+        Ok(())
+    }
+}
+
+mod insert_into_tests {
+    use super::*;
+    use arrow_array::{types, Int64Array, PrimitiveArray, StringArray};
+    use datafusion::datasource::MemTable;
+    use datafusion::logical_expr::dml::InsertOp;
+    use deltalake_core::operations::create::CreateBuilder;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_sql_insert_into_partitioned_table() -> TestResult {
+        let table_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("value", ArrowDataType::Int64, false),
+            ArrowField::new("part", ArrowDataType::Utf8, false),
+        ]));
+
+        let storage = Box::<LocalStorageIntegration>::default();
+        let context = IntegrationContext::new(storage)?;
+        let table_uri = context.uri_for_table(TestTables::Simple);
+
+        let table = CreateBuilder::new()
+            .with_location(&table_uri)
+            .with_columns(vec![
+                StructField::new(
+                    "value".to_string(),
+                    DataType::Primitive(PrimitiveType::Long),
+                    false,
+                ),
+                StructField::new(
+                    "part".to_string(),
+                    DataType::Primitive(PrimitiveType::String),
+                    false,
+                ),
+            ])
+            .with_partition_columns(vec!["part"])
+            .await?;
+
+        let values = Int64Array::from(vec![1, 2, 3, 4]);
+        let parts = StringArray::from(vec!["a", "b", "a", "b"]);
+        let batch = RecordBatch::try_new(
+            table_schema.clone(),
+            vec![Arc::new(values), Arc::new(parts)],
+        )?;
+
+        let ctx = SessionContext::new();
+        let scan_config = DeltaScanConfigBuilder::new().build(table.snapshot()?)?;
+        let table_provider: Arc<dyn TableProvider> = Arc::new(DeltaTableProvider::try_new(
+            table.snapshot()?.clone(),
+            table.log_store(),
+            scan_config,
+        )?);
+        ctx.register_table("delta_table", table_provider)?;
+
+        let source_table = Arc::new(MemTable::try_new(table_schema, vec![vec![batch]])?);
+        ctx.register_table("source_data", source_table)?;
+
+        let insert_result = ctx
+            .sql("INSERT INTO delta_table SELECT * FROM source_data")
+            .await?
+            .collect()
+            .await?;
+
+        assert_eq!(insert_result.len(), 1);
+        let count_batch = &insert_result[0];
+        assert_eq!(count_batch.num_rows(), 1);
+        assert_eq!(count_batch.schema().field(0).name(), "count");
+
+        let count_array = arrow::array::UInt64Array::from(count_batch.column(0).to_data());
+        let inserted_count = count_array.value(0);
+        assert_eq!(inserted_count, 4); // Should match the number of rows inserted
+
+        ctx.deregister_table("delta_table")?;
+        let refreshed_table = deltalake_core::open_table(url::Url::parse(&table_uri)?).await?;
+        let refreshed_table_provider: Arc<dyn TableProvider> = Arc::new(refreshed_table);
+        ctx.register_table("delta_table", refreshed_table_provider)?;
+
+        let df_a = ctx
+            .sql("SELECT value FROM delta_table WHERE part = 'a'")
+            .await?;
+        let result_a = df_a.collect().await?;
+        let expected_a = vec![
+            "+-------+",
+            "| value |",
+            "+-------+",
+            "| 1     |",
+            "| 3     |",
+            "+-------+",
+        ];
+        assert_batches_sorted_eq!(&expected_a, &result_a);
+
+        let df_b = ctx
+            .sql("SELECT value FROM delta_table WHERE part = 'b'")
+            .await?;
+        let result_b = df_b.collect().await?;
+        let expected_b = vec![
+            "+-------+",
+            "| value |",
+            "+-------+",
+            "| 2     |",
+            "| 4     |",
+            "+-------+",
+        ];
+        assert_batches_sorted_eq!(&expected_b, &result_b);
+
+        let final_table = deltalake_core::open_table(url::Url::parse(&table_uri)?).await?;
+        assert_eq!(final_table.version(), Some(1)); // CREATE + SQL INSERT = version 1
+
+        let partition_columns = final_table.snapshot()?.metadata().partition_columns();
+        assert_eq!(partition_columns.len(), 1);
+        assert_eq!(partition_columns[0], "part");
+
+        let history = final_table.history(None).await?;
+        assert_eq!(history.len(), 2); // CREATE + SQL INSERT
+        assert_eq!(history[0].operation.as_ref().unwrap(), "WRITE");
+
+        let commit_info = &history[0];
+        assert!(commit_info.operation_parameters.is_some());
+        let operation_params = commit_info.operation_parameters.as_ref().unwrap();
+        assert_eq!(
+            operation_params.get("mode"),
+            Some(&serde_json::Value::String("Append".to_string()))
+        );
+
+        if let Some(partition_by) = operation_params.get("partitionBy") {
+            if let serde_json::Value::Array(partition_array) = partition_by {
+                assert_eq!(partition_array.len(), 1);
+                assert_eq!(partition_array[0], "part");
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_append_mode() -> TestResult {
+        let table_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("name", ArrowDataType::Utf8, false),
+            ArrowField::new("age", ArrowDataType::Int64, false),
+        ]));
+
+        let storage = Box::<LocalStorageIntegration>::default();
+        let context = IntegrationContext::new(storage)?;
+        let table_uri = context.uri_for_table(TestTables::Simple);
+
+        let table = CreateBuilder::new()
+            .with_location(&table_uri)
+            .with_columns(vec![
+                StructField::new(
+                    "name".to_string(),
+                    DataType::Primitive(PrimitiveType::String),
+                    false,
+                ),
+                StructField::new(
+                    "age".to_string(),
+                    DataType::Primitive(PrimitiveType::Long),
+                    false,
+                ),
+            ])
+            .await?;
+
+        let initial_names = StringArray::from(vec!["Thierry", "Bernard"]);
+        let initial_ages = Int64Array::from(vec![22, 24]);
+        let initial_batch = RecordBatch::try_new(
+            table_schema.clone(),
+            vec![Arc::new(initial_names), Arc::new(initial_ages)],
+        )?;
+
+        let ctx = SessionContext::new();
+        let scan_config = DeltaScanConfigBuilder::new().build(table.snapshot()?)?;
+        let table_provider: Arc<dyn TableProvider> = Arc::new(DeltaTableProvider::try_new(
+            table.snapshot()?.clone(),
+            table.log_store(),
+            scan_config,
+        )?);
+        ctx.register_table("test_table", table_provider.clone())?;
+
+        let initial_mem_table = Arc::new(MemTable::try_new(
+            table_schema.clone(),
+            vec![vec![initial_batch]],
+        )?);
+        let initial_plan = initial_mem_table
+            .scan(&ctx.state(), None, &[], None)
+            .await?;
+
+        let initial_result_plan = table_provider
+            .insert_into(&ctx.state(), initial_plan, InsertOp::Append)
+            .await?;
+        let initial_results =
+            datafusion::physical_plan::collect(initial_result_plan, ctx.task_ctx()).await?;
+        assert_eq!(initial_results.len(), 1);
+        let initial_batch = &initial_results[0];
+        assert_eq!(initial_batch.num_rows(), 1);
+        let initial_count_array = initial_batch.column_by_name("count").unwrap();
+        let initial_count_val =
+            arrow::array::UInt64Array::from(initial_count_array.to_data()).value(0);
+        assert_eq!(initial_count_val, 2); // 2 initial rows inserted
+
+        let append_names = StringArray::from(vec!["Robert", "Ion", "Denny", "Tyler"]);
+        let append_ages = Int64Array::from(vec![25, 30, 35, 40]);
+        let append_batch = RecordBatch::try_new(
+            table_schema.clone(),
+            vec![Arc::new(append_names), Arc::new(append_ages)],
+        )?;
+
+        let append_mem_table = Arc::new(MemTable::try_new(
+            table_schema.clone(),
+            vec![vec![append_batch]],
+        )?);
+        let append_plan = append_mem_table.scan(&ctx.state(), None, &[], None).await?;
+
+        let result_plan = table_provider
+            .insert_into(&ctx.state(), append_plan, InsertOp::Append)
+            .await?;
+
+        let results = datafusion::physical_plan::collect(result_plan, ctx.task_ctx()).await?;
+        assert_eq!(results.len(), 1);
+        let batch = &results[0];
+        assert_eq!(batch.num_rows(), 1);
+        let count_array = batch.column_by_name("count").unwrap();
+        let count_val = arrow::array::UInt64Array::from(count_array.to_data()).value(0);
+        assert_eq!(count_val, 4); // 4 new rows appended
+
+        ctx.deregister_table("test_table")?;
+        let refreshed_table = deltalake_core::open_table(url::Url::parse(&table_uri)?).await?;
+        let refreshed_scan_config =
+            DeltaScanConfigBuilder::new().build(refreshed_table.snapshot()?)?;
+        let refreshed_table_provider: Arc<dyn TableProvider> =
+            Arc::new(DeltaTableProvider::try_new(
+                refreshed_table.snapshot()?.clone(),
+                refreshed_table.log_store(),
+                refreshed_scan_config,
+            )?);
+        ctx.register_table("test_table", refreshed_table_provider)?;
+
+        let all_data = ctx
+            .sql("SELECT name, age FROM test_table ORDER BY age")
+            .await?
+            .collect()
+            .await?;
+
+        assert_eq!(all_data.len(), 1);
+        let data_batch = &all_data[0];
+        assert_eq!(data_batch.num_rows(), 6); // 2 initial + 4 appended = 6 total
+
+        let names_col = data_batch.column_by_name("name").unwrap();
+        let ages_col = data_batch.column_by_name("age").unwrap();
+        let names_array = arrow::array::StringArray::from(names_col.to_data());
+        let ages_array = arrow::array::Int64Array::from(ages_col.to_data());
+
+        assert_eq!(names_array.value(0), "Thierry");
+        assert_eq!(ages_array.value(0), 22);
+        assert_eq!(names_array.value(1), "Bernard");
+        assert_eq!(ages_array.value(1), 24);
+        assert_eq!(names_array.value(2), "Robert");
+        assert_eq!(ages_array.value(2), 25);
+        assert_eq!(names_array.value(3), "Ion");
+        assert_eq!(ages_array.value(3), 30);
+        assert_eq!(names_array.value(4), "Denny");
+        assert_eq!(ages_array.value(4), 35);
+        assert_eq!(names_array.value(5), "Tyler");
+        assert_eq!(ages_array.value(5), 40);
+
+        let final_table = deltalake_core::open_table(url::Url::parse(&table_uri)?).await?;
+        assert_eq!(final_table.version(), Some(2));
+        let history = final_table.history(None).await?;
+
+        assert_eq!(history.len(), 3); // CREATE + 2 INSERTTs
+        assert_eq!(history[0].operation.as_ref().unwrap(), "WRITE");
+        assert_eq!(history[1].operation.as_ref().unwrap(), "WRITE");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_overwrite_mode() -> TestResult {
+        let table_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("name", ArrowDataType::Utf8, false),
+            ArrowField::new("age", ArrowDataType::Int64, false),
+        ]));
+
+        let storage = Box::<LocalStorageIntegration>::default();
+        let context = IntegrationContext::new(storage)?;
+        let table_uri = context.uri_for_table(TestTables::Simple);
+
+        let table = CreateBuilder::new()
+            .with_location(&table_uri)
+            .with_columns(vec![
+                StructField::new(
+                    "name".to_string(),
+                    DataType::Primitive(PrimitiveType::String),
+                    false,
+                ),
+                StructField::new(
+                    "age".to_string(),
+                    DataType::Primitive(PrimitiveType::Long),
+                    false,
+                ),
+            ])
+            .await?;
+
+        let names1 = StringArray::from(vec!["Initial", "Data"]);
+        let ages1: PrimitiveArray<types::Int64Type> = Int64Array::from(vec![20, 21]);
+        let batch1 = RecordBatch::try_new(
+            table_schema.clone(),
+            vec![Arc::new(names1), Arc::new(ages1)],
+        )?;
+
+        let ctx = SessionContext::new();
+        let scan_config = DeltaScanConfigBuilder::new().build(table.snapshot()?)?;
+        let table_provider: Arc<dyn TableProvider> = Arc::new(DeltaTableProvider::try_new(
+            table.snapshot()?.clone(),
+            table.log_store(),
+            scan_config,
+        )?);
+        ctx.register_table("test_table", table_provider.clone())?;
+
+        let mem_table1 = Arc::new(MemTable::try_new(table_schema.clone(), vec![vec![batch1]])?);
+        let plan1 = mem_table1.scan(&ctx.state(), None, &[], None).await?;
+
+        let _ = table_provider
+            .insert_into(&ctx.state(), plan1, InsertOp::Append)
+            .await?;
+
+        let names2 = StringArray::from(vec!["Robert", "Ion", "Denny", "Tyler"]);
+        let ages2 = Int64Array::from(vec![25, 30, 35, 40]);
+        let batch2 = RecordBatch::try_new(
+            table_schema.clone(),
+            vec![Arc::new(names2), Arc::new(ages2)],
+        )?;
+
+        let mem_table2 = Arc::new(MemTable::try_new(table_schema.clone(), vec![vec![batch2]])?);
+        let plan2 = mem_table2.scan(&ctx.state(), None, &[], None).await?;
+
+        let result_plan = table_provider
+            .insert_into(&ctx.state(), plan2, InsertOp::Overwrite)
+            .await?;
+
+        let results = datafusion::physical_plan::collect(result_plan, ctx.task_ctx()).await?;
+        assert_eq!(results.len(), 1);
+        let batch = &results[0];
+        assert_eq!(batch.num_rows(), 1);
+        let count_array = batch.column_by_name("count").unwrap();
+        let count_val = arrow::array::UInt64Array::from(count_array.to_data()).value(0);
+        assert_eq!(count_val, 4);
+
+        ctx.deregister_table("test_table")?;
+        let final_table = deltalake_core::open_table(url::Url::parse(&table_uri)?).await?;
+        let final_scan_config = DeltaScanConfigBuilder::new().build(final_table.snapshot()?)?;
+        let final_table_provider: Arc<dyn TableProvider> = Arc::new(DeltaTableProvider::try_new(
+            final_table.snapshot()?.clone(),
+            final_table.log_store(),
+            final_scan_config,
+        )?);
+        ctx.register_table("test_table", final_table_provider)?;
+
+        let all_data = ctx
+            .sql("SELECT name, age FROM test_table ORDER BY age")
+            .await?
+            .collect()
+            .await?;
+
+        assert_eq!(all_data.len(), 1);
+        let data_batch = &all_data[0];
+        assert_eq!(data_batch.num_rows(), 4); // Only 4 rows from overwrite, initial data should be gone
+
+        let names_col = data_batch.column_by_name("name").unwrap();
+        let ages_col = data_batch.column_by_name("age").unwrap();
+        let names_array = arrow::array::StringArray::from(names_col.to_data());
+        let ages_array = arrow::array::Int64Array::from(ages_col.to_data());
+
+        assert_eq!(names_array.value(0), "Robert");
+        assert_eq!(ages_array.value(0), 25);
+        assert_eq!(names_array.value(1), "Ion");
+        assert_eq!(ages_array.value(1), 30);
+        assert_eq!(names_array.value(2), "Denny");
+        assert_eq!(ages_array.value(2), 35);
+        assert_eq!(names_array.value(3), "Tyler");
+        assert_eq!(ages_array.value(3), 40);
+
+        assert_eq!(final_table.version(), Some(1)); // CREATE + OVERWRITE = version 1 (the initial append might not commit separately)
+
+        let history = final_table.history(None).await?;
+        assert_eq!(history.len(), 2); // CREATE + OVERWRITE
+
+        assert_eq!(history[0].operation.as_ref().unwrap(), "WRITE");
+
+        let commit_info = &history[0];
+        assert!(commit_info.operation_parameters.is_some());
+        let operation_params = commit_info.operation_parameters.as_ref().unwrap();
+        assert_eq!(
+            operation_params.get("mode"),
+            Some(&serde_json::Value::String("Overwrite".to_string()))
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_sql_insert_statement() -> TestResult {
+        let table_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("name", ArrowDataType::Utf8, false),
+            ArrowField::new("age", ArrowDataType::Int64, false),
+        ]));
+
+        let storage = Box::<LocalStorageIntegration>::default();
+        let context = IntegrationContext::new(storage)?;
+        let table_uri = context.uri_for_table(TestTables::Simple);
+
+        let table = CreateBuilder::new()
+            .with_location(&table_uri)
+            .with_columns(vec![
+                StructField::new(
+                    "name".to_string(),
+                    DataType::Primitive(PrimitiveType::String),
+                    false,
+                ),
+                StructField::new(
+                    "age".to_string(),
+                    DataType::Primitive(PrimitiveType::Long),
+                    false,
+                ),
+            ])
+            .await?;
+
+        let names = StringArray::from(vec!["Robert", "Ion", "Denny", "Tyler"]);
+        let ages = Int64Array::from(vec![25, 30, 35, 40]);
+        let batch =
+            RecordBatch::try_new(table_schema.clone(), vec![Arc::new(names), Arc::new(ages)])?;
+
+        let ctx = SessionContext::new();
+        let scan_config = DeltaScanConfigBuilder::new().build(table.snapshot()?)?;
+        let table_provider: Arc<dyn TableProvider> = Arc::new(DeltaTableProvider::try_new(
+            table.snapshot()?.clone(),
+            table.log_store(),
+            scan_config,
+        )?);
+        ctx.register_table("delta_table", table_provider)?;
+
+        let source_table = Arc::new(MemTable::try_new(table_schema, vec![vec![batch]])?);
+        ctx.register_table("source_data", source_table)?;
+
+        let insert_result = ctx
+            .sql("INSERT INTO delta_table SELECT * FROM source_data")
+            .await?
+            .collect()
+            .await?;
+
+        assert_eq!(insert_result.len(), 1);
+        let count_batch = &insert_result[0];
+        assert_eq!(count_batch.num_rows(), 1);
+        assert_eq!(count_batch.schema().field(0).name(), "count");
+
+        let count_array = arrow::array::UInt64Array::from(count_batch.column(0).to_data());
+        let inserted_count = count_array.value(0);
+        assert_eq!(inserted_count, 4); // 4 rows inserted
+
+        ctx.deregister_table("delta_table")?;
+        let refreshed_table = deltalake_core::open_table(url::Url::parse(&table_uri)?).await?;
+        let refreshed_table_provider: Arc<dyn TableProvider> = Arc::new(refreshed_table);
+        ctx.register_table("delta_table", refreshed_table_provider)?;
+
+        let df = ctx
+            .sql("SELECT COUNT(*) as row_count FROM delta_table")
+            .await?;
+        let result = df.collect().await?;
+
+        assert_eq!(result.len(), 1);
+        let batch = &result[0];
+        assert_eq!(batch.num_rows(), 1);
+
+        let count_array = arrow::array::Int64Array::from(batch.column(0).to_data());
+        let row_count = count_array.value(0);
+        assert_eq!(row_count, 4);
+
+        let content_result = ctx
+            .sql("SELECT name, age FROM delta_table ORDER BY age")
+            .await?
+            .collect()
+            .await?;
+
+        assert_eq!(content_result.len(), 1);
+        let content_batch = &content_result[0];
+        assert_eq!(content_batch.num_rows(), 4);
+
+        let names_col = content_batch.column_by_name("name").unwrap();
+        let ages_col = content_batch.column_by_name("age").unwrap();
+        let names_array = arrow::array::StringArray::from(names_col.to_data());
+        let ages_array = arrow::array::Int64Array::from(ages_col.to_data());
+
+        assert_eq!(names_array.value(0), "Robert");
+        assert_eq!(ages_array.value(0), 25);
+        assert_eq!(names_array.value(1), "Ion");
+        assert_eq!(ages_array.value(1), 30);
+        assert_eq!(names_array.value(2), "Denny");
+        assert_eq!(ages_array.value(2), 35);
+        assert_eq!(names_array.value(3), "Tyler");
+        assert_eq!(ages_array.value(3), 40);
+
+        let final_table = deltalake_core::open_table(url::Url::parse(&table_uri)?).await?;
+        assert_eq!(final_table.version(), Some(1)); // CREATE + SQL INSERT = version 1
+
+        let history = final_table.history(None).await?;
+        assert_eq!(history.len(), 2); // CREATE + SQL INSERT
+        assert_eq!(history[0].operation.as_ref().unwrap(), "WRITE");
+
+        let commit_info = &history[0];
+        assert!(commit_info.operation_parameters.is_some());
+        let operation_params = commit_info.operation_parameters.as_ref().unwrap();
+        assert_eq!(
+            operation_params.get("mode"),
+            Some(&serde_json::Value::String("Append".to_string()))
+        );
+
+        if let Some(stats) = final_table.statistics() {
+            if let datafusion::common::stats::Precision::Exact(num_rows) = stats.num_rows {
+                assert_eq!(
+                    num_rows, 4,
+                    "Table should have exactly 4 rows from SQL INSERT"
+                );
+            }
+        }
+
+        let file_count = final_table.get_file_uris()?.count();
+        assert!(
+            file_count > 0,
+            "Table should have data files after SQL INSERT"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
# Description
Implement `TableProvider::insert_into` to support programmatic API calls, and extend `DataSink` to enable SQL insert operations in DataFusion.

# Related Issue(s)
- closes #3084

# Documentation
- [insert_into](https://docs.rs/datafusion/latest/datafusion/datasource/trait.TableProvider.html#tymethod.insert_into) from `TableProvider`
- [DataSink](https://docs.rs/datafusion/latest/datafusion/datasource/sink/trait.DataSink.html)
