### PR TITLE
chore: deprecate file_actions on state

### DIFF
--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -677,7 +677,12 @@ mod tests {
             count,
             "Expected {count} transactions"
         );
-        let pre_checkpoint_actions = table.snapshot()?.file_actions(&table.log_store).await?;
+        let pre_checkpoint_actions: Vec<_> = table
+            .snapshot()?
+            .snapshot()
+            .file_views(&table.log_store, None)
+            .try_collect()
+            .await?;
 
         let before = table.version();
         let res = create_checkpoint(&table, None).await;
@@ -692,7 +697,12 @@ mod tests {
             "Why on earth did a checkpoint creata version?"
         );
 
-        let post_checkpoint_actions = table.snapshot()?.file_actions(&table.log_store).await?;
+        let post_checkpoint_actions: Vec<_> = table
+            .snapshot()?
+            .snapshot()
+            .file_views(&table.log_store, None)
+            .try_collect()
+            .await?;
 
         assert_eq!(
             pre_checkpoint_actions.len(),

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -140,12 +140,20 @@ impl DeltaTableState {
 
     /// Full list of add actions representing all parquet files that are part of the current
     /// delta table state.
+    #[deprecated(
+        since = "0.29.1",
+        note = "Use `.snapshot().file_views(log_store, predicate)` instead."
+    )]
     pub async fn file_actions(&self, log_store: &dyn LogStore) -> DeltaResult<Vec<Add>> {
         self.file_actions_iter(log_store).try_collect().await
     }
 
     /// Full list of add actions representing all parquet files that are part of the current
     /// delta table state.
+    #[deprecated(
+        since = "0.29.1",
+        note = "Use `.snapshot().file_views(log_store, predicate)` instead."
+    )]
     pub fn file_actions_iter(&self, log_store: &dyn LogStore) -> BoxStream<'_, DeltaResult<Add>> {
         self.snapshot
             .file_views(log_store, None)


### PR DESCRIPTION
# Description

In one of @fvaleye's latest PRs (#3841), we got rid of the last call sites of `file_actions` on `DeltaTableState`. Since we generally discourage materialising `Add` actions and rather do processing/planning on the view into the underlying arrow data, it's high time we deprecate these methods and remove the last invocations within our tests.

This PR does just that.  