### PR TITLE
chore: add the unity catalog dependency back

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -17,6 +17,9 @@ name = "deltalake"
 crate-type = ["cdylib"]
 doc = false
 
+[package.metadata.cargo-machete]
+ignored = ["deltalake-catalog-unity"]
+
 [dependencies]
 delta_kernel.workspace = true
 url.workspace = true


### PR DESCRIPTION
# Description
Turns out a prior commit of cargo machete removed the unity catalog dependency. It was added via features but with the default config (So AWS only), it seems the solution was as easy as just adding it back. 

# Related Issue(s)
Closes #4129 (hopefully)
