### PR TITLE
refactor!: more logical writes

### DIFF
--- a/crates/core/src/kernel/schema/cast/merge_schema.rs
+++ b/crates/core/src/kernel/schema/cast/merge_schema.rs
@@ -287,12 +287,12 @@ pub(crate) fn merge_arrow_field(
 }
 
 /// Merges Arrow Table schema and Arrow Batch Schema, by allowing Large/View Types to passthrough.
-// Sometimes fields can't be merged because they are not the same types. So table has int32,
-// but batch int64. We want the preserve the table type. At later stage we will call cast_record_batch
-// which will cast the batch int64->int32. This is desired behavior so we can have flexibility
-// in the batch data types. But preserve the correct table and parquet types.
-//
-// Preserve_new_fields can also be disabled if you just want to only use the passthrough functionality
+/// Sometimes fields can't be merged because they are not the same types. So table has int32,
+/// but batch int64. We want the preserve the table type. At later stage we will call cast_record_batch
+/// which will cast the batch int64->int32. This is desired behavior so we can have flexibility
+/// in the batch data types. But preserve the correct table and parquet types.
+///
+/// Preserve_new_fields can also be disabled if you just want to only use the passthrough functionality
 pub(crate) fn merge_arrow_schema(
     table_schema: ArrowSchemaRef,
     batch_schema: ArrowSchemaRef,

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -380,11 +380,11 @@ mod local {
         // Build a new context from scratch and deserialize the plan
         let ctx = create_session().into_inner();
         let state = ctx.state();
-        let source_scan = Arc::new(logical_plan_from_bytes_with_extension_codec(
+        let source_scan = logical_plan_from_bytes_with_extension_codec(
             &source_scan_bytes,
             &ctx.task_ctx(),
             &DeltaLogicalCodec {},
-        )?);
+        )?;
         let schema: StructType = source_scan.schema().as_arrow().try_into_kernel().unwrap();
         let fields = schema.fields().cloned();
 
@@ -400,7 +400,7 @@ mod local {
             target_table.log_store(),
             target_table.snapshot().ok().map(|s| s.snapshot()).cloned(),
         )
-        .with_input_execution_plan(source_scan)
+        .with_input_plan(source_scan)
         .with_session_state(Arc::new(state))
         .await?;
         target_table.update_datafusion_session(&ctx.state())?;
@@ -1286,16 +1286,15 @@ mod local {
             );
         let tbl = tbl.await.unwrap();
         let ctx = SessionContext::new();
-        let plan = Arc::new(
-            ctx.sql("SELECT 1 as id")
-                .await
-                .unwrap()
-                .logical_plan()
-                .clone(),
-        );
+        let plan = ctx
+            .sql("SELECT 1 as id")
+            .await
+            .unwrap()
+            .logical_plan()
+            .clone();
         let write_builder = WriteBuilder::new(log_store, tbl.state.map(|s| s.snapshot().clone()));
         let _ = write_builder
-            .with_input_execution_plan(plan)
+            .with_input_plan(plan)
             .with_save_mode(SaveMode::Overwrite)
             .with_schema_mode(deltalake_core::operations::write::SchemaMode::Overwrite)
             .await

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1778,7 +1778,7 @@ impl RawDeltaTable {
                 .build()
                 .map_err(PythonError::from)?;
 
-            builder = builder.with_input_execution_plan(Arc::new(plan));
+            builder = builder.with_input_plan(plan);
 
             if let Some(schema_mode) = schema_mode {
                 builder = builder.with_schema_mode(schema_mode.parse().map_err(PythonError::from)?);


### PR DESCRIPTION
# Description

It seems we may have found an avenue into moving further into logical planning that does not break stuff 😆. This PR updates the write operation to no longer make use of `DataFrame` and use logical plans.

Turns out that handling generated columns is a significant part of this. I'll try and remove the the usage of current gc-related function in a follow-up. This touches merge though, so keeping it separate.


