### PR TITLE
feat: push predicates into parquet scans

### DIFF
--- a/crates/core/src/delta_datafusion/engine/expressions/to_datafusion.rs
+++ b/crates/core/src/delta_datafusion/engine/expressions/to_datafusion.rs
@@ -160,7 +160,7 @@ fn binary_pred_to_df(bin: &BinaryPredicate, output_type: &DataType) -> DFResult<
     })
 }
 
-fn predicate_to_df(predicate: &Predicate, output_type: &DataType) -> DFResult<Expr> {
+pub(crate) fn predicate_to_df(predicate: &Predicate, output_type: &DataType) -> DFResult<Expr> {
     match predicate {
         Predicate::BooleanExpression(expr) => to_datafusion_expr(expr, output_type),
         Predicate::Not(expr) => Ok(!(predicate_to_df(expr, output_type)?)),

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -813,6 +813,7 @@ mod tests {
     use datafusion::physical_plan::empty::EmptyExec;
     use datafusion::physical_plan::{ExecutionPlanVisitor, PhysicalExpr, visit_execution_plan};
     use datafusion::prelude::{SessionConfig, col};
+    use datafusion_datasource::file::FileSource as _;
     use datafusion_proto::physical_plan::AsExecutionPlan;
     use datafusion_proto::protobuf;
     use delta_kernel::path::{LogPathFileType, ParsedLogPath};
@@ -1693,7 +1694,7 @@ mod tests {
                 .downcast_ref::<ParquetSource>()
             {
                 self.options = Some(parquet_source.table_parquet_options().clone());
-                self.predicate = parquet_source.predicate().cloned();
+                self.predicate = parquet_source.filter();
             }
 
             Ok(true)

--- a/crates/core/src/delta_datafusion/table_provider/next/scan.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan.rs
@@ -757,12 +757,12 @@ mod tests {
         {
             // skip boolean and binary columns as they do not have min/max stats
             if matches!(field.data_type(), &DataType::Boolean | &DataType::Binary) {
-                assert!(matches!(col_stat.null_count, Precision::Exact(_)));
+                assert!(matches!(col_stat.null_count, Precision::Inexact(_)));
                 continue;
             }
-            assert!(matches!(col_stat.null_count, Precision::Exact(_)));
-            assert!(matches!(col_stat.min_value, Precision::Exact(_)));
-            assert!(matches!(col_stat.max_value, Precision::Exact(_)));
+            assert!(matches!(col_stat.null_count, Precision::Inexact(_)));
+            assert!(matches!(col_stat.min_value, Precision::Inexact(_)));
+            assert!(matches!(col_stat.max_value, Precision::Inexact(_)));
         }
 
         Ok(())
@@ -792,9 +792,9 @@ mod tests {
             provider.schema().fields().len()
         );
         for col_stat in statistics.column_statistics.iter() {
-            assert!(matches!(col_stat.null_count, Precision::Exact(_)));
-            assert!(matches!(col_stat.min_value, Precision::Exact(_)));
-            assert!(matches!(col_stat.max_value, Precision::Exact(_)));
+            assert!(matches!(col_stat.null_count, Precision::Inexact(_)));
+            assert!(matches!(col_stat.min_value, Precision::Inexact(_)));
+            assert!(matches!(col_stat.max_value, Precision::Inexact(_)));
         }
 
         Ok(())
@@ -824,9 +824,18 @@ mod tests {
             .iter()
             .zip(provider.schema().fields())
         {
-            assert!(matches!(col_stat.null_count, Precision::Exact(_)));
-            assert!(matches!(col_stat.min_value, Precision::Exact(_)));
-            assert!(matches!(col_stat.max_value, Precision::Exact(_)));
+            assert!(matches!(
+                col_stat.null_count,
+                Precision::Exact(_) | Precision::Inexact(_)
+            ));
+            assert!(matches!(
+                col_stat.min_value,
+                Precision::Exact(_) | Precision::Inexact(_)
+            ));
+            assert!(matches!(
+                col_stat.max_value,
+                Precision::Exact(_) | Precision::Inexact(_)
+            ));
         }
 
         Ok(())

--- a/crates/core/tests/datafusion_table_provider.rs
+++ b/crates/core/tests/datafusion_table_provider.rs
@@ -94,8 +94,7 @@ async fn test_all_primitive_types() -> TestResult<()> {
     ];
     assert_batches_sorted_eq!(&expected, &batches);
 
-    // While we are passing a filter, the table provider does not yet push down
-    // the filter to the parquet scan, so we expect the same result as above.
+    // Also test with a predicate
     let pred = col("float64").gt(lit(2.0_f64));
     let plan = provider
         .scan(&session.state(), Some(&vec![1, 3, 6]), &[pred], None)
@@ -105,9 +104,6 @@ async fn test_all_primitive_types() -> TestResult<()> {
         "+-------+-------+---------+",
         "| int64 | int16 | float64 |",
         "+-------+-------+---------+",
-        "| 0     | 0     | 0.0     |",
-        "| 1     | 1     | 1.0     |",
-        "| 2     | 2     | 2.0     |",
         "| 3     | 3     | 3.0     |",
         "| 4     | 4     | 4.0     |",
         "+-------+-------+---------+",


### PR DESCRIPTION
# Description

This PR further improves the kernel based scan implementation by:
- pushing some predicates into the parquet scan
- integrating with datafsuion's file metadata cache

We also add some more tests and validate that imputation of missing columns in the parquet scan works for nested data.