### PR TITLE
chore: pin cargo-machete action to the sha right before a regression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Run Machete to check for unused dependencies
-        uses: bnjbvr/cargo-machete@main
+        uses: bnjbvr/cargo-machete@aa070c61641e482bc2b5d41c97b496ee4755bf37
 
       - name: Default build
         run: (cd crates/deltalake && cargo build --tests)


### PR DESCRIPTION
Committed a fix upstream
[here](https://github.com/bnjbvr/cargo-machete/pull/199)
