### PR TITLE
fix: somehow the right test value didn't make it into the pr

### DIFF
--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -60,7 +60,7 @@ def test_read_simple_table_to_dict():
 def test_table_count():
     table_path = "../crates/test/tests/data/COVID-19_NYT"
     dt = DeltaTable(table_path)
-    assert dt.count() == 1
+    assert dt.count() == 1111930
 
 
 class _SerializableException(BaseException):


### PR DESCRIPTION
The check that caught this wasn't apparently "required" when I had refactored our repo rules a month or so ago.

I had also made this change locally, there might even be video evidence of it :smile: but I must not have correctly pushed it
