### PR TITLE
[RFC] use datafusion sql parsing

### DIFF
--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -21,247 +21,16 @@
 
 //! Utility functions for Datafusion's Expressions
 use std::fmt::{self, Display, Error, Formatter, Write};
-use std::marker::PhantomData;
-use std::sync::Arc;
 
-use arrow_array::{Array, GenericListArray};
-use arrow_schema::{DataType, Field};
 use chrono::{DateTime, NaiveDate};
 use datafusion::catalog::Session;
-use datafusion::common::Result as DFResult;
-use datafusion::common::{DFSchema, Result, ScalarValue, TableReference, config::ConfigOptions};
+use datafusion::common::{DFSchema, Result, ScalarValue};
 use datafusion::execution::context::SessionState;
-use datafusion::execution::session_state::SessionStateBuilder;
-use datafusion::functions_nested::make_array::MakeArray;
-use datafusion::functions_nested::planner::{FieldAccessPlanner, NestedFunctionPlanner};
 use datafusion::logical_expr::expr::InList;
-use datafusion::logical_expr::planner::ExprPlanner;
-use datafusion::logical_expr::{
-    AggregateUDF, Between, BinaryExpr, Cast, Expr, Like, ScalarFunctionArgs, TableSource,
-};
-// Needed for MakeParquetArray
-use datafusion::functions::core::planner::CoreFunctionPlanner;
-use datafusion::logical_expr::{ColumnarValue, Documentation, ScalarUDF, ScalarUDFImpl, Signature};
-use datafusion::sql::planner::{ContextProvider, SqlToRel};
+use datafusion::logical_expr::{Between, BinaryExpr, Cast, Expr, Like};
 use datafusion::sql::sqlparser::ast::escape_quoted_string;
-use datafusion::sql::sqlparser::dialect::GenericDialect;
-use datafusion::sql::sqlparser::parser::Parser;
-use datafusion::sql::sqlparser::tokenizer::Tokenizer;
-use tracing::log::*;
 
-use crate::delta_datafusion::session::DeltaParserOptions;
 use crate::{DeltaResult, DeltaTableError};
-
-/// This struct is like Datafusion's MakeArray but ensures that `element` is used rather than `item
-/// as the field name within the list.
-#[derive(Debug, Hash, PartialEq, Eq)]
-struct MakeParquetArray {
-    /// The actual upstream UDF, which we're just totally cheating and using
-    actual: MakeArray,
-    /// Aliases for this UDF
-    aliases: Vec<String>,
-}
-
-impl MakeParquetArray {
-    pub fn new() -> Self {
-        let actual = MakeArray::default();
-        let aliases = vec!["make_array".into(), "make_list".into()];
-        Self { actual, aliases }
-    }
-}
-
-impl ScalarUDFImpl for MakeParquetArray {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn name(&self) -> &str {
-        "make_parquet_array"
-    }
-
-    fn signature(&self) -> &Signature {
-        self.actual.signature()
-    }
-
-    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        let r_type = match arg_types.len() {
-            0 => Ok(DataType::List(Arc::new(Field::new(
-                "element",
-                DataType::Int32,
-                true,
-            )))),
-            _ => {
-                // At this point, all the type in array should be coerced to the same one
-                Ok(DataType::List(Arc::new(Field::new(
-                    "element",
-                    arg_types[0].to_owned(),
-                    true,
-                ))))
-            }
-        };
-        debug!("MakeParquetArray return_type -> {r_type:?}");
-        r_type
-    }
-
-    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let mut data_type = DataType::Null;
-        for arg in &args.args {
-            data_type = arg.data_type();
-        }
-
-        match self.actual.invoke_with_args(args)? {
-            ColumnarValue::Scalar(ScalarValue::List(df_array)) => {
-                let field = Arc::new(Field::new("element", data_type, true));
-                let result = Ok(ColumnarValue::Scalar(ScalarValue::List(Arc::new(
-                    GenericListArray::<i32>::try_new(
-                        field,
-                        df_array.offsets().clone(),
-                        arrow_array::make_array(df_array.values().into_data()),
-                        None,
-                    )?,
-                ))));
-                debug!("MakeParquetArray;invoke returning: {result:?}");
-                result
-            }
-            others => {
-                error!("Unexpected response inside MakeParquetArray! {others:?}");
-                Ok(others)
-            }
-        }
-    }
-
-    fn aliases(&self) -> &[String] {
-        &self.aliases
-    }
-
-    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        self.actual.coerce_types(arg_types)
-    }
-
-    fn documentation(&self) -> Option<&Documentation> {
-        self.actual.documentation()
-    }
-}
-
-/// This exists because the NestedFunctionPlanner, _not_ the UserDefinedFunctionPlanner, handles the
-/// insertion of "make_array" which is used to turn [100] into List<field=element, values=[100]>
-///
-/// **screaming intensifies**
-#[derive(Debug)]
-struct CustomNestedFunctionPlanner {
-    original: NestedFunctionPlanner,
-}
-
-impl Default for CustomNestedFunctionPlanner {
-    fn default() -> Self {
-        Self {
-            original: NestedFunctionPlanner,
-        }
-    }
-}
-
-use datafusion::logical_expr::planner::{PlannerResult, RawBinaryExpr};
-impl ExprPlanner for CustomNestedFunctionPlanner {
-    fn plan_array_literal(
-        &self,
-        exprs: Vec<Expr>,
-        _schema: &DFSchema,
-    ) -> Result<PlannerResult<Vec<Expr>>> {
-        let udf = Arc::new(ScalarUDF::from(MakeParquetArray::new()));
-
-        Ok(PlannerResult::Planned(udf.call(exprs)))
-    }
-    fn plan_binary_op(
-        &self,
-        expr: RawBinaryExpr,
-        schema: &DFSchema,
-    ) -> Result<PlannerResult<RawBinaryExpr>> {
-        self.original.plan_binary_op(expr, schema)
-    }
-    fn plan_make_map(&self, args: Vec<Expr>) -> Result<PlannerResult<Vec<Expr>>> {
-        self.original.plan_make_map(args)
-    }
-    fn plan_any(&self, expr: RawBinaryExpr) -> Result<PlannerResult<RawBinaryExpr>> {
-        self.original.plan_any(expr)
-    }
-}
-
-pub(crate) struct DeltaContextProvider<'a> {
-    state: SessionState,
-    planners: Vec<Arc<dyn ExprPlanner>>,
-    /// Keeping this around just to make use of the 'a lifetime
-    _phantom: PhantomData<&'a SessionState>,
-}
-
-impl<'a> DeltaContextProvider<'a> {
-    fn new(session: &'a dyn Session) -> Self {
-        // default planners are [CoreFunctionPlanner, NestedFunctionPlanner, FieldAccessPlanner,
-        // UserDefinedFunctionPlanner]
-        let planners: Vec<Arc<dyn ExprPlanner>> = vec![
-            Arc::new(CoreFunctionPlanner::default()),
-            Arc::new(CustomNestedFunctionPlanner::default()),
-            Arc::new(FieldAccessPlanner),
-            Arc::new(datafusion::functions::unicode::planner::UnicodeFunctionPlanner),
-            Arc::new(datafusion::functions::datetime::planner::DatetimeFunctionPlanner),
-        ];
-        // Disable the above for testing
-        //let planners = state.expr_planners();
-        let new_state = session
-            .as_any()
-            .downcast_ref::<SessionState>()
-            .map(|state| SessionStateBuilder::new_from_existing(state.clone()))
-            .unwrap_or_default()
-            .with_expr_planners(planners.clone())
-            .build();
-        DeltaContextProvider {
-            planners,
-            state: new_state,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl ContextProvider for DeltaContextProvider<'_> {
-    fn get_table_source(&self, _name: TableReference) -> DFResult<Arc<dyn TableSource>> {
-        unimplemented!()
-    }
-
-    fn get_expr_planners(&self) -> &[Arc<dyn ExprPlanner>] {
-        self.planners.as_slice()
-    }
-
-    fn get_function_meta(&self, name: &str) -> Option<Arc<datafusion::logical_expr::ScalarUDF>> {
-        self.state.scalar_functions().get(name).cloned()
-    }
-
-    fn get_aggregate_meta(&self, name: &str) -> Option<Arc<AggregateUDF>> {
-        self.state.aggregate_functions().get(name).cloned()
-    }
-
-    fn get_window_meta(&self, name: &str) -> Option<Arc<datafusion::logical_expr::WindowUDF>> {
-        self.state.window_functions().get(name).cloned()
-    }
-
-    fn get_variable_type(&self, _var: &[String]) -> Option<DataType> {
-        unimplemented!()
-    }
-
-    fn options(&self) -> &ConfigOptions {
-        self.state.config_options()
-    }
-
-    fn udf_names(&self) -> Vec<String> {
-        self.state.scalar_functions().keys().cloned().collect()
-    }
-
-    fn udaf_names(&self) -> Vec<String> {
-        self.state.aggregate_functions().keys().cloned().collect()
-    }
-
-    fn udwf_names(&self) -> Vec<String> {
-        self.state.window_functions().keys().cloned().collect()
-    }
-}
 
 /// Parse a string predicate into an `Expr`
 pub fn parse_predicate_expression(
@@ -269,25 +38,15 @@ pub fn parse_predicate_expression(
     expr: impl AsRef<str>,
     session: &dyn Session,
 ) -> DeltaResult<Expr> {
-    let dialect = &GenericDialect {};
-    let mut tokenizer = Tokenizer::new(dialect, expr.as_ref());
-    let tokens = tokenizer
-        .tokenize()
-        .map_err(|err| DeltaTableError::GenericError {
-            source: Box::new(err),
+    let session_ref = session
+        .as_any()
+        .downcast_ref::<SessionState>()
+        .ok_or_else(|| {
+            DeltaTableError::Generic(
+                "Unable to downcast Session to SessionState for expression parsing".to_owned(),
+            )
         })?;
-    let sql = Parser::new(dialect)
-        .with_tokens(tokens)
-        .parse_expr()
-        .map_err(|err| DeltaTableError::GenericError {
-            source: Box::new(err),
-        })?;
-
-    let context_provider = DeltaContextProvider::new(session);
-    let sql_to_rel =
-        SqlToRel::new_with_options(&context_provider, DeltaParserOptions::default().into());
-
-    Ok(sql_to_rel.sql_to_expr(sql, schema, &mut Default::default())?)
+    Ok(session_ref.create_logical_expr(expr.as_ref(), schema)?)
 }
 
 struct SqlFormat<'a> {


### PR DESCRIPTION
# Description

After some recent discussions, it turns out, that we may have to look at how we want to use `SessionState` - a core challenge being SQL parsing is not possible with just `dyn Session`.

Then I also wanted to know if we still need to have this custom parsing code.

So my question is, should we in some places just go ahead and depend on `SessionState` after all, and just have everything after we created logical plans (or at least parsed all we need into `Expr`s) be `Session` only? 