### PR TITLE
feat(python): add post_commithook_properties to alter metadata apis

### DIFF
--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -169,16 +169,19 @@ class RawDeltaTable:
         properties: dict[str, str],
         raise_if_not_exists: bool,
         commit_properties: CommitProperties | None,
+        post_commithook_properties: PostCommitHookProperties | None,
     ) -> None: ...
     def set_table_name(
         self,
         name: str,
         commit_properties: CommitProperties | None = None,
+        post_commithook_properties: PostCommitHookProperties | None = None,
     ) -> None: ...
     def set_table_description(
         self,
         description: str,
         commit_properties: CommitProperties | None = None,
+        post_commithook_properties: PostCommitHookProperties | None = None,
     ) -> None: ...
     def restore(
         self,

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1853,6 +1853,7 @@ class TableAlterer:
         properties: dict[str, str],
         raise_if_not_exists: bool = True,
         commit_properties: CommitProperties | None = None,
+        post_commithook_properties: PostCommitHookProperties | None = None,
     ) -> None:
         """
         Set properties from the table.
@@ -1861,6 +1862,7 @@ class TableAlterer:
             properties: properties which set
             raise_if_not_exists: set if should raise if not exists.
             commit_properties: properties of the transaction commit. If None, default values are used.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
 
         Example:
             ```python
@@ -1881,12 +1883,14 @@ class TableAlterer:
             properties,
             raise_if_not_exists,
             commit_properties,
+            post_commithook_properties,
         )
 
     def set_table_name(
         self,
         name: str,
         commit_properties: CommitProperties | None = None,
+        post_commithook_properties: PostCommitHookProperties | None = None,
     ) -> None:
         """
         Set the name of the table.
@@ -1894,7 +1898,7 @@ class TableAlterer:
         Args:
             name: the name of the table
             commit_properties: properties of the transaction commit. If None, default values are used.
-                              Note: This parameter is not yet implemented and will be ignored.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
 
         Example:
             ```python
@@ -1903,12 +1907,15 @@ class TableAlterer:
             dt.alter.set_table_name("new_table_name")
             ```
         """
-        self.table._table.set_table_name(name, commit_properties)
+        self.table._table.set_table_name(
+            name, commit_properties, post_commithook_properties
+        )
 
     def set_table_description(
         self,
         description: str,
         commit_properties: CommitProperties | None = None,
+        post_commithook_properties: PostCommitHookProperties | None = None,
     ) -> None:
         """
         Set the description of the table.
@@ -1916,7 +1923,7 @@ class TableAlterer:
         Args:
             description: the description of the table
             commit_properties: properties of the transaction commit. If None, default values are used.
-                              Note: This parameter is not yet implemented and will be ignored.
+            post_commithook_properties: properties for the post commit hook. If None, default values are used.
 
         Example:
             ```python
@@ -1925,7 +1932,9 @@ class TableAlterer:
             dt.alter.set_table_description("new_table_description")
             ```
         """
-        self.table._table.set_table_description(description, commit_properties)
+        self.table._table.set_table_description(
+            description, commit_properties, post_commithook_properties
+        )
 
     def set_column_metadata(
         self,

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1814,12 +1814,18 @@ impl RawDeltaTable {
         Ok(serde_json::to_string(&metrics).unwrap())
     }
 
-    #[pyo3(signature = (properties, raise_if_not_exists, commit_properties=None))]
+    #[pyo3(signature = (
+        properties,
+        raise_if_not_exists,
+        commit_properties=None,
+        post_commithook_properties=None
+    ))]
     pub fn set_table_properties(
         &self,
         properties: HashMap<String, String>,
         raise_if_not_exists: bool,
         commit_properties: Option<PyCommitProperties>,
+        post_commithook_properties: Option<PyPostCommitHookProperties>,
     ) -> PyResult<()> {
         let table = self._table.lock().map_err(to_rt_err)?.clone();
         let mut cmd = table
@@ -1827,7 +1833,9 @@ impl RawDeltaTable {
             .with_properties(properties)
             .with_raise_if_not_exists(raise_if_not_exists);
 
-        if let Some(commit_properties) = maybe_create_commit_properties(commit_properties, None) {
+        if let Some(commit_properties) =
+            maybe_create_commit_properties(commit_properties, post_commithook_properties)
+        {
             cmd = cmd.with_commit_properties(commit_properties);
         }
 
@@ -1842,11 +1850,12 @@ impl RawDeltaTable {
         Ok(())
     }
 
-    #[pyo3(signature = (name, commit_properties=None))]
+    #[pyo3(signature = (name, commit_properties=None, post_commithook_properties=None))]
     pub fn set_table_name(
         &self,
         name: String,
         commit_properties: Option<PyCommitProperties>,
+        post_commithook_properties: Option<PyPostCommitHookProperties>,
     ) -> PyResult<()> {
         let update = TableMetadataUpdate {
             name: Some(name),
@@ -1855,7 +1864,9 @@ impl RawDeltaTable {
         let table = self._table.lock().map_err(to_rt_err)?.clone();
         let mut cmd = table.update_table_metadata().with_update(update);
 
-        if let Some(commit_properties) = maybe_create_commit_properties(commit_properties, None) {
+        if let Some(commit_properties) =
+            maybe_create_commit_properties(commit_properties, post_commithook_properties)
+        {
             cmd = cmd.with_commit_properties(commit_properties);
         }
 
@@ -1870,11 +1881,16 @@ impl RawDeltaTable {
         Ok(())
     }
 
-    #[pyo3(signature = (description, commit_properties=None))]
+    #[pyo3(signature = (
+        description,
+        commit_properties=None,
+        post_commithook_properties=None
+    ))]
     pub fn set_table_description(
         &self,
         description: String,
         commit_properties: Option<PyCommitProperties>,
+        post_commithook_properties: Option<PyPostCommitHookProperties>,
     ) -> PyResult<()> {
         let update = TableMetadataUpdate {
             name: None,
@@ -1883,7 +1899,9 @@ impl RawDeltaTable {
         let table = self._table.lock().map_err(to_rt_err)?.clone();
         let mut cmd = table.update_table_metadata().with_update(update);
 
-        if let Some(commit_properties) = maybe_create_commit_properties(commit_properties, None) {
+        if let Some(commit_properties) =
+            maybe_create_commit_properties(commit_properties, post_commithook_properties)
+        {
             cmd = cmd.with_commit_properties(commit_properties);
         }
 

--- a/python/tests/test_alter.py
+++ b/python/tests/test_alter.py
@@ -4,7 +4,13 @@ from typing import TYPE_CHECKING
 import pytest
 from arro3.core import Array, DataType, Field, Schema, Table
 
-from deltalake import CommitProperties, DeltaTable, TableFeatures, write_deltalake
+from deltalake import (
+    CommitProperties,
+    DeltaTable,
+    PostCommitHookProperties,
+    TableFeatures,
+    write_deltalake,
+)
 from deltalake.exceptions import DeltaError
 from deltalake.schema import Field as DeltaField
 from deltalake.schema import PrimitiveType, StructType
@@ -559,6 +565,32 @@ def test_set_table_description(tmp_path: pathlib.Path, sample_table: Table):
 
     last_action = dt.history(1)[0]
     assert last_action["operation"] == "UPDATE TABLE METADATA"
+
+
+def test_set_table_metadata_with_post_commithook_properties(
+    tmp_path: pathlib.Path, sample_table: Table
+):
+    write_deltalake(tmp_path, sample_table)
+    dt = DeltaTable(tmp_path)
+    post_commithook_properties = PostCommitHookProperties(cleanup_expired_logs=False)
+
+    dt.alter.set_table_properties(
+        {"delta.appendOnly": "false"},
+        post_commithook_properties=post_commithook_properties,
+    )
+    dt.alter.set_table_name(
+        "hook_enabled_table",
+        post_commithook_properties=post_commithook_properties,
+    )
+    dt.alter.set_table_description(
+        "table description with hook props",
+        post_commithook_properties=post_commithook_properties,
+    )
+
+    metadata = dt.metadata()
+    assert metadata.configuration["delta.appendOnly"] == "false"
+    assert metadata.name == "hook_enabled_table"
+    assert metadata.description == "table description with hook props"
 
 
 def test_set_table_name_overwrite(tmp_path: pathlib.Path, sample_table: Table):


### PR DESCRIPTION
# Description
adds `post_commithook_properties` support to the missing `table.alter` metadata methods, so cleanup and checkpoint creation behavior can be controlled consistently via `cleanup_expired_logs` and `create_checkpoint` respectively

## Validation
- `make tests`
- `cargo check -p deltalake-python`
- `cargo fmt --all --check`