### PR TITLE
feat: move data validation on a stream

### DIFF
--- a/crates/core/src/delta_datafusion/data_validation.rs
+++ b/crates/core/src/delta_datafusion/data_validation.rs
@@ -1,0 +1,867 @@
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::array::AsArray;
+use arrow_array::RecordBatch;
+use arrow_schema::{DataType, SchemaRef};
+use datafusion::catalog::Session;
+use datafusion::common::{DFSchema, Statistics, exec_err, plan_datafusion_err, plan_err};
+use datafusion::config::ConfigOptions;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::utils::conjunction;
+use datafusion::logical_expr::{ColumnarValue, Operator};
+use datafusion::optimizer::simplify_expressions::simplify_predicates;
+use datafusion::physical_plan::execution_plan::CardinalityEffect;
+use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, PlanProperties,
+};
+use datafusion::prelude::{Expr, binary_expr, col};
+use datafusion::scalar::ScalarValue;
+use delta_kernel::table_configuration::TableConfiguration;
+use delta_kernel::table_features::TableFeature;
+use futures::Stream;
+use itertools::Itertools as _;
+use pin_project_lite::pin_project;
+
+use crate::StructTypeExt as _;
+use crate::delta_datafusion::expr::parse_predicate_expression;
+use crate::delta_datafusion::table_provider::simplify_expr;
+use crate::table::config::TablePropertiesExt as _;
+use crate::table::{Constraint, GeneratedColumn};
+
+/// Generate validation predicates based on the table configuration
+///
+/// This function generates a list of DataFusion expressions
+/// that represent the data validation rules specified in the
+/// Delta table configuration. This includes:
+/// - Non-nullable column checks
+/// - [column invariants]
+/// - [check constraints]
+/// - [generated columns]
+///
+/// # Arguments
+/// - `session`: The DataFusion session
+/// - `input`: The input execution plan
+/// - `table_configuration`: Configuration object of Delta table
+///
+/// [column invariants]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#column-invariants
+/// [check constraints]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#check-constraints
+/// [generated columns]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#generated-columns
+pub(crate) fn validation_predicates(
+    session: &dyn Session,
+    input: Arc<dyn ExecutionPlan>,
+    table_configuration: &TableConfiguration,
+) -> Result<Vec<Expr>> {
+    let df_schema = DFSchema::try_from(input.schema())?;
+
+    let mut validations = table_configuration
+        .schema()
+        .fields()
+        .filter(|f| !f.is_nullable())
+        .map(|f| col(f.name()).is_not_null())
+        .collect_vec();
+
+    if table_configuration.is_feature_enabled(&TableFeature::Invariants) {
+        let invariants = table_configuration
+            .schema()
+            .get_invariants()
+            .map_err(|e| plan_datafusion_err!("Failed to read invariants from schema: {}", e))?;
+        for invariant in invariants {
+            let expr = parse_predicate_expression(&df_schema, &invariant.invariant_sql, session)?;
+            validations.push(expr);
+        }
+    }
+
+    if table_configuration.is_feature_enabled(&TableFeature::CheckConstraints) {
+        let constraints = table_configuration.table_properties().get_constraints();
+        validations.extend(constraints_to_exprs(session, &df_schema, &constraints)?);
+    }
+
+    if table_configuration.is_feature_enabled(&TableFeature::GeneratedColumns) {
+        let generated = table_configuration
+            .schema()
+            .get_generated_columns()
+            .map_err(|e| {
+                plan_datafusion_err!("Failed to read generated columns from schema: {}", e)
+            })?;
+        validations.extend(generated_columns_to_exprs(session, &df_schema, &generated)?);
+    }
+
+    Ok(validations)
+}
+
+pub(crate) fn constraints_to_exprs<'a>(
+    session: &dyn Session,
+    df_schema: &DFSchema,
+    constraints: impl IntoIterator<Item = &'a Constraint>,
+) -> Result<Vec<Expr>> {
+    Ok(constraints
+        .into_iter()
+        .map(|constraint| parse_predicate_expression(df_schema, &constraint.expr, session))
+        .try_collect()?)
+}
+
+pub(crate) fn generated_columns_to_exprs<'a>(
+    session: &dyn Session,
+    df_schema: &DFSchema,
+    generated_columns: impl IntoIterator<Item = &'a GeneratedColumn>,
+) -> Result<Vec<Expr>> {
+    generated_columns
+        .into_iter()
+        .map(|gen_col| {
+            let expr = parse_predicate_expression(df_schema, &gen_col.generation_expr, session)?;
+            let col_expr = col(&gen_col.name);
+            let validation_expr = binary_expr(col_expr, Operator::IsNotDistinctFrom, expr);
+            Ok::<_, DataFusionError>(validation_expr)
+        })
+        .collect()
+}
+
+/// Execution plan for validating data
+///
+/// The Delta protocol specifies data validation steps that must be
+/// performed when writing data to a Delta table mainly via the
+/// [column invariants], [check constraints], and [generated columns]
+/// features. Additionally, the table schema contains nullability information
+/// that must also be enforced.
+///
+/// [column invariants]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#column-invariants
+/// [check constraints]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#check-constraints
+/// [generated columns]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#generated-columns
+#[derive(Clone, Debug)]
+pub struct DataValidationExec {
+    /// The input execution plan
+    input: Arc<dyn ExecutionPlan>,
+    /// The expression to use for checking data validity
+    check_expression: Arc<dyn PhysicalExpr>,
+}
+
+impl DataValidationExec {
+    pub fn try_new_with_config(
+        session: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        config: &TableConfiguration,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let predicates = validation_predicates(session, Arc::clone(&input), config)?;
+        Self::try_new_with_predicates(session, input, predicates)
+    }
+
+    /// Create a new [`DataValidationExec`] if there are any predicates to apply
+    /// otherwise return the input execution plan as-is.
+    pub fn try_new_with_predicates(
+        session: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        predicates: Vec<Expr>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let df_schema = DFSchema::try_from(input.schema())?;
+        if let Some(validation_expr) = conjunction(simplify_predicates(predicates)?) {
+            let check_expression = simplify_expr(session, df_schema.into(), validation_expr)?;
+            return Ok(Arc::new(Self::try_new(input, check_expression)?));
+        }
+        Ok(input)
+    }
+
+    /// Create a new [`DataValidationExec`]
+    pub fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        check_expression: Arc<dyn PhysicalExpr>,
+    ) -> Result<Self> {
+        let result_type = check_expression.data_type(input.schema().as_ref())?;
+        if !matches!(result_type, DataType::Boolean) {
+            return plan_err!(
+                "Data validation expression must return boolean values, got {:?}",
+                result_type
+            );
+        }
+        Ok(Self {
+            input,
+            check_expression,
+        })
+    }
+}
+
+impl DisplayAs for DataValidationExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default
+            | DisplayFormatType::TreeRender
+            | DisplayFormatType::Verbose => {
+                write!(
+                    f,
+                    "DataValidationExec: check_expression={:?}",
+                    self.check_expression
+                )
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for DataValidationExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "DataValidationExec"
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        self.input.properties()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return plan_err!(
+                "DataValidationExec wrong number of children: expected 1, got {}",
+                children.len()
+            );
+        }
+        Ok(Arc::new(Self {
+            input: children.remove(0),
+            check_expression: Arc::clone(&self.check_expression),
+        }))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        Ok(Box::pin(DataValidationStream::new(
+            self.input.execute(partition, context)?,
+            self.input.schema(),
+            Arc::clone(&self.check_expression),
+        )))
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        self.input.partition_statistics(partition)
+    }
+
+    fn statistics(&self) -> Result<Statistics> {
+        self.partition_statistics(None)
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true; self.children().len()]
+    }
+
+    fn repartitioned(
+        &self,
+        target_partitions: usize,
+        config: &ConfigOptions,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        if let Some(repartitioned) = self.input.repartitioned(target_partitions, config)? {
+            Ok(Some(Arc::new(Self {
+                input: repartitioned,
+                check_expression: Arc::clone(&self.check_expression),
+            })))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        self.input.supports_limit_pushdown()
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let input_with_fetch = self.input.with_fetch(limit)?;
+        Some(Arc::new(Self {
+            input: input_with_fetch,
+            check_expression: Arc::clone(&self.check_expression),
+        }))
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        self.input.cardinality_effect()
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        FilterDescription::from_children(parent_filters, &self.children())
+    }
+}
+
+pin_project! {
+    /// Stream that validates data according to a check expression
+    /// before yielding it.
+    pub(crate) struct DataValidationStream<S> {
+        // The expression to use for checking data validity
+        check_expression: Arc<dyn PhysicalExpr>,
+
+        // The schema of the output stream
+        schema: SchemaRef,
+
+        #[pin]
+        // The input stream
+        stream: S,
+    }
+}
+
+impl<S> DataValidationStream<S> {
+    /// Create a new DataValidationStream
+    pub(crate) fn new(
+        stream: S,
+        schema: SchemaRef,
+        check_expression: Arc<dyn PhysicalExpr>,
+    ) -> DataValidationStream<S> {
+        DataValidationStream {
+            check_expression,
+            schema,
+            stream,
+        }
+    }
+}
+
+impl<S> Stream for DataValidationStream<S>
+where
+    S: Stream<Item = Result<RecordBatch>>,
+{
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        match this.stream.poll_next(cx) {
+            Poll::Ready(Some(Ok(batch))) => {
+                match this.check_expression.evaluate(&batch)? {
+                    ColumnarValue::Array(array) => {
+                        let invalid_count = array
+                            .as_boolean()
+                            .iter()
+                            .filter(|v| matches!(v, Some(false) | None))
+                            .count();
+                        if invalid_count > 0 {
+                            return Poll::Ready(Some(exec_err!(
+                                "Invalid data found: {invalid_count} rows failed validation check."
+                            )));
+                        }
+                    }
+                    ColumnarValue::Scalar(value) => {
+                        if !matches!(value, ScalarValue::Boolean(Some(true))) {
+                            return Poll::Ready(Some(exec_err!(
+                                "Invalid data found: scalar validation check failed with value {value:?}."
+                            )));
+                        }
+                    }
+                }
+                Poll::Ready(Some(Ok(batch)))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<S> RecordBatchStream for DataValidationStream<S>
+where
+    S: Stream<Item = Result<RecordBatch>>,
+{
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow_array::{Int32Array, RecordBatch, StringArray};
+    use datafusion::catalog::{MemTable, TableProvider};
+    // use datafusion::physical_plan::MemoryExec;
+    use datafusion::physical_plan::empty::EmptyExec;
+    use datafusion::physical_plan::{collect, displayable};
+    use datafusion::prelude::{SessionContext, binary_expr, col};
+    use futures::StreamExt;
+
+    fn create_test_schema(nullable: bool) -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, nullable),
+            Field::new("name", DataType::Utf8, true),
+        ]))
+    }
+
+    fn create_test_batch(
+        schema: SchemaRef,
+        ids: Vec<Option<i32>>,
+        names: Vec<Option<&str>>,
+    ) -> RecordBatch {
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(StringArray::from(names)),
+            ],
+        )
+        .unwrap()
+    }
+
+    async fn get_memory_exec(
+        session: &dyn Session,
+        schema: SchemaRef,
+        batches: Vec<RecordBatch>,
+    ) -> Arc<dyn ExecutionPlan> {
+        let table = MemTable::try_new(schema, vec![batches]).unwrap();
+        table.scan(session, None, &[], None).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_validation_nullability_pass() -> Result<()> {
+        let schema = create_test_schema(false);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(1), Some(2), Some(3)],
+            vec![Some("a"), Some("b"), Some("c")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        // Create validation for non-nullable id column
+        let predicates = vec![col("id").is_not_null()];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let result = collect(validated_exec, ctx.task_ctx()).await?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].num_rows(), 3);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_check_constraint_pass() -> Result<()> {
+        let schema = create_test_schema(true);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(10), Some(20), Some(30)],
+            vec![Some("a"), Some("b"), Some("c")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        // Create validation: id > 5
+        let predicates = vec![col("id").gt(datafusion::prelude::lit(5i32))];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let result = collect(validated_exec, ctx.task_ctx()).await?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].num_rows(), 3);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_check_constraint_fail() -> Result<()> {
+        let schema = create_test_schema(true);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(10), Some(2), Some(30)], // One value fails constraint
+            vec![Some("a"), Some("b"), Some("c")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        // Create validation: id > 5
+        let predicates = vec![col("id").gt(datafusion::prelude::lit(5i32))];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let result = collect(validated_exec, ctx.task_ctx()).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid data found")
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_multiple_constraints() -> Result<()> {
+        let schema = create_test_schema(false);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(10), Some(20), Some(30)],
+            vec![Some("a"), Some("b"), Some("c")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        // Multiple validations: id NOT NULL AND id > 5 AND id < 100
+        let predicates = vec![
+            col("id").is_not_null(),
+            col("id").gt(datafusion::prelude::lit(5i32)),
+            col("id").lt(datafusion::prelude::lit(100i32)),
+        ];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let result = collect(validated_exec, ctx.task_ctx()).await?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].num_rows(), 3);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_multiple_constraints_fail() -> Result<()> {
+        let schema = create_test_schema(false);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(10), Some(200), Some(30)], // 200 fails id < 100 constraint
+            vec![Some("a"), Some("b"), Some("c")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        let predicates = vec![
+            col("id").is_not_null(),
+            col("id").gt(datafusion::prelude::lit(5i32)),
+            col("id").lt(datafusion::prelude::lit(100i32)),
+        ];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let result = collect(validated_exec, ctx.task_ctx()).await;
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_generated_column_match() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("id_times_2", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![2, 4, 6])), // Correctly doubled
+            ],
+        )?;
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        // Validate: id_times_2 IS NOT DISTINCT FROM (id * 2)
+        let predicates = vec![binary_expr(
+            col("id_times_2"),
+            Operator::IsNotDistinctFrom,
+            col("id") * datafusion::prelude::lit(2i32),
+        )];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let result = collect(validated_exec, ctx.task_ctx()).await?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].num_rows(), 3);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_generated_column_mismatch() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("id_times_2", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![2, 5, 6])), // 5 is incorrect (should be 4)
+            ],
+        )?;
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        let predicates = vec![binary_expr(
+            col("id_times_2"),
+            Operator::IsNotDistinctFrom,
+            col("id") * datafusion::prelude::lit(2i32),
+        )];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let result = collect(validated_exec, ctx.task_ctx()).await;
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_empty_batch() -> Result<()> {
+        let schema = create_test_schema(false);
+        let batch = create_test_batch(schema.clone(), vec![], vec![]);
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        let predicates = vec![col("id").is_not_null()];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let result = collect(validated_exec, ctx.task_ctx()).await?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].num_rows(), 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_no_predicates() -> Result<()> {
+        let schema = create_test_schema(true);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(1), Some(2)],
+            vec![Some("a"), Some("b")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        // No predicates - should return input plan unchanged
+        let predicates = vec![];
+        let result_exec = DataValidationExec::try_new_with_predicates(
+            &ctx.state(),
+            memory_exec.clone(),
+            predicates,
+        )?;
+
+        // When no predicates, should return the input plan
+        assert!(Arc::ptr_eq(
+            &result_exec,
+            &(memory_exec as Arc<dyn ExecutionPlan>)
+        ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_partial_batch_failure() -> Result<()> {
+        let schema = create_test_schema(true);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(10), Some(2), Some(30), Some(1)], // Two values fail
+            vec![Some("a"), Some("b"), Some("c"), Some("d")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        let predicates = vec![col("id").gt(datafusion::prelude::lit(5i32))];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let result = collect(validated_exec, ctx.task_ctx()).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("2 rows failed validation"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_maintains_order() -> Result<()> {
+        let schema = create_test_schema(true);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(10), Some(20), Some(30)],
+            vec![Some("a"), Some("b"), Some("c")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        let predicates = vec![col("id").is_not_null()];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        // Check that maintains_input_order returns true
+        let downcast = validated_exec
+            .as_any()
+            .downcast_ref::<DataValidationExec>()
+            .unwrap();
+        assert_eq!(downcast.maintains_input_order(), vec![true]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_display() -> Result<()> {
+        let schema = create_test_schema(true);
+        let empty_exec = Arc::new(EmptyExec::new(schema));
+        let ctx = SessionContext::new();
+
+        let predicates = vec![col("id").is_not_null()];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), empty_exec, predicates)?;
+
+        let display_str = displayable(validated_exec.as_ref())
+            .indent(false)
+            .to_string();
+        assert!(display_str.contains("DataValidationExec"));
+        assert!(display_str.contains("check_expression"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_with_new_children() -> Result<()> {
+        let schema = create_test_schema(true);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(10), Some(20)],
+            vec![Some("a"), Some("b")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec1 = get_memory_exec(&ctx.state(), schema.clone(), vec![batch.clone()]).await;
+        let memory_exec2 = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        let predicates = vec![col("id").is_not_null()];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec1, predicates)?;
+
+        // Create new plan with different child
+        let new_exec = validated_exec.with_new_children(vec![memory_exec2])?;
+        assert!(
+            new_exec
+                .as_any()
+                .downcast_ref::<DataValidationExec>()
+                .is_some()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_wrong_number_of_children() -> Result<()> {
+        let schema = create_test_schema(true);
+        let memory_exec = Arc::new(EmptyExec::new(schema));
+        let ctx = SessionContext::new();
+
+        let predicates = vec![col("id").is_not_null()];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        // Try to create with wrong number of children
+        let result = validated_exec.with_new_children(vec![]);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("wrong number of children")
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_stream_directly() -> Result<()> {
+        let schema = create_test_schema(true);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(10), Some(20)],
+            vec![Some("a"), Some("b")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        let predicates = vec![col("id").gt(datafusion::prelude::lit(5i32))];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let mut stream = validated_exec.execute(0, ctx.task_ctx())?;
+
+        // Manually poll the stream
+        let mut count = 0;
+        while let Some(result) = stream.next().await {
+            result?;
+            count += 1;
+        }
+        assert_eq!(count, 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_scalar_true() -> Result<()> {
+        let schema = create_test_schema(true);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(10), Some(20)],
+            vec![Some("a"), Some("b")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        // Use a literal true predicate (scalar)
+        let predicates = vec![datafusion::prelude::lit(true)];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let result = collect(validated_exec, ctx.task_ctx()).await?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].num_rows(), 2);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_scalar_false() -> Result<()> {
+        let schema = create_test_schema(true);
+        let batch = create_test_batch(
+            schema.clone(),
+            vec![Some(10), Some(20)],
+            vec![Some("a"), Some("b")],
+        );
+
+        let ctx = SessionContext::new();
+        let memory_exec = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
+
+        // Use a literal false predicate (scalar)
+        let predicates = vec![datafusion::prelude::lit(false)];
+        let validated_exec =
+            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
+
+        let result = collect(validated_exec, ctx.task_ctx()).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("scalar validation check failed"));
+
+        Ok(())
+    }
+}

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -28,7 +28,6 @@ use std::sync::Arc;
 
 use arrow::array::types::UInt16Type;
 use arrow::array::{Array, DictionaryArray, RecordBatch, StringArray, TypedDictionaryArray};
-use arrow_cast::display::array_value_to_string;
 use arrow_cast::{CastOptions, cast_with_options};
 use arrow_schema::{
     DataType as ArrowDataType, Schema as ArrowSchema, SchemaRef, SchemaRef as ArrowSchemaRef,
@@ -39,8 +38,8 @@ use datafusion::common::scalar::ScalarValue;
 use datafusion::common::{
     Column, DFSchema, DataFusionError, Result as DataFusionResult, TableReference, ToDFSchema,
 };
+use datafusion::datasource::TableProvider;
 use datafusion::datasource::physical_plan::wrap_partition_type_in_dict;
-use datafusion::datasource::{MemTable, TableProvider};
 use datafusion::execution::TaskContext;
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
@@ -53,20 +52,15 @@ use datafusion_proto::logical_plan::LogicalExtensionCodec;
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use either::Either;
-use itertools::Itertools;
 use url::Url;
 
 use crate::delta_datafusion::expr::parse_predicate_expression;
 use crate::delta_datafusion::table_provider::DeltaScanWire;
 use crate::ensure_table_uri;
 use crate::errors::{DeltaResult, DeltaTableError};
-use crate::kernel::{
-    Add, DataCheck, EagerSnapshot, Invariant, LogDataHandler, Snapshot, StructTypeExt,
-};
+use crate::kernel::{Add, EagerSnapshot, LogDataHandler, Snapshot};
 use crate::logstore::{LogStore, LogStoreRef};
-use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
-use crate::table::{Constraint, GeneratedColumn};
 use crate::{open_table, open_table_with_storage_options};
 
 pub(crate) use self::session::session_state_from_session;
@@ -74,13 +68,22 @@ pub use self::session::{
     DeltaParserOptions, DeltaRuntimeEnvBuilder, DeltaSessionConfig, DeltaSessionContext,
     create_session,
 };
-pub use self::table_provider::next::SnapshotWrapper;
-pub use self::table_provider::next::{DeltaScan as DeltaScanNext, DeltaScanExec};
+pub use self::table_provider::next::DeltaScan as DeltaScanNext;
+pub use cdf::scan::DeltaCdfTableProvider;
+pub(crate) use data_validation::{
+    DataValidationExec, constraints_to_exprs, generated_columns_to_exprs, validation_predicates,
+};
 pub(crate) use find_files::*;
+pub use table_provider::{
+    DeltaScan, DeltaScanConfig, DeltaScanConfigBuilder, DeltaTableProvider, TableProviderBuilder,
+    next::DeltaScanExec,
+};
+pub(crate) use table_provider::{DeltaScanBuilder, update_datafusion_session};
 
 pub(crate) const PATH_COLUMN: &str = "__delta_rs_path";
 
 pub mod cdf;
+mod data_validation;
 pub mod engine;
 pub mod expr;
 mod find_files;
@@ -90,10 +93,6 @@ pub mod planner;
 mod schema_adapter;
 mod session;
 mod table_provider;
-
-pub use cdf::scan::DeltaCdfTableProvider;
-pub(crate) use table_provider::DeltaScanBuilder;
-pub use table_provider::{DeltaScan, DeltaScanConfig, DeltaScanConfigBuilder, DeltaTableProvider};
 
 impl From<DeltaTableError> for DataFusionError {
     fn from(err: DeltaTableError) -> Self {
@@ -452,197 +451,6 @@ pub(crate) fn to_correct_scalar_value(
     }
 }
 
-/// Responsible for checking batches of data conform to table's invariants, constraints and nullability.
-#[derive(Clone, Default)]
-pub struct DeltaDataChecker {
-    constraints: Vec<Constraint>,
-    invariants: Vec<Invariant>,
-    generated_columns: Vec<GeneratedColumn>,
-    non_nullable_columns: Vec<String>,
-    ctx: SessionContext,
-}
-
-impl DeltaDataChecker {
-    /// Create a new DeltaDataChecker with no invariants or constraints
-    pub fn empty() -> Self {
-        Self {
-            invariants: vec![],
-            constraints: vec![],
-            generated_columns: vec![],
-            non_nullable_columns: vec![],
-            ctx: DeltaSessionContext::default().into(),
-        }
-    }
-
-    /// Create a new DeltaDataChecker with a specified set of invariants
-    pub fn new_with_invariants(invariants: Vec<Invariant>) -> Self {
-        Self {
-            invariants,
-            constraints: vec![],
-            generated_columns: vec![],
-            non_nullable_columns: vec![],
-            ctx: DeltaSessionContext::default().into(),
-        }
-    }
-
-    /// Create a new DeltaDataChecker with a specified set of constraints
-    pub fn new_with_constraints(constraints: Vec<Constraint>) -> Self {
-        Self {
-            constraints,
-            invariants: vec![],
-            generated_columns: vec![],
-            non_nullable_columns: vec![],
-            ctx: DeltaSessionContext::default().into(),
-        }
-    }
-
-    /// Create a new DeltaDataChecker with a specified set of generated columns
-    pub fn new_with_generated_columns(generated_columns: Vec<GeneratedColumn>) -> Self {
-        Self {
-            constraints: vec![],
-            invariants: vec![],
-            generated_columns,
-            non_nullable_columns: vec![],
-            ctx: DeltaSessionContext::default().into(),
-        }
-    }
-
-    /// Specify the Datafusion context
-    pub fn with_session_context(mut self, context: SessionContext) -> Self {
-        self.ctx = context;
-        self
-    }
-
-    /// Add the specified set of constraints to the current DeltaDataChecker's constraints
-    pub fn with_extra_constraints(mut self, constraints: Vec<Constraint>) -> Self {
-        self.constraints.extend(constraints);
-        self
-    }
-
-    /// Create a new DeltaDataChecker
-    pub fn new(snapshot: &EagerSnapshot) -> Self {
-        let invariants = snapshot.schema().get_invariants().unwrap_or_default();
-        let generated_columns = snapshot
-            .schema()
-            .get_generated_columns()
-            .unwrap_or_default();
-        let constraints = snapshot.table_properties().get_constraints();
-        let non_nullable_columns = snapshot
-            .schema()
-            .fields()
-            .filter_map(|f| {
-                if !f.is_nullable() {
-                    Some(f.name().clone())
-                } else {
-                    None
-                }
-            })
-            .collect_vec();
-        Self {
-            invariants,
-            constraints,
-            generated_columns,
-            non_nullable_columns,
-            ctx: DeltaSessionContext::default().into(),
-        }
-    }
-
-    /// Check that a record batch conforms to table's invariants.
-    ///
-    /// If it does not, it will return [DeltaTableError::InvalidData] with a list
-    /// of values that violated each invariant.
-    pub async fn check_batch(&self, record_batch: &RecordBatch) -> Result<(), DeltaTableError> {
-        self.check_nullability(record_batch)?;
-        self.enforce_checks(record_batch, &self.invariants).await?;
-        self.enforce_checks(record_batch, &self.constraints).await?;
-        self.enforce_checks(record_batch, &self.generated_columns)
-            .await
-    }
-
-    /// Return true if all the nullability checks are valid
-    fn check_nullability(&self, record_batch: &RecordBatch) -> Result<bool, DeltaTableError> {
-        let mut violations = Vec::with_capacity(self.non_nullable_columns.len());
-        for col in self.non_nullable_columns.iter() {
-            if let Some(arr) = record_batch.column_by_name(col) {
-                if arr.null_count() > 0 {
-                    violations.push(format!(
-                        "Non-nullable column violation for {col}, found {} null values",
-                        arr.null_count()
-                    ));
-                }
-            } else {
-                violations.push(format!(
-                    "Non-nullable column violation for {col}, not found in batch!"
-                ));
-            }
-        }
-        if !violations.is_empty() {
-            Err(DeltaTableError::InvalidData { violations })
-        } else {
-            Ok(true)
-        }
-    }
-
-    async fn enforce_checks<C: DataCheck>(
-        &self,
-        record_batch: &RecordBatch,
-        checks: &[C],
-    ) -> Result<(), DeltaTableError> {
-        if checks.is_empty() {
-            return Ok(());
-        }
-        let table = MemTable::try_new(record_batch.schema(), vec![vec![record_batch.clone()]])?;
-        table.schema();
-        // Use a random table name to avoid clashes when running multiple parallel tasks, e.g. when using a partitioned table
-        let table_name: String = uuid::Uuid::new_v4().to_string();
-        self.ctx.register_table(&table_name, Arc::new(table))?;
-
-        let mut violations: Vec<String> = Vec::with_capacity(checks.len());
-
-        for check in checks {
-            if check.get_name().contains('.') {
-                return Err(DeltaTableError::Generic(
-                    "delta constraints for nested columns are not supported at the moment."
-                        .to_string(),
-                ));
-            }
-
-            let field_to_select = if check.as_any().is::<Constraint>() {
-                "*"
-            } else {
-                check.get_name()
-            };
-            let sql = format!(
-                "SELECT {} FROM `{table_name}` WHERE NOT ({}) LIMIT 1",
-                field_to_select,
-                check.get_expression()
-            );
-
-            let dfs: Vec<RecordBatch> = self.ctx.sql(&sql).await?.collect().await?;
-            if !dfs.is_empty() && dfs[0].num_rows() > 0 {
-                let value: String = dfs[0]
-                    .columns()
-                    .iter()
-                    .map(|c| array_value_to_string(c, 0).unwrap_or(String::from("null")))
-                    .join(", ");
-
-                let msg = format!(
-                    "Check or Invariant ({}) violated by value in row: [{value}]",
-                    check.get_expression(),
-                );
-                violations.push(msg);
-            }
-        }
-
-        self.ctx.deregister_table(&table_name)?;
-        if !violations.is_empty() {
-            Err(DeltaTableError::InvalidData { violations })
-        } else {
-            Ok(())
-        }
-    }
-}
-
 /// A codec for deltalake physical plans
 #[derive(Debug)]
 pub struct DeltaPhysicalCodec {}
@@ -906,191 +714,6 @@ mod tests {
             let scalar = to_correct_scalar_value(raw, data_type).unwrap().unwrap();
             assert_eq!(*ref_scalar, scalar)
         }
-    }
-
-    #[tokio::test]
-    async fn test_enforce_invariants() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("a", ArrowDataType::Utf8, false),
-            Field::new("b", ArrowDataType::Int32, false),
-        ]));
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(arrow::array::StringArray::from(vec!["a", "b", "c", "d"])),
-                Arc::new(arrow::array::Int32Array::from(vec![1, 10, 10, 100])),
-            ],
-        )
-        .unwrap();
-        // Empty invariants is okay
-        let invariants: Vec<Invariant> = vec![];
-        assert!(
-            DeltaDataChecker::new_with_invariants(invariants)
-                .check_batch(&batch)
-                .await
-                .is_ok()
-        );
-
-        // Valid invariants return Ok(())
-        let invariants = vec![
-            Invariant::new("a", "a is not null"),
-            Invariant::new("b", "b < 1000"),
-        ];
-        assert!(
-            DeltaDataChecker::new_with_invariants(invariants)
-                .check_batch(&batch)
-                .await
-                .is_ok()
-        );
-
-        // Violated invariants returns an error with list of violations
-        let invariants = vec![
-            Invariant::new("a", "a is null"),
-            Invariant::new("b", "b < 100"),
-        ];
-        let result = DeltaDataChecker::new_with_invariants(invariants)
-            .check_batch(&batch)
-            .await;
-        assert!(result.is_err());
-        assert!(matches!(result, Err(DeltaTableError::InvalidData { .. })));
-        if let Err(DeltaTableError::InvalidData { violations }) = result {
-            assert_eq!(violations.len(), 2);
-        }
-
-        // Irrelevant invariants return a different error
-        let invariants = vec![Invariant::new("c", "c > 2000")];
-        let result = DeltaDataChecker::new_with_invariants(invariants)
-            .check_batch(&batch)
-            .await;
-        assert!(result.is_err());
-
-        // Nested invariants are unsupported
-        let struct_fields = schema.fields().clone();
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "x",
-            ArrowDataType::Struct(struct_fields),
-            false,
-        )]));
-        let inner = Arc::new(StructArray::from(batch));
-        let batch = RecordBatch::try_new(schema, vec![inner]).unwrap();
-
-        let invariants = vec![Invariant::new("x.b", "x.b < 1000")];
-        let result = DeltaDataChecker::new_with_invariants(invariants)
-            .check_batch(&batch)
-            .await;
-        assert!(result.is_err());
-        assert!(matches!(result, Err(DeltaTableError::Generic { .. })));
-    }
-
-    #[tokio::test]
-    async fn test_enforce_constraints() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("a", ArrowDataType::Utf8, false),
-            Field::new("b", ArrowDataType::Int32, false),
-        ]));
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(arrow::array::StringArray::from(vec!["a", "b", "c", "d"])),
-                Arc::new(arrow::array::Int32Array::from(vec![1, 10, 10, 100])),
-            ],
-        )
-        .unwrap();
-        // Empty constraints is okay
-        let constraints: Vec<Constraint> = vec![];
-        assert!(
-            DeltaDataChecker::new_with_constraints(constraints)
-                .check_batch(&batch)
-                .await
-                .is_ok()
-        );
-
-        // Valid invariants return Ok(())
-        let constraints = vec![
-            Constraint::new("custom_a", "a is not null"),
-            Constraint::new("custom_b", "b < 1000"),
-        ];
-        assert!(
-            DeltaDataChecker::new_with_constraints(constraints)
-                .check_batch(&batch)
-                .await
-                .is_ok()
-        );
-
-        // Violated invariants returns an error with list of violations
-        let constraints = vec![
-            Constraint::new("custom_a", "a is null"),
-            Constraint::new("custom_B", "b < 100"),
-        ];
-        let result = DeltaDataChecker::new_with_constraints(constraints)
-            .check_batch(&batch)
-            .await;
-        assert!(result.is_err());
-        assert!(matches!(result, Err(DeltaTableError::InvalidData { .. })));
-        if let Err(DeltaTableError::InvalidData { violations }) = result {
-            assert_eq!(violations.len(), 2);
-        }
-
-        // Irrelevant constraints return a different error
-        let constraints = vec![Constraint::new("custom_c", "c > 2000")];
-        let result = DeltaDataChecker::new_with_constraints(constraints)
-            .check_batch(&batch)
-            .await;
-        assert!(result.is_err());
-    }
-
-    /// Ensure that constraints when there are spaces in the field name still work
-    ///
-    /// See <https://github.com/delta-io/delta-rs/pull/3374>
-    #[tokio::test]
-    async fn test_constraints_with_spacey_fields() -> DeltaResult<()> {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("a", ArrowDataType::Utf8, false),
-            Field::new("b bop", ArrowDataType::Int32, false),
-        ]));
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(arrow::array::StringArray::from(vec![
-                    "a", "b bop", "c", "d",
-                ])),
-                Arc::new(arrow::array::Int32Array::from(vec![1, 10, 10, 100])),
-            ],
-        )?;
-
-        // Valid invariants return Ok(())
-        let constraints = vec![
-            Constraint::new("custom a", "a is not null"),
-            Constraint::new("custom_b", "`b bop` < 1000"),
-        ];
-        assert!(
-            DeltaDataChecker::new_with_constraints(constraints)
-                .check_batch(&batch)
-                .await
-                .is_ok()
-        );
-
-        // Violated invariants returns an error with list of violations
-        let constraints = vec![
-            Constraint::new("custom_a", "a is null"),
-            Constraint::new("custom_B", "\"b bop\" < 100"),
-        ];
-        let result = DeltaDataChecker::new_with_constraints(constraints)
-            .check_batch(&batch)
-            .await;
-        assert!(result.is_err());
-        assert!(matches!(result, Err(DeltaTableError::InvalidData { .. })));
-        if let Err(DeltaTableError::InvalidData { violations }) = result {
-            assert_eq!(violations.len(), 2);
-        }
-
-        // Irrelevant constraints return a different error
-        let constraints = vec![Constraint::new("custom_c", "c > 2000")];
-        let result = DeltaDataChecker::new_with_constraints(constraints)
-            .check_batch(&batch)
-            .await;
-        assert!(result.is_err());
-        Ok(())
     }
 
     #[test]
@@ -1712,40 +1335,6 @@ mod tests {
         let actual = df.collect().await.unwrap();
 
         assert_eq!(actual.len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_check_nullability() -> DeltaResult<()> {
-        use arrow::array::StringArray;
-
-        let data_checker = DeltaDataChecker {
-            non_nullable_columns: vec!["zed".to_string(), "yap".to_string()],
-            ..Default::default()
-        };
-
-        let arr: Arc<dyn Array> = Arc::new(StringArray::from(vec!["s"]));
-        let nulls: Arc<dyn Array> = Arc::new(StringArray::new_null(1));
-        let batch = RecordBatch::try_from_iter(vec![("a", arr), ("zed", nulls)]).unwrap();
-
-        let result = data_checker.check_nullability(&batch);
-        assert!(
-            result.is_err(),
-            "The result should have errored! {result:?}"
-        );
-
-        let arr: Arc<dyn Array> = Arc::new(StringArray::from(vec!["s"]));
-        let batch = RecordBatch::try_from_iter(vec![("zed", arr)]).unwrap();
-        let result = data_checker.check_nullability(&batch);
-        assert!(
-            result.is_err(),
-            "The result should have errored! {result:?}"
-        );
-
-        let arr: Arc<dyn Array> = Arc::new(StringArray::from(vec!["s"]));
-        let batch = RecordBatch::try_from_iter(vec![("zed", arr.clone()), ("yap", arr)]).unwrap();
-        let _ = data_checker.check_nullability(&batch)?;
-
-        Ok(())
     }
 
     #[tokio::test]

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -60,6 +60,30 @@ pub enum SnapshotWrapper {
     EagerSnapshot(Arc<EagerSnapshot>),
 }
 
+impl From<Arc<Snapshot>> for SnapshotWrapper {
+    fn from(snap: Arc<Snapshot>) -> Self {
+        SnapshotWrapper::Snapshot(snap)
+    }
+}
+
+impl From<Snapshot> for SnapshotWrapper {
+    fn from(snap: Snapshot) -> Self {
+        SnapshotWrapper::Snapshot(snap.into())
+    }
+}
+
+impl From<Arc<EagerSnapshot>> for SnapshotWrapper {
+    fn from(esnap: Arc<EagerSnapshot>) -> Self {
+        SnapshotWrapper::EagerSnapshot(esnap)
+    }
+}
+
+impl From<EagerSnapshot> for SnapshotWrapper {
+    fn from(esnap: EagerSnapshot) -> Self {
+        SnapshotWrapper::EagerSnapshot(esnap.into())
+    }
+}
+
 impl SnapshotWrapper {
     fn table_configuration(&self) -> &TableConfiguration {
         match self {
@@ -87,7 +111,8 @@ pub struct DeltaScan {
 
 impl DeltaScan {
     // create new delta scan
-    pub fn new(snapshot: SnapshotWrapper, config: DeltaScanConfig) -> Result<Self> {
+    pub fn new(snapshot: impl Into<SnapshotWrapper>, config: DeltaScanConfig) -> Result<Self> {
+        let snapshot = snapshot.into();
         let scan_schema = config.table_schema(snapshot.table_configuration())?;
         let full_schema = if config.retain_file_id() {
             let mut fields = scan_schema.fields().to_vec();

--- a/crates/core/src/operations/constraints.rs
+++ b/crates/core/src/operations/constraints.rs
@@ -4,16 +4,18 @@ use std::sync::Arc;
 
 use datafusion::catalog::Session;
 use datafusion::common::ToDFSchema;
-use datafusion::execution::SendableRecordBatchStream;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::execute_stream;
 use delta_kernel::table_features::TableFeature;
-use futures::StreamExt;
+use futures::StreamExt as _;
 use futures::future::BoxFuture;
 
 use super::datafusion_utils::into_expr;
 use super::{CustomExecuteHandler, Operation};
 use crate::delta_datafusion::expr::fmt_expr_to_sql;
-use crate::delta_datafusion::{DeltaDataChecker, DeltaScanBuilder, create_session, register_store};
+use crate::delta_datafusion::{
+    DataValidationExec, DeltaScanNext, constraints_to_exprs, create_session,
+    update_datafusion_session,
+};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{
     EagerSnapshot, MetadataExt, ProtocolExt as _, ProtocolInner, resolve_snapshot,
@@ -147,13 +149,16 @@ impl std::future::IntoFuture for ConstraintBuilder {
             let session = this
                 .session
                 .unwrap_or_else(|| Arc::new(create_session().into_inner().state()));
-            register_store(this.log_store.clone(), session.runtime_env().as_ref());
+            update_datafusion_session(
+                this.log_store.as_ref(),
+                session.as_ref(),
+                Some(operation_id),
+            )?;
 
-            let scan = DeltaScanBuilder::new(&snapshot, this.log_store.clone(), session.as_ref())
-                .build()
+            let proivider = DeltaScanNext::builder()
+                .with_eager_snapshot(snapshot.clone())
                 .await?;
-
-            let schema = scan.schema().to_dfschema()?;
+            let schema = proivider.schema().to_dfschema()?;
 
             // Create an Hashmap of the name to the processed expression
             let mut constraints_sql_mapper = HashMap::with_capacity(this.check_constraints.len());
@@ -186,32 +191,20 @@ impl std::future::IntoFuture for ConstraintBuilder {
                 .map(|sql| Constraint::new("*", sql))
                 .collect();
 
-            // Checker built here with the one time constraint to check.
-            let checker = DeltaDataChecker::new_with_constraints(constraints_checker);
-            let plan: Arc<dyn ExecutionPlan> = Arc::new(scan);
-            let mut tasks = vec![];
-            for p in 0..plan.properties().output_partitioning().partition_count() {
-                let inner_plan = plan.clone();
-                let inner_checker = checker.clone();
-                let mut record_stream: SendableRecordBatchStream =
-                    inner_plan.execute(p, session.task_ctx())?;
-                let handle: tokio::task::JoinHandle<DeltaResult<()>> =
-                    tokio::task::spawn(async move {
-                        while let Some(maybe_batch) = record_stream.next().await {
-                            let batch = maybe_batch?;
-                            inner_checker.check_batch(&batch).await?;
-                        }
-                        Ok(())
-                    });
-                tasks.push(handle);
+            let plan = DataValidationExec::try_new_with_predicates(
+                session.as_ref(),
+                proivider.scan(session.as_ref(), None, &[], None).await?,
+                constraints_to_exprs(session.as_ref(), &schema, &constraints_checker)?,
+            )?;
+
+            // We must not just try to collect the plan here, because that would load
+            // everything into memory. Instead we stream the results and discard them.
+            let mut result_stream = execute_stream(plan, session.task_ctx())?;
+            while let Some(maybe_batch) = result_stream.next().await {
+                // No need to do anything with the data, if we get data back it means
+                // the constraints are satisfied. We do want to propagate any errors though.
+                let _result = maybe_batch?;
             }
-            futures::future::join_all(tasks)
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|err| DeltaTableError::Generic(err.to_string()))?
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()?;
 
             // We have validated the table passes it's constraints, now to add the constraint to
             // the table.

--- a/python/src/query.rs
+++ b/python/src/query.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use deltalake::{
     datafusion::{catalog::TableProvider, prelude::SessionContext},
-    delta_datafusion::{DeltaScanConfig, DeltaScanNext, DeltaSessionContext, SnapshotWrapper},
+    delta_datafusion::{DeltaScanConfig, DeltaScanNext, DeltaSessionContext},
 };
 use pyo3::prelude::*;
 use pyo3_arrow::PyRecordBatchReader;
@@ -43,10 +43,8 @@ impl PyQueryBuilder {
             .register_object_store(url, log_store.root_object_store(None));
 
         let config = DeltaScanConfig::new().with_wrap_partition_values(false);
-        let snapshot_wrapped = SnapshotWrapper::EagerSnapshot(Arc::new(snapshot));
-        let provider =
-            Arc::new(DeltaScanNext::new(snapshot_wrapped, config).map_err(PythonError::from)?)
-                as Arc<dyn TableProvider>;
+        let provider = Arc::new(DeltaScanNext::new(snapshot, config).map_err(PythonError::from)?)
+            as Arc<dyn TableProvider>;
 
         self.ctx
             .register_table(table_name, provider)

--- a/python/tests/pyspark_integration/test_write_to_pyspark.py
+++ b/python/tests/pyspark_integration/test_write_to_pyspark.py
@@ -8,7 +8,6 @@ from arro3.core import Array, DataType, Table
 from arro3.core import Field as ArrowField
 
 from deltalake import DeltaTable, write_deltalake
-from deltalake.exceptions import DeltaProtocolError
 
 from .utils import assert_spark_read_equal, get_spark, run_stream_with_checkpoint
 
@@ -91,9 +90,7 @@ def test_write_invariant(tmp_path: pathlib.Path):
         }
     )
 
-    with pytest.raises(
-        DeltaProtocolError, match=r"Invariant \(c1 > 3\) violated by value .+2"
-    ):
+    with pytest.raises(Exception, match="Invalid data found:"):
         # raise DeltaProtocolError("test")
         write_deltalake(str(tmp_path), invalid_data, mode="overwrite")
 

--- a/python/tests/test_alter.py
+++ b/python/tests/test_alter.py
@@ -5,7 +5,7 @@ import pytest
 from arro3.core import Array, DataType, Field, Schema, Table
 
 from deltalake import CommitProperties, DeltaTable, TableFeatures, write_deltalake
-from deltalake.exceptions import DeltaError, DeltaProtocolError
+from deltalake.exceptions import DeltaError
 from deltalake.schema import Field as DeltaField
 from deltalake.schema import PrimitiveType, StructType
 
@@ -32,7 +32,7 @@ def test_add_constraint(tmp_path: pathlib.Path, sample_table: Table):
         # Invalid constraint
         dt.alter.add_constraint({"check_price": "price < 0"})
 
-    with pytest.raises(DeltaProtocolError):
+    with pytest.raises(Exception):
         data = Table(
             {
                 "id": Array(["1"], DataType.string()),

--- a/python/tests/test_constraint.py
+++ b/python/tests/test_constraint.py
@@ -2,7 +2,7 @@ import pytest
 from arro3.core import Array, DataType, Field, Schema, Table
 
 from deltalake import DeltaTable, write_deltalake
-from deltalake.exceptions import DeltaError, DeltaProtocolError
+from deltalake.exceptions import DeltaError
 
 
 @pytest.fixture()
@@ -110,7 +110,7 @@ def test_add_constraint(tmp_path, sample_table: Table, sql_string: str):
         # Invalid constraint
         dt.alter.add_constraint({"check_price": '"high price" < 0'})
 
-    with pytest.raises(DeltaProtocolError):
+    with pytest.raises(Exception):
         data = Table(
             {
                 "id": Array(["1"], DataType.string()),
@@ -143,7 +143,7 @@ def test_add_multiple_constraint(tmp_path, sample_table: Table):
     }
     assert dt.protocol().min_writer_version == 3
 
-    with pytest.raises(DeltaProtocolError):
+    with pytest.raises(Exception):
         data = Table(
             {
                 "id": Array(["1"], DataType.string()),

--- a/python/tests/test_generated_columns.py
+++ b/python/tests/test_generated_columns.py
@@ -124,10 +124,8 @@ def test_write_with_invalid_gc(tmp_path, invalid_gc_data):
     import re
 
     with pytest.raises(
-        DeltaError,
-        match=re.escape(
-            'Invariant violations: ["Check or Invariant (gc <=> 10) violated by value in row: [5]"]'
-        ),
+        Exception,
+        match=re.escape("Invalid data found: 1 rows failed validation check."),
     ):
         write_deltalake(tmp_path, mode="append", data=invalid_gc_data)
 
@@ -136,10 +134,8 @@ def test_write_with_invalid_gc_to_table(table_with_gc, invalid_gc_data):
     import re
 
     with pytest.raises(
-        DeltaError,
-        match=re.escape(
-            'Invariant violations: ["Check or Invariant (gc <=> 5) violated by value in row: [10]"]'
-        ),
+        Exception,
+        match=re.escape("Invalid data found: 1 rows failed validation check."),
     ):
         write_deltalake(table_with_gc, mode="append", data=invalid_gc_data)
 
@@ -301,10 +297,8 @@ def test_merge_with_gc_invalid(table_with_gc: DeltaTable, invalid_gc_data):
     import re
 
     with pytest.raises(
-        DeltaError,
-        match=re.escape(
-            'Invariant violations: ["Check or Invariant (gc <=> 5) violated by value in row: [10]"]'
-        ),
+        Exception,
+        match=re.escape("Invalid data found: 1 rows failed validation check."),
     ):
         (
             table_with_gc.merge(

--- a/python/tests/test_lakefs.py
+++ b/python/tests/test_lakefs.py
@@ -9,7 +9,7 @@ from arro3.core import Field as ArrowField
 
 from deltalake import CommitProperties, DeltaTable, TableFeatures
 from deltalake._internal import Field, PrimitiveType, Schema
-from deltalake.exceptions import DeltaError, DeltaProtocolError
+from deltalake.exceptions import DeltaError
 from deltalake.query import QueryBuilder
 from deltalake.writer import write_deltalake
 from tests.test_alter import _sort_fields
@@ -265,7 +265,7 @@ def test_add_constraint(lakefs_path, sample_table: Table, lakefs_storage_options
         # Invalid constraint
         dt.alter.add_constraint({"check_price": "price < 0"})
 
-    with pytest.raises(DeltaProtocolError):
+    with pytest.raises(Exception, match="Invalid data found:"):
         data = Table(
             {
                 "id": Array(

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -14,7 +14,6 @@ from deltalake import (
     Schema,
     write_deltalake,
 )
-from deltalake.exceptions import DeltaProtocolError
 from deltalake.query import QueryBuilder
 from deltalake.schema import PrimitiveType
 
@@ -2257,10 +2256,8 @@ def test_merge_non_nullable(tmp_path):
     )
 
     with pytest.raises(
-        DeltaProtocolError,
-        match=re.escape(
-            'Invariant violations: ["Non-nullable column violation for bool, found 1 null values"]'
-        ),
+        Exception,
+        match=re.escape("Invalid data found:"),
     ):
         dt.merge(
             source=df,

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -22,7 +22,6 @@ from deltalake._internal import (
 )
 from deltalake.exceptions import (
     DeltaError,
-    DeltaProtocolError,
     SchemaMismatchError,
 )
 from deltalake.query import QueryBuilder
@@ -1169,7 +1168,7 @@ def test_partition_overwrite(
         )
         == expected_data
     )
-    with pytest.raises(DeltaProtocolError, match="Invariant violations"):
+    with pytest.raises(Exception, match="Invalid data found:"):
         write_deltalake(
             tmp_path,
             sample_data_pyarrow,
@@ -1460,8 +1459,8 @@ def test_partition_overwrite_with_wrong_partition(
     )
 
     with pytest.raises(
-        DeltaProtocolError,
-        match="Invariant violations",
+        Exception,
+        match="Invalid data found: 1 rows failed validation check.",
     ):
         write_deltalake(
             tmp_path,


### PR DESCRIPTION
# Description

Moves data validation into a Datafusion execution plan and associated stream. We make this change in the hopes of fully leveraging Datafusion's execution model and more seamlessly integrating validation in other code paths.

We now compile all collected predicates we need to evaluate into a single, optimised physical predicate. This however means, we do loose the ability to track back failures to individual predicates.