### PR TITLE
fix: maintaining load config from state

### DIFF
--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -126,10 +126,11 @@ impl DeltaTable {
     /// NOTE: This is for advanced users. If you don't know why you need to use this method,
     /// please call one of the `open_table` helper methods instead.
     pub(crate) fn new_with_state(log_store: LogStoreRef, state: DeltaTableState) -> Self {
+        let config = state.load_config().clone();
         Self {
             state: Some(state),
             log_store,
-            config: Default::default(),
+            config,
         }
     }
 


### PR DESCRIPTION
# Description
When creating a DeltaTable with new_from_state we should persist the `load_config` from the state also on the DeltaTable Struct, in reality this has no true effect because we **never** hit a code path of using the config from DeltaTable after we have `Some(DeltaTableState)` since we only look at the LoadConfig within the snapshot. The config on the DeltaTable struct is only used when creating the snapshot and then it's passed through it. After we have a snapshot, the config is only used from within there.

But this is more correct so lets prevent footguns in the future if we do for some reason look at the DeltaTable struct for the config.


@corwinjoy 