### PR TITLE
chore: set compression for partition optimization as well

### DIFF
--- a/crates/core/src/operations/write/writer.rs
+++ b/crates/core/src/operations/write/writer.rs
@@ -325,6 +325,7 @@ impl PartitionWriterConfig {
         let writer_properties = writer_properties.unwrap_or_else(|| {
             WriterProperties::builder()
                 .set_created_by(format!("delta-rs version {}", crate_version()))
+                .set_compression(Compression::SNAPPY)
                 .build()
         });
         let target_file_size = target_file_size.unwrap_or(DEFAULT_TARGET_FILE_SIZE);


### PR DESCRIPTION
This is a good example of different routes for partitioned/non-partitioned tables gets us in trouble
