### PR TITLE
chore: upgrade datafusion, arrow and parquet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,24 +34,24 @@ delta_kernel = { version = "0.16.0", features = [
 
 
 # arrow
-arrow = { version = "56.0.0" }
-arrow-arith = { version = "56.0.0" }
-arrow-array = { version = "56.0.0", features = ["chrono-tz"] }
-arrow-buffer = { version = "56.0.0" }
-arrow-cast = { version = "56.0.0" }
-arrow-ipc = { version = "56.0.0" }
-arrow-json = { version = "56.0.0" }
-arrow-ord = { version = "56.0.0" }
-arrow-row = { version = "56.0.0" }
-arrow-schema = { version = "56.0.0" }
-arrow-select = { version = "56.0.0" }
+arrow = { version = "56.2" }
+arrow-arith = { version = "56.2" }
+arrow-array = { version = "56.2", features = ["chrono-tz"] }
+arrow-buffer = { version = "56.2" }
+arrow-cast = { version = "56.2" }
+arrow-ipc = { version = "56.2" }
+arrow-json = { version = "56.2" }
+arrow-ord = { version = "56.2" }
+arrow-row = { version = "56.2" }
+arrow-schema = { version = "56.2" }
+arrow-select = { version = "56.2" }
 object_store = { version = "0.12.1" }
-parquet = { version = "56.0.0" }
+parquet = { version = "56.2" }
 
 # datafusion
-datafusion = "50.0.0"
-datafusion-ffi = "50.0.0"
-datafusion-proto = "50.0.0"
+datafusion = "50.2"
+datafusion-ffi = "50.2"
+datafusion-proto = "50.2"
 
 # serde
 serde = { version = "1.0.194", features = ["derive"] }


### PR DESCRIPTION
# Description
This PR upgrades parquet, arrow and datafusion to their latest version.

Motivation:
- I'm working on a [project](https://github.com/Mooncake-Labs/moonlink) which supports both datafusion as query engine, and iceberg / delta as storage backend
- Currently iceberg and delta have different dependent versions of df/arrow/parquet, which makes it hard to find a compatible version and make them live in the same project
- This PR upgrades all of them to their latest version, I'm pushing the same effort on iceberg side