### PR TITLE
fix(python): handle void type in schema Arrow conversion

### DIFF
--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -12,13 +12,13 @@ use deltalake::kernel::{
 };
 use pyo3::exceptions::{PyException, PyNotImplementedError, PyTypeError, PyValueError};
 use pyo3::types::PyCapsule;
-use pyo3::{IntoPyObjectExt, prelude::*};
-use pyo3_arrow::PyDataType;
-use pyo3_arrow::PyField;
-use pyo3_arrow::PySchema as PyArrow3Schema;
+use pyo3::{prelude::*, IntoPyObjectExt};
 use pyo3_arrow::error::PyArrowResult;
 use pyo3_arrow::export::{Arro3DataType, Arro3Field, Arro3Schema};
 use pyo3_arrow::ffi::to_schema_pycapsule;
+use pyo3_arrow::PyDataType;
+use pyo3_arrow::PyField;
+use pyo3_arrow::PySchema as PyArrow3Schema;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -31,6 +31,24 @@ use crate::utils::warn;
 // See: https://github.com/PyO3/pyo3/issues/1836
 
 // Decimal is separate special case, since it has parameters
+
+fn is_void_type(data_type: &DataType) -> bool {
+    matches!(data_type, DataType::Primitive(p) if p.to_string() == "void")
+}
+
+/// Filter out void fields from a struct type.
+/// Per the Delta protocol: "Existing tables may have void data type columns.
+/// Behavior is undefined for void data type columns but it is recommended
+/// to drop any void data type columns on reads."
+fn filter_void_fields(struct_type: &DeltaStructType) -> PyResult<DeltaStructType> {
+    let fields: Vec<StructField> = struct_type
+        .fields()
+        .filter(|f| !is_void_type(f.data_type()))
+        .cloned()
+        .collect();
+    DeltaStructType::try_new(fields)
+        .map_err(|e| PyException::new_err(format!("Failed to filter void fields: {e}")))
+}
 
 fn schema_type_to_python(schema_type: DataType, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
     match schema_type {
@@ -698,7 +716,8 @@ impl StructType {
 
     #[pyo3(text_signature = "($self)")]
     fn to_arrow(&self) -> PyResult<Arro3DataType> {
-        let inner_type = DataType::Struct(Box::new(self.inner_type.clone()));
+        let filtered = filter_void_fields(&self.inner_type)?;
+        let inner_type = DataType::Struct(Box::new(filtered));
         let arrow_type: ArrowDataType = (&inner_type)
             .try_into_arrow()
             .map_err(|err: ArrowError| PyException::new_err(err.to_string()))?;
@@ -717,7 +736,8 @@ impl StructType {
     }
 
     fn __arrow_c_schema__<'py>(&self, py: Python<'py>) -> PyArrowResult<Bound<'py, PyCapsule>> {
-        let inner_type = DataType::Struct(Box::new(self.inner_type.clone()));
+        let filtered = filter_void_fields(&self.inner_type)?;
+        let inner_type = DataType::Struct(Box::new(filtered));
         let arrow_type: ArrowDataType = (&inner_type)
             .try_into_arrow()
             .map_err(|err: ArrowError| PyException::new_err(err.to_string()))?;
@@ -799,7 +819,8 @@ impl PySchema {
     #[pyo3(signature = (as_large_types = false))]
     fn to_arrow(self_: PyRef<'_, Self>, as_large_types: bool) -> PyResult<Arro3Schema> {
         let super_ = self_.as_ref();
-        let res: ArrowSchema = (&super_.inner_type.clone())
+        let filtered = filter_void_fields(&super_.inner_type)?;
+        let res: ArrowSchema = (&filtered)
             .try_into_arrow()
             .map_err(|err: ArrowError| PyException::new_err(err.to_string()))?;
 
@@ -871,8 +892,8 @@ impl PySchema {
         py: Python<'py>,
     ) -> PyArrowResult<Bound<'py, PyCapsule>> {
         let super_ = self_.as_ref();
-
-        let res: ArrowSchema = (&super_.inner_type.clone())
+        let filtered = filter_void_fields(&super_.inner_type)?;
+        let res: ArrowSchema = (&filtered)
             .try_into_arrow()
             .map_err(|err: ArrowError| PyException::new_err(err.to_string()))?;
         to_schema_pycapsule(py, res)

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -238,3 +238,33 @@ def test_field_serialization():
     f = Field("fieldname", "binary", metadata={"key": "value"})
     assert f.name == "fieldname"
     assert f.metadata == {"key": "value"}
+
+
+# <https://github.com/delta-io/delta-rs/issues/1947>
+@pytest.mark.pyarrow
+def test_void_type_to_arrow():
+    """Test that void type fields are dropped in Arrow conversion.
+
+    Per the Delta protocol, void data type columns may exist in tables and
+    it is recommended to drop them on reads. Void fields originate from
+    Delta log metadata, so we use from_json() to simulate this.
+    """
+    import pyarrow as pa
+
+    # StructType with void fields should drop them
+    struct_json = '{"type":"struct","fields":[{"name":"a","type":"long","nullable":true,"metadata":{}},{"name":"b","type":"void","nullable":true,"metadata":{}}]}'
+    struct_type = StructType.from_json(struct_json)
+    arrow_struct = struct_type.to_arrow()
+    struct_dt = pa.DataType._import_from_c(arrow_struct.__arrow_c_schema__())
+    assert struct_dt.num_fields == 1
+    assert struct_dt.field(0).name == "a"
+
+    # Schema with no void fields should work as before
+    normal_schema = Schema(
+        [
+            Field("x", "integer", nullable=True),
+            Field("y", "string", nullable=False),
+        ]
+    )
+    normal_arrow = normal_schema.to_arrow()
+    assert len(normal_arrow) == 2


### PR DESCRIPTION
   # Description

   Fix `schema().to_pyarrow()` failing with `ArrowError("Invalid data type for Arrow: void")` when a Delta table
  contains void type columns.

   Per the Delta protocol, void data type columns may exist in tables and it is recommended to drop them on reads.
  This PR handles void type at the Python binding layer by filtering void fields during Arrow conversion and mapping
  individual void types to Arrow Null.

   # Related Issue(s)

   - closes #1947

   # Documentation

   - [Delta Protocol - Primitive Types](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types)