### PR TITLE
feat: add logical DataValidation node

### DIFF
--- a/crates/core/src/delta_datafusion/planner.rs
+++ b/crates/core/src/delta_datafusion/planner.rs
@@ -34,6 +34,7 @@ use datafusion::{
 };
 
 use crate::delta_datafusion::DataFusionResult;
+use crate::delta_datafusion::data_validation::DataValidationExtensionPlanner;
 use crate::operations::delete::DeleteMetricExtensionPlanner;
 use crate::operations::merge::MergeMetricExtensionPlanner;
 use crate::operations::update::UpdateMetricExtensionPlanner;
@@ -46,6 +47,7 @@ const DELTA_EXTENSION_PLANNERS: LazyLock<Vec<Arc<dyn ExtensionPlanner + Send + S
             WriteMetricExtensionPlanner::new(),
             DeleteMetricExtensionPlanner::new(),
             UpdateMetricExtensionPlanner::new(),
+            DataValidationExtensionPlanner::new(),
         ]
     });
 


### PR DESCRIPTION
## Description

Stacked pr, lust look at the last commit to review.
* https://github.com/delta-io/delta-rs/pull/4120
* https://github.com/delta-io/delta-rs/pull/4119
* https://github.com/delta-io/delta-rs/pull/4117
* __->__ https://github.com/delta-io/delta-rs/pull/4116

When writing data to delta tables we support writing this a change set containing both data to be written to data files and cdf data to be written to CDF files. When rewriting files we currently need to separate the writes for data we keep and data we update due to predicate handling.

To better reuse these advanced writing features it is useful if we can perform data validation on subtrees (e.g. only on newly inserted data) in our plans. For this we add a logical data validation node we can conveniently integrate into our logical planning.
