### PR TITLE
feat: enable deletion vector features for working with tables

### DIFF
--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -144,14 +144,14 @@ mod local {
             .with_columns(table_schema.fields().cloned())
             .with_partition_columns(partitions)
             .await
-            .unwrap();
+            .expect("Failed to create table");
 
         for batch in batches {
             table = table
                 .write(vec![batch])
                 .with_save_mode(save_mode)
                 .await
-                .unwrap();
+                .expect("Failed to prepare when writing");
         }
 
         (table_dir, table)

--- a/python/tests/test_create.py
+++ b/python/tests/test_create.py
@@ -80,7 +80,6 @@ def test_create_schema(tmp_path: pathlib.Path):
     assert dt.schema() == schema
 
 
-@pytest.mark.skip(reason="not implemented")
 def test_create_with_deletion_vectors_enabled(tmp_path: pathlib.Path):
     """append only is set to false so shouldn't be converted to a feature"""
     dt = DeltaTable.create(
@@ -105,8 +104,8 @@ def test_create_with_deletion_vectors_enabled(tmp_path: pathlib.Path):
     }
     assert protocol.min_reader_version == 3
     assert protocol.min_writer_version == 7
-    assert protocol.writer_features == ["deletionVectors"]  # type: ignore
-    assert protocol.reader_features == ["deletionVectors"]
+    assert "deletionVectors" in protocol.writer_features
+    assert "deletionVectors" in protocol.reader_features
     assert dt.history()[0]["userName"] == "John Doe"
 
 

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1169,3 +1169,11 @@ def test_read_query_builder_join_multiple_tables(tmp_path):
         .read_all()
     )
     assert expected == actual
+
+
+def test_read_deletion_vectors():
+    table_path = "../crates/test/tests/data/table-with-dv-small"
+    dt = DeltaTable(table_path)
+    assert QueryBuilder().register("tbl", dt).execute("select * from tbl").read_all()[
+        "value"
+    ].to_pylist() == [1, 2, 3, 4, 5, 6, 7, 8]

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -2647,3 +2647,40 @@ def test_url_encoding_timestamp(tmp_path):
     write_deltalake(
         table_or_uri=tmp_path, data=data, mode="overwrite", predicate="value >= 10"
     )
+
+
+def test_write_table_with_deletion_vectors(tmp_path: pathlib.Path):
+    """
+    Tables with deletion vectors should still be writeable even without writing deletion vectors directly
+    """
+    schema = Schema(
+        fields=[
+            Field("id", type=PrimitiveType("string"), nullable=True),
+            Field("price", type=PrimitiveType("long"), nullable=True),
+        ]
+    )
+    dt = DeltaTable.create(
+        tmp_path,
+        schema,
+        name="test_name",
+        description="test_desc",
+        configuration={
+            "delta.enableDeletionVectors": "true",
+        },
+    )
+    assert dt.protocol().min_writer_version == 7
+    assert dt.version() == 0
+    print(dt.protocol().writer_features)
+
+    data = Table.from_pydict(
+        {
+            "id": Array(["1 2"], DataType.string()),
+            "price": Array([10], DataType.int64()),
+        },
+        schema=schema,
+    )
+
+    write_deltalake(dt, data, mode="append")
+
+    dt = DeltaTable(tmp_path)
+    assert dt.version() == 1, "Expected a write to have occurred!"


### PR DESCRIPTION
This relaxes the strictness of some of our deletion vector checks, even
if we cannot produce deletion vectors at the moment, the datafusion work
happening in `main` and the underlying kernel supports reading them now.

Closes #3994
