### PR TITLE
refactor: remove table_url from Snapshot

### DIFF
--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -35,7 +35,6 @@ use itertools::Itertools;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use tokio::task::spawn_blocking;
-use url::Url;
 
 use super::{Action, CommitInfo, Metadata, Protocol, Remove};
 use crate::kernel::arrow::engine_ext::{ScanExt, SnapshotExt};
@@ -69,8 +68,6 @@ pub struct Snapshot {
     config: DeltaTableConfig,
     /// Logical table schema
     schema: SchemaRef,
-    /// Fully qualified URL of the table
-    table_url: Url,
 }
 
 impl Snapshot {
@@ -118,7 +115,6 @@ impl Snapshot {
             inner: snapshot,
             config,
             schema,
-            table_url: log_store.config().location.clone(),
         })
     }
 
@@ -136,7 +132,7 @@ impl Snapshot {
             store.put(&uri, data.into()).await?;
         }
 
-        let table_url = Url::parse("memory:///").unwrap();
+        let table_url = url::Url::parse("memory:///").unwrap();
 
         let log_store = default_logstore(
             store.clone(),
@@ -154,7 +150,6 @@ impl Snapshot {
                 inner: snapshot,
                 config: Default::default(),
                 schema,
-                table_url,
             },
             log_store,
         ))
@@ -221,7 +216,7 @@ impl Snapshot {
 
     /// Get the table root of the snapshot
     pub(crate) fn table_root_path(&self) -> DeltaResult<Path> {
-        Ok(Path::from_url_path(self.table_url.path())?)
+        Ok(Path::from_url_path(self.inner.table_root().path())?)
     }
 
     /// Well known properties of the table

--- a/crates/core/src/kernel/snapshot/serde.rs
+++ b/crates/core/src/kernel/snapshot/serde.rs
@@ -54,7 +54,7 @@ impl Serialize for Snapshot {
         let mut seq = serializer.serialize_seq(None)?;
 
         seq.serialize_element(&self.version())?;
-        seq.serialize_element(&self.table_url)?;
+        seq.serialize_element(&self.inner.table_root())?;
         seq.serialize_element(&self.protocol())?;
         seq.serialize_element(&self.metadata())?;
         seq.serialize_element(&ascending_commit_files)?;
@@ -202,7 +202,6 @@ impl<'de> Visitor<'de> for SnapshotVisitor {
 
         Ok(Snapshot {
             inner: Arc::new(snapshot),
-            table_url,
             schema: Arc::new(schema),
             config,
         })


### PR DESCRIPTION
# Description

Our internal checkpoint currently tracks the table URL which is also accessible on the kernel snapshot. This PR just removes the field in favour of accessing it on the snapshot directly.