### PR TITLE
refactor: reduce clippy warnings in core create

### DIFF
--- a/crates/core/src/delta_datafusion/data_validation.rs
+++ b/crates/core/src/delta_datafusion/data_validation.rs
@@ -129,21 +129,15 @@ impl TreeNodeVisitor<'_> for NotNullExtractor {
                 // we dont't actually need a kernel expression here, but DF field access
                 // if somewhat tedious to extract and the kernel ColumnName is convenient
                 // for this purpose.
-                match to_delta_expression(expr) {
-                    Ok(Expression::Column(col_name)) => {
-                        self.non_nullable_columns.push(col_name);
-                    }
-                    _ => {}
+                if let Ok(Expression::Column(col_name)) = to_delta_expression(expr) {
+                    self.non_nullable_columns.push(col_name);
                 }
                 Ok(TreeNodeRecursion::Continue)
             }
             Expr::Not(expr) => match expr.as_ref() {
                 Expr::IsNull(inner_expr) => {
-                    match to_delta_expression(inner_expr) {
-                        Ok(Expression::Column(col_name)) => {
-                            self.non_nullable_columns.push(col_name);
-                        }
-                        _ => {}
+                    if let Ok(Expression::Column(col_name)) = to_delta_expression(inner_expr) {
+                        self.non_nullable_columns.push(col_name);
                     }
                     Ok(TreeNodeRecursion::Continue)
                 }
@@ -594,7 +588,7 @@ where
                             .filter(|v| matches!(v, Some(false) | None))
                             .count();
                         if invalid_count > 0 {
-                            let invalid_data = filter_record_batch(&batch, &not(&validity_mask)?)?;
+                            let invalid_data = filter_record_batch(&batch, &not(validity_mask)?)?;
                             let invalid_slice =
                                 invalid_data.slice(0, invalid_data.num_rows().min(5));
                             let preview = pretty_format_batches(&[invalid_slice])?;
@@ -618,7 +612,7 @@ where
                 }
                 let (_, arrays, _) = batch.into_parts();
                 Poll::Ready(Some(Ok(RecordBatch::try_new(
-                    Arc::clone(&this.schema),
+                    Arc::clone(this.schema),
                     arrays,
                 )?)))
             }
@@ -731,7 +725,7 @@ pub(crate) fn make_fields_non_nullable(schema: &Schema, paths: &[ColumnName]) ->
     // Convert ColumnName paths to Vec<String> for easier comparison
     let target_paths: HashSet<Vec<String>> = paths
         .iter()
-        .map(|col_name| col_name.path().iter().map(|s| s.clone()).collect())
+        .map(|col_name| col_name.path().to_vec())
         .collect();
 
     // Recursively update fields

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -172,7 +172,7 @@ pub(crate) fn redact_url_str_for_error(urlish: &str) -> String {
     Url::parse(urlish).map_or_else(
         |_| {
             urlish
-                .split(|c| c == '?' || c == '#')
+                .split(['?', '#'])
                 .next()
                 .unwrap_or(urlish)
                 .to_string()

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -245,7 +245,7 @@ impl std::future::IntoFuture for DeleteBuilder {
                 .transpose()?;
 
             let operation = DeltaOperation::Delete {
-                predicate: predicate.as_ref().map(|p| fmt_expr_to_sql(p)).transpose()?,
+                predicate: predicate.as_ref().map(fmt_expr_to_sql).transpose()?,
             };
 
             let (actions, metrics) = execute(
@@ -347,9 +347,11 @@ async fn execute(
     operation_id: Uuid,
 ) -> DeltaResult<(Vec<Action>, DeleteMetrics)> {
     let exec_start = Instant::now();
-    let mut metrics = DeleteMetrics::default();
-    metrics.num_removed_files = 0;
-    metrics.num_added_files = 0;
+    let mut metrics = DeleteMetrics {
+        num_removed_files: 0,
+        num_added_files: 0,
+        ..Default::default()
+    };
 
     let scan_start = Instant::now();
 

--- a/crates/core/src/operations/write/generated_columns.rs
+++ b/crates/core/src/operations/write/generated_columns.rs
@@ -99,7 +99,7 @@ pub fn with_generated_columns(
         projection.push(expr);
     }
 
-    Ok(LogicalPlanBuilder::new(plan).project(projection)?.build()?)
+    LogicalPlanBuilder::new(plan).project(projection)?.build()
 }
 
 /// Add generated column expressions to a dataframe

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -499,8 +499,7 @@ impl std::future::IntoFuture for WriteBuilder {
                         source,
                         &table_schema,
                         &snapshot.schema().get_generated_columns()?,
-                    )?
-                    .into();
+                    )?;
                 }
 
                 let source_schema: Arc<Schema> = normalize_for_delta(source.schema().inner());
@@ -666,10 +665,7 @@ impl std::future::IntoFuture for WriteBuilder {
                     .predicate
                     .map(|p| p.resolve(&session, Arc::new(df_schema)))
                     .transpose()?;
-                let predicate_str = predicate
-                    .as_ref()
-                    .map(|pred| fmt_expr_to_sql(pred))
-                    .transpose()?;
+                let predicate_str = predicate.as_ref().map(fmt_expr_to_sql).transpose()?;
 
                 let config = this
                     .snapshot


### PR DESCRIPTION
# Description
The aim is to reduce clippy warnings in core module. Warnings count is reduced from 40 to 29 (dont know how it went up to 40 in the first place?!, anyway getting there)

These are minor fixes mainly suggestions by clippy itself.

# Related Issue(s)
https://github.com/delta-io/delta-rs/pull/4259
https://github.com/delta-io/delta-rs/pull/4270

# Documentation
NA
