### PR TITLE
chore: remove wildcard dependency for publishing

### DIFF
--- a/crates/aws/Cargo.toml
+++ b/crates/aws/Cargo.toml
@@ -54,7 +54,7 @@ chrono = { workspace = true }
 deltalake-core = { path = "../core" }
 deltalake-test = { path = "../test" }
 pretty_env_logger = "0.5.0"
-pretty_assertions = "*"
+pretty_assertions = "1"
 rand = "0.8"
 serde_json = { workspace = true }
 serial_test = "3"


### PR DESCRIPTION
I didn't realize wildcards in `dev-dependencies` were still verboten for published crates
