### PR TITLE
fix: update pyproject.toml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "deltalake"
 description = "Native Delta Lake Python binding based on delta-rs with Pandas integration"
 readme = "README.md"
-license = "MIT"
+license = "Apache-2.0"
 requires-python = ">=3.9"
 keywords = ["deltalake", "delta", "datalake", "pandas", "arrow"]
 classifiers = [


### PR DESCRIPTION
update license from MIT to Apache-2.0

# Description
update pyproject.toml

# Related Issue(s)
<!---
For example:

- closes #3853
--->

# Documentation

<!---
Share links to useful documentation
--->
