### PR TITLE
fix(python): object store registration missing in session

### DIFF
--- a/python/src/datafusion.rs
+++ b/python/src/datafusion.rs
@@ -14,9 +14,11 @@ use datafusion::physical_plan::{ExecutionPlan, Statistics};
 use deltalake::datafusion::catalog::{Session, TableProvider};
 use deltalake::datafusion::common::{Column, DFSchema, Result as DataFusionResult};
 use deltalake::datafusion::datasource::TableType;
+use deltalake::datafusion::execution::object_store::ObjectStoreUrl;
 use deltalake::datafusion::logical_expr::{LogicalPlan, TableProviderFilterPushDown};
 use deltalake::datafusion::prelude::Expr;
 use deltalake::delta_datafusion::DeltaScanNext;
+use deltalake::logstore::object_store::DynObjectStore;
 use deltalake::{datafusion, DeltaResult, DeltaTableError};
 use parking_lot::RwLock;
 use tokio::runtime::Handle;
@@ -123,11 +125,28 @@ impl TableProvider for LazyTableProvider {
 pub struct TokioDeltaScan {
     inner: DeltaScanNext,
     handle: Handle,
+    object_store_url: Option<ObjectStoreUrl>,
+    object_store: Option<Arc<DynObjectStore>>,
 }
 
 impl TokioDeltaScan {
     pub fn new(inner: DeltaScanNext, handle: Handle) -> Self {
-        Self { inner, handle }
+        Self {
+            inner,
+            handle,
+            object_store_url: None,
+            object_store: None,
+        }
+    }
+
+    pub fn with_object_store(
+        mut self,
+        object_store_url: ObjectStoreUrl,
+        object_store: Arc<DynObjectStore>,
+    ) -> Self {
+        self.object_store_url = Some(object_store_url);
+        self.object_store = Some(object_store);
+        self
     }
 }
 
@@ -160,6 +179,12 @@ impl TableProvider for TokioDeltaScan {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if let (Some(url), Some(store)) = (&self.object_store_url, &self.object_store) {
+            session
+                .runtime_env()
+                .register_object_store(url.as_ref(), store.clone());
+        }
+
         let inner = &self.inner;
 
         self.handle


### PR DESCRIPTION
# Description
This PR adds the ability to pass an object store to the `TokioDeltaScan`.

# Related Issue(s)
- Closes #4104 

# Documentation

Nothing new