### PR TITLE
chore: allow integration tests to be run in parallel with nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+[profile.ci]
+fail-fast = false
+retries = 1
+slow-timeout = "60s"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,6 +39,7 @@ jobs:
       AZURE_STORAGE_ALLOW_HTTP: "1"
       AZURITE_BLOB_STORAGE_URL: "http://localhost:10000"
       AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;"
+      NEXTEST_PROFILE: 'ci'
 
     steps:
       - uses: actions/checkout@v5
@@ -54,6 +55,7 @@ jobs:
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
 
       - name: Start emulated services
         run: docker compose up -d
@@ -61,7 +63,7 @@ jobs:
       - name: Run tests with rustls (default)
         run: |
           gmake setup-dat
-          cargo llvm-cov --profile=ci \
+          cargo llvm-cov nextest --cargo-profile=ci \
             --package deltalake-${{ matrix.target.name }} \
             --features integration_test \
             --codecov \
@@ -101,13 +103,15 @@ jobs:
           toolchain: stable
           cache: true
 
+      - uses: taiki-e/install-action@nextest
+
       - name: Start emulated services
         run: docker compose up -d
 
       - name: Run tests with native-tls
         run: |
           gmake setup-dat
-          cargo test --profile=ci \
+          cargo nextest r --cargo-profile=ci \
             --package deltalake-aws \
             --no-default-features \
             --features integration_test,native-tls
@@ -129,6 +133,7 @@ jobs:
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
 
       # Install Java and Hadoop for HDFS integration tests
       - uses: actions/setup-java@v4
@@ -145,7 +150,7 @@ jobs:
       - name: Run tests with rustls (default)
         run: |
           gmake setup-dat
-          cargo llvm-cov --profile=ci \
+          cargo llvm-cov nextest --cargo-profile=ci \
             --features integration_test \
             --package deltalake-hdfs \
             --codecov \
@@ -177,6 +182,7 @@ jobs:
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
 
       - name: Download Lakectl
         run: |
@@ -190,7 +196,7 @@ jobs:
       - name: Run tests
         run: |
           gmake setup-dat
-          cargo llvm-cov --profile=ci \
+          cargo llvm-cov nextest --cargo-profile=ci \
             --package deltalake-lakefs \
             --features integration_test_lakefs \
             --codecov \

--- a/crates/aws/tests/common.rs
+++ b/crates/aws/tests/common.rs
@@ -3,6 +3,7 @@ use deltalake_aws::constants;
 use deltalake_aws::register_handlers;
 use deltalake_aws::storage::*;
 use deltalake_test::utils::*;
+use rand::RngCore;
 use rand::random;
 use std::process::{Command, ExitStatus, Stdio};
 
@@ -14,8 +15,9 @@ pub struct S3Integration {
 impl Default for S3Integration {
     fn default() -> Self {
         register_handlers(None);
+        let task_id = format!("{}", rand::thread_rng().next_u64());
         Self {
-            bucket_name: format!("test-delta-table-{}", Utc::now().timestamp()),
+            bucket_name: format!("delta-table-{}-{task_id}", Utc::now().timestamp()),
         }
     }
 }

--- a/crates/azure/tests/context.rs
+++ b/crates/azure/tests/context.rs
@@ -2,6 +2,7 @@ use azure_storage_blobs::prelude::*;
 use chrono::Utc;
 use deltalake_azure::register_handlers;
 use deltalake_test::utils::*;
+use rand::RngCore;
 use std::path::PathBuf;
 use std::process::ExitStatus;
 use tokio::runtime::Handle;
@@ -17,7 +18,8 @@ pub enum MsftIntegration {
 impl Default for MsftIntegration {
     fn default() -> Self {
         register_handlers(None);
-        Self::Azure(format!("test-delta-table-{}", Utc::now().timestamp()))
+        let task_id = format!("{}", rand::thread_rng().next_u64());
+        Self::Azure(format!("delta-table-{}-{task_id}", Utc::now().timestamp()))
     }
 }
 


### PR DESCRIPTION
For the AWS integration tests this is a 77% speedup on my machine when
running the tests. Compile/link times are not changed here, but at least
the tests run faster!

Signed-off-by: R. Tyler Croy <rtyler@brokenco.de>
