### PR TITLE
chore: fix windows uri test

### DIFF
--- a/crates/core/src/table/builder.rs
+++ b/crates/core/src/table/builder.rs
@@ -522,7 +522,7 @@ mod tests {
     fn test_windows_uri() {
         let map_cases = &[
             // extra slashes are removed
-            ("c:/", "file:///C:"),
+            ("c://", "file:///C:/"),
         ];
 
         for (case, expected) in map_cases {


### PR DESCRIPTION
# Description
So the test prior was wrong. Windows base URLs handle the trailing slash on drive roots in an _interesting_ way. For example, `C:/` is the actual root of the drive, where as `C:` is actually the current working directory. So there should always be a trailing slash for base root drives. The code already handles this correctly, I'm just updating the test to reflect that. 

# Documentation
https://stackoverflow.com/questions/23955968/windows-path-with-no-slash-after-drive-letter-and-colon-what-does-it-point-to
