### PR TITLE
refactor: add insert_into to DeltaScan, replace file_id IN(...) with FileSelection

### DIFF
--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -25,8 +25,8 @@ use percent_encoding::percent_decode_str;
 use tracing::*;
 
 use crate::delta_datafusion::engine::to_delta_predicate;
-use crate::delta_datafusion::file_id::wrap_file_id_value;
 use crate::delta_datafusion::logical::LogicalPlanBuilderExt as _;
+use crate::delta_datafusion::table_provider::next::{FileSelection, MissingFilePolicy};
 use crate::delta_datafusion::{
     DataFusionMixins as _, DeltaScanBuilder, DeltaScanConfigBuilder, DeltaScanNext,
     FILE_ID_COLUMN_DEFAULT, PATH_COLUMN, get_path_column,
@@ -521,16 +521,31 @@ pub(crate) async fn scan_files_where_matches(
         .flat_map(|batches| batches.iter().map(|b| b.column(0).as_string_view().clone()))
         .collect_vec();
 
-    // Create a table scan limiting the data to that originating from valid files.
-    // TODO(delta-io/delta-rs#4113): Avoid plan-time `IN (...)` lists by pushing a matched-file
-    // allowlist into scan planning.
-    let file_list = valid_files
-        .iter()
-        .flat_map(|arr| arr.iter().flatten().map(|v| v.to_string()))
-        .map(|v| lit(wrap_file_id_value(v)))
-        .collect_vec();
-    let plan = LogicalPlanBuilder::scan("source", table_source, None)?
-        .filter(col(FILE_ID_COLUMN_DEFAULT).in_list(file_list, false))?
+    // Create a table scan limited to the matched files by forwarding an explicit
+    // file selection into the table provider.
+    let table_root = snapshot
+        .snapshot()
+        .scan_builder()
+        .build()?
+        .table_root()
+        .clone();
+    let file_selection = FileSelection::from_paths(
+        valid_files
+            .iter()
+            .flat_map(|arr| arr.iter().flatten().map(|v| v.to_string())),
+        &table_root,
+    )?
+    .with_missing_file_policy(MissingFilePolicy::Ignore);
+    let selected_table_source = provider_as_source(
+        DeltaScanNext::builder()
+            .with_eager_snapshot(snapshot.clone())
+            .with_file_skipping_predicates(skipping_pred)
+            .with_file_column(FILE_ID_COLUMN_DEFAULT)
+            .with_file_selection(file_selection)
+            .await?,
+    );
+
+    let plan = LogicalPlanBuilder::scan("source", selected_table_source, None)?
         .drop_columns([FILE_ID_COLUMN_DEFAULT])?
         .build()?;
 
@@ -572,6 +587,30 @@ mod tests {
 
         let plan = session.create_physical_plan(scan.scan()).await?;
         let _data = collect(plan, session.task_ctx()).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_files_where_matches_plan_has_no_file_id_in_list_filter() -> TestResult {
+        let mut table = open_fs_path("../test/tests/data/simple_table");
+        table.load().await?;
+
+        let ctx = create_session().into_inner();
+        let session = ctx.state();
+        table.update_datafusion_session(&session)?;
+
+        let snapshot = table.snapshot()?.snapshot().clone();
+        let predicate = col("id").gt(lit(-1i64));
+        let Some(scan) = scan_files_where_matches(&session, &snapshot, predicate).await? else {
+            panic!("Expected at least one matching file");
+        };
+
+        let plan_debug = format!("{:?}", scan.scan());
+        assert!(
+            !(plan_debug.contains("InList(") && plan_debug.contains(FILE_ID_COLUMN_DEFAULT)),
+            "unexpected plan with file-id IN filter: {plan_debug}"
+        );
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -30,9 +30,9 @@ use std::collections::HashSet;
 use std::{borrow::Cow, sync::Arc};
 
 use arrow::datatypes::{Schema, SchemaRef};
-use datafusion::common::Result;
-use datafusion::datasource::TableType;
-use datafusion::logical_expr::TableProviderFilterPushDown;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::{TableType, sink::DataSinkExec};
+use datafusion::logical_expr::{TableProviderFilterPushDown, dml::InsertOp};
 use datafusion::prelude::Expr;
 use datafusion::{
     catalog::{Session, TableProvider},
@@ -45,11 +45,14 @@ use url::Url;
 
 pub use self::scan::DeltaScanExec;
 pub(crate) use self::scan::KernelScanPlan;
+use super::data_sink::DeltaDataSink;
 use crate::DeltaTableError;
 use crate::delta_datafusion::DeltaScanConfig;
 use crate::delta_datafusion::engine::DataFusionEngine;
 use crate::delta_datafusion::table_provider::TableProviderBuilder;
 use crate::kernel::{EagerSnapshot, SendableScanMetadataStream, Snapshot};
+use crate::logstore::LogStoreRef;
+use crate::protocol::SaveMode;
 
 mod scan;
 
@@ -86,7 +89,6 @@ pub(crate) enum MissingFilePolicy {
     Error,
     /// Silently skip file IDs that are not found in the scan.
     /// Useful for operations like compaction where files may have been concurrently removed.
-    #[allow(dead_code)]
     Ignore,
 }
 
@@ -101,10 +103,8 @@ impl FileSelection {
     /// Create a selection from pre-normalized file IDs.
     ///
     /// This constructor does not normalize or validate the input IDs.
-    /// Callers with relative paths or Add actions should prefer:
+    /// Callers with relative paths should prefer:
     /// - [`FileSelection::from_paths`]
-    /// - [`FileSelection::from_adds`]
-    /// - [`normalize_path_as_file_id`]
     pub(crate) fn new(file_ids: impl IntoIterator<Item = String>) -> Self {
         Self {
             file_ids: file_ids.into_iter().collect(),
@@ -132,17 +132,7 @@ impl FileSelection {
             file_ids.insert(file_id);
         }
 
-        Ok(Self {
-            file_ids,
-            missing_file_policy: MissingFilePolicy::Error,
-        })
-    }
-
-    pub(crate) fn from_adds(
-        adds: impl IntoIterator<Item = crate::kernel::Add>,
-        table_root_url: &Url,
-    ) -> crate::DeltaResult<Self> {
-        Self::from_paths(adds.into_iter().map(|a| a.path), table_root_url)
+        Ok(Self::new(file_ids).with_missing_file_policy(MissingFilePolicy::Error))
     }
 }
 
@@ -201,15 +191,6 @@ fn normalize_path_as_file_id_with_table_root(
     Ok(file_url.to_string())
 }
 
-pub(crate) fn normalize_path_as_file_id(
-    path: &str,
-    table_root_url: &Url,
-    context: &'static str,
-) -> crate::DeltaResult<String> {
-    let table_root_url = ensure_table_root_url(table_root_url);
-    normalize_path_as_file_id_with_table_root(path, &table_root_url, context)
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SnapshotWrapper {
     Snapshot(Arc<Snapshot>),
@@ -265,6 +246,8 @@ pub struct DeltaScan {
     full_schema: SchemaRef,
     #[serde(skip)]
     file_skipping_predicate: Option<Vec<Expr>>,
+    #[serde(skip)]
+    log_store: Option<LogStoreRef>,
     file_selection: Option<FileSelection>,
 }
 
@@ -295,6 +278,7 @@ impl DeltaScan {
             scan_schema,
             full_schema,
             file_skipping_predicate: None,
+            log_store: None,
             file_selection: None,
         })
     }
@@ -356,6 +340,12 @@ impl DeltaScan {
                 }
             }
         }
+    }
+
+    /// Attach the runtime log store handle required for write operations.
+    pub(crate) fn with_log_store(mut self, log_store: impl Into<LogStoreRef>) -> Self {
+        self.log_store = Some(log_store.into());
+        self
     }
 
     pub fn builder() -> TableProviderBuilder {
@@ -429,6 +419,46 @@ impl TableProvider for DeltaScan {
         .await
     }
 
+    async fn insert_into(
+        &self,
+        state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        insert_op: InsertOp,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let log_store = self.log_store.clone().ok_or_else(|| {
+            DataFusionError::Plan(
+                "DeltaScan insert_into requires a runtime log_store handle".to_string(),
+            )
+        })?;
+
+        super::update_datafusion_session(log_store.as_ref(), state, None)?;
+
+        let snapshot = match &self.snapshot {
+            SnapshotWrapper::EagerSnapshot(esnap) => esnap.as_ref().clone(),
+            SnapshotWrapper::Snapshot(snap) => {
+                EagerSnapshot::try_new_with_snapshot(log_store.as_ref(), snap.clone()).await?
+            }
+        };
+
+        let save_mode = match insert_op {
+            InsertOp::Append => SaveMode::Append,
+            InsertOp::Overwrite => SaveMode::Overwrite,
+            InsertOp::Replace => {
+                return Err(DataFusionError::Plan(
+                    "Replace operation is not supported for DeltaScan".to_string(),
+                ));
+            }
+        };
+
+        let data_sink = DeltaDataSink::new(log_store, snapshot, save_mode);
+
+        Ok(Arc::new(DataSinkExec::new(
+            input,
+            Arc::new(data_sink),
+            None,
+        )))
+    }
+
     fn supports_filters_pushdown(
         &self,
         filter: &[&Expr],
@@ -443,9 +473,13 @@ impl TableProvider for DeltaScan {
 
 #[cfg(test)]
 mod tests {
+    use arrow::{array::Int64Array, record_batch::RecordBatch};
     use datafusion::{
+        catalog::Session,
+        datasource::MemTable,
         datasource::{physical_plan::FileScanConfig, source::DataSource},
         error::DataFusionError,
+        logical_expr::dml::InsertOp,
         physical_plan::{ExecutionPlanVisitor, collect_partitioned, visit_execution_plan},
     };
     use datafusion_datasource::source::DataSourceExec;
@@ -457,8 +491,8 @@ mod tests {
 
     use crate::{
         assert_batches_sorted_eq,
-        delta_datafusion::{DeltaScanConfig, session::create_session},
-        kernel::{EagerSnapshot, Snapshot},
+        delta_datafusion::session::create_session,
+        kernel::{DataType, PrimitiveType, Snapshot, StructField, StructType},
         test_utils::{TestResult, TestTables},
     };
 
@@ -523,6 +557,188 @@ mod tests {
 
             Ok(true)
         }
+    }
+
+    async fn create_in_memory_id_table() -> crate::DeltaResult<crate::DeltaTable> {
+        let schema = StructType::try_new(vec![StructField::new(
+            "id".to_string(),
+            DataType::Primitive(PrimitiveType::Long),
+            true,
+        )])?;
+        crate::DeltaTable::new_in_memory()
+            .create()
+            .with_columns(schema.fields().cloned())
+            .await
+    }
+
+    async fn build_insert_input(
+        state: &dyn Session,
+        schema: SchemaRef,
+        values: Vec<i64>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(values))])?;
+        let mem_table = MemTable::try_new(schema, vec![vec![batch]])?;
+        mem_table.scan(state, None, &[], None).await
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_append_works() -> TestResult {
+        let table = create_in_memory_id_table().await?;
+        let log_store = table.log_store();
+        let provider = DeltaScan::builder()
+            .with_log_store(log_store.clone())
+            .build()
+            .await?;
+
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+        let input = build_insert_input(&state, provider.schema(), vec![11, 13]).await?;
+
+        let write_plan = provider
+            .insert_into(&state, input, InsertOp::Append)
+            .await?;
+        let _write_batches: Vec<_> = collect_partitioned(write_plan, session.task_ctx())
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
+
+        let read_provider = DeltaScan::builder().with_log_store(log_store).await?;
+        session.register_table("delta_table", read_provider)?;
+        let batches = session
+            .sql("SELECT id FROM delta_table ORDER BY id")
+            .await?
+            .collect()
+            .await?;
+        let expected = vec!["+----+", "| id |", "+----+", "| 11 |", "| 13 |", "+----+"];
+        assert_batches_sorted_eq!(&expected, &batches);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_overwrite_works() -> TestResult {
+        let table = create_in_memory_id_table().await?;
+        let log_store = table.log_store();
+
+        let append_provider = DeltaScan::builder()
+            .with_log_store(log_store.clone())
+            .build()
+            .await?;
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+
+        let append_input = build_insert_input(&state, append_provider.schema(), vec![1, 2]).await?;
+        let append_plan = append_provider
+            .insert_into(&state, append_input, InsertOp::Append)
+            .await?;
+        let _append_batches: Vec<_> = collect_partitioned(append_plan, session.task_ctx())
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
+
+        let overwrite_provider = DeltaScan::builder()
+            .with_log_store(log_store.clone())
+            .build()
+            .await?;
+        let overwrite_input =
+            build_insert_input(&state, overwrite_provider.schema(), vec![11, 13]).await?;
+        let overwrite_plan = overwrite_provider
+            .insert_into(&state, overwrite_input, InsertOp::Overwrite)
+            .await?;
+        let _overwrite_batches: Vec<_> = collect_partitioned(overwrite_plan, session.task_ctx())
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
+
+        let read_provider = DeltaScan::builder().with_log_store(log_store).await?;
+        session.register_table("delta_table", read_provider)?;
+        let batches = session
+            .sql("SELECT id FROM delta_table ORDER BY id")
+            .await?
+            .collect()
+            .await?;
+        let expected = vec!["+----+", "| id |", "+----+", "| 11 |", "| 13 |", "+----+"];
+        assert_batches_sorted_eq!(&expected, &batches);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_rejects_replace() -> TestResult {
+        let table = create_in_memory_id_table().await?;
+        let provider = DeltaScan::builder()
+            .with_log_store(table.log_store())
+            .build()
+            .await?;
+
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+        let input = build_insert_input(&state, provider.schema(), vec![1]).await?;
+
+        let err = provider
+            .insert_into(&state, input, InsertOp::Replace)
+            .await
+            .unwrap_err();
+        let err_str = err.to_string();
+        assert!(err_str.contains("Replace"), "unexpected error: {err_str}");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_requires_log_store() -> TestResult {
+        let table = create_in_memory_id_table().await?;
+        let snapshot = table.snapshot()?.snapshot().snapshot().clone();
+        let provider = DeltaScan::builder().with_snapshot(snapshot).build().await?;
+
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+        let input = build_insert_input(&state, provider.schema(), vec![1]).await?;
+
+        let err = provider
+            .insert_into(&state, input, InsertOp::Append)
+            .await
+            .unwrap_err();
+        let err_str = err.to_string();
+        assert!(err_str.contains("log_store"), "unexpected error: {err_str}");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_serde_roundtrip_is_read_only() -> TestResult {
+        let log_store = TestTables::Simple.table_builder()?.build_storage()?;
+        let snapshot = Snapshot::try_new(&log_store, Default::default(), None).await?;
+        let provider = DeltaScan::builder()
+            .with_snapshot(snapshot)
+            .with_log_store(log_store.clone())
+            .build()
+            .await?;
+
+        let serialized = serde_json::to_vec(&provider)?;
+        let decoded: DeltaScan = serde_json::from_slice(&serialized)?;
+
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+        let read_plan = decoded.scan(&state, None, &[], None).await?;
+        let _read_batches: Vec<_> = collect_partitioned(read_plan, session.task_ctx())
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
+
+        let input = build_insert_input(&state, decoded.schema(), vec![1]).await?;
+        let err = decoded
+            .insert_into(&state, input, InsertOp::Append)
+            .await
+            .unwrap_err();
+        let err_str = err.to_string();
+        assert!(err_str.contains("log_store"), "unexpected error: {err_str}");
+
+        Ok(())
     }
 
     #[tokio::test]
@@ -678,6 +894,41 @@ mod tests {
             .build()
             .await?
             .with_file_selection(selection);
+
+        let plan = provider.scan(&state, None, &[], None).await?;
+        let mut visitor = DeltaScanVisitor::default();
+        visit_execution_plan(plan.as_ref(), &mut visitor).unwrap();
+        assert_eq!(visitor.num_scanned, Some(1));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_builder_with_file_selection_forwards_selection() -> TestResult {
+        let log_store = TestTables::Simple.table_builder()?.build_storage()?;
+        let snapshot = Arc::new(Snapshot::try_new(&log_store, Default::default(), None).await?);
+        let table_root = snapshot.scan_builder().build()?.table_root().clone();
+
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+
+        let selected_path = snapshot
+            .file_views(log_store.as_ref(), None)
+            .take(1)
+            .map_ok(|view| view.path_raw().to_string())
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
+            .next()
+            .unwrap();
+        let selection = FileSelection::from_paths([selected_path.as_str()], &table_root)?;
+
+        let provider = DeltaScan::builder()
+            .with_snapshot(snapshot)
+            .with_file_column(FILE_ID_COLUMN_DEFAULT)
+            .with_file_selection(selection)
+            .build()
+            .await?;
 
         let plan = provider.scan(&state, None, &[], None).await?;
         let mut visitor = DeltaScanVisitor::default();


### PR DESCRIPTION
# Description

Migration step toward `DeltaTableProvider` removal. Adds write path support to `DeltaScan` and replaces the plan time `file_id IN (...)` literal list with provider level file selection.

Adds `TableProvider::insert_into` to `DeltaScan` using `DeltaDataSink` + `DataSinkExec`. Runtime `LogStoreRef` is
carried on `DeltaScan` with `#[serde(skip)]`. Deserialized providers are read only unless re-wired at runtime.

Replaces matched file `IN (...)` construction in `scan_files_where_matches` with `FileSelection::from_paths(...)` forwarded into next scan planning/replay. Uses `MissingFilePolicy::Ignore` for matched file rewrites.

# Related Issue(s)
- part of #4113
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
