### PR TITLE
fix: enable default features on `WriteBuilder` datafusion context

### DIFF
--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -448,7 +448,7 @@ impl std::future::IntoFuture for WriteBuilder {
                     .session
                     .and_then(|session| session.as_any().downcast_ref::<SessionState>().cloned())
                     .map(SessionStateBuilder::new_from_existing)
-                    .unwrap_or_default()
+                    .unwrap_or_else(SessionStateBuilder::new_with_default_features)
                     .with_query_planner(write_planner)
                     .build();
                 register_store(this.log_store.clone(), session.runtime_env().as_ref());


### PR DESCRIPTION
# Description

Ran into this edge case where if writing to a table that has a generated column defined by a SQL function (say, as a partition column, `to_char(timestamp)`, the write builder will fail since a default SessionState does not have UDFs unless `new_with_default_features` is specified.

# Related Issue(s)

Regression from #3816 

# Documentation

Left as draft since I want to write a regression test to assert this doesn't happen again
