### PR TITLE
perf: support pushing physical filters down through DeltaScan

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -29,6 +29,7 @@ use datafusion::logical_expr::utils::split_conjunction;
 use datafusion::logical_expr::{BinaryExpr, LogicalPlan, Operator};
 use datafusion::optimizer::simplify_expressions::ExprSimplifier;
 use datafusion::physical_optimizer::pruning::PruningPredicate;
+use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
 use datafusion::physical_plan::{
     stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr,
@@ -979,6 +980,18 @@ impl ExecutionPlan for DeltaScan {
 
     fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
         self.parquet_scan.partition_statistics(partition)
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        Ok(FilterDescription::from_children(
+            parent_filters,
+            &self.children(),
+        )?)
     }
 }
 


### PR DESCRIPTION
# Description
This change enables physical expr filter pushdown through the DeltaScan ExecutionPlan impl. gather_filters_for_pushdown by default assume that no filters can be pushed down, but since DeltaScan is a wrap around the Parquet data source exec, we can push the filters to that.

This is important to leverage [dynamic filter pushdown for hash join](https://datafusion.apache.org/blog/2025/09/10/dynamic-filters/#hash-join-dynamic-filters) for example. 

To verify these changes I did the following:
* Created a 100 million row table of uuidv7 ID strings so it would have good statistics.
* Created a small table of three of those uuidv7 IDs
* Analyzed a simple join: EXPLAIN ANALYZE SELECT * FROM small JOIN big ON small.id = big.id

### Results (these are the metrics from the parquet scan of the big table):
#### Without pushdown
```
metrics=[
    output_rows=100000000,
    elapsed_compute=10ns,
    batches_split=0,
    bytes_scanned=1542517765,
    file_open_errors=0,
    file_scan_errors=0,
    files_ranges_pruned_statistics=0,
    num_predicate_creation_errors=0,
    page_index_rows_matched=0,
    page_index_rows_pruned=0,
    predicate_evaluation_errors=0,
    pushdown_rows_matched=0,
    pushdown_rows_pruned=0,
    row_groups_matched_bloom_filter=0,
    row_groups_matched_statistics=0,
    row_groups_pruned_bloom_filter=0,
    row_groups_pruned_statistics=0,
    bloom_filter_eval_time=218ns,
    metadata_load_time=393.613861ms,
    page_index_eval_time=218ns,
    row_pushdown_eval_time=218ns,
    statistics_eval_time=218ns,
    time_elapsed_opening=17.92454ms,
    time_elapsed_processing=65.071375545s,
    time_elapsed_scanning_total=101.423530818s,
    time_elapsed_scanning_until_data=2.46365709s
]
```
#### With pushdown
```
metrics=[
    output_rows=6327680,
    elapsed_compute=10ns,
    batches_split=0,
    bytes_scanned=98546937,
    file_open_errors=0,
    file_scan_errors=0,
    files_ranges_pruned_statistics=0,
    num_predicate_creation_errors=0,
    page_index_rows_matched=6327680,
    page_index_rows_pruned=672320,
    predicate_evaluation_errors=0,
    pushdown_rows_matched=0,
    pushdown_rows_pruned=0,
    row_groups_matched_bloom_filter=0,
    row_groups_matched_statistics=7,
    row_groups_pruned_bloom_filter=0,
    row_groups_pruned_statistics=93,
    bloom_filter_eval_time=2.246653ms,
    metadata_load_time=466.780613ms,
    page_index_eval_time=1.693939ms,
    row_pushdown_eval_time=218ns,
    statistics_eval_time=12.888981ms,
    time_elapsed_opening=464.314794ms,
    time_elapsed_processing=3.527617582s,
    time_elapsed_scanning_total=4.976550961s,
    time_elapsed_scanning_until_data=262.494821ms
]
```
Notice the output rows was reduced from 100 million to ~6 million and the cumulative time spent scanning from 101s to 5s. You will also see the various statistics and pruning metrics being nonzero indicating it was able to leverage the dynamic filter built out of the left hand side of the hash join.

# Related Issue(s)
n/a

# Documentation
Docs for the method implemented, [gather_filters_for_pushdown](https://docs.rs/datafusion/latest/datafusion/physical_plan/trait.ExecutionPlan.html#method.gather_filters_for_pushdown)

Also, the associated method, [handle_child_pushdown_result](https://docs.rs/datafusion/latest/datafusion/physical_plan/trait.ExecutionPlan.html#method.handle_child_pushdown_result)

I am leaving that as the [default impl](https://docs.rs/datafusion-physical-plan/50.2.0/src/datafusion_physical_plan/execution_plan.rs.html#643-648)
