### PR TITLE
ci: split out integration tests

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -16,9 +16,6 @@ runs:
   using: "composite"
 
   steps:
-    - name: checkout
-      uses: actions/checkout@v5
-
     - name: Install uv
       uses: astral-sh/setup-uv@v3
 
@@ -35,3 +32,5 @@ runs:
       with:
         toolchain: ${{ inputs.rust-toolchain }}
         cache: true
+        # if we ever get rid of all the clippy warnings, we can remove this line
+        rustflags: ""

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -17,7 +17,7 @@ runs:
 
   steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v3
@@ -27,14 +27,11 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: default
-        toolchain: ${{ inputs.rust-toolchain }}
-        override: true
-        components: rustfmt, clippy
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
 
-    - uses: Swatinem/rust-cache@v2
+    - name: Setup Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        cache-targets: false
+        toolchain: ${{ inputs.rust-toolchain }}
+        cache: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,16 +8,35 @@ on:
   merge_group:
 
 env:
-  DEFAULT_FEATURES: "azure,datafusion,s3,gcs,glue,hdfs "
-  # Disable full debug symbol generation to speed up CI build and keep memory down
-  RUSTFLAGS: -C debuginfo=line-tables-only
-  # Disable incremental builds by cargo for CI which should save disk space
-  # and hopefully avoid final link "No space left on device"
-  CARGO_INCREMENTAL: 0
+  DEFAULT_FEATURES: "azure,datafusion,s3,gcs,glue,hdfs"
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: true
+
+      - name: Format
+        run: cargo fmt -- --check
+
+      - name: Run Machete to check for unused dependencies
+        uses: bnjbvr/cargo-machete@aa070c61641e482bc2b5d41c97b496ee4755bf37
+
+      - name: build and lint with clippy
+        run: cargo clippy --features ${{ env.DEFAULT_FEATURES }} --tests
+
   # run various build configurations, fmt, and clippy.
   build:
     strategy:
@@ -30,48 +49,30 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Run sccache-cache
+      - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Install minimal stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: default
-          toolchain: "1.86"
-          override: true
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: "rust-cache-${{ matrix.os }}"
-          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
-          cache-all-crates: true
-          cache-targets: false
-
-      - name: Format
-        run: cargo fmt -- --check
-
-      - name: Run Machete to check for unused dependencies
-        uses: bnjbvr/cargo-machete@aa070c61641e482bc2b5d41c97b496ee4755bf37
+          toolchain: stable
+          cache: true
 
       - name: Default build
-        run: (cd crates/deltalake && cargo build --tests)
+        run: cargo build --package deltalake
 
-      - name: build and lint with clippy
-        run: cargo clippy --features ${{ env.DEFAULT_FEATURES }} --tests
+      - name: Default features with clippy
+        run: cargo clippy --features ${{ env.DEFAULT_FEATURES }}
 
       - name: Spot-check build for native-tls features
-        run: cargo clippy --no-default-features --features azure,datafusion,s3-native-tls,gcs,glue --tests
+        run: cargo build --no-default-features --features azure,datafusion,s3-native-tls,gcs,glue
 
       - name: Check no default features (except rustls)
         run: cargo check --no-default-features --features rustls
 
-      - name: Check docs
-        run: cargo doc --no-deps --features ${{ env.DEFAULT_FEATURES }}
-
-  unit_test:
-    name: Unit Tests
+  test:
     strategy:
       fail-fast: true
       matrix:
@@ -82,259 +83,18 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Run sccache-cache
+      - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Install minimal stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: default
-          toolchain: "1.86"
-          override: true
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: "rust-cache-${{ matrix.os }}"
-          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
-          cache-all-crates: true
-          cache-targets: false
+          toolchain: stable
+          cache: true
 
       - name: Run tests
         run: |
           make setup-dat
           cargo test --features ${{ env.DEFAULT_FEATURES }}
-
-  integration_test:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    env:
-      # https://github.com/rust-lang/cargo/issues/10280
-      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-      AWS_DEFAULT_REGION: "us-east-1"
-      AWS_ACCESS_KEY_ID: deltalake
-      AWS_SECRET_ACCESS_KEY: weloverust
-      AWS_ENDPOINT_URL: http://localhost:4566
-      AWS_ALLOW_HTTP: "1"
-      AZURE_USE_EMULATOR: "1"
-      AZURE_STORAGE_ALLOW_HTTP: "1"
-      AZURITE_BLOB_STORAGE_URL: "http://localhost:10000"
-      AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;"
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Install minimal stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: "1.86"
-          override: true
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "rust-cache-integration-tests"
-          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
-          cache-all-crates: true
-          cache-targets: false
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Start emulated services
-        run: docker compose up -d
-
-      - name: Run tests with rustls (default)
-        run: |
-          gmake setup-dat
-          cargo llvm-cov \
-            --features integration_test,${{ env.DEFAULT_FEATURES }} \
-            --workspace \
-            --exclude delta-inspect \
-            --exclude deltalake-hdfs \
-            --exclude deltalake-lakefs \
-            --codecov \
-            --output-path codecov.json
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: codecov.json
-          fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  integration_test_native_tls:
-    name: Integration Tests (Native TLS)
-    runs-on: ubuntu-latest
-    env:
-      # https://github.com/rust-lang/cargo/issues/10280
-      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-      AWS_DEFAULT_REGION: "us-east-1"
-      AWS_ACCESS_KEY_ID: deltalake
-      AWS_SECRET_ACCESS_KEY: weloverust
-      AWS_ENDPOINT_URL: http://localhost:4566
-      AWS_ALLOW_HTTP: "1"
-      AZURE_USE_EMULATOR: "1"
-      AZURE_STORAGE_ALLOW_HTTP: "1"
-      AZURITE_BLOB_STORAGE_URL: "http://localhost:10000"
-      AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;"
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Install minimal stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: "1.86"
-          override: true
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "rust-cache-integration-tests"
-          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
-          cache-all-crates: true
-          cache-targets: false
-
-      # Install Java and Hadoop for HDFS integration tests
-      - uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
-      - name: Download Hadoop
-        run: |
-          wget -q https://dlcdn.apache.org/hadoop/common/hadoop-3.4.0/hadoop-3.4.0.tar.gz
-          tar -xf hadoop-3.4.0.tar.gz -C $GITHUB_WORKSPACE
-          echo "$GITHUB_WORKSPACE/hadoop-3.4.0/bin" >> $GITHUB_PATH
-
-      - name: Start emulated services
-        run: docker compose up -d
-
-      - name: Run tests with native-tls
-        run: |
-          gmake setup-dat
-          cargo test --no-default-features --features integration_test,s3-native-tls,datafusion
-
-  integration_test_hdfs:
-    name: Integration Tests (HDFS)
-    runs-on: ubuntu-latest
-    env:
-      # https://github.com/rust-lang/cargo/issues/10280
-      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Install minimal stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: "1.86"
-          override: true
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "rust-cache-integration-tests-hdfs"
-          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
-          cache-all-crates: true
-          cache-targets: false
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      # Install Java and Hadoop for HDFS integration tests
-      - uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
-      - name: Download Hadoop
-        run: |
-          wget -q https://dlcdn.apache.org/hadoop/common/hadoop-3.4.0/hadoop-3.4.0.tar.gz
-          tar -xf hadoop-3.4.0.tar.gz -C $GITHUB_WORKSPACE
-          echo "$GITHUB_WORKSPACE/hadoop-3.4.0/bin" >> $GITHUB_PATH
-
-      - name: Run tests with rustls (default)
-        run: |
-          gmake setup-dat
-          cargo llvm-cov \
-            --features integration_test \
-            --package deltalake-hdfs \
-            --codecov \
-            --output-path codecov.json
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: codecov.json
-          fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  integration_test_lakefs:
-    name: Integration Tests (LakeFS v1.48)
-    runs-on: ubuntu-latest
-    env:
-      # https://github.com/rust-lang/cargo/issues/10280
-      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Install minimal stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: default
-          toolchain: "1.86"
-          override: true
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "rust-cache-integration-tests-lakefs"
-          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
-          cache-all-crates: true
-          cache-targets: false
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Download Lakectl
-        run: |
-          wget -q https://github.com/treeverse/lakeFS/releases/download/v1.48.1/lakeFS_1.48.1_Linux_x86_64.tar.gz
-          tar -xf lakeFS_1.48.1_Linux_x86_64.tar.gz -C $GITHUB_WORKSPACE
-          echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
-
-      - name: Start emulated services
-        run: docker compose -f docker-compose-lakefs.yml up -d
-
-      - name: Run tests with rustls (default)
-        run: |
-          gmake setup-dat
-          cargo llvm-cov \
-            --package deltalake-lakefs \
-            --features integration_test_lakefs \
-            --codecov \
-            --output-path codecov.json
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: codecov.json
-          fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,7 @@ jobs:
             --workspace \
             --codecov \
             --output-path codecov.json \
+            --exclude deltalake \
             --exclude deltalake-azure \
             --exclude deltalake-aws \
             --exclude deltalake-hdfs \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,8 @@ jobs:
         with:
           toolchain: stable
           cache: true
+          # if we ever get rid of all the clippy warnings, we can remove this line
+          rustflags: ""
 
       - name: Run tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
           fi
 
   build:
+    needs: test-matrix
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,10 +108,7 @@ jobs:
       - name: Run tests
         run: |
           make setup-dat
-          cargo llvm-cov \
-            --features ${{ env.DEFAULT_FEATURES }} \
-            --codecov \
-            --output-path codecov.json
+          cargo llvm-cov --features ${{ env.DEFAULT_FEATURES }}  --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,15 +80,29 @@ jobs:
       - name: Check no default features (except rustls)
         run: cargo check --no-default-features --features rustls
 
+  test-matrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      targets: ${{ steps.matrix.outputs.os }}
+
+    steps:
+      - name: Define test matrix
+        id: matrix
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo 'os=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'os=["ubuntu-latest", "windows-latest", "macos-latest"]' >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Unit Tests
+    needs: test-matrix
     strategy:
       fail-fast: true
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+        os: ${{ fromJSON(needs.test-matrix.outputs.targets) }}
     runs-on: ${{ matrix.os }}
     env:
       DEFAULT_FEATURES: "datafusion"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
         run: |
           make setup-dat
           cargo llvm-cov --features ${{ env.DEFAULT_FEATURES }} \
+            --workspace \
             --codecov \
             --output-path codecov.json \
             --exclude deltalake-azure \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          components: rustfmt
+          components: rustfmt,clippy
           cache: true
           # if we ever get rid of all the clippy warnings, we can remove this line
           rustflags: ""
@@ -34,11 +34,11 @@ jobs:
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
 
-      - name: Run Machete to check for unused dependencies
-        uses: bnjbvr/cargo-machete@aa070c61641e482bc2b5d41c97b496ee4755bf37
-
       - name: build and lint with clippy
         run: cargo clippy --features ${{ env.DEFAULT_FEATURES }} --tests
+
+      - name: Run Machete to check for unused dependencies
+        uses: bnjbvr/cargo-machete@aa070c61641e482bc2b5d41c97b496ee4755bf37
 
   build:
     strategy:
@@ -60,6 +60,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          components: clippy
           cache: true
           # if we ever get rid of all the clippy warnings, we can remove this line
           rustflags: ""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,14 +41,27 @@ jobs:
       - name: Run Machete to check for unused dependencies
         uses: bnjbvr/cargo-machete@aa070c61641e482bc2b5d41c97b496ee4755bf37
 
+  test-matrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      targets: ${{ steps.matrix.outputs.os }}
+
+    steps:
+      - name: Define test matrix
+        id: matrix
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo 'os=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'os=["ubuntu-latest", "windows-latest", "macos-latest"]' >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     strategy:
       fail-fast: true
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+        os: ${{ fromJSON(needs.test-matrix.outputs.targets) }}
     runs-on: ${{ matrix.os }}
     env:
       DEFAULT_FEATURES: "azure,datafusion,s3,gcs,glue,hdfs"
@@ -80,22 +93,6 @@ jobs:
       - name: Check no default features (except rustls)
         run: cargo check --no-default-features --features rustls
 
-  test-matrix:
-    runs-on: ubuntu-latest
-
-    outputs:
-      targets: ${{ steps.matrix.outputs.os }}
-
-    steps:
-      - name: Define test matrix
-        id: matrix
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo 'os=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
-          else
-            echo 'os=["ubuntu-latest", "windows-latest", "macos-latest"]' >> "$GITHUB_OUTPUT"
-          fi
-
   test:
     name: Unit Tests
     needs: test-matrix
@@ -106,7 +103,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       DEFAULT_FEATURES: "datafusion"
-      EXCLUDES: "deltalake-azure,deltalake-aws,deltalake-hdfs,deltalake-lakefs"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,22 @@ jobs:
           # if we ever get rid of all the clippy warnings, we can remove this line
           rustflags: ""
 
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
       - name: Run tests
         run: |
           make setup-dat
-          cargo test --features ${{ env.DEFAULT_FEATURES }}
+          cargo llvm-cov \
+            --package deltalake-lakefs \
+            --features ${{ env.DEFAULT_FEATURES }} \
+            --codecov \
+            --output-path codecov.json
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: codecov.json
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,13 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          components: rustfmt
           cache: true
+          # if we ever get rid of all the clippy warnings, we can remove this line
+          rustflags: ""
 
-      - name: Format
-        run: cargo fmt -- --check
+      - name: Rustfmt Check
+        uses: actions-rust-lang/rustfmt@v1
 
       - name: Run Machete to check for unused dependencies
         uses: bnjbvr/cargo-machete@aa070c61641e482bc2b5d41c97b496ee4755bf37
@@ -37,7 +40,6 @@ jobs:
       - name: build and lint with clippy
         run: cargo clippy --features ${{ env.DEFAULT_FEATURES }} --tests
 
-  # run various build configurations, fmt, and clippy.
   build:
     strategy:
       fail-fast: true
@@ -59,6 +61,8 @@ jobs:
         with:
           toolchain: stable
           cache: true
+          # if we ever get rid of all the clippy warnings, we can remove this line
+          rustflags: ""
 
       - name: Default build
         run: cargo build --package deltalake
@@ -73,6 +77,7 @@ jobs:
         run: cargo check --no-default-features --features rustls
 
   test:
+    name: Unit Tests
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,14 @@ on:
   merge_group:
 
 env:
-  DEFAULT_FEATURES: "azure,datafusion,s3,gcs,glue,hdfs "
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    env:
+      DEFAULT_FEATURES: "azure,datafusion,s3,gcs,glue,hdfs"
 
     steps:
       - uses: actions/checkout@v5
@@ -49,6 +50,8 @@ jobs:
           - windows-latest
           - macos-latest
     runs-on: ${{ matrix.os }}
+    env:
+      DEFAULT_FEATURES: "azure,datafusion,s3,gcs,glue,hdfs"
 
     steps:
       - uses: actions/checkout@v5
@@ -87,6 +90,8 @@ jobs:
           - windows-latest
           - macos-latest
     runs-on: ${{ matrix.os }}
+    env:
+      DEFAULT_FEATURES: "datafusion"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       DEFAULT_FEATURES: "datafusion"
+      EXCLUDES: "deltalake-azure,deltalake-aws,deltalake-hdfs,deltalake-lakefs"
 
     steps:
       - uses: actions/checkout@v5
@@ -113,7 +114,13 @@ jobs:
       - name: Run tests
         run: |
           make setup-dat
-          cargo llvm-cov --features ${{ env.DEFAULT_FEATURES }}  --codecov --output-path codecov.json
+          cargo llvm-cov --features ${{ env.DEFAULT_FEATURES }} \
+            --codecov \
+            --output-path codecov.json \
+            --exclude deltalake-azure \
+            --exclude deltalake-aws \
+            --exclude deltalake-hdfs \
+            --exclude deltalake-lakefs
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Run tests
+        shell: bash
         run: |
           make setup-dat
           cargo llvm-cov --features ${{ env.DEFAULT_FEATURES }} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
   merge_group:
 
 env:
-  DEFAULT_FEATURES: "azure,datafusion,s3,gcs,glue,hdfs"
+  DEFAULT_FEATURES: "azure,datafusion,s3,gcs,glue,hdfs "
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,6 @@ jobs:
         run: |
           make setup-dat
           cargo llvm-cov \
-            --package deltalake-lakefs \
             --features ${{ env.DEFAULT_FEATURES }} \
             --codecov \
             --output-path codecov.json

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -82,11 +82,3 @@ jobs:
               body: message
             })
             core.setFailed(message)
-
-  typos:
-    name: Spell Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Check spelling
-        uses: crate-ci/typos@v1

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Assign GitHub labels
         if: |
@@ -41,7 +41,7 @@ jobs:
           node-version: "18"
       - run: npm install -g @commitlint/cli @commitlint/config-conventional
       # Checkout to get the commitlint configuration.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: commitlint --verbose <<< $COMMIT_MSG
         env:
           COMMIT_MSG: >
@@ -87,6 +87,6 @@ jobs:
     name: Spell Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check spelling
         uses: crate-ci/typos@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,10 +22,10 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses:  tcort/github-action-markdown-link-check@v1
+      - uses: actions/checkout@v5
+      - uses: tcort/github-action-markdown-link-check@v1
         with:
-          config-file: 'docs/mlc_config.json'
+          config-file: "docs/mlc_config.json"
           folder-path: docs
           base-branch: main
           use-quiet-mode: yes
@@ -34,7 +34,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: |
           cd docs
           make check
@@ -45,7 +45,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Build (and maybe release) the documentation
+name: docs
 
 on:
   merge_group:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,208 @@
+name: build
+
+on:
+  push:
+    branches: [main, "rust-v*"]
+  pull_request:
+    branches: [main, "rust-v*", next, next/*]
+  merge_group:
+
+env:
+  # https://github.com/rust-lang/cargo/issues/10280
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  DEFAULT_FEATURES: "azure,datafusion,s3,gcs,glue,hdfs "
+  # Disable full debug symbol generation to speed up CI build and keep memory down
+  RUSTFLAGS: -C debuginfo=line-tables-only
+  # Disable incremental builds by cargo for CI which should save disk space
+  # and hopefully avoid final link "No space left on device"
+  CARGO_INCREMENTAL: 0
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
+jobs:
+  cloud:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+          - name: aws
+          - name: azure
+          - name: gcp
+
+    env:
+      AWS_DEFAULT_REGION: "us-east-1"
+      AWS_ACCESS_KEY_ID: deltalake
+      AWS_SECRET_ACCESS_KEY: weloverust
+      AWS_ENDPOINT_URL: http://localhost:4566
+      AWS_ALLOW_HTTP: "1"
+      AZURE_USE_EMULATOR: "1"
+      AZURE_STORAGE_ALLOW_HTTP: "1"
+      AZURITE_BLOB_STORAGE_URL: "http://localhost:10000"
+      AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: true
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Start emulated services
+        run: docker compose up -d
+
+      - name: Run tests with rustls (default)
+        run: |
+          gmake setup-dat
+          cargo llvm-cov \
+            --package deltalake-${{ matrix.target.name }} \
+            --features integration_test \
+            --codecov \
+            --output-path codecov.json
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: codecov.json
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  native_tls:
+    name: aws-native-tls
+    runs-on: ubuntu-latest
+    env:
+      AWS_DEFAULT_REGION: "us-east-1"
+      AWS_ACCESS_KEY_ID: deltalake
+      AWS_SECRET_ACCESS_KEY: weloverust
+      AWS_ENDPOINT_URL: http://localhost:4566
+      AWS_ALLOW_HTTP: "1"
+      AZURE_USE_EMULATOR: "1"
+      AZURE_STORAGE_ALLOW_HTTP: "1"
+      AZURITE_BLOB_STORAGE_URL: "http://localhost:10000"
+      AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: true
+
+      - name: Start emulated services
+        run: docker compose up -d
+
+      - name: Run tests with native-tls
+        run: |
+          gmake setup-dat
+          cargo test \
+            --package deltalake-aws
+            --no-default-features \
+            --features integration_test,native-tls
+
+  integration_test_hdfs:
+    name: Integration Tests (HDFS)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: true
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      # Install Java and Hadoop for HDFS integration tests
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Download Hadoop
+        run: |
+          wget -q https://dlcdn.apache.org/hadoop/common/hadoop-3.4.0/hadoop-3.4.0.tar.gz
+          tar -xf hadoop-3.4.0.tar.gz -C $GITHUB_WORKSPACE
+          echo "$GITHUB_WORKSPACE/hadoop-3.4.0/bin" >> $GITHUB_PATH
+
+      - name: Run tests with rustls (default)
+        run: |
+          gmake setup-dat
+          cargo llvm-cov \
+            --features integration_test \
+            --package deltalake-hdfs \
+            --codecov \
+            --output-path codecov.json
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: codecov.json
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  integration_test_lakefs:
+    name: Integration Tests (LakeFS v1.48)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: true
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Download Lakectl
+        run: |
+          wget -q https://github.com/treeverse/lakeFS/releases/download/v1.48.1/lakeFS_1.48.1_Linux_x86_64.tar.gz
+          tar -xf lakeFS_1.48.1_Linux_x86_64.tar.gz -C $GITHUB_WORKSPACE
+          echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
+
+      - name: Start emulated services
+        run: docker compose -f docker-compose-lakefs.yml up -d
+
+      - name: Run tests
+        run: |
+          gmake setup-dat
+          cargo llvm-cov \
+            --package deltalake-lakefs \
+            --features integration_test_lakefs \
+            --codecov \
+            --output-path codecov.json
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: codecov.json
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: build
+name: integration
 
 on:
   push:
@@ -21,7 +21,6 @@ env:
 
 jobs:
   cloud:
-    name: Integration Tests
     runs-on: ubuntu-latest
 
     strategy:
@@ -111,11 +110,11 @@ jobs:
         run: |
           gmake setup-dat
           cargo test \
-            --package deltalake-aws
+            --package deltalake-aws \
             --no-default-features \
             --features integration_test,native-tls
 
-  integration_test_hdfs:
+  hdfs:
     name: Integration Tests (HDFS)
     runs-on: ubuntu-latest
     steps:
@@ -162,7 +161,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  integration_test_lakefs:
+  lakefs:
     name: Integration Tests (LakeFS v1.48)
     runs-on: ubuntu-latest
 

--- a/.github/workflows/python_benchmark.yml
+++ b/.github/workflows/python_benchmark.yml
@@ -18,7 +18,7 @@ jobs:
       CARGO_INCREMENTAL: 0
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -63,17 +63,16 @@ jobs:
       RUSTC_WRAPPER: "sccache"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Run sccache-cache
+      - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          shared-key: "rust-cache-python-builds"
-          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
-          cache-all-crates: true
-          cache-targets: false
+          toolchain: stable
+          cache: true
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -19,6 +19,8 @@ jobs:
   test-minimal:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
+
       - name: Setup Environment
         uses: ./.github/actions/setup-env
         with:
@@ -42,6 +44,8 @@ jobs:
     name: Python Build (Python 3.10 PyArrow latest)
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
+
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
@@ -69,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v5
+
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
@@ -86,6 +92,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v5
+
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
@@ -107,6 +115,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v5
+
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
@@ -128,6 +138,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v5
+
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
@@ -151,7 +163,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -12,27 +12,13 @@ defaults:
     working-directory: ./python
 
 env:
-  RUSTFLAGS: "-C debuginfo=line-tables-only"
-  CARGO_INCREMENTAL: 0
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   test-minimal:
     runs-on: ubuntu-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
     steps:
-      - uses: actions/checkout@v4
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "rust-cache-python-builds"
-          env-vars: "CARGO CC CFLAGS CXX CMAKE RUST"
-          cache-all-crates: true
-          cache-targets: false
-
       - name: Setup Environment
         uses: ./.github/actions/setup-env
         with:
@@ -42,9 +28,6 @@ jobs:
         run: |
           uv sync --no-install-project
           make check-python
-
-      - name: Check Rust
-        run: make check-rust
 
       - name: Build and install deltalake
         run: |
@@ -58,22 +41,7 @@ jobs:
   test:
     name: Python Build (Python 3.10 PyArrow latest)
     runs-on: ubuntu-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
-
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-          cache: true
-
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
@@ -101,8 +69,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
@@ -120,8 +86,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
@@ -143,8 +107,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
@@ -166,8 +128,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
@@ -185,9 +145,6 @@ jobs:
   multi-python-running:
     name: Running with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "-C debuginfo=line-tables-only"
-      CARGO_INCREMENTAL: 0
 
     strategy:
       matrix:

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Validate git tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: compare git tag with cargo metadata
         run: |
           PUSHED_TAG=${GITHUB_REF##*/}
@@ -32,7 +32,7 @@ jobs:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -52,7 +52,7 @@ jobs:
     name: PyPI release on Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -72,7 +72,7 @@ jobs:
     name: PyPI release manylinux-2_17 x86_64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -93,7 +93,7 @@ jobs:
     name: PyPI release manylinux-2_17 aarch64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -117,7 +117,7 @@ jobs:
     name: PyPI release manylinux-2_28 aarch64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -138,7 +138,7 @@ jobs:
     name: PyPI release musl-2_17 x86_64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Validate git tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: compare git tag with cargo metadata
         run: |
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,15 @@
+name: chores
+
+# Trigger whenever a PR is changed (title as well as new / changed commits)
+on:
+  pull_request:
+
+jobs:
+  typos:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check spelling
+        uses: crate-ci/typos@v1


### PR DESCRIPTION
# Description

This is another attempt at making our CI a bit more pleasant to work with. The basic idea is - more smaller jobs as well as avoiding some redundant work.

we moved integration tests into their own job and streamlined the build job.

- `build/check`: fmt, clippy (with --test), docs, on linux only
- `build/build`: previous buid and check commands but without `--test`, all os
- `build/test`: unit tests on all os

In integration we now run a job for every crate that has integration tests. azure, aws, gcp, hdfs, lakefs