### PR TITLE
fix: coerce decimal literals in target subset filters

### DIFF
--- a/crates/core/src/delta_datafusion/utils.rs
+++ b/crates/core/src/delta_datafusion/utils.rs
@@ -72,11 +72,12 @@ pub(crate) fn maybe_into_expr(
 
 /// Coerce literal types in predicates to match the column types from the schema.
 ///
-/// This function walks the expression tree and for binary comparison expressions
-/// (e.g., `column = 3`), it ensures that literal values are cast to match the
-/// actual column type from the schema. This is necessary because SQL parsers
-/// typically infer literal types independently (e.g., `3` becomes `Int64`),
-/// which may not match the schema's column type (e.g., `Int32`).
+/// This function walks the expression tree and for comparison expressions
+/// (e.g., `column = 3` or `column BETWEEN 1 AND 3`), it ensures that literal
+/// values are cast to match the actual column type from the schema. This is
+/// necessary because SQL parsers and dynamically constructed expressions often
+/// infer literal types independently (e.g., `3` becomes `Int64`), which may not
+/// match the schema's column type (e.g., `Int32`).
 ///
 /// # Arguments
 /// * `expr` - The expression to transform
@@ -129,6 +130,39 @@ pub(crate) fn coerce_predicate_literals(expr: Expr, schema: &DFSchema) -> Result
                 };
 
                 Ok(Transformed::yes(new_binary))
+            }
+            Expr::Between(between) => {
+                let expr_type = between.expr.get_type(schema)?;
+                let mut changed = false;
+
+                let low = match between.low.as_ref() {
+                    Expr::Literal(value, _) if value.data_type() != expr_type => {
+                        changed = true;
+                        Box::new(Expr::Literal(value.cast_to(&expr_type)?, None))
+                    }
+                    _ => between.low.clone(),
+                };
+
+                let high = match between.high.as_ref() {
+                    Expr::Literal(value, _) if value.data_type() != expr_type => {
+                        changed = true;
+                        Box::new(Expr::Literal(value.cast_to(&expr_type)?, None))
+                    }
+                    _ => between.high.clone(),
+                };
+
+                if !changed {
+                    return Ok(Transformed::no(e));
+                }
+
+                Ok(Transformed::yes(Expr::Between(
+                    datafusion::logical_expr::Between {
+                        expr: between.expr.clone(),
+                        negated: between.negated,
+                        low,
+                        high,
+                    },
+                )))
             }
             _ => Ok(Transformed::no(e)),
         }
@@ -232,6 +266,43 @@ mod tests {
                 }
                 _ => panic!("Expected BinaryExpr"),
             }
+        }
+    }
+
+    #[test]
+    fn test_coerce_between_decimal_literals() {
+        use arrow_schema::{Field, Schema};
+
+        let schema = Schema::new(vec![Field::new(
+            "decimal_col",
+            ArrowDataType::Decimal128(6, 1),
+            true,
+        )])
+        .to_dfschema()
+        .unwrap();
+
+        let expr = col("decimal_col").between(
+            lit(ScalarValue::Decimal128(Some(1505), 4, 1)),
+            lit(ScalarValue::Decimal128(Some(1505), 4, 1)),
+        );
+        let result = coerce_predicate_literals(expr, &schema).unwrap();
+
+        match result {
+            Expr::Between(between) => {
+                match between.low.as_ref() {
+                    Expr::Literal(val, _) => {
+                        assert_eq!(val, &ScalarValue::Decimal128(Some(1505), 6, 1));
+                    }
+                    _ => panic!("Expected Literal in BETWEEN low bound"),
+                }
+                match between.high.as_ref() {
+                    Expr::Literal(val, _) => {
+                        assert_eq!(val, &ScalarValue::Decimal128(Some(1505), 6, 1));
+                    }
+                    _ => panic!("Expected Literal in BETWEEN high bound"),
+                }
+            }
+            _ => panic!("Expected Between expression, got {:?}", result),
         }
     }
 

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -37,7 +37,9 @@ use arrow_schema::{DataType, Field, SchemaBuilder};
 use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::common::tree_node::{Transformed, TreeNode};
-use datafusion::common::{Column, DFSchema, ExprSchema, ScalarValue, TableReference, plan_err};
+use datafusion::common::{
+    Column, DFSchema, DFSchemaRef, ExprSchema, ScalarValue, TableReference, plan_err,
+};
 use datafusion::datasource::provider_as_source;
 use datafusion::error::Result as DataFusionResult;
 use datafusion::execution::session_state::SessionStateBuilder;
@@ -74,6 +76,7 @@ use crate::delta_datafusion::expr::fmt_expr_to_sql;
 use crate::delta_datafusion::logical::MetricObserver;
 use crate::delta_datafusion::physical::{MetricObserverExec, find_metric_node, get_metric};
 use crate::delta_datafusion::planner::DeltaPlanner;
+use crate::delta_datafusion::utils::coerce_predicate_literals;
 use crate::delta_datafusion::{
     DataFusionMixins, DeltaColumn, DeltaScan, DeltaScanConfigBuilder, DeltaSessionExt,
     DeltaTableProvider, SessionFallbackPolicy, SessionResolveContext, create_session,
@@ -888,13 +891,8 @@ async fn execute(
         )
         .await?
     }
-    .map(|e| {
-        // simplify the expression so we have
-        let props = ExecutionProps::new();
-        let simplify_context = SimplifyContext::new(&props).with_schema(target.schema().clone());
-        let simplifier = ExprSimplifier::new(simplify_context).with_max_cycles(10);
-        simplifier.simplify(e).unwrap()
-    });
+    .map(|e| normalize_target_subset_filter(target.schema().clone(), e))
+    .transpose()?;
 
     // Predicate will be used for conflict detection
     let commit_predicate = match target_subset_filter.clone() {
@@ -1544,6 +1542,14 @@ fn remove_table_alias(expr: Expr, table_alias: &str) -> Expr {
     .data
 }
 
+fn normalize_target_subset_filter(target_schema: DFSchemaRef, expr: Expr) -> DeltaResult<Expr> {
+    let expr = coerce_predicate_literals(expr, target_schema.as_ref())?;
+    let props = ExecutionProps::new();
+    let simplify_context = SimplifyContext::new(&props).with_schema(target_schema);
+    let simplifier = ExprSimplifier::new(simplify_context).with_max_cycles(10);
+    Ok(simplifier.simplify(expr)?)
+}
+
 impl std::future::IntoFuture for MergeBuilder {
     type Output = DeltaResult<(DeltaTable, MergeMetrics)>;
     type IntoFuture = BoxFuture<'static, Self::Output>;
@@ -1622,10 +1628,10 @@ mod tests {
     use arrow_schema::DataType as ArrowDataType;
     use arrow_schema::Field;
     use datafusion::assert_batches_sorted_eq;
-    use datafusion::common::Column;
-    use datafusion::common::TableReference;
+    use datafusion::common::{Column, ScalarValue, TableReference, ToDFSchema};
     use datafusion::logical_expr::Expr;
     use datafusion::logical_expr::col;
+    use datafusion::logical_expr::expr::BinaryExpr;
     use datafusion::logical_expr::expr::Placeholder;
     use datafusion::logical_expr::lit;
     use datafusion::physical_plan::collect;
@@ -1786,6 +1792,33 @@ mod tests {
         ];
         let actual = get_data(&table).await;
         assert_batches_sorted_eq!(&expected, &actual);
+    }
+
+    #[test]
+    fn test_normalize_target_subset_filter_coerces_decimal_literals() {
+        let schema = ArrowSchema::new(vec![Field::new(
+            "altitude",
+            ArrowDataType::Decimal128(6, 1),
+            true,
+        )])
+        .to_dfschema()
+        .unwrap();
+
+        let normalized = super::normalize_target_subset_filter(
+            Arc::new(schema),
+            col("altitude").eq(lit(ScalarValue::Decimal128(Some(1505), 4, 1))),
+        )
+        .unwrap();
+
+        match normalized {
+            Expr::BinaryExpr(BinaryExpr { right, .. }) => match right.as_ref() {
+                Expr::Literal(value, _) => {
+                    assert_eq!(value, &ScalarValue::Decimal128(Some(1505), 6, 1));
+                }
+                other => panic!("expected decimal literal, got {other:?}"),
+            },
+            other => panic!("expected binary expr, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -2444,7 +2444,7 @@ def test_merge_on_decimal_3033(tmp_path):
 
     assert (
         string_predicate
-        == "timestamp = arrow_cast('2024-03-20T12:30:00.000000', 'Timestamp(Microsecond, None)') AND altitude = '1505'::decimal(4, 1)"
+        == "timestamp = arrow_cast('2024-03-20T12:30:00.000000', 'Timestamp(Microsecond, None)') AND altitude = '1505'::decimal(6, 1)"
     )
 
 


### PR DESCRIPTION
# Description

Found this while working on #4266.

Merge target subset filters can retain decimal precision/scale from the source expression instead of the target schema. For example `decimal(4, 1)` when the column is `decimal(6, 1)`. The newer file skipping path rejects the mismatch.

This fix is normalize `target_subset_filter` against the target schema before simplification, and extend literal coercion to handle between bounds.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
