### PR TITLE
fix: Change visibility of add_action method to public

### DIFF
--- a/crates/core/src/kernel/snapshot/iterators.rs
+++ b/crates/core/src/kernel/snapshot/iterators.rs
@@ -283,7 +283,7 @@ impl LogicalFileView {
     }
 
     /// Converts this file view into an Add action for log operations.
-    pub(crate) fn add_action(&self) -> Add {
+    pub fn add_action(&self) -> Add {
         Add {
             path: self.path().to_string(),
             partition_values: self.partition_values_map(),


### PR DESCRIPTION
Following the same pattern for `remove_action`. With it, we can get a Add action from a `LogicalFileView`.
