### PR TITLE
feat: allow for concurrent deletes in conflict checker if `data_change` is false

### DIFF
--- a/crates/core/src/kernel/transaction/conflict_checker.rs
+++ b/crates/core/src/kernel/transaction/conflict_checker.rs
@@ -1236,7 +1236,11 @@ mod tests {
 
         let result = execute_test(
             Some(setup_actions),
-            Some(col("value").gt(lit::<i32>(1)).and(col("value").lt_eq(lit::<i32>(3)))), // empty read
+            Some(
+                col("value")
+                    .gt(lit::<i32>(1))
+                    .and(col("value").lt_eq(lit::<i32>(3))),
+            ), // empty read
             vec![simple_add(true, "5", "5").into()], // disjoint from read predicate
             vec![simple_add(true, "2", "2").into()],
             false,


### PR DESCRIPTION
# Description

Consider the following case:

1. I kick off a compaction of a delta table
2. Simultaneously, I start a write
3. The compaction finishes, logically removing/adding some files
4. I go to commit my write

This will currently fail, as the state of the write depended on the state of the table at a given time. However, if the contents of the data in that file was only reorganized (ie: with a compact/zorder), then we don't need to consider this a concurrency violation.

# Related Issue(s)

An alternative, perhaps more correct protocol-wise approach to #3890 

# Documentation

Marked as draft as again, I try to stick to the protocol as much as possible and I don't want to create data corruption unintentionally.
