### PR TITLE
feat: expose arrow schema on snapshots

### DIFF
--- a/crates/core/src/delta_datafusion/cdf/scan.rs
+++ b/crates/core/src/delta_datafusion/cdf/scan.rs
@@ -28,7 +28,7 @@ pub struct DeltaCdfTableProvider {
 impl DeltaCdfTableProvider {
     /// Build a DeltaCDFTableProvider
     pub fn try_new(cdf_builder: CdfLoadBuilder) -> DeltaResult<Self> {
-        let mut fields = cdf_builder.snapshot.input_schema()?.fields().to_vec();
+        let mut fields = cdf_builder.snapshot.input_schema().fields().to_vec();
         for f in ADD_PARTITION_SCHEMA.clone() {
             fields.push(f.into());
         }

--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -818,7 +818,6 @@ mod test {
                             .unwrap()
                             .snapshot()
                             .input_schema()
-                            .unwrap()
                             .as_ref()
                             .to_owned()
                             .to_dfschema()

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -144,7 +144,7 @@ impl DataFusionMixins for Snapshot {
         expr: impl AsRef<str>,
         df_state: &SessionState,
     ) -> DeltaResult<Expr> {
-        let schema = DFSchema::try_from(self.arrow_schema()?.as_ref().to_owned())?;
+        let schema = DFSchema::try_from(self.arrow_schema().as_ref().to_owned())?;
         parse_predicate_expression(&schema, expr, df_state)
     }
 }
@@ -170,7 +170,7 @@ impl DataFusionMixins for LogDataHandler<'_> {
 
 impl DataFusionMixins for EagerSnapshot {
     fn arrow_schema(&self) -> DeltaResult<ArrowSchemaRef> {
-        self.snapshot().arrow_schema()
+        Ok(self.snapshot().arrow_schema())
     }
 
     fn input_schema(&self) -> DeltaResult<ArrowSchemaRef> {

--- a/crates/core/src/kernel/snapshot/iterators/scan_row.rs
+++ b/crates/core/src/kernel/snapshot/iterators/scan_row.rs
@@ -51,7 +51,7 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
         match this.stream.poll_next(cx) {
-            Poll::Ready(Some(Ok(batch))) => match parse_stats_column(&this.snapshot, &batch) {
+            Poll::Ready(Some(Ok(batch))) => match parse_stats_column(this.snapshot, &batch) {
                 Ok(batch) => Poll::Ready(Some(Ok(batch))),
                 Err(err) => Poll::Ready(Some(Err(err))),
             },

--- a/crates/core/src/kernel/snapshot/serde.rs
+++ b/crates/core/src/kernel/snapshot/serde.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use arrow_ipc::reader::FileReader;
 use arrow_ipc::writer::FileWriter;
 use delta_kernel::actions::{Metadata, Protocol};
+use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::log_segment::{ListedLogFiles, LogSegment};
 use delta_kernel::path::ParsedLogPath;
 use delta_kernel::snapshot::Snapshot as KernelSnapshot;
@@ -196,8 +197,10 @@ impl<'de> Visitor<'de> for SnapshotVisitor {
 
         let snapshot = KernelSnapshot::new(log_segment, table_configuration);
         let schema = snapshot
-            .metadata()
-            .parse_schema()
+            .table_configuration()
+            .schema()
+            .as_ref()
+            .try_into_arrow()
             .map_err(de::Error::custom)?;
 
         Ok(Snapshot {

--- a/crates/core/src/kernel/transaction/conflict_checker.rs
+++ b/crates/core/src/kernel/transaction/conflict_checker.rs
@@ -473,11 +473,7 @@ impl<'a> ConflictChecker<'a> {
                     &self.txn_info.read_predicates,
                     self.txn_info.read_whole_table(),
                 ) {
-                    let arrow_schema = self.txn_info.read_snapshot.arrow_schema().map_err(|err| {
-                        CommitConflictError::CorruptedState {
-                            source: Box::new(err),
-                        }
-                    })?;
+                    let arrow_schema = self.txn_info.read_snapshot.read_schema();
                     let partition_columns = &self
                         .txn_info
                         .read_snapshot

--- a/crates/core/src/operations/add_column.rs
+++ b/crates/core/src/operations/add_column.rs
@@ -96,7 +96,7 @@ impl std::future::IntoFuture for AddColumnBuilder {
             }
 
             let table_schema = this.snapshot.schema();
-            let new_table_schema = merge_delta_struct(table_schema, fields_right)?;
+            let new_table_schema = merge_delta_struct(table_schema.as_ref(), fields_right)?;
 
             let current_protocol = this.snapshot.protocol();
 

--- a/crates/core/src/operations/create.rs
+++ b/crates/core/src/operations/create.rs
@@ -418,7 +418,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.snapshot().unwrap().schema(), &table_schema)
+        assert_eq!(table.snapshot().unwrap().schema().as_ref(), &table_schema)
     }
 
     #[tokio::test]
@@ -442,7 +442,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.snapshot().unwrap().schema(), &table_schema)
+        assert_eq!(table.snapshot().unwrap().schema().as_ref(), &table_schema)
     }
 
     #[tokio::test]
@@ -479,7 +479,7 @@ mod tests {
             snapshot.protocol().min_writer_version(),
             PROTOCOL.default_writer_version()
         );
-        assert_eq!(snapshot.schema(), &schema);
+        assert_eq!(snapshot.schema().as_ref(), &schema);
 
         // check we can overwrite default settings via adding actions
         let protocol = ProtocolInner {

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -218,7 +218,7 @@ async fn execute_non_empty_expr(
 
     let scan_config = DeltaScanConfigBuilder::default()
         .with_file_column(false)
-        .with_schema(snapshot.input_schema()?)
+        .with_schema(snapshot.input_schema())
         .build(snapshot)?;
 
     let target_provider = Arc::new(

--- a/crates/core/src/operations/load.rs
+++ b/crates/core/src/operations/load.rs
@@ -7,6 +7,7 @@ use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use futures::future::BoxFuture;
 
 use super::CustomExecuteHandler;
+use crate::delta_datafusion::DataFusionMixins as _;
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::PROTOCOL;
 use crate::kernel::EagerSnapshot;
@@ -69,7 +70,7 @@ impl std::future::IntoFuture for LoadBuilder {
                     snapshot: this.snapshot,
                 },
             );
-            let schema = table.snapshot()?.snapshot().arrow_schema();
+            let schema = table.snapshot()?.snapshot().read_schema();
             let projection = this
                 .columns
                 .map(|cols| {

--- a/crates/core/src/operations/load.rs
+++ b/crates/core/src/operations/load.rs
@@ -7,7 +7,6 @@ use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use futures::future::BoxFuture;
 
 use super::CustomExecuteHandler;
-use crate::delta_datafusion::DataFusionMixins;
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::PROTOCOL;
 use crate::kernel::EagerSnapshot;
@@ -70,7 +69,7 @@ impl std::future::IntoFuture for LoadBuilder {
                     snapshot: this.snapshot,
                 },
             );
-            let schema = table.snapshot()?.snapshot().arrow_schema()?;
+            let schema = table.snapshot()?.snapshot().arrow_schema();
             let projection = this
                 .columns
                 .map(|cols| {

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -334,10 +334,8 @@ impl CdfLoadBuilder {
         register_store(self.log_store.clone(), session.runtime_env().clone());
 
         let partition_values = self.snapshot.metadata().partition_columns().clone();
-        let schema = self.snapshot.input_schema()?;
-        let schema_fields: Vec<Arc<Field>> = self
-            .snapshot
-            .input_schema()?
+        let schema = self.snapshot.input_schema();
+        let schema_fields: Vec<Arc<Field>> = schema
             .fields()
             .into_iter()
             .filter(|f| !partition_values.contains(f.name()))

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -974,7 +974,7 @@ async fn execute(
         let schema = Arc::new(schema_builder.finish());
         new_schema = Some(schema.clone());
         let schema_struct: StructType = schema.try_into_kernel()?;
-        if &schema_struct != snapshot.schema() {
+        if &schema_struct != snapshot.schema().as_ref() {
             let action = Action::Metadata(new_metadata(
                 &schema_struct,
                 current_metadata.partition_columns(),
@@ -1097,7 +1097,7 @@ async fn execute(
     let mut write_projection_with_cdf = Vec::new();
 
     let schema = if let Some(schema) = new_schema {
-        &schema.try_into_kernel()?
+        Arc::new(schema.try_into_kernel()?)
     } else {
         snapshot.schema()
     };
@@ -1902,7 +1902,8 @@ mod tests {
             .unwrap();
 
         // Verify schema nullability is preserved after merge
-        let final_fields: Vec<_> = merged_table.snapshot().unwrap().schema().fields().collect();
+        let schema = merged_table.snapshot().unwrap().schema();
+        let final_fields: Vec<_> = schema.fields().collect();
         assert!(
             !final_fields[0].is_nullable(),
             "id should remain non-nullable after merge"
@@ -2269,7 +2270,10 @@ mod tests {
         ];
         let actual = get_data(&table).await;
         let expected_schema_struct: StructType = Arc::clone(&schema).try_into_kernel().unwrap();
-        assert_eq!(&expected_schema_struct, table.snapshot().unwrap().schema());
+        assert_eq!(
+            &expected_schema_struct,
+            table.snapshot().unwrap().schema().as_ref()
+        );
         assert_batches_sorted_eq!(&expected, &actual);
     }
 
@@ -2336,7 +2340,10 @@ mod tests {
         ];
         let actual = get_data(&table).await;
         let expected_schema_struct: StructType = Arc::clone(&schema).try_into_kernel().unwrap();
-        assert_eq!(&expected_schema_struct, table.snapshot().unwrap().schema());
+        assert_eq!(
+            &expected_schema_struct,
+            table.snapshot().unwrap().schema().as_ref()
+        );
         assert_batches_sorted_eq!(&expected, &actual);
     }
 
@@ -3410,7 +3417,10 @@ mod tests {
         ];
         let actual = get_data(&table).await;
         let expected_schema_struct: StructType = schema.as_ref().try_into_kernel().unwrap();
-        assert_eq!(&expected_schema_struct, table.snapshot().unwrap().schema());
+        assert_eq!(
+            &expected_schema_struct,
+            table.snapshot().unwrap().schema().as_ref()
+        );
         assert_batches_sorted_eq!(&expected, &actual);
     }
 
@@ -4244,7 +4254,10 @@ mod tests {
         ];
         let actual = get_data(&table).await;
         let expected_schema_struct: StructType = source_schema.try_into_kernel().unwrap();
-        assert_eq!(&expected_schema_struct, table.snapshot().unwrap().schema());
+        assert_eq!(
+            &expected_schema_struct,
+            table.snapshot().unwrap().schema().as_ref()
+        );
         assert_batches_sorted_eq!(&expected, &actual);
 
         let ctx = SessionContext::new();

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -820,7 +820,7 @@ async fn execute(
     let scan_config = DeltaScanConfigBuilder::default()
         .with_file_column(true)
         .with_parquet_pushdown(false)
-        .with_schema(snapshot.input_schema()?)
+        .with_schema(snapshot.input_schema())
         .build(&snapshot)?;
 
     let target_provider = Arc::new(DeltaTableProvider::try_new(
@@ -944,7 +944,7 @@ async fn execute(
     let mut schema_action = None;
     if merge_schema {
         let merge_schema = merge_arrow_schema(
-            snapshot.input_schema()?,
+            snapshot.input_schema(),
             source_schema.inner().clone(),
             false,
         )?;

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -859,7 +859,7 @@ pub async fn create_merge_plan(
         predicate: serde_json::to_string(filters).ok(),
     };
     let file_schema = arrow_schema_without_partitions(
-        &Arc::new(snapshot.schema().try_into_arrow()?),
+        &Arc::new(snapshot.schema().as_ref().try_into_arrow()?),
         partitions_keys,
     );
 

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -702,7 +702,7 @@ impl MergePlan {
 
                 let scan_config = DeltaScanConfigBuilder::default()
                     .with_file_column(false)
-                    .with_schema(snapshot.input_schema()?)
+                    .with_schema(snapshot.input_schema())
                     .build(snapshot)?;
 
                 // For each rewrite evaluate the predicate and then modify each expression

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -328,7 +328,7 @@ async fn execute(
 
     let scan_config = DeltaScanConfigBuilder::default()
         .with_file_column(false)
-        .with_schema(snapshot.input_schema()?)
+        .with_schema(snapshot.input_schema())
         .build(&snapshot)?;
 
     // For each rewrite evaluate the predicate and then modify each expression

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -138,7 +138,7 @@ pub(crate) async fn execute_non_empty_expr(
     // Take the insert plan schema since it might have been schema evolved, if its not
     // it is simply the table schema
     let scan_config = DeltaScanConfigBuilder::new()
-        .with_schema(snapshot.input_schema()?)
+        .with_schema(snapshot.input_schema())
         .build(snapshot)?;
 
     let target_provider = Arc::new(

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -560,7 +560,7 @@ impl std::future::IntoFuture for WriteBuilder {
                     Some(SchemaMode::Merge) if schema_drift => true,
                     Some(SchemaMode::Overwrite) if this.mode == SaveMode::Overwrite => {
                         let delta_schema: StructType = schema.as_ref().try_into_kernel()?;
-                        &delta_schema != snapshot.schema()
+                        &delta_schema != snapshot.schema().as_ref()
                     }
                     _ => false,
                 };
@@ -568,7 +568,7 @@ impl std::future::IntoFuture for WriteBuilder {
                 if should_update_schema {
                     let schema_struct: StructType = schema.clone().try_into_kernel()?;
                     // Verify if delta schema changed
-                    if &schema_struct != snapshot.schema() {
+                    if &schema_struct != snapshot.schema().as_ref() {
                         let current_protocol = snapshot.protocol();
                         let configuration = snapshot.metadata().configuration().clone();
                         let new_protocol = current_protocol
@@ -2030,7 +2030,8 @@ mod tests {
             .await?;
 
         // Verify initial schema has correct nullability
-        let schema_fields: Vec<_> = table.snapshot().unwrap().schema().fields().collect();
+        let schema = table.snapshot().unwrap().schema();
+        let schema_fields: Vec<_> = schema.fields().collect();
         assert!(!schema_fields[0].is_nullable(), "id should be non-nullable");
         assert!(schema_fields[1].is_nullable(), "name should be nullable");
         assert!(
@@ -2076,7 +2077,8 @@ mod tests {
             .await?;
 
         // Verify that nullability constraints are preserved
-        let final_fields: Vec<_> = table.snapshot().unwrap().schema().fields().collect();
+        let schema = table.snapshot().unwrap().schema();
+        let final_fields: Vec<_> = schema.fields().collect();
         assert!(
             !final_fields[0].is_nullable(),
             "id should remain non-nullable after overwrite"
@@ -2176,7 +2178,8 @@ mod tests {
             .await?;
 
         // Verify schema was NOT updated
-        let after_overwrite_fields: Vec<_> = table.snapshot().unwrap().schema().fields().collect();
+        let schema = table.snapshot().unwrap().schema();
+        let after_overwrite_fields: Vec<_> = schema.fields().collect();
 
         // Schema should be EXACTLY the same as before
         assert_eq!(
@@ -2269,7 +2272,8 @@ mod tests {
         );
 
         // Verify the table data and schema remain unchanged after failed writes
-        let final_fields: Vec<_> = table.snapshot().unwrap().schema().fields().collect();
+        let schema = table.snapshot().unwrap().schema();
+        let final_fields: Vec<_> = schema.fields().collect();
 
         // Schema should still be the original schema
         assert!(
@@ -2359,7 +2363,8 @@ mod tests {
             .await?;
 
         // Verify schema is preserved
-        let final_fields: Vec<_> = table.snapshot().unwrap().schema().fields().collect();
+        let schema = table.snapshot().unwrap().schema();
+        let final_fields: Vec<_> = schema.fields().collect();
 
         for (i, field) in final_fields.iter().enumerate() {
             assert_eq!(

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -469,7 +469,7 @@ impl std::future::IntoFuture for WriteBuilder {
             // in this case we have to insert the generated column and it's type in the schema of the batch
             let mut new_schema = None;
             if let Some(snapshot) = &this.snapshot {
-                let table_schema = snapshot.input_schema()?;
+                let table_schema = snapshot.input_schema();
 
                 if let Err(schema_err) =
                     try_cast_schema(source_schema.fields(), table_schema.fields())

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -358,7 +358,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.snapshot().unwrap().schema(), &table_schema);
+        assert_eq!(table.snapshot().unwrap().schema().as_ref(), &table_schema);
         let res = create_checkpoint_for(0, table.log_store.as_ref(), None).await;
         assert!(res.is_ok());
 
@@ -388,7 +388,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.snapshot().unwrap().schema(), &table_schema);
+        assert_eq!(table.snapshot().unwrap().schema().as_ref(), &table_schema);
 
         let part_cols: Vec<String> = vec![];
         let metadata =
@@ -476,7 +476,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        assert_eq!(table.snapshot().unwrap().schema(), &table_schema);
+        assert_eq!(table.snapshot().unwrap().schema().as_ref(), &table_schema);
         match create_checkpoint_for(1, table.log_store.as_ref(), None).await {
             Ok(_) => {
                 /*

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use self::builder::DeltaTableConfig;
 use self::state::DeltaTableState;
-use crate::kernel::{CommitInfo, DataCheck, LogicalFileView, Metadata, Protocol, StructType};
+use crate::kernel::{CommitInfo, DataCheck, LogicalFileView, Metadata, Protocol};
 use crate::logstore::{
     commit_uri_from_version, extract_version_from_filename, LogStoreConfig, LogStoreExt,
     LogStoreRef, ObjectStoreRef,
@@ -337,20 +337,6 @@ impl DeltaTable {
     #[deprecated(since = "0.27.1", note = "Use `snapshot()?.metadata()` instead")]
     pub fn metadata(&self) -> Result<&Metadata, DeltaTableError> {
         Ok(self.snapshot()?.metadata())
-    }
-
-    /// Return table schema parsed from transaction log. Return None if table hasn't been loaded or
-    /// no metadata was found in the log.
-    #[deprecated(since = "0.27.1", note = "Use `snapshot()?.schema()` instead")]
-    pub fn schema(&self) -> Option<&StructType> {
-        Some(self.snapshot().ok()?.schema())
-    }
-
-    /// Return table schema parsed from transaction log. Return `DeltaTableError` if table hasn't
-    /// been loaded or no metadata was found in the log.
-    #[deprecated(since = "0.27.1", note = "Use `snapshot()?.schema()` instead")]
-    pub fn get_schema(&self) -> Result<&StructType, DeltaTableError> {
-        Ok(self.snapshot()?.schema())
     }
 
     /// Time travel Delta table to the latest version that's created at or before provided

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -6,7 +6,7 @@ use arrow::compute::concat_batches;
 use chrono::Utc;
 use delta_kernel::engine::arrow_conversion::TryIntoKernel;
 use delta_kernel::expressions::column_expr_ref;
-use delta_kernel::schema::StructField;
+use delta_kernel::schema::{SchemaRef as KernelSchemaRef, StructField};
 use delta_kernel::table_properties::TableProperties;
 use delta_kernel::{EvaluationHandler, Expression};
 use futures::stream::BoxStream;
@@ -19,7 +19,7 @@ use crate::kernel::arrow::engine_ext::{ExpressionEvaluatorExt, SnapshotExt};
 #[cfg(test)]
 use crate::kernel::Action;
 use crate::kernel::{
-    Add, DataType, EagerSnapshot, LogDataHandler, LogicalFileView, Metadata, Protocol, StructType,
+    Add, DataType, EagerSnapshot, LogDataHandler, LogicalFileView, Metadata, Protocol,
     TombstoneView, ARROW_HANDLER,
 };
 use crate::logstore::LogStore;
@@ -67,7 +67,7 @@ impl DeltaTableState {
     }
 
     /// The table schema
-    pub fn schema(&self) -> &StructType {
+    pub fn schema(&self) -> KernelSchemaRef {
         self.snapshot.schema()
     }
 

--- a/crates/core/src/writer/json.rs
+++ b/crates/core/src/writer/json.rs
@@ -264,6 +264,7 @@ impl JsonWriter {
             .schema();
         Arc::new(
             schema
+                .as_ref()
                 .try_into_arrow()
                 .expect("Failed to coerce delta schema to arrow"),
         )
@@ -497,11 +498,10 @@ mod tests {
     async fn test_partition_not_written_to_parquet() {
         let table_dir = tempfile::tempdir().unwrap();
         let table = get_test_table(&table_dir).await;
-        let schema = table.snapshot().unwrap().schema();
-        let arrow_schema: ArrowSchema = schema.try_into_arrow().unwrap();
+        let arrow_schema = table.snapshot().unwrap().snapshot().arrow_schema();
         let mut writer = JsonWriter::try_new(
             ensure_table_uri(&table.table_uri()).unwrap(),
-            Arc::new(arrow_schema),
+            arrow_schema,
             Some(vec!["modified".to_string()]),
             None,
         )
@@ -574,11 +574,10 @@ mod tests {
         let table_dir = tempfile::tempdir().unwrap();
         let table = get_test_table(&table_dir).await;
 
-        let arrow_schema: ArrowSchema =
-            table.snapshot().unwrap().schema().try_into_arrow().unwrap();
+        let arrow_schema = table.snapshot().unwrap().snapshot().arrow_schema();
         let mut writer = JsonWriter::try_new(
             ensure_table_uri(&table.table_uri()).unwrap(),
-            Arc::new(arrow_schema),
+            arrow_schema,
             Some(vec!["modified".to_string()]),
             None,
         )
@@ -612,11 +611,10 @@ mod tests {
             let table_dir = tempfile::tempdir().unwrap();
             let table = get_test_table(&table_dir).await;
 
-            let arrow_schema: ArrowSchema =
-                table.snapshot().unwrap().schema().try_into_arrow().unwrap();
+            let arrow_schema = table.snapshot().unwrap().snapshot().arrow_schema();
             let mut writer = JsonWriter::try_new(
                 Url::from_directory_path(table_dir.path()).unwrap(),
-                Arc::new(arrow_schema),
+                arrow_schema,
                 Some(vec!["modified".to_string()]),
                 None,
             )
@@ -653,11 +651,9 @@ mod tests {
             let table_dir = tempfile::tempdir().unwrap();
             let mut table = get_test_table(&table_dir).await;
 
-            let schema = table.snapshot().unwrap().schema();
-            let arrow_schema: ArrowSchema = schema.try_into_arrow().unwrap();
             let mut writer = JsonWriter::try_new(
                 ensure_table_uri(&table.table_uri()).unwrap(),
-                Arc::new(arrow_schema),
+                table.snapshot().unwrap().snapshot().arrow_schema(),
                 Some(vec!["modified".to_string()]),
                 None,
             )
@@ -761,11 +757,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        let arrow_schema: ArrowSchema =
-            table.snapshot().unwrap().schema().try_into_arrow().unwrap();
+        let arrow_schema = table.snapshot().unwrap().snapshot().arrow_schema();
         let mut writer = JsonWriter::try_new(
             crate::ensure_table_uri(&table.table_uri()).unwrap(),
-            Arc::new(arrow_schema),
+            arrow_schema,
             Some(vec!["modified".to_string()]),
             None,
         )
@@ -825,11 +820,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(table.version(), Some(0));
-        let arrow_schema: ArrowSchema =
-            table.snapshot().unwrap().schema().try_into_arrow().unwrap();
+        let arrow_schema = table.snapshot().unwrap().snapshot().arrow_schema();
         let mut writer = JsonWriter::try_new(
             crate::ensure_table_uri(&table.table_uri()).unwrap(),
-            Arc::new(arrow_schema),
+            arrow_schema,
             Some(vec!["modified".to_string()]),
             None,
         )

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -27,8 +27,7 @@ use deltalake::errors::DeltaTableError;
 use deltalake::kernel::scalars::ScalarExt;
 use deltalake::kernel::transaction::{CommitBuilder, CommitProperties, TableReference};
 use deltalake::kernel::{
-    Action, Add, EagerSnapshot, LogicalFileView, MetadataExt as _, StructDataExt as _, StructType,
-    Transaction,
+    Action, Add, EagerSnapshot, LogicalFileView, MetadataExt as _, StructDataExt as _, Transaction,
 };
 use deltalake::lakefs::LakeFSCustomExecuteHandler;
 use deltalake::logstore::LogStoreRef;
@@ -469,7 +468,7 @@ impl RawDeltaTable {
 
     #[getter]
     pub fn schema<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let schema: StructType = self.with_table(|t| {
+        let schema = self.with_table(|t| {
             let snapshot = t
                 .snapshot()
                 .map_err(PythonError::from)
@@ -1269,7 +1268,7 @@ impl RawDeltaTable {
                     }
 
                     // Update metadata with new schema
-                    if schema != existing_schema {
+                    if &schema != existing_schema.as_ref() {
                         let mut metadata = self.with_table(|t| {
                             let snapshot = t
                                 .snapshot()
@@ -1286,7 +1285,7 @@ impl RawDeltaTable {
                 }
                 _ => {
                     // This should be unreachable from Python
-                    if schema != existing_schema {
+                    if &schema != existing_schema.as_ref() {
                         DeltaProtocolError::new_err("Cannot change schema except in overwrite.");
                     }
                 }

--- a/python/src/query.rs
+++ b/python/src/query.rs
@@ -41,7 +41,7 @@ impl PyQueryBuilder {
         let log_store = delta_table.log_store()?;
 
         let scan_config = DeltaScanConfigBuilder::default()
-            .with_schema(snapshot.input_schema().map_err(PythonError::from)?)
+            .with_schema(snapshot.input_schema())
             .build(&snapshot)
             .map_err(PythonError::from)?;
 

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -725,7 +725,10 @@ impl StructType {
     }
 }
 
-pub fn schema_to_pyobject(schema: DeltaStructType, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+pub fn schema_to_pyobject(
+    schema: Arc<DeltaStructType>,
+    py: Python<'_>,
+) -> PyResult<Bound<'_, PyAny>> {
     let fields = schema.fields().map(|field| Field {
         inner: field.clone(),
     });
@@ -883,7 +886,7 @@ impl PySchema {
             .try_into_kernel()
             .map_err(|err: ArrowError| PyException::new_err(err.to_string()))?;
 
-        schema_to_pyobject(inner_type, py)
+        schema_to_pyobject(Arc::new(inner_type), py)
     }
 
     #[pyo3(text_signature = "($self)")]


### PR DESCRIPTION
# Description

In many places we require the arrow schema of a snapshot. As such we replicate converting schemas in many places. In this PR we track a reference to an arrow schema on our innermost snapshot and start using it in some places.

We also now expose the kernel schema as an arc to better alogn with how delta kernel and datafusion expose schemas.

part-of: #3733