### PR TITLE
fix(core): align file stats with parquet read schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ datafusion = { version = "52.1.0" }
 datafusion-datasource = { version = "52.1.0" }
 datafusion-ffi = { version = "52.1.0" }
 datafusion-proto = { version = "52.1.0" }
-datafusion-physical-expr-adapter = { version = "52.1.0" }
 
 # serde
 serde = { version = "1.0.194", features = ["derive"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -38,7 +38,6 @@ object_store = { workspace = true }
 datafusion = { workspace = true, optional = true }
 datafusion-datasource = { workspace = true, optional = true }
 datafusion-proto = { workspace = true, optional = true }
-datafusion-physical-expr-adapter = { workspace = true, optional = true }
 
 # serde
 serde = { workspace = true, features = ["derive"] }
@@ -110,7 +109,6 @@ datafusion = [
     "dep:datafusion",
     "datafusion-datasource",
     "datafusion-proto",
-    "datafusion-physical-expr-adapter",
 ]
 datafusion-ext = ["datafusion"]
 json = ["parquet/json"]

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -151,9 +151,6 @@ impl DeltaScanExec {
         }
     }
 
-    pub(crate) fn delta_plan(&self) -> &KernelScanPlan {
-        self.scan_plan.as_ref()
-    }
     /// Transform the statistics from the inner physical parquet read plan to the logical
     /// schema we expose via the table provider. We do not attempt to provide meaningful
     /// statistics for metadata columns as we do not expect these to be useful in planning.
@@ -1086,9 +1083,9 @@ mod tests {
             .downcast_ref::<DeltaScanExec>()
             .expect("Expected DeltaScanExec");
 
-        let kernel_type = Arc::clone(exec.delta_plan().scan.logical_schema()).into();
+        let kernel_type = Arc::clone(exec.scan_plan.scan.logical_schema()).into();
 
-        let mut scan_plan = exec.delta_plan().clone();
+        let mut scan_plan = exec.scan_plan.as_ref().clone();
         scan_plan.result_schema = Arc::new(Schema::new(vec![Field::new(
             "value",
             DataType::Int32,

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
@@ -23,6 +23,7 @@ use datafusion::common::{HashMap, HashSet, exec_err, plan_err};
 use datafusion::logical_expr::TableProviderFilterPushDown;
 use datafusion::logical_expr::utils::conjunction;
 use datafusion::prelude::Expr;
+use datafusion::scalar::ScalarValue;
 use datafusion_datasource::file_scan_config::wrap_partition_type_in_dict;
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow as _, TryIntoKernel as _};
 use delta_kernel::schema::DataType as KernelDataType;
@@ -71,12 +72,6 @@ pub(crate) struct KernelScanPlan {
     pub(crate) parquet_read_schema: SchemaRef,
     /// If set, indicates a predicate to apply at the Parquet scan level
     pub(crate) parquet_predicate: Option<Expr>,
-    /// Predicate passed to delta kernel for file skipping,
-    ///
-    /// If this is configured, the predicates pushed into the scan will
-    /// not be considered for file skipping. This is to handle file re-write
-    /// cases in UPDATE, MERGE, etc.
-    pub(crate) skipping_predicate: Option<PredicateRef>,
 }
 
 impl KernelScanPlan {
@@ -111,14 +106,7 @@ impl KernelScanPlan {
 
         let Some(projection) = projection else {
             let scan = Arc::new(scan_builder.build()?);
-            return Self::try_new_with_scan(
-                scan,
-                config,
-                table_schema,
-                None,
-                parquet_predicate,
-                scan_predicate,
-            );
+            return Self::try_new_with_scan(scan, config, table_schema, None, parquet_predicate);
         };
 
         // The table projection may not include all columns referenced in filters,
@@ -184,7 +172,6 @@ impl KernelScanPlan {
             result_schema,
             result_projection,
             parquet_predicate,
-            scan_predicate,
         )
     }
 
@@ -194,7 +181,6 @@ impl KernelScanPlan {
         result_schema: SchemaRef,
         result_projection: Option<Vec<usize>>,
         parquet_predicate: Option<Expr>,
-        skipping_predicate: Option<PredicateRef>,
     ) -> Result<Self> {
         let output_schema = if config.retain_file_id() {
             let mut schema_builder = SchemaBuilder::from(result_schema.as_ref());
@@ -203,8 +189,10 @@ impl KernelScanPlan {
         } else {
             result_schema.clone()
         };
-        let parquet_read_schema =
-            config.parquet_file_schema(&scan.physical_schema().as_ref().try_into_arrow()?)?;
+        let parquet_read_schema = config.physical_arrow_schema(
+            scan.snapshot().table_configuration(),
+            &scan.physical_schema().as_ref().try_into_arrow()?,
+        )?;
         Ok(Self {
             scan,
             result_schema,
@@ -212,7 +200,6 @@ impl KernelScanPlan {
             result_projection,
             parquet_read_schema,
             parquet_predicate,
-            skipping_predicate,
         })
     }
 
@@ -273,61 +260,6 @@ impl DeltaScanConfig {
                 .collect_vec(),
         ));
         Ok(table_schema)
-    }
-
-    fn parquet_file_schema(&self, base: &Schema) -> Result<SchemaRef> {
-        // IMPORTANT: This schema is used for Parquet reading and predicate evaluation.
-        //
-        // DataFusion can materialize `Utf8View/BinaryView` when requested, but predicate
-        // pushdown is evaluated against the physical file schema before schema-rewriter casts
-        // are applied, and those coercions are not consistently propagated through nested field
-        // accesses nor to literals. This can produce mismatches during evaluation such as:
-        // `Invalid comparison operation: Utf8 == Utf8View`.
-        //
-        // To keep pushdown stable, we request base `Utf8/Binary` here and only expose view
-        // types at the DeltaScan boundary (see `map_field`).
-        //
-        // NOTE: This Parquet read schema is intentionally not the same as the table provider
-        // output schema. The output schema may force view types (Utf8View/BinaryView) and other
-        // presentation-level physical types, but Parquet read + predicate pushdown must operate
-        // on the file's base types.
-        let table_schema = Arc::new(Schema::new(
-            base.fields()
-                .iter()
-                .map(|f| self.map_field_for_parquet(f.clone()))
-                .collect_vec(),
-        ));
-        Ok(table_schema)
-    }
-
-    fn map_field_for_parquet(&self, field: FieldRef) -> FieldRef {
-        let dt = match field.data_type() {
-            DataType::Struct(fields) => DataType::Struct(
-                fields
-                    .iter()
-                    .map(|f| self.map_field_for_parquet(f.clone()))
-                    .collect(),
-            ),
-            DataType::List(inner) => DataType::List(self.map_field_for_parquet(inner.clone())),
-            DataType::LargeList(inner) => {
-                DataType::LargeList(self.map_field_for_parquet(inner.clone()))
-            }
-            DataType::ListView(inner) => {
-                DataType::ListView(self.map_field_for_parquet(inner.clone()))
-            }
-            // Always use base types for the Parquet read schema.
-            DataType::Utf8View => DataType::Utf8,
-            DataType::BinaryView => DataType::Binary,
-            _ => field.data_type().clone(),
-        };
-
-        let field = if &dt != field.data_type() {
-            Arc::new(field.as_ref().clone().with_data_type(dt))
-        } else {
-            field
-        };
-
-        field
     }
 
     fn map_field(&self, field: FieldRef, partition_cols: &[String]) -> FieldRef {
@@ -392,6 +324,22 @@ impl DeltaScanConfig {
                 ))
                 .into(),
             _ => field,
+        }
+    }
+
+    // internal helper function to map scalar values
+    //
+    // This is specifically meant to align file stats values with the parquet
+    // scan. We track it here to have one place where view type mapping is handled.
+    pub(super) fn map_scalar_value(&self, value: ScalarValue) -> ScalarValue {
+        match value {
+            ScalarValue::Utf8(Some(v)) if self.schema_force_view_types => {
+                ScalarValue::Utf8View(Some(v))
+            }
+            ScalarValue::Binary(Some(v)) if self.schema_force_view_types => {
+                ScalarValue::BinaryView(Some(v))
+            }
+            other => other,
         }
     }
 }
@@ -580,29 +528,6 @@ mod tests {
 
     use super::*;
 
-    fn schema_has_view_types(schema: &Schema) -> bool {
-        schema
-            .fields()
-            .iter()
-            .any(|f| data_type_has_view_types(f.data_type()))
-    }
-
-    fn data_type_has_view_types(dt: &DataType) -> bool {
-        match dt {
-            DataType::Utf8View | DataType::BinaryView => true,
-            DataType::Dictionary(_, value) => data_type_has_view_types(value.as_ref()),
-            DataType::Map(entry, _) => data_type_has_view_types(entry.data_type()),
-            DataType::Struct(fields) => fields
-                .iter()
-                .any(|f| data_type_has_view_types(f.data_type())),
-            DataType::List(inner)
-            | DataType::LargeList(inner)
-            | DataType::ListView(inner)
-            | DataType::FixedSizeList(inner, _) => data_type_has_view_types(inner.data_type()),
-            _ => false,
-        }
-    }
-
     #[tokio::test]
     async fn test_rewrite_expression() -> TestResult {
         let mut table = open_fs_path("../test/tests/data/table_with_column_mapping");
@@ -688,8 +613,7 @@ mod tests {
         let batches = collect(scan, ctx.task_ctx()).await?;
         assert_batches_sorted_eq!(&expected, &batches);
 
-        let filter =
-            col(r#""Company Very Short""#).eq(lit(ScalarValue::Utf8View(Some("BME".to_string()))));
+        let filter = col(r#""Company Very Short""#).eq(lit("BME"));
         let batches = ctx
             .read_table(provider.clone())?
             .filter(filter.clone())?
@@ -703,49 +627,30 @@ mod tests {
             "+--------------------+--------------+",
         ];
         assert_batches_sorted_eq!(&expected, &batches);
+
+        // we need to pass a more specific type here since we are not going
+        // through datafusions predicate handling.
+        let filter =
+            col(r#""Company Very Short""#).eq(lit(ScalarValue::Utf8View(Some("BME".to_string()))));
         let scan = provider.scan(&ctx.state(), None, &[filter], None).await?;
         let batches = collect(scan, ctx.task_ctx()).await?;
         assert_batches_sorted_eq!(&expected, &batches);
 
-        let filter =
-            col(r#""Super Name""#).eq(lit(ScalarValue::Utf8View(Some("Timothy Lamb".to_string()))));
+        let filter = col(r#""Super Name""#).eq(lit("Timothy Lamb"));
         let batches = ctx
             .read_table(provider.clone())?
             .filter(filter.clone())?
             .collect()
             .await?;
         assert_batches_sorted_eq!(&expected, &batches);
+
+        let filter =
+            col(r#""Super Name""#).eq(lit(ScalarValue::Utf8View(Some("Timothy Lamb".to_string()))));
         let scan = provider
             .scan(&ctx.state(), None, &[filter.clone()], None)
             .await?;
         let batches = collect(scan, ctx.task_ctx()).await?;
         assert_batches_sorted_eq!(&expected, &batches);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_view_types_only_exposed_in_result_schema() -> TestResult {
-        let mut table = open_fs_path("../test/tests/data/table_with_column_mapping");
-        table.load().await?;
-
-        let snapshot = table.snapshot()?.snapshot().snapshot();
-
-        let mut config = DeltaScanConfig::default();
-        config.schema_force_view_types = true;
-        let scan_plan = KernelScanPlan::try_new(snapshot, None, &[], &config, None)?;
-        assert!(schema_has_view_types(scan_plan.result_schema.as_ref()));
-        assert!(!schema_has_view_types(
-            scan_plan.parquet_read_schema.as_ref()
-        ));
-
-        let mut config = DeltaScanConfig::default();
-        config.schema_force_view_types = false;
-        let scan_plan = KernelScanPlan::try_new(snapshot, None, &[], &config, None)?;
-        assert!(!schema_has_view_types(scan_plan.result_schema.as_ref()));
-        assert!(!schema_has_view_types(
-            scan_plan.parquet_read_schema.as_ref()
-        ));
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
@@ -37,7 +37,7 @@ use url::Url;
 
 use crate::{
     DeltaResult,
-    delta_datafusion::engine::to_datafusion_scalar,
+    delta_datafusion::{DeltaScanConfig, engine::to_datafusion_scalar},
     kernel::{
         LogicalFileView, ReceiverStreamBuilder, Scan, StructDataExt,
         arrow::engine_ext::stats_schema, parse_stats_column_with_schema,
@@ -137,6 +137,8 @@ pin_project! {
 
         kernel_scan: Arc<KernelScan>,
 
+        scan_config: DeltaScanConfig,
+
         pub(crate) dv_stream: ReceiverStreamBuilder<(Url, Option<Vec<bool>>)>,
 
         #[pin]
@@ -145,7 +147,12 @@ pin_project! {
 }
 
 impl<S> ScanFileStream<S> {
-    pub(crate) fn new(engine: Arc<dyn Engine>, scan: &Arc<Scan>, stream: S) -> Self {
+    pub(crate) fn new(
+        engine: Arc<dyn Engine>,
+        scan: &Arc<Scan>,
+        scan_config: DeltaScanConfig,
+        stream: S,
+    ) -> Self {
         Self {
             metrics: ReplayStats::new(),
             dv_stream: ReceiverStreamBuilder::<(Url, Option<Vec<bool>>)>::new(100),
@@ -153,6 +160,7 @@ impl<S> ScanFileStream<S> {
             table_root: scan.table_root().clone(),
             kernel_scan: scan.inner().clone(),
             stream,
+            scan_config,
         }
     }
 }
@@ -223,6 +231,7 @@ where
                 // TODO: do we need to mnake the stats inexact if deletion vectors are present?
                 let mut file_statistics = extract_file_statistics(
                     this.kernel_scan,
+                    &this.scan_config,
                     parsed_stats,
                     predicate_columns.as_ref(),
                 );
@@ -269,6 +278,7 @@ where
 /// - [`StructData`]: Partition values to be materialized in the output
 fn extract_file_statistics(
     scan: &KernelScan,
+    scan_config: &DeltaScanConfig,
     parsed_stats: RecordBatch,
     predicate_columns: Option<&HashSet<String>>,
 ) -> HashMap<Url, (Statistics, Option<StructData>)> {
@@ -322,8 +332,10 @@ fn extract_file_statistics(
                         Precision::Absent
                     };
 
-                    let max_value = extract_precision(&max_values, f.name());
-                    let min_value = extract_precision(&min_values, f.name());
+                    let max_value =
+                        physical_precision(extract_precision(&max_values, f.name()), scan_config);
+                    let min_value =
+                        physical_precision(extract_precision(&min_values, f.name()), scan_config);
 
                     ColumnStatistics {
                         null_count,
@@ -349,6 +361,18 @@ fn extract_file_statistics(
             ))
         })
         .collect()
+}
+
+#[inline]
+fn physical_precision(
+    precision: Precision<ScalarValue>,
+    scan_config: &DeltaScanConfig,
+) -> Precision<ScalarValue> {
+    match precision {
+        Precision::Exact(v) => Precision::Exact(scan_config.map_scalar_value(v)),
+        Precision::Inexact(v) => Precision::Inexact(scan_config.map_scalar_value(v)),
+        Precision::Absent => Precision::Absent,
+    }
 }
 
 fn extract_precision(data: &Option<StructData>, name: impl AsRef<str>) -> Precision<ScalarValue> {

--- a/crates/core/src/delta_datafusion/utils.rs
+++ b/crates/core/src/delta_datafusion/utils.rs
@@ -2,16 +2,13 @@ use std::sync::Arc;
 
 use datafusion::common::DFSchemaRef;
 use datafusion::common::tree_node::{Transformed, TreeNode as _};
-use datafusion::error::{DataFusionError, Result};
+use datafusion::error::Result;
 use datafusion::logical_expr::simplify::SimplifyContext;
 use datafusion::logical_expr::{BinaryExpr, Expr, ExprSchemable as _};
 use datafusion::logical_expr_common::operator::Operator;
 use datafusion::optimizer::simplify_expressions::ExprSimplifier;
-use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanVisitor};
 use datafusion::{catalog::Session, common::DFSchema};
 
-use crate::delta_datafusion::DeltaScanExec;
-use crate::delta_datafusion::table_provider::next::KernelScanPlan;
 use crate::{DeltaResult, delta_datafusion::expr::parse_predicate_expression};
 
 /// Used to represent user input of either a Datafusion expression or string expression
@@ -71,31 +68,6 @@ pub(crate) fn maybe_into_expr(
         Some(predicate) => Some(into_expr(predicate, schema, session)?),
         None => None,
     })
-}
-
-/// Extracts fields from the parquet scan
-#[derive(Default)]
-pub(crate) struct DeltaScanVisitor {
-    pub(crate) delta_plan: Option<KernelScanPlan>,
-}
-
-impl DeltaScanVisitor {
-    fn pre_visit_delta_scan(&mut self, delta_scan_exec: &DeltaScanExec) -> Result<bool> {
-        self.delta_plan = Some(delta_scan_exec.delta_plan().clone());
-        Ok(true)
-    }
-}
-
-impl ExecutionPlanVisitor for DeltaScanVisitor {
-    type Error = DataFusionError;
-
-    fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
-        if let Some(delta_scan_exec) = plan.as_any().downcast_ref::<DeltaScanExec>() {
-            return self.pre_visit_delta_scan(delta_scan_exec);
-        };
-
-        Ok(true)
-    }
 }
 
 /// Coerce literal types in predicates to match the column types from the schema.


### PR DESCRIPTION
# Description

During the update to DF 52 we needed to introduce a `PhysicalExprAdapter` to handle some test failures, but it did elude me why that would be needed. While trying to get rid of it I believe I found the root cause.

As we see in #4127, we need to be very deliberate when it comes to schemas and expressions. I think the DF update introduced an optimization in that if the optimizer can prove that a value is constant within a file via file stats, it replaces the column reference with a literal value taken from the file stats. However the file stats were not aligned to the physical read schema but were using default types leading to invalid comparisons.

This PR also cleans up some unused fields/structs that are leftovers from previous refactors.

cc: @ethan-tyler


