### PR TITLE
refactor: consolidate datafusion session setup

### DIFF
--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -49,7 +49,7 @@ use datafusion::sql::sqlparser::parser::Parser;
 use datafusion::sql::sqlparser::tokenizer::Tokenizer;
 use tracing::log::*;
 
-use super::DeltaParserOptions;
+use crate::delta_datafusion::session::DeltaParserOptions;
 use crate::{DeltaResult, DeltaTableError};
 
 /// This struct is like Datafusion's MakeArray but ensures that `element` is used rather than `item

--- a/crates/core/src/delta_datafusion/session.rs
+++ b/crates/core/src/delta_datafusion/session.rs
@@ -1,0 +1,101 @@
+use datafusion::{
+    catalog::Session,
+    common::{exec_datafusion_err, Result as DataFusionResult},
+    execution::{SessionState, SessionStateBuilder},
+    prelude::{SessionConfig, SessionContext},
+    sql::planner::ParserOptions,
+};
+
+use crate::delta_datafusion::planner::DeltaPlanner;
+
+pub fn create_session() -> DeltaSessionContext {
+    DeltaSessionContext::default()
+}
+
+// Given a `Session` reference, get the concrete `SessionState` reference
+// Note: this may stop working in future versions,
+#[deprecated(
+    since = "0.29.1",
+    note = "Stop gap to get rid of all explicit session state references"
+)]
+pub(crate) fn session_state_from_session(session: &dyn Session) -> DataFusionResult<&SessionState> {
+    session
+        .as_any()
+        .downcast_ref::<SessionState>()
+        .ok_or_else(|| exec_datafusion_err!("Failed to downcast Session to SessionState"))
+}
+
+/// A wrapper for sql_parser's ParserOptions to capture sane default table defaults
+pub struct DeltaParserOptions {
+    inner: ParserOptions,
+}
+
+impl Default for DeltaParserOptions {
+    fn default() -> Self {
+        DeltaParserOptions {
+            inner: ParserOptions {
+                enable_ident_normalization: false,
+                ..ParserOptions::default()
+            },
+        }
+    }
+}
+
+impl From<DeltaParserOptions> for ParserOptions {
+    fn from(value: DeltaParserOptions) -> Self {
+        value.inner
+    }
+}
+
+/// A wrapper for Deltafusion's SessionConfig to capture sane default table defaults
+pub struct DeltaSessionConfig {
+    inner: SessionConfig,
+}
+
+impl Default for DeltaSessionConfig {
+    fn default() -> Self {
+        DeltaSessionConfig {
+            inner: SessionConfig::default()
+                .set_bool("datafusion.sql_parser.enable_ident_normalization", false),
+        }
+    }
+}
+
+impl From<DeltaSessionConfig> for SessionConfig {
+    fn from(value: DeltaSessionConfig) -> Self {
+        value.inner
+    }
+}
+
+/// A wrapper for Deltafusion's SessionContext to capture sane default table defaults
+pub struct DeltaSessionContext {
+    inner: SessionContext,
+}
+
+impl DeltaSessionContext {
+    pub fn new() -> Self {
+        let ctx = SessionContext::new_with_config(DeltaSessionConfig::default().into());
+        let planner = DeltaPlanner::new();
+        let state = SessionStateBuilder::new_from_existing(ctx.state())
+            .with_query_planner(planner)
+            .build();
+        let inner = SessionContext::new_with_state(state);
+        Self { inner }
+    }
+
+    pub fn into_inner(self) -> SessionContext {
+        self.inner
+    }
+}
+
+impl Default for DeltaSessionContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<DeltaSessionContext> for SessionContext {
+    fn from(value: DeltaSessionContext) -> Self {
+        value.inner
+    }
+}

--- a/crates/core/src/logstore/factories.rs
+++ b/crates/core/src/logstore/factories.rs
@@ -66,9 +66,9 @@ fn default_parse_url_opts(
 /// Access global registry of object store factories
 pub fn object_store_factories() -> ObjectStoreFactoryRegistry {
     static REGISTRY: OnceLock<ObjectStoreFactoryRegistry> = OnceLock::new();
-    let factory = Arc::new(DefaultObjectStoreFactory::default());
     REGISTRY
         .get_or_init(|| {
+            let factory = Arc::new(DefaultObjectStoreFactory::default());
             let registry = ObjectStoreFactoryRegistry::default();
             registry.insert(Url::parse("memory://").unwrap(), factory.clone());
             registry.insert(Url::parse("file://").unwrap(), factory);

--- a/crates/core/src/operations/merge/filter.rs
+++ b/crates/core/src/operations/merge/filter.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::compute::concat_batches;
+use datafusion::catalog::Session;
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::common::{ScalarValue, TableReference};
-use datafusion::execution::context::SessionState;
 use datafusion::functions_aggregate::expr_fn::{max, min};
 use datafusion::logical_expr::expr::{InList, Placeholder};
 use datafusion::logical_expr::{lit, Aggregate, Between, BinaryExpr, Expr, LogicalPlan, Operator};
@@ -325,7 +325,7 @@ pub(crate) fn generalize_filter(
 pub(crate) async fn try_construct_early_filter(
     join_predicate: Expr,
     table_snapshot: &EagerSnapshot,
-    session_state: &SessionState,
+    session_state: &dyn Session,
     source: &LogicalPlan,
     source_name: &TableReference,
     target_name: &TableReference,
@@ -397,7 +397,7 @@ pub(crate) async fn try_construct_early_filter(
 }
 
 async fn execute_plan_to_batch(
-    state: &SessionState,
+    state: &dyn Session,
     plan: Arc<dyn ExecutionPlan>,
 ) -> DeltaResult<arrow::record_batch::RecordBatch> {
     let data = futures::future::try_join_all(

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -529,7 +529,7 @@ impl MergeOperation {
     fn try_from(
         config: MergeOperationConfig,
         schema: &DFSchema,
-        state: &SessionState,
+        state: &dyn Session,
         target_alias: &Option<String>,
     ) -> DeltaResult<MergeOperation> {
         let mut ops = HashMap::with_capacity(config.operations.capacity());
@@ -1402,7 +1402,7 @@ async fn execute(
 
     let (mut actions, write_plan_metrics) = write_execution_plan_v2(
         Some(&snapshot),
-        state.clone(),
+        &state,
         write,
         table_partition_cols.clone(),
         log_store.object_store(Some(operation_id)),

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -25,8 +25,8 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use arrow_array::RecordBatch;
-use arrow_schema::SchemaRef as ArrowSchemaRef;
+use arrow::array::RecordBatch;
+use arrow::datatypes::SchemaRef;
 use datafusion::catalog::Session;
 use datafusion::execution::context::SessionState;
 use datafusion::execution::memory_pool::FairSpillPool;
@@ -491,7 +491,7 @@ pub struct MergeTaskParameters {
     /// Parameters passed to optimize operation
     input_parameters: OptimizeInput,
     /// Schema of written files
-    file_schema: ArrowSchemaRef,
+    file_schema: SchemaRef,
     /// Properties passed to parquet writer
     writer_properties: WriterProperties,
     /// Num index cols to collect stats for

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -28,8 +28,7 @@ use std::sync::Arc;
 use chrono::{Duration, Utc};
 use futures::future::{ready, BoxFuture};
 use futures::{StreamExt, TryStreamExt};
-use object_store::Error;
-use object_store::{path::Path, ObjectStore};
+use object_store::{path::Path, Error, ObjectStore};
 use serde::Serialize;
 use tracing::*;
 

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -23,34 +23,21 @@
 //! let table = ops.write(vec![batch]).await?;
 //! ````
 
-pub(crate) mod async_utils;
-pub mod configs;
-pub(crate) mod execution;
-pub(crate) mod generated_columns;
-pub(crate) mod metrics;
-pub(crate) mod schema_evolution;
-pub mod writer;
-
-use arrow_schema::Schema;
-pub use configs::WriterStatsConfig;
-use datafusion::execution::SessionStateBuilder;
-use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
-use generated_columns::{able_to_gc, add_generated_columns, add_missing_generated_columns};
-use metrics::{SOURCE_COUNT_ID, SOURCE_COUNT_METRIC};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use std::vec;
 
-use arrow_array::RecordBatch;
+use arrow::array::RecordBatch;
+use arrow_schema::Schema;
 use datafusion::catalog::{Session, TableProvider};
 use datafusion::common::{Column, DFSchema, Result, ScalarValue};
 use datafusion::datasource::MemTable;
 use datafusion::execution::context::{SessionContext, SessionState};
 use datafusion::logical_expr::{cast, lit, try_cast, Expr, Extension, LogicalPlan};
 use datafusion::prelude::DataFrame;
-use execution::{prepare_predicate_actions, write_execution_plan_v2};
+use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
 use futures::future::BoxFuture;
 use parquet::file::properties::WriterProperties;
 use schema_evolution::try_cast_schema;
@@ -58,6 +45,10 @@ use serde::{Deserialize, Serialize};
 use tracing::log::*;
 use tracing::Instrument;
 
+pub use self::configs::WriterStatsConfig;
+use self::execution::{prepare_predicate_actions, write_execution_plan_v2};
+use self::generated_columns::{able_to_gc, add_generated_columns, add_missing_generated_columns};
+use self::metrics::{SOURCE_COUNT_ID, SOURCE_COUNT_METRIC};
 use super::cdc::CDC_COLUMN_NAME;
 use super::datafusion_utils::Expression;
 use super::{CreateBuilder, CustomExecuteHandler, Operation};
@@ -66,8 +57,8 @@ use crate::delta_datafusion::expr::parse_predicate_expression;
 use crate::delta_datafusion::logical::MetricObserver;
 use crate::delta_datafusion::physical::{find_metric_node, get_metric};
 use crate::delta_datafusion::planner::DeltaPlanner;
-use crate::delta_datafusion::register_store;
-use crate::delta_datafusion::DataFusionMixins;
+use crate::delta_datafusion::{create_session, register_store};
+use crate::delta_datafusion::{session_state_from_session, DataFusionMixins};
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::schema::cast::merge_arrow_schema;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, TableReference, PROTOCOL};
@@ -78,6 +69,14 @@ use crate::kernel::{
 use crate::logstore::LogStoreRef;
 use crate::protocol::{DeltaOperation, SaveMode};
 use crate::DeltaTable;
+
+pub(crate) mod async_utils;
+pub mod configs;
+pub(crate) mod execution;
+pub(crate) mod generated_columns;
+pub(crate) mod metrics;
+pub(crate) mod schema_evolution;
+pub mod writer;
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum WriteError {
@@ -446,18 +445,15 @@ impl std::future::IntoFuture for WriteBuilder {
 
                 let session = this
                     .session
-                    .and_then(|session| session.as_any().downcast_ref::<SessionState>().cloned())
-                    .map(SessionStateBuilder::new_from_existing)
-                    .unwrap_or_default()
-                    .with_query_planner(write_planner)
-                    .build();
+                    .unwrap_or_else(|| Arc::new(create_session().into_inner().state()));
                 register_store(this.log_store.clone(), session.runtime_env().as_ref());
+                let state = session_state_from_session(session.as_ref())?;
 
                 let mut schema_drift = false;
                 let mut generated_col_exp = None;
                 let mut missing_gen_col = None;
                 let mut source =
-                    DataFrame::new(session.clone(), this.input.unwrap().as_ref().clone());
+                    DataFrame::new(state.clone(), this.input.unwrap().as_ref().clone());
                 if let Some(snapshot) = &this.snapshot {
                     if able_to_gc(snapshot)? {
                         let generated_col_expressions =
@@ -546,7 +542,7 @@ impl std::future::IntoFuture for WriteBuilder {
                             source,
                             &generated_columns_exp,
                             &missing_generated_col,
-                            &session,
+                            state,
                         )?;
                     }
                 }
@@ -559,7 +555,7 @@ impl std::future::IntoFuture for WriteBuilder {
                     }),
                 });
 
-                let mut source = DataFrame::new(session.clone(), source);
+                let mut source = DataFrame::new(state.clone(), source);
 
                 let schema = Arc::new(source.schema().as_arrow().clone());
 
@@ -607,7 +603,7 @@ impl std::future::IntoFuture for WriteBuilder {
                             Expression::DataFusion(expr) => expr,
                             Expression::String(s) => {
                                 let df_schema = DFSchema::try_from(schema.as_ref().to_owned())?;
-                                parse_predicate_expression(&df_schema, s, &session)?
+                                parse_predicate_expression(&df_schema, s, session.as_ref())?
                             }
                         };
                         (Some(fmt_expr_to_sql(&pred)?), Some(pred))
@@ -647,7 +643,7 @@ impl std::future::IntoFuture for WriteBuilder {
                                     pred.clone(),
                                     this.log_store.clone(),
                                     snapshot,
-                                    session.clone(),
+                                    session.as_ref(),
                                     partition_columns.clone(),
                                     this.writer_properties.clone(),
                                     deletion_timestamp,
@@ -687,7 +683,7 @@ impl std::future::IntoFuture for WriteBuilder {
                 // Here we need to validate if the new data conforms to a predicate if one is provided
                 let (add_actions, _) = write_execution_plan_v2(
                     this.snapshot.as_ref(),
-                    session.clone(),
+                    session.as_ref(),
                     source_plan.clone(),
                     partition_columns.clone(),
                     this.log_store.object_store(Some(operation_id)).clone(),


### PR DESCRIPTION
# Description

We are still creating sessions in several places in the codebase. With this PR, we create a single code path (or at least module) to create datafusion sessions. We also further generalise some APIs to use the `Session` trait.

The main code paths where we still use `SessionState` whenever we need to use the `DataFrame` abstraction. These might disappear once we start planning more based on data.

Closing the related issue for now, since further improvements are part of larger refactorings.

# Related Issue(s)

* closes: #3799