### PR TITLE
perf: cache schema per stream instead of per batch

### DIFF
--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -260,7 +260,10 @@ impl Snapshot {
             .scan_metadata(engine)
             .map(|d| Ok(rb_from_scan_meta(d?)?));
 
-        ScanRowOutStream::new(self.inner.clone(), stream).boxed()
+        match ScanRowOutStream::try_new(self.inner.clone(), stream) {
+            Ok(s) => s.boxed(),
+            Err(err) => Box::pin(once(ready(Err(err)))),
+        }
     }
 
     pub(crate) fn files_from<T: Iterator<Item = RecordBatch> + Send + 'static>(
@@ -281,7 +284,10 @@ impl Snapshot {
             .scan_metadata_from(engine, existing_version, existing_data, existing_predicate)
             .map(|d| Ok(rb_from_scan_meta(d?)?));
 
-        ScanRowOutStream::new(self.inner.clone(), stream).boxed()
+        match ScanRowOutStream::try_new(self.inner.clone(), stream) {
+            Ok(s) => s.boxed(),
+            Err(err) => Box::pin(once(ready(Err(err)))),
+        }
     }
 
     /// Stream the active files in the snapshot


### PR DESCRIPTION
# Description
Cache `stats_schema`, `partitions_schema`, and `column_mapping_mode` once per `ScanRowOutStream` instead of recomputing them for every batch.

**Before:**
Each batch is called `snapshot.stats_schema()` and `snapshot.partitions_schema()`, which involves filtering schema fields, applying column mapping transformations, and building nested schema structures.

**After:**
Values are computed once at stream creation and reused for all batches.

### Benchmark
Just did a quick benchmark with a local table (on larger tables, the percentage gains will be smaller)
| Table | Before | After |
|-------|--------|-------|
| delta-0.8.0 (2 files) | 0.54ms | 0.28ms | 