### PR TITLE
refactor: towards lazier snapshots

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -44,8 +44,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
-use futures::StreamExt as _;
-use itertools::Itertools;
+use futures::{StreamExt as _, TryStreamExt as _};
 use object_store::ObjectMeta;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -499,10 +498,10 @@ impl<'a> DeltaScanBuilder<'a> {
                 if logical_filter.is_none() && self.limit.is_none() {
                     let files = self
                         .snapshot
-                        .log_data()
-                        .iter()
-                        .map(|f| f.add_action())
-                        .collect_vec();
+                        .file_views(&self.log_store, None)
+                        .map_ok(|f| f.add_action())
+                        .try_collect::<Vec<_>>()
+                        .await?;
                     let files_scanned = files.len();
                     (files, files_scanned, 0, None)
                 } else {
@@ -524,10 +523,10 @@ impl<'a> DeltaScanBuilder<'a> {
 
                     let file_actions: Vec<_> = self
                         .snapshot
-                        .log_data()
-                        .iter()
-                        .map(|f| f.add_action())
-                        .collect();
+                        .file_views(&self.log_store, None)
+                        .map_ok(|f| f.add_action())
+                        .try_collect::<Vec<_>>()
+                        .await?;
 
                     for (action, keep) in
                         file_actions.into_iter().zip(files_to_prune.iter().cloned())


### PR DESCRIPTION
# Description

As we try to merge `Snapshot` and `EagerSnapshot` we need to normalize on APIs that we can expose on both snapshots. The `LogDataView` construct is something that assumes materialised log data, which is not something we can expose on a lazy snapshot.

This PR extends `Snapshot` to expose `file_views` as the eager variant and removes some call sites of `log_data`.