### PR TITLE
fix: change visibility of add_action method to public

### DIFF
--- a/crates/core/src/kernel/snapshot/iterators.rs
+++ b/crates/core/src/kernel/snapshot/iterators.rs
@@ -283,7 +283,10 @@ impl LogicalFileView {
     }
 
     /// Converts this file view into an Add action for log operations.
-    #[deprecated(since = "0.31.0", note = "Use Arrow arrays directly instead of converting to Add actions.")]
+    #[deprecated(
+        since = "0.31.0",
+        note = "Use Arrow arrays directly instead of converting to Add actions."
+    )]
     pub fn add_action(&self) -> Add {
         Add {
             path: self.path().to_string(),


### PR DESCRIPTION
# Description
This pull request makes a small change to the visibility of the `add_action` method in the `LogicalFileView` implementation. This follow the same standard for the `remove_action` method and allows extracting the Add from a LogicalFileView. 
