### PR TITLE
feat: datafusion native kernel engine

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -48,6 +48,7 @@ strum = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, default-features = false, features = ["clock"] }
 regex = { workspace = true }
+reqwest = { version = "0.12", default-features = false }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 url = { workspace = true, features = ["serde"] }

--- a/crates/core/src/delta_datafusion/engine/mod.rs
+++ b/crates/core/src/delta_datafusion/engine/mod.rs
@@ -2,21 +2,42 @@ use std::sync::Arc;
 
 use datafusion::catalog::Session;
 use datafusion::execution::TaskContext;
-use delta_kernel::{Engine, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler};
+use delta_kernel::{
+    DeltaResult, Engine, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler,
+};
+use futures::{StreamExt as _, stream::BoxStream};
 use tokio::runtime::Handle;
+use tracing::Instrument;
+use url::Url;
 
 pub(crate) use self::expressions::*;
 use self::file_formats::DataFusionFileFormatHandler;
-pub use self::storage::AsObjectStoreUrl;
-use self::storage::DataFusionStorageHandler;
+pub use self::storage::{AsObjectStoreUrl, DataFusionStorageHandler};
 use crate::kernel::ARROW_HANDLER;
 
 mod expressions;
 mod file_formats;
 mod storage;
 
+#[derive(Clone, Debug)]
+pub struct TracedHandle(Handle);
+
+impl From<Handle> for TracedHandle {
+    fn from(handle: Handle) -> Self {
+        TracedHandle(handle)
+    }
+}
+
+impl TracedHandle {
+    fn block_on<F: std::future::Future>(&self, future: F) -> F::Output {
+        let current_span = tracing::Span::current();
+        let task = async move { future.instrument(current_span).await };
+        self.0.block_on(task)
+    }
+}
+
 /// A Datafusion based Kernel Engine
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DataFusionEngine {
     storage: Arc<DataFusionStorageHandler>,
     formats: Arc<DataFusionFileFormatHandler>,
@@ -31,7 +52,8 @@ impl DataFusionEngine {
         Self::new(ctx, Handle::current()).into()
     }
 
-    pub fn new(ctx: Arc<TaskContext>, handle: Handle) -> Self {
+    pub fn new(ctx: Arc<TaskContext>, handle: impl Into<TracedHandle>) -> Self {
+        let handle = handle.into();
         let storage = Arc::new(DataFusionStorageHandler::new(ctx.clone(), handle.clone()));
         let formats = Arc::new(DataFusionFileFormatHandler::new(ctx, handle));
         Self { storage, formats }
@@ -53,5 +75,79 @@ impl Engine for DataFusionEngine {
 
     fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
         self.formats.clone()
+    }
+}
+
+/// Converts a Stream-producing future to a synchronous iterator.
+///
+/// This method performs the initial blocking call to extract the stream from the future, and each
+/// subsequent call to `next` on the iterator translates to a blocking `stream.next()` call, using
+/// the provided `task_executor`. Buffered streams allow concurrency in the form of prefetching,
+/// because that initial call will attempt to populate the N buffer slots; every call to
+/// `stream.next()` leaves an empty slot (out of N buffer slots) that the stream immediately
+/// attempts to fill by launching another future that can make progress in the background while we
+/// block on and consume each of the N-1 entries that precede it.
+///
+/// This is an internal utility for bridging object_store's async API to
+/// Delta Kernel's synchronous handler traits.
+pub(crate) fn stream_future_to_iter<T: Send + 'static>(
+    handle: TracedHandle,
+    stream_future: impl Future<Output = DeltaResult<BoxStream<'static, T>>> + Send + 'static,
+) -> DeltaResult<Box<dyn Iterator<Item = T> + Send>> {
+    Ok(Box::new(BlockingStreamIterator {
+        stream: Some(handle.block_on(stream_future)?),
+        handle,
+    }))
+}
+
+struct BlockingStreamIterator<T: Send + 'static> {
+    stream: Option<BoxStream<'static, T>>,
+    handle: TracedHandle,
+}
+
+impl<T: Send + 'static> Iterator for BlockingStreamIterator<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Move the stream into the future so we can block on it.
+        let mut stream = self.stream.take()?;
+        let task = async move { (stream.next().await, stream) };
+        let (item, stream) = self.handle.block_on(task);
+
+        // We must not poll an exhausted stream after it returned None.
+        if item.is_some() {
+            self.stream = Some(stream);
+        }
+
+        item
+    }
+}
+
+trait UrlExt {
+    // Check if a given url is a presigned url and can be used
+    // to access the object store via simple http requests
+    fn is_presigned(&self) -> bool;
+}
+
+impl UrlExt for Url {
+    fn is_presigned(&self) -> bool {
+        matches!(self.scheme(), "http" | "https")
+            && (
+                // https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+                // https://developers.cloudflare.com/r2/api/s3/presigned-urls/
+                self
+                .query_pairs()
+                .any(|(k, _)| k.eq_ignore_ascii_case("X-Amz-Signature")) ||
+                // https://learn.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas#version-2020-12-06-and-later
+                // note signed permission (sp) must always be present
+                self
+                .query_pairs().any(|(k, _)| k.eq_ignore_ascii_case("sp")) ||
+                // https://cloud.google.com/storage/docs/authentication/signatures
+                self
+                .query_pairs().any(|(k, _)| k.eq_ignore_ascii_case("X-Goog-Credential")) ||
+                // https://www.alibabacloud.com/help/en/oss/user-guide/upload-files-using-presigned-urls
+                self
+                .query_pairs().any(|(k, _)| k.eq_ignore_ascii_case("X-OSS-Credential"))
+            )
     }
 }

--- a/crates/core/src/delta_datafusion/engine/storage.rs
+++ b/crates/core/src/delta_datafusion/engine/storage.rs
@@ -1,109 +1,251 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
-use dashmap::DashMap;
-use dashmap::mapref::one::Ref;
 use datafusion::execution::TaskContext;
-use datafusion::execution::object_store::{ObjectStoreRegistry, ObjectStoreUrl};
-use delta_kernel::engine::default::executor::tokio::{
-    TokioBackgroundExecutor, TokioMultiThreadExecutor,
-};
-use delta_kernel::engine::default::filesystem::ObjectStoreStorageHandler;
-use delta_kernel::{DeltaResult, Error as DeltaError, FileMeta, FileSlice, StorageHandler};
+use datafusion::execution::object_store::ObjectStoreUrl;
+use delta_kernel::{DeltaResult, Error, FileMeta, FileSlice, StorageHandler};
+use futures::TryStreamExt as _;
+use futures::stream::{self, BoxStream, StreamExt};
 use itertools::Itertools;
-use tokio::runtime::{Handle, RuntimeFlavor};
+use object_store::path::Path;
+use object_store::{DynObjectStore, ObjectStore, PutMode};
+use tracing::instrument;
 use url::Url;
 
-#[derive(Clone)]
+use crate::delta_datafusion::engine::{TracedHandle, UrlExt as _};
+
+#[derive(Debug, Clone)]
 pub struct DataFusionStorageHandler {
-    /// Object store registry shared with datafusion session
     ctx: Arc<TaskContext>,
-    /// Registry of object store handlers
-    registry: Arc<DashMap<ObjectStoreUrl, Arc<dyn StorageHandler>>>,
-    /// The executor to run async tasks on
-    handle: Handle,
+    task_executor: TracedHandle,
+    readahead: usize,
 }
 
 impl DataFusionStorageHandler {
-    /// Create a new [`DataFusionStorageHandler`] instance.
-    pub fn new(ctx: Arc<TaskContext>, handle: Handle) -> Self {
+    pub(crate) fn new(ctx: Arc<TaskContext>, task_executor: TracedHandle) -> Self {
         Self {
             ctx,
-            registry: DashMap::new().into(),
-            handle,
+            task_executor,
+            readahead: 10,
         }
     }
 
-    fn registry(&self) -> Arc<dyn ObjectStoreRegistry> {
-        self.ctx.runtime_env().object_store_registry.clone()
-    }
-
-    fn get_or_create(
-        &self,
-        url: ObjectStoreUrl,
-    ) -> DeltaResult<Ref<'_, ObjectStoreUrl, Arc<dyn StorageHandler>>> {
-        if let Some(handler) = self.registry.get(&url) {
-            return Ok(handler);
-        }
-        let store = self
-            .registry()
-            .get_store(url.as_ref())
-            .map_err(DeltaError::generic_err)?;
-
-        let handler: Arc<dyn StorageHandler> = match self.handle.runtime_flavor() {
-            RuntimeFlavor::MultiThread => Arc::new(ObjectStoreStorageHandler::new(
-                store,
-                Arc::new(TokioMultiThreadExecutor::new(self.handle.clone())),
-                None,
-            )),
-            RuntimeFlavor::CurrentThread => Arc::new(ObjectStoreStorageHandler::new(
-                store,
-                Arc::new(TokioBackgroundExecutor::new()),
-                None,
-            )),
-            _ => panic!("unsupported runtime flavor"),
-        };
-
-        self.registry.insert(url.clone(), handler);
-        Ok(self.registry.get(&url).unwrap())
+    /// Set the maximum number of files to read in parallel.
+    pub fn with_readahead(mut self, readahead: usize) -> Self {
+        self.readahead = readahead;
+        self
     }
 }
 
+/// Native async implementation for list_from
+async fn list_from_impl(
+    store: Arc<DynObjectStore>,
+    path: Url,
+) -> DeltaResult<BoxStream<'static, DeltaResult<FileMeta>>> {
+    // The offset is used for list-after; the prefix is used to restrict the listing to a specific directory.
+    // Unfortunately, `Path` provides no easy way to check whether a name is directory-like,
+    // because it strips trailing /, so we're reduced to manually checking the original URL.
+    let offset = Path::from_url_path(path.path())?;
+    let prefix = if path.path().ends_with('/') {
+        offset.clone()
+    } else {
+        let mut parts = offset.parts().collect_vec();
+        if parts.pop().is_none() {
+            return Err(Error::Generic(format!(
+                "Offset path must not be a root directory. Got: '{path}'",
+            )));
+        }
+        Path::from_iter(parts)
+    };
+
+    // HACK to check if we're using a LocalFileSystem from ObjectStore. We need this because
+    // local filesystem doesn't return a sorted list by default. Although the `object_store`
+    // crate explicitly says it _does not_ return a sorted listing, in practice all the cloud
+    // implementations actually do:
+    // - AWS:
+    //   [`ListObjectsV2`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html)
+    //   states: "For general purpose buckets, ListObjectsV2 returns objects in lexicographical
+    //   order based on their key names." (Directory buckets are out of scope for now)
+    // - Azure: Docs state
+    //   [here](https://learn.microsoft.com/en-us/rest/api/storageservices/enumerating-blob-resources):
+    //   "A listing operation returns an XML response that contains all or part of the requested
+    //   list. The operation returns entities in alphabetical order."
+    // - GCP: The [main](https://cloud.google.com/storage/docs/xml-api/get-bucket-list) doc
+    //   doesn't indicate order, but [this
+    //   page](https://cloud.google.com/storage/docs/xml-api/get-bucket-list) does say: "This page
+    //   shows you how to list the [objects](https://cloud.google.com/storage/docs/objects) stored
+    //   in your Cloud Storage buckets, which are ordered in the list lexicographically by name."
+    // So we just need to know if we're local and then if so, we sort the returned file list
+    let has_ordered_listing = path.scheme() != "file";
+
+    let stream = store
+        .list_with_offset(Some(&prefix), &offset)
+        .map(move |meta| {
+            let meta = meta?;
+            let mut location = path.clone();
+            location.set_path(&format!("/{}", meta.location.as_ref()));
+            Ok::<_, Error>(FileMeta {
+                location,
+                last_modified: meta.last_modified.timestamp_millis(),
+                size: meta.size,
+            })
+        });
+
+    if !has_ordered_listing {
+        // Local filesystem doesn't return sorted list - need to collect and sort
+        let mut items: Vec<_> = stream.try_collect().await?;
+        items.sort_unstable();
+        Ok(Box::pin(stream::iter(items.into_iter().map(Ok))) as _)
+    } else {
+        Ok(Box::pin(stream))
+    }
+}
+
+/// Native async implementation for read_files
+async fn read_files_impl(
+    store: Arc<DynObjectStore>,
+    files: Vec<FileSlice>,
+    readahead: usize,
+) -> DeltaResult<BoxStream<'static, DeltaResult<Bytes>>> {
+    let files = stream::iter(files).map(move |(url, range)| {
+        let store = store.clone();
+        async move {
+            // Wasn't checking the scheme before calling to_file_path causing the url path to
+            // be eaten in a strange way. Now, if not a file scheme, just blindly convert to a path.
+            // https://docs.rs/url/latest/url/struct.Url.html#method.to_file_path has more
+            // details about why this check is necessary
+            let path = if url.scheme() == "file" {
+                let file_path = url
+                    .to_file_path()
+                    .map_err(|_| Error::InvalidTableLocation(format!("Invalid file URL: {url}")))?;
+                Path::from_absolute_path(file_path)
+                    .map_err(|e| Error::InvalidTableLocation(format!("Invalid file path: {e}")))?
+            } else {
+                Path::from(url.path())
+            };
+            if url.is_presigned() {
+                // have to annotate type here or rustc can't figure it out
+                Ok::<bytes::Bytes, Error>(reqwest::get(url).await?.bytes().await?)
+            } else if let Some(rng) = range {
+                Ok(store.get_range(&path, rng).await?)
+            } else {
+                let result = store.get(&path).await?;
+                Ok(result.bytes().await?)
+            }
+        }
+    });
+
+    // We allow executing up to `readahead` futures concurrently and
+    // buffer the results. This allows us to achieve async concurrency.
+    Ok(Box::pin(files.buffered(readahead)))
+}
+
+/// Native async implementation for copy_atomic
+async fn copy_atomic_impl(
+    store: Arc<DynObjectStore>,
+    src_path: Path,
+    dest_path: Path,
+) -> DeltaResult<()> {
+    // Read source file then write atomically with PutMode::Create. Note that a GET/PUT is not
+    // necessarily atomic, but since the source file is immutable, we aren't exposed to the
+    // possibility of source file changing while we do the PUT.
+    let data = store.get(&src_path).await?.bytes().await?;
+    let result = store
+        .put_opts(&dest_path, data.into(), PutMode::Create.into())
+        .await;
+
+    result.map_err(|e| match e {
+        object_store::Error::AlreadyExists { .. } => Error::FileAlreadyExists(dest_path.into()),
+        e => e.into(),
+    })?;
+    Ok(())
+}
+
+/// Native async implementation for head
+async fn head_impl(store: Arc<DynObjectStore>, url: Url) -> DeltaResult<FileMeta> {
+    let meta = store.head(&Path::from_url_path(url.path())?).await?;
+    Ok(FileMeta {
+        location: url,
+        last_modified: meta.last_modified.timestamp_millis(),
+        size: meta.size,
+    })
+}
+
 impl StorageHandler for DataFusionStorageHandler {
+    #[instrument(skip(self))]
     fn list_from(
         &self,
         path: &Url,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
-        self.get_or_create(path.as_object_store_url())?
-            .list_from(path)
+        let store_url = path.as_object_store_url();
+        let store = self
+            .ctx
+            .runtime_env()
+            .object_store(store_url)
+            .map_err(Error::generic_err)?;
+        let future = list_from_impl(store, path.clone());
+        let iter = super::stream_future_to_iter(self.task_executor.clone(), future)?;
+        Ok(iter) // type coercion drops the unneeded Send bound
     }
 
+    /// Read data specified by the start and end offset from the file.
+    ///
+    /// This will return the data in the same order as the provided file slices.
+    ///
+    /// Multiple reads may occur in parallel, depending on the configured readahead.
+    /// See [`Self::with_readahead`].
+    #[instrument(skip(self))]
     fn read_files(
         &self,
         files: Vec<FileSlice>,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
-        let grouped_files = group_by_store(files);
-        Ok(Box::new(
-            grouped_files
-                .into_iter()
-                .map(|(url, files)| self.get_or_create(url)?.read_files(files))
-                // TODO: this should not do any blocking operations, since this should
-                // happen when the iterators are polled and we are just creating a vec of iterators.
-                // Is this correct?
-                .try_collect::<_, Vec<_>, _>()?
-                .into_iter()
-                .flatten(),
-        ))
+        if files.is_empty() {
+            return Ok(Box::new(std::iter::empty()));
+        }
+        let store_url = files
+            .first()
+            .expect("files is not empty")
+            .0
+            .as_object_store_url();
+        let store = self
+            .ctx
+            .runtime_env()
+            .object_store(store_url)
+            .map_err(Error::generic_err)?;
+
+        let future = read_files_impl(store, files, self.readahead);
+        let iter = super::stream_future_to_iter(self.task_executor.clone(), future)?;
+        Ok(iter) // type coercion drops the unneeded Send bound
     }
 
-    fn copy_atomic(&self, _from: &Url, _to: &Url) -> DeltaResult<()> {
-        // TODO: Implement atomic copy operation
-        Err(delta_kernel::Error::generic("copy_atomic not implemented"))
+    #[instrument(skip(self))]
+    fn copy_atomic(&self, src: &Url, dest: &Url) -> DeltaResult<()> {
+        let store_url = src.as_object_store_url();
+        let store = self
+            .ctx
+            .runtime_env()
+            .object_store(store_url)
+            .map_err(Error::generic_err)?;
+
+        let src_path = Path::from_url_path(src.path())?;
+        let dest_path = Path::from_url_path(dest.path())?;
+        let future = copy_atomic_impl(store, src_path, dest_path);
+
+        self.task_executor.block_on(future)
     }
 
-    fn head(&self, _path: &Url) -> DeltaResult<FileMeta> {
-        // TODO: Implement atomic copy operation
-        Err(delta_kernel::Error::generic("head not implemented"))
+    #[instrument(skip(self))]
+    fn head(&self, path: &Url) -> DeltaResult<FileMeta> {
+        let store_url = path.as_object_store_url();
+        let store = self
+            .ctx
+            .runtime_env()
+            .object_store(store_url)
+            .map_err(Error::generic_err)?;
+
+        let future = head_impl(store, path.clone());
+
+        self.task_executor.block_on(future)
     }
 }
 
@@ -147,15 +289,6 @@ fn get_store_url(url: &url::Url) -> ObjectStoreUrl {
     .unwrap()
 }
 
-pub(crate) fn group_by_store<T: IntoIterator<Item = impl AsObjectStoreUrl>>(
-    files: T,
-) -> std::collections::HashMap<ObjectStoreUrl, Vec<T::Item>> {
-    files
-        .into_iter()
-        .map(|item| (item.as_object_store_url(), item))
-        .into_group_map()
-}
-
 #[cfg(test)]
 mod tests {
     use std::ops::Range;
@@ -163,6 +296,7 @@ mod tests {
     use datafusion::prelude::SessionContext;
     use object_store::{ObjectStore, local::LocalFileSystem, path::Path};
     use rstest::*;
+    use tokio::runtime::Handle;
 
     use crate::test_utils::TestResult;
 
@@ -173,7 +307,7 @@ mod tests {
         let session = SessionContext::new();
         let ctx = session.task_ctx();
 
-        DataFusionStorageHandler::new(ctx, handle)
+        DataFusionStorageHandler::new(ctx, TracedHandle(handle))
     }
 
     pub fn delta_path_for_version(version: u64, suffix: &str) -> Path {


### PR DESCRIPTION
# Description

This PR updates our datafusion engine implementation to make use of datafusion execution plants also in the parquet and json handler.

Since we are using the engine only during the metadata phase, we do no longer handle the case where files may be located in multiple stores. This is still of course handled when plan a scan.