### PR TITLE
fix: remove unsupported create_add from public API

### DIFF
--- a/crates/core/src/writer/mod.rs
+++ b/crates/core/src/writer/mod.rs
@@ -14,7 +14,6 @@ use crate::protocol::{ColumnCountStat, DeltaOperation, SaveMode};
 
 pub use json::JsonWriter;
 pub use record_batch::RecordBatchWriter;
-pub use stats::create_add;
 
 pub mod json;
 pub mod record_batch;

--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -23,7 +23,7 @@ use crate::kernel::{Add, scalars::ScalarExt};
 use crate::protocol::{ColumnValueStat, Stats};
 
 /// Creates an [`Add`] log action struct.
-pub fn create_add(
+pub(crate) fn create_add(
     partition_values: &IndexMap<String, Scalar>,
     path: String,
     size: i64,

--- a/crates/core/tests/create_add_removed.rs
+++ b/crates/core/tests/create_add_removed.rs
@@ -1,0 +1,64 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn write_file(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+}
+
+fn toml_basic_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[test]
+fn create_add_is_not_available_to_downstream_crates() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let crate_dir = temp_dir.path();
+    let src_dir = crate_dir.join("src");
+
+    fs::create_dir(&src_dir).unwrap();
+
+    write_file(
+        &crate_dir.join("Cargo.toml"),
+        &format!(
+            r#"[package]
+name = "create-add-public-api-check"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+deltalake-core = {{ path = "{}" }}
+"#,
+            toml_basic_string(env!("CARGO_MANIFEST_DIR"))
+        ),
+    );
+    write_file(
+        &src_dir.join("main.rs"),
+        r#"use deltalake_core::writer::create_add;
+
+fn main() {}
+"#,
+    );
+
+    let output = Command::new("cargo")
+        .arg("check")
+        .current_dir(crate_dir)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected downstream import of writer::create_add to fail, but it succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no `create_add` in `writer`")
+            || stderr.contains("no create_add in writer")
+            || stderr.contains("unresolved import"),
+        "expected missing public export error, got stderr:\n{}",
+        stderr,
+    );
+}


### PR DESCRIPTION
# Description

Closes #4273

`create_add` was publicly exported but its signature depended on types not reachable from `deltalake` alone. It has not been an actively maintained public entry point since February 2024.

- Remove pub re-export from writer module
- Make the helper crate private

Internal write paths that use the helper are unchanged

# Related Issue(s)
- #4273
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
