### PR TITLE
fix(performance): improve CPU and memory efficiency through several optimizations

### DIFF
--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -197,7 +197,10 @@ async fn find_files_scan(
         .log_data()
         .iter()
         .map(|f| f.add_action())
-        .map(|add| (add.path.clone(), add.to_owned()))
+        .map(|add| {
+            let path = add.path.clone();
+            (path, add)
+        })
         .collect();
 
     let scan_config = DeltaScanConfigBuilder::default()

--- a/crates/core/src/kernel/snapshot/iterators/scan_row.rs
+++ b/crates/core/src/kernel/snapshot/iterators/scan_row.rs
@@ -208,7 +208,7 @@ pub(crate) fn parse_partitions(
                     let arr = match p {
                         PrimitiveType::String => {
                             Arc::new(StringArray::from_iter(values.iter().map(|v| match v {
-                                Scalar::String(s) => Some(s.clone()),
+                                Scalar::String(s) => Some(s.as_str()),
                                 Scalar::Null(_) => None,
                                 _ => panic!("unexpected scalar type"),
                             }))) as ArrayRef

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -87,9 +87,7 @@ impl<'a> LogDataHandler<'a> {
 
     pub fn iter(&self) -> impl Iterator<Item = LogicalFileView> + '_ {
         self.data.iter().flat_map(|batch| {
-            let batch = batch.clone();
-            let num_rows = batch.num_rows();
-            (0..num_rows).map(move |idx| LogicalFileView::new(batch.clone(), idx))
+            (0..batch.num_rows()).map(move |idx| LogicalFileView::new(batch.clone(), idx))
         })
     }
 }
@@ -100,8 +98,7 @@ impl IntoIterator for LogDataHandler<'_> {
 
     fn into_iter(self) -> Self::IntoIter {
         Box::new(self.data.to_vec().into_iter().flat_map(|batch| {
-            let num_rows = batch.num_rows();
-            (0..num_rows).map(move |idx| LogicalFileView::new(batch.clone(), idx))
+            (0..batch.num_rows()).map(move |idx| LogicalFileView::new(batch.clone(), idx))
         }))
     }
 }

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -87,8 +87,9 @@ impl<'a> LogDataHandler<'a> {
 
     pub fn iter(&self) -> impl Iterator<Item = LogicalFileView> + '_ {
         self.data.iter().flat_map(|batch| {
-            let batch = Arc::new(batch.clone());
-            (0..batch.num_rows()).map(move |idx| LogicalFileView::new(Arc::clone(&batch), idx))
+            let batch = batch.clone();
+            let num_rows = batch.num_rows();
+            (0..num_rows).map(move |idx| LogicalFileView::new(batch.clone(), idx))
         })
     }
 }
@@ -99,8 +100,8 @@ impl IntoIterator for LogDataHandler<'_> {
 
     fn into_iter(self) -> Self::IntoIter {
         Box::new(self.data.to_vec().into_iter().flat_map(|batch| {
-            let batch = Arc::new(batch);
-            (0..batch.num_rows()).map(move |idx| LogicalFileView::new(Arc::clone(&batch), idx))
+            let num_rows = batch.num_rows();
+            (0..num_rows).map(move |idx| LogicalFileView::new(batch.clone(), idx))
         }))
     }
 }

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -87,7 +87,8 @@ impl<'a> LogDataHandler<'a> {
 
     pub fn iter(&self) -> impl Iterator<Item = LogicalFileView> + '_ {
         self.data.iter().flat_map(|batch| {
-            (0..batch.num_rows()).map(move |idx| LogicalFileView::new(batch.clone(), idx))
+            let batch = Arc::new(batch.clone());
+            (0..batch.num_rows()).map(move |idx| LogicalFileView::new(Arc::clone(&batch), idx))
         })
     }
 }
@@ -98,7 +99,8 @@ impl IntoIterator for LogDataHandler<'_> {
 
     fn into_iter(self) -> Self::IntoIter {
         Box::new(self.data.to_vec().into_iter().flat_map(|batch| {
-            (0..batch.num_rows()).map(move |idx| LogicalFileView::new(batch.clone(), idx))
+            let batch = Arc::new(batch);
+            (0..batch.num_rows()).map(move |idx| LogicalFileView::new(Arc::clone(&batch), idx))
         }))
     }
 }

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -586,7 +586,7 @@ impl EagerSnapshot {
             .map_ok(|batch| {
                 let batch = Arc::new(batch);
                 futures::stream::iter(0..batch.num_rows()).map(move |idx| {
-                    Ok::<_, DeltaTableError>(LogicalFileView::new(Arc::clone(&batch), idx))
+                    Ok::<_, DeltaTableError>(LogicalFileView::new((*batch).clone(), idx))
                 })
             })
             .try_flatten()

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -489,7 +489,7 @@ impl EagerSnapshot {
                 log_store,
                 None,
                 current_version,
-                Box::new(self.files.clone().into_iter()),
+                Box::new(std::mem::take(&mut self.files).into_iter()),
                 None,
             )
             .try_collect()

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -584,9 +584,8 @@ impl EagerSnapshot {
                 None,
             )
             .map_ok(|batch| {
-                let batch = Arc::new(batch);
                 futures::stream::iter(0..batch.num_rows()).map(move |idx| {
-                    Ok::<_, DeltaTableError>(LogicalFileView::new((*batch).clone(), idx))
+                    Ok::<_, DeltaTableError>(LogicalFileView::new(batch.clone(), idx))
                 })
             })
             .try_flatten()

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -584,8 +584,9 @@ impl EagerSnapshot {
                 None,
             )
             .map_ok(|batch| {
+                let batch = Arc::new(batch);
                 futures::stream::iter(0..batch.num_rows()).map(move |idx| {
-                    Ok::<_, DeltaTableError>(LogicalFileView::new(batch.clone(), idx))
+                    Ok::<_, DeltaTableError>(LogicalFileView::new(Arc::clone(&batch), idx))
                 })
             })
             .try_flatten()

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -964,7 +964,8 @@ async fn build_compaction_plan(
         file.sort_by(|a, b| b.size.cmp(&a.size));
     }
 
-    let mut operations: HashMap<String, (IndexMap<String, Scalar>, Vec<MergeBin>)> = HashMap::new();
+    let mut operations: HashMap<String, (IndexMap<String, Scalar>, Vec<MergeBin>)> =
+        HashMap::with_capacity(partition_files.len());
     for (part, (partition, files)) in partition_files {
         let mut merge_bins = vec![MergeBin::new()];
 

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -944,11 +944,12 @@ async fn build_compaction_plan(
         let partition_values = file
             .partition_values()
             .map(|v| {
-                v.fields()
-                    .iter()
-                    .zip(v.values().iter())
-                    .map(|(k, v)| (k.name().to_string(), v.clone()))
-                    .collect::<IndexMap<_, _>>()
+                let fields_count = v.fields().len();
+                let mut map = IndexMap::with_capacity(fields_count);
+                for (field, value) in v.fields().iter().zip(v.values().iter()) {
+                    map.insert(field.name().to_string(), value.clone());
+                }
+                map
             })
             .unwrap_or_default();
 

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -261,12 +261,9 @@ impl VacuumBuilder {
                 .await?;
                 for version in sorted_versions {
                     state.update(&self.log_store, Some(version)).await?;
-                    let files: Vec<String> = state
-                        .file_paths_iter()
-                        .map(|path| path.to_string())
-                        .collect();
-                    debug!("keep version:{version}\n, {files:#?}");
-                    keep_files.extend(files);
+                    let files_iter = state.file_paths_iter().map(|path| path.to_string());
+                    debug!("keep version:{version}");
+                    keep_files.extend(files_iter);
                 }
 
                 keep_files

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -391,10 +391,9 @@ pub(crate) async fn write_execution_plan_v2(
 
                     let write_start = std::time::Instant::now();
                     // split batch since we unioned upstream the operation write and cdf plan
-                    let table_provider: Arc<dyn TableProvider> = Arc::new(MemTable::try_new(
-                        batch.schema(),
-                        vec![vec![batch.clone()]],
-                    )?);
+                    let batch_schema = batch.schema();
+                    let table_provider: Arc<dyn TableProvider> =
+                        Arc::new(MemTable::try_new(batch_schema, vec![vec![batch]])?);
                     let batch_df = session_context.read_table(table_provider).unwrap();
 
                     let normal_df = batch_df.clone().filter(col(CDC_COLUMN_NAME).in_list(

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -10,9 +10,8 @@ use std::{collections::HashMap, sync::Arc};
 use arrow_array::{new_null_array, Array, ArrayRef, RecordBatch, UInt32Array};
 use arrow_ord::partition::partition;
 use arrow_row::{RowConverter, SortField};
-use arrow_schema::{ArrowError, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
+use arrow_schema::{Schema as ArrowSchema, SchemaRef as ArrowSchemaRef};
 use arrow_select::take::take;
-use bytes::Bytes;
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow, TryIntoKernel};
 use delta_kernel::expressions::Scalar;
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
@@ -267,7 +266,7 @@ impl DeltaWriter<RecordBatch> for RecordBatchWriter {
             let prefix = Path::parse(writer.partition_values.hive_partition_path())?;
             let uuid = Uuid::new_v4();
             let path = next_data_path(&prefix, 0, &uuid, &writer.writer_properties);
-            let obj_bytes = Bytes::from(writer.buffer.to_vec());
+            let obj_bytes = writer.buffer.to_bytes();
             let file_size = obj_bytes.len() as i64;
             self.storage
                 .put_with_retries(&path, obj_bytes.into(), 15)

--- a/crates/core/src/writer/utils.rs
+++ b/crates/core/src/writer/utils.rs
@@ -141,6 +141,13 @@ impl ShareableBuffer {
             buffer: Arc::new(RwLock::new(bytes.to_vec())),
         }
     }
+
+    /// Truncates the buffer to the specified length.
+    /// If the buffer is shorter than the specified length, this is a no-op.
+    pub fn truncate(&self, len: usize) {
+        let mut inner = self.buffer.write();
+        inner.truncate(len);
+    }
 }
 
 impl Write for ShareableBuffer {


### PR DESCRIPTION
# Description
I spent some time identifying areas where we could reduce memory usage, such as avoiding unnecessary cloning or pre-allocating memory. I also analyzed CPU-intensive operations to look for potential improvements.

This work is mainly intended to spark discussion on whether small code changes could lead to performance benefits.

**1. JSON parsing:**
- Reduce String allocation by using bytes and slice operations

**2. ShareableBuffer with BytesMut**
- Mostly to use zero-copy operations (previously with intermediate `to_vec` operations)

**3. Partition processing**
- Pre-compute sorted columns once, then use `slice()` instead of `take()` per partition

**4. HashMap pre-allocation**
- Use more `HashMap::with_capacity(estimated_capacity)` when known

**5. String Clone Reduction** 

**6. Memory Take Optimization**
- Use `std::mem::take()` to move files instead of cloning