### PR TITLE
fix: restore incremental update to reuse existing table state

### DIFF
--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -189,6 +189,14 @@ impl Snapshot {
         self.inner.version() as i64
     }
 
+    /// Get the checkpoint version currently backing this snapshot, if any.
+    pub(crate) fn checkpoint_version(&self) -> Option<i64> {
+        self.inner
+            .log_segment()
+            .checkpoint_version
+            .map(|v| v as i64)
+    }
+
     /// Get the table schema of the snapshot
     pub fn schema(&self) -> KernelSchemaRef {
         self.inner.table_configuration().schema()
@@ -618,6 +626,11 @@ impl EagerSnapshot {
     /// Get the table version of the snapshot
     pub fn version(&self) -> i64 {
         self.snapshot.version()
+    }
+
+    /// Get the checkpoint version currently backing this snapshot, if any.
+    pub(crate) fn checkpoint_version(&self) -> Option<i64> {
+        self.snapshot.checkpoint_version()
     }
 
     /// Get the timestamp of the given version

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -2,6 +2,7 @@
 
 use std::sync::LazyLock;
 
+use delta_kernel::last_checkpoint_hint::LastCheckpointHint;
 use parquet::file::properties::WriterProperties;
 use url::Url;
 
@@ -9,12 +10,12 @@ use chrono::{TimeZone, Utc};
 use delta_kernel::FileMeta;
 use delta_kernel::snapshot::Snapshot;
 use futures::{StreamExt, TryStreamExt};
-use object_store::ObjectStore;
 use object_store::path::Path;
+use object_store::{Error as ObjectStoreError, ObjectStore};
 use parquet::arrow::AsyncArrowWriter;
 use parquet::arrow::async_writer::ParquetObjectWriter;
 use regex::Regex;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use crate::kernel::spawn_blocking_with_span;
@@ -26,6 +27,27 @@ use crate::{DeltaTable, open_table_with_version};
 
 static CHECKPOINT_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"_delta_log/(\d{20})\.(checkpoint).*$").unwrap());
+
+/// Try reading the `_last_checkpoint` file.
+///
+/// Missing or invalid hints are treated as absent so callers can safely fall
+/// back to directory listing.
+pub(crate) async fn read_last_checkpoint(
+    storage: &dyn ObjectStore,
+    log_path: &Path,
+) -> DeltaResult<Option<LastCheckpointHint>> {
+    const LAST_CHECKPOINT_FILE_NAME: &str = "_last_checkpoint";
+    let file_path = log_path.child(LAST_CHECKPOINT_FILE_NAME);
+    let maybe_data = storage.get(&file_path).await;
+    let data = match maybe_data {
+        Ok(data) => data.bytes().await?,
+        Err(ObjectStoreError::NotFound { .. }) => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    Ok(serde_json::from_slice(&data)
+        .inspect_err(|e| warn!("invalid _last_checkpoint JSON: {e}"))
+        .ok())
+}
 
 /// Creates checkpoint for a given table version, table state and object store
 #[tracing::instrument(skip(log_store), fields(operation = "checkpoint", version = version, table_uri = %log_store.root_url()))]
@@ -302,36 +324,10 @@ pub async fn cleanup_expired_logs_for(
 mod tests {
     use super::*;
 
-    use delta_kernel::last_checkpoint_hint::LastCheckpointHint;
-    use object_store::Error;
     use object_store::path::Path;
-    use tracing::warn;
 
     use crate::DeltaResult;
     use crate::writer::test_utils::get_delta_schema;
-
-    /// Try reading the `_last_checkpoint` file.
-    ///
-    /// Note that we typically want to ignore a missing/invalid `_last_checkpoint` file without failing
-    /// the read. Thus, the semantics of this function are to return `None` if the file is not found or
-    /// is invalid JSON. Unexpected/unrecoverable errors are returned as `Err` case and are assumed to
-    /// cause failure.
-    async fn read_last_checkpoint(
-        storage: &dyn ObjectStore,
-        log_path: &Path,
-    ) -> DeltaResult<Option<LastCheckpointHint>> {
-        const LAST_CHECKPOINT_FILE_NAME: &str = "_last_checkpoint";
-        let file_path = log_path.child(LAST_CHECKPOINT_FILE_NAME);
-        let maybe_data = storage.get(&file_path).await;
-        let data = match maybe_data {
-            Ok(data) => data.bytes().await?,
-            Err(Error::NotFound { .. }) => return Ok(None),
-            Err(err) => return Err(err.into()),
-        };
-        Ok(serde_json::from_slice(&data)
-            .inspect_err(|e| warn!("invalid _last_checkpoint JSON: {e}"))
-            .ok())
-    }
 
     #[tokio::test]
     async fn test_create_checkpoint_for() {

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -196,15 +196,31 @@ impl DeltaTable {
         self.update_incremental(None).await
     }
 
-    /// Updates the DeltaTable to the latest version by incrementally applying newer versions.
-    /// It assumes that the table is already updated to the current version `self.version`.
+    /// Updates the DeltaTable by incrementally applying newer versions, optionally bounded by
+    /// `max_version`.
+    ///
+    /// This API is forward-only. Use [`DeltaTable::load_version`] to load an older version.
     pub async fn update_incremental(
         &mut self,
         max_version: Option<i64>,
     ) -> Result<(), DeltaTableError> {
-        self.state = Some(
-            DeltaTableState::try_new(&self.log_store, self.config.clone(), max_version).await?,
-        );
+        let Some(state) = self.state.as_mut() else {
+            self.state = Some(
+                DeltaTableState::try_new(&self.log_store, self.config.clone(), max_version).await?,
+            );
+            return Ok(());
+        };
+
+        let current_version = state.version();
+        if let Some(requested_version) = max_version
+            && requested_version < current_version
+        {
+            return Err(DeltaTableError::generic(format!(
+                "Cannot downgrade via update_incremental from version {current_version} to {requested_version}; use load_version"
+            )));
+        }
+
+        state.update(&self.log_store, max_version).await?;
         Ok(())
     }
 

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -22,6 +22,7 @@ use crate::kernel::{
     ARROW_HANDLER, DataType, EagerSnapshot, LogDataHandler, Metadata, Protocol, TombstoneView,
 };
 use crate::logstore::LogStore;
+use crate::protocol::checkpoints::read_last_checkpoint;
 use crate::{DeltaResult, DeltaTableError};
 
 /// State snapshot currently held by the Delta Table instance.
@@ -161,10 +162,50 @@ impl DeltaTableState {
         version: Option<i64>,
     ) -> Result<(), DeltaTableError> {
         log_store.refresh().await?;
+        let current_version = self.version();
+        let loaded_checkpoint_version = self.snapshot.checkpoint_version();
         self.snapshot
             .update(log_store, version.map(|v| v as u64))
             .await?;
+
+        let refreshed_version = self.version();
+        if refreshed_version == current_version
+            && self
+                .should_reload_for_current_checkpoint(
+                    log_store,
+                    refreshed_version,
+                    loaded_checkpoint_version,
+                )
+                .await?
+        {
+            tracing::trace!(
+                version = refreshed_version,
+                loaded_checkpoint_version = ?loaded_checkpoint_version,
+                "reloading table state to pick up a newer checkpoint at the current version"
+            );
+            let config = self.load_config().clone();
+            *self = Self::try_new(log_store, config, Some(refreshed_version)).await?;
+        }
         Ok(())
+    }
+
+    // This is intentionally narrow: only detect a newer checkpoint for the
+    // already-loaded table version. General checkpoint selection stays in the
+    // snapshot/kernel update path.
+    async fn should_reload_for_current_checkpoint(
+        &self,
+        log_store: &dyn LogStore,
+        current_version: i64,
+        loaded_checkpoint_version: Option<i64>,
+    ) -> Result<bool, DeltaTableError> {
+        if loaded_checkpoint_version == Some(current_version) {
+            return Ok(false);
+        }
+
+        Ok(matches!(
+            read_last_checkpoint(log_store.object_store(None).as_ref(), log_store.log_path()).await?,
+            Some(last_checkpoint) if last_checkpoint.version as i64 == current_version
+        ))
     }
 
     /// Get an [arrow::record_batch::RecordBatch] containing add action data.

--- a/crates/core/tests/checkpoint_writer.rs
+++ b/crates/core/tests/checkpoint_writer.rs
@@ -131,11 +131,29 @@ mod delete_expired_delta_log_in_checkpoint {
     use std::collections::HashMap;
     use std::fs::{FileTimes, OpenOptions};
     use std::ops::Sub;
+    use std::path::Path as FsPath;
     use std::time::{Duration, SystemTime};
 
     use ::object_store::path::Path as ObjectStorePath;
     use deltalake_core::table::config::TableProperty;
     use deltalake_core::*;
+
+    fn set_delta_log_file_last_modified(
+        table_path: &FsPath,
+        version: usize,
+        last_modified_millis: u64,
+        suffix: &str,
+    ) {
+        let path = table_path
+            .join("_delta_log")
+            .join(format!("{version:020}.{suffix}"));
+        let file = OpenOptions::new().write(true).open(path).unwrap();
+        let last_modified = SystemTime::now().sub(Duration::from_millis(last_modified_millis));
+        let times = FileTimes::new()
+            .set_modified(last_modified)
+            .set_accessed(last_modified);
+        file.set_times(times).unwrap();
+    }
 
     #[tokio::test]
     async fn test_delete_expired_logs() -> DeltaResult<()> {
@@ -158,17 +176,6 @@ mod delete_expired_delta_log_in_checkpoint {
             .table_url()
             .to_file_path()
             .expect("Failed toc convert the table's Url to a file path");
-        let set_file_last_modified = |version: usize, last_modified_millis: u64| {
-            let mut path = table_path.clone();
-            path.push("_delta_log");
-            path.push(format!("{version:020}.json"));
-            let file = OpenOptions::new().write(true).open(path).unwrap();
-            let last_modified = SystemTime::now().sub(Duration::from_millis(last_modified_millis));
-            let times = FileTimes::new()
-                .set_modified(last_modified)
-                .set_accessed(last_modified);
-            file.set_times(times).unwrap();
-        };
 
         // create 2 commits
         let a1 = fs_common::add(0);
@@ -177,9 +184,9 @@ mod delete_expired_delta_log_in_checkpoint {
         assert_eq!(2, fs_common::commit_add(&mut table, &a2).await);
 
         // set last_modified
-        set_file_last_modified(0, 25 * 60 * 1000); // 25 mins ago, should be deleted
-        set_file_last_modified(1, 15 * 60 * 1000); // 15 mins ago, should be deleted
-        set_file_last_modified(2, 5 * 60 * 1000); // 5 mins ago, should be kept as last safe checkpoint
+        set_delta_log_file_last_modified(&table_path, 0, 25 * 60 * 1000, "json"); // 25 mins ago, should be deleted
+        set_delta_log_file_last_modified(&table_path, 1, 15 * 60 * 1000, "json"); // 15 mins ago, should be deleted
+        set_delta_log_file_last_modified(&table_path, 2, 5 * 60 * 1000, "json"); // 5 mins ago, should be kept as last safe checkpoint
 
         table.load_version(0).await.expect("Cannot load version 0");
         table.load_version(1).await.expect("Cannot load version 1");
@@ -195,9 +202,9 @@ mod delete_expired_delta_log_in_checkpoint {
         .expect("Failed to create a checkpoint and cleanup");
 
         table
-            .load()
+            .update_state()
             .await
-            .expect("Failed to read the checkpoint back");
+            .expect("Failed to refresh the table state from the new checkpoint");
         assert_eq!(
             table
                 .get_files_by_partitions(&[])
@@ -220,6 +227,74 @@ mod delete_expired_delta_log_in_checkpoint {
             .expect_err("Should not load version 1");
         // log file 2 is kept
         table.load_version(2).await.expect("Cannot load version 2");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_load_version_same_version_refreshes_checkpoint_base() -> DeltaResult<()> {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let table_location = tmp_dir.path().to_string_lossy().into_owned();
+        let mut table = fs_common::create_table(
+            &table_location,
+            Some(HashMap::from([
+                (
+                    TableProperty::LogRetentionDuration.as_ref().into(),
+                    Some("interval 0 minute".to_string()),
+                ),
+                (
+                    TableProperty::EnableExpiredLogCleanup.as_ref().into(),
+                    Some("true".to_string()),
+                ),
+            ])),
+        )
+        .await;
+
+        let table_path = table
+            .table_url()
+            .to_file_path()
+            .expect("Failed toc convert the table's Url to a file path");
+
+        let a1 = fs_common::add(0);
+        let a2 = fs_common::add(0);
+        let a3 = fs_common::add(0);
+        assert_eq!(1, fs_common::commit_add(&mut table, &a1).await);
+        assert_eq!(2, fs_common::commit_add(&mut table, &a2).await);
+
+        set_delta_log_file_last_modified(&table_path, 0, 25 * 60 * 1000, "json");
+        set_delta_log_file_last_modified(&table_path, 1, 15 * 60 * 1000, "json");
+        set_delta_log_file_last_modified(&table_path, 2, 5 * 60 * 1000, "json");
+
+        checkpoints::create_checkpoint_from_table_url_and_cleanup(
+            table.table_url().clone(),
+            table.version().expect("Failed to load version() on table"),
+            None,
+            None,
+        )
+        .await
+        .expect("Failed to create a checkpoint and cleanup");
+
+        table
+            .load_version(2)
+            .await
+            .expect("Failed to refresh the current version from the new checkpoint");
+
+        assert_eq!(3, fs_common::commit_add(&mut table, &a3).await);
+        table
+            .load_version(3)
+            .await
+            .expect("Failed to increment from the refreshed checkpoint base");
+        assert_eq!(
+            table
+                .get_files_by_partitions(&[])
+                .await
+                .expect("Failed to get_files_by_partitions()"),
+            vec![
+                ObjectStorePath::from(a3.path.as_ref()),
+                ObjectStorePath::from(a2.path.as_ref()),
+                ObjectStorePath::from(a1.path.as_ref()),
+            ]
+        );
+
         Ok(())
     }
 
@@ -248,17 +323,6 @@ mod delete_expired_delta_log_in_checkpoint {
             .table_url()
             .to_file_path()
             .expect("Failed toc convert the table's Url to a file path");
-        let set_file_last_modified = |version: usize, last_modified_millis: u64, suffix: &str| {
-            let mut path = table_path.clone();
-            path.push("_delta_log");
-            path.push(format!("{version:020}.{suffix}"));
-            let file = OpenOptions::new().write(true).open(path).unwrap();
-            let last_modified = SystemTime::now().sub(Duration::from_millis(last_modified_millis));
-            let times = FileTimes::new()
-                .set_modified(last_modified)
-                .set_accessed(last_modified);
-            file.set_times(times).unwrap();
-        };
 
         // create 4 commits
         let a1 = fs_common::add(0);
@@ -271,11 +335,11 @@ mod delete_expired_delta_log_in_checkpoint {
         assert_eq!(4, fs_common::commit_add(&mut table, &a4).await);
 
         // set last_modified
-        set_file_last_modified(0, 25 * 60 * 1000, "json"); // 25 mins ago, should be deleted
-        set_file_last_modified(1, 20 * 60 * 1000, "json"); // 20 mins ago, last safe checkpoint, should be kept
-        set_file_last_modified(2, 15 * 60 * 1000, "json"); // 15 mins ago, fails retention cutoff, but needed by v3
-        set_file_last_modified(3, 6 * 60 * 1000, "json"); // 6 mins ago, should be kept by retention cutoff
-        set_file_last_modified(4, 5 * 60 * 1000, "json"); // 5 mins ago, should be kept by retention cutoff
+        set_delta_log_file_last_modified(&table_path, 0, 25 * 60 * 1000, "json"); // 25 mins ago, should be deleted
+        set_delta_log_file_last_modified(&table_path, 1, 20 * 60 * 1000, "json"); // 20 mins ago, last safe checkpoint, should be kept
+        set_delta_log_file_last_modified(&table_path, 2, 15 * 60 * 1000, "json"); // 15 mins ago, fails retention cutoff, but needed by v3
+        set_delta_log_file_last_modified(&table_path, 3, 6 * 60 * 1000, "json"); // 6 mins ago, should be kept by retention cutoff
+        set_delta_log_file_last_modified(&table_path, 4, 5 * 60 * 1000, "json"); // 5 mins ago, should be kept by retention cutoff
 
         table.load_version(0).await.expect("Cannot load version 0");
         table.load_version(1).await.expect("Cannot load version 1");
@@ -294,7 +358,7 @@ mod delete_expired_delta_log_in_checkpoint {
         .unwrap();
 
         // Update checkpoint time for version 1 to be just after version 1 data
-        set_file_last_modified(1, 20 * 60 * 1000 - 10, "checkpoint.parquet");
+        set_delta_log_file_last_modified(&table_path, 1, 20 * 60 * 1000 - 10, "checkpoint.parquet");
 
         // Checkpoint final version
         checkpoints::create_checkpoint_from_table_url_and_cleanup(

--- a/crates/core/tests/fs_common/mod.rs
+++ b/crates/core/tests/fs_common/mod.rs
@@ -2,19 +2,12 @@ use chrono::Utc;
 use deltalake_core::DeltaTable;
 use deltalake_core::kernel::transaction::CommitBuilder;
 use deltalake_core::kernel::{Action, Add, DataType, PrimitiveType, StructField, StructType};
-use deltalake_core::logstore::object_store::{GetResult, Result as ObjectStoreResult};
 use deltalake_core::operations::create::CreateBuilder;
 use deltalake_core::protocol::{DeltaOperation, SaveMode};
-use object_store::path::Path as StorePath;
-use object_store::{
-    MultipartUpload, ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
-};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
-use url::Url;
 use uuid::Uuid;
 
 pub fn cleanup_dir_except<P: AsRef<Path>>(path: P, ignore_files: Vec<String>) {
@@ -125,153 +118,4 @@ pub async fn commit_actions(
         .await
         .expect("Failed to commit_actions: {actions:?}");
     version
-}
-
-#[derive(Debug)]
-pub struct SlowStore {
-    inner: Arc<dyn ObjectStore>,
-}
-impl std::fmt::Display for SlowStore {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
-impl SlowStore {
-    #[allow(dead_code)]
-    pub fn new(location: Url) -> deltalake_core::DeltaResult<Self> {
-        Ok(Self {
-            inner: deltalake_core::logstore::store_for(&location, None::<(&str, &str)>)?,
-        })
-    }
-}
-
-#[async_trait::async_trait]
-impl ObjectStore for SlowStore {
-    /// Save the provided bytes to the specified location.
-    async fn put(&self, location: &StorePath, bytes: PutPayload) -> ObjectStoreResult<PutResult> {
-        self.inner.put(location, bytes).await
-    }
-
-    async fn put_opts(
-        &self,
-        location: &StorePath,
-        bytes: PutPayload,
-        options: PutOptions,
-    ) -> ObjectStoreResult<PutResult> {
-        self.inner.put_opts(location, bytes, options).await
-    }
-
-    /// Return the bytes that are stored at the specified location.
-    async fn get(&self, location: &StorePath) -> ObjectStoreResult<GetResult> {
-        tokio::time::sleep(tokio::time::Duration::from_secs_f64(0.01)).await;
-        self.inner.get(location).await
-    }
-
-    /// Perform a get request with options
-    ///
-    /// Note: options.range will be ignored if [`GetResult::File`]
-    async fn get_opts(
-        &self,
-        location: &StorePath,
-        options: object_store::GetOptions,
-    ) -> ObjectStoreResult<GetResult> {
-        self.inner.get_opts(location, options).await
-    }
-
-    /// Return the bytes that are stored at the specified location
-    /// in the given byte range
-    async fn get_range(
-        &self,
-        location: &StorePath,
-        range: std::ops::Range<u64>,
-    ) -> ObjectStoreResult<bytes::Bytes> {
-        self.inner.get_range(location, range).await
-    }
-
-    /// Return the metadata for the specified location
-    async fn head(&self, location: &StorePath) -> ObjectStoreResult<object_store::ObjectMeta> {
-        self.inner.head(location).await
-    }
-
-    /// Delete the object at the specified location.
-    async fn delete(&self, location: &StorePath) -> ObjectStoreResult<()> {
-        self.inner.delete(location).await
-    }
-
-    /// List all the objects with the given prefix.
-    ///
-    /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
-    /// `foo/bar_baz/x`.
-    fn list(
-        &self,
-        prefix: Option<&StorePath>,
-    ) -> futures::stream::BoxStream<'static, ObjectStoreResult<object_store::ObjectMeta>> {
-        self.inner.list(prefix)
-    }
-
-    /// List all the objects with the given prefix and a location greater than `offset`
-    ///
-    /// Some stores, such as S3 and GCS, may be able to push `offset` down to reduce
-    /// the number of network requests required
-    fn list_with_offset(
-        &self,
-        prefix: Option<&StorePath>,
-        offset: &StorePath,
-    ) -> futures::stream::BoxStream<'static, ObjectStoreResult<object_store::ObjectMeta>> {
-        self.inner.list_with_offset(prefix, offset)
-    }
-
-    /// List objects with the given prefix and an implementation specific
-    /// delimiter. Returns common prefixes (directories) in addition to object
-    /// metadata.
-    ///
-    /// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
-    /// `foo/bar_baz/x`.
-    async fn list_with_delimiter(
-        &self,
-        prefix: Option<&StorePath>,
-    ) -> ObjectStoreResult<object_store::ListResult> {
-        self.inner.list_with_delimiter(prefix).await
-    }
-
-    /// Copy an object from one path to another in the same object store.
-    ///
-    /// If there exists an object at the destination, it will be overwritten.
-    async fn copy(&self, from: &StorePath, to: &StorePath) -> ObjectStoreResult<()> {
-        self.inner.copy(from, to).await
-    }
-
-    /// Copy an object from one path to another, only if destination is empty.
-    ///
-    /// Will return an error if the destination already has an object.
-    async fn copy_if_not_exists(&self, from: &StorePath, to: &StorePath) -> ObjectStoreResult<()> {
-        self.inner.copy_if_not_exists(from, to).await
-    }
-
-    /// Move an object from one path to another in the same object store.
-    ///
-    /// Will return an error if the destination already has an object.
-    async fn rename_if_not_exists(
-        &self,
-        from: &StorePath,
-        to: &StorePath,
-    ) -> ObjectStoreResult<()> {
-        self.inner.rename_if_not_exists(from, to).await
-    }
-
-    async fn put_multipart(
-        &self,
-        location: &StorePath,
-    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
-        self.inner.put_multipart(location).await
-    }
-
-    async fn put_multipart_opts(
-        &self,
-        location: &StorePath,
-        options: PutMultipartOptions,
-    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
-        self.inner.put_multipart_opts(location, options).await
-    }
 }

--- a/crates/core/tests/read_delta_log_test.rs
+++ b/crates/core/tests/read_delta_log_test.rs
@@ -1,7 +1,15 @@
-use deltalake_core::{DeltaResult, DeltaTableBuilder};
+use deltalake_core::logstore::object_store::{GetResult, Result as ObjectStoreResult};
+use deltalake_core::table::builder::DeltaTableConfig;
+use deltalake_core::table::state::DeltaTableState;
+use deltalake_core::{DeltaResult, DeltaTableBuilder, DeltaTableError};
+use object_store::path::Path as StorePath;
+use object_store::{
+    MultipartUpload, ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+};
 use pretty_assertions::assert_eq;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 use url::Url;
 
@@ -15,6 +23,167 @@ fn find_git_root() -> PathBuf {
         .output()
         .unwrap();
     PathBuf::from(String::from_utf8(output.stdout).unwrap().trim())
+}
+
+#[derive(Debug)]
+struct InstrumentedStore {
+    inner: Arc<dyn ObjectStore>,
+    recorded_gets: Option<Mutex<Vec<String>>>,
+    delay_gets: bool,
+}
+
+impl std::fmt::Display for InstrumentedStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl InstrumentedStore {
+    fn new_slow(location: Url) -> DeltaResult<Self> {
+        Ok(Self {
+            inner: deltalake_core::logstore::store_for(&location, None::<(&str, &str)>)?,
+            recorded_gets: None,
+            delay_gets: true,
+        })
+    }
+
+    fn new_recording(location: Url) -> DeltaResult<Self> {
+        Ok(Self {
+            inner: deltalake_core::logstore::store_for(&location, None::<(&str, &str)>)?,
+            recorded_gets: Some(Mutex::new(Vec::new())),
+            delay_gets: false,
+        })
+    }
+
+    fn recorded_gets(&self) -> Vec<String> {
+        self.recorded_gets
+            .as_ref()
+            .expect("recorded_gets not enabled for this store")
+            .lock()
+            .expect("recorded_gets mutex poisoned")
+            .clone()
+    }
+
+    fn clear_recorded_gets(&self) {
+        self.recorded_gets
+            .as_ref()
+            .expect("recorded_gets not enabled for this store")
+            .lock()
+            .expect("recorded_gets mutex poisoned")
+            .clear();
+    }
+
+    fn record_get(&self, location: &StorePath) {
+        if let Some(recorded_gets) = &self.recorded_gets {
+            recorded_gets
+                .lock()
+                .expect("recorded_gets mutex poisoned")
+                .push(location.to_string());
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for InstrumentedStore {
+    async fn put(&self, location: &StorePath, bytes: PutPayload) -> ObjectStoreResult<PutResult> {
+        self.inner.put(location, bytes).await
+    }
+
+    async fn put_opts(
+        &self,
+        location: &StorePath,
+        bytes: PutPayload,
+        options: PutOptions,
+    ) -> ObjectStoreResult<PutResult> {
+        self.inner.put_opts(location, bytes, options).await
+    }
+
+    async fn get(&self, location: &StorePath) -> ObjectStoreResult<GetResult> {
+        self.record_get(location);
+        if self.delay_gets {
+            tokio::time::sleep(tokio::time::Duration::from_secs_f64(0.01)).await;
+        }
+        self.inner.get(location).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &StorePath,
+        options: object_store::GetOptions,
+    ) -> ObjectStoreResult<GetResult> {
+        self.record_get(location);
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn get_range(
+        &self,
+        location: &StorePath,
+        range: std::ops::Range<u64>,
+    ) -> ObjectStoreResult<bytes::Bytes> {
+        self.record_get(location);
+        self.inner.get_range(location, range).await
+    }
+
+    async fn head(&self, location: &StorePath) -> ObjectStoreResult<object_store::ObjectMeta> {
+        self.inner.head(location).await
+    }
+
+    async fn delete(&self, location: &StorePath) -> ObjectStoreResult<()> {
+        self.inner.delete(location).await
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&StorePath>,
+    ) -> futures::stream::BoxStream<'static, ObjectStoreResult<object_store::ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&StorePath>,
+        offset: &StorePath,
+    ) -> futures::stream::BoxStream<'static, ObjectStoreResult<object_store::ObjectMeta>> {
+        self.inner.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        prefix: Option<&StorePath>,
+    ) -> ObjectStoreResult<object_store::ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &StorePath, to: &StorePath) -> ObjectStoreResult<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &StorePath, to: &StorePath) -> ObjectStoreResult<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+
+    async fn rename_if_not_exists(
+        &self,
+        from: &StorePath,
+        to: &StorePath,
+    ) -> ObjectStoreResult<()> {
+        self.inner.rename_if_not_exists(from, to).await
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &StorePath,
+    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart(location).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &StorePath,
+        options: PutMultipartOptions,
+    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, options).await
+    }
 }
 
 #[tokio::test]
@@ -34,7 +203,7 @@ async fn test_log_buffering() {
     let location = Url::from_directory_path(path).unwrap();
 
     // use storage that sleeps 10ms on every `get`
-    let store = std::sync::Arc::new(fs_common::SlowStore::new(location.clone()).unwrap());
+    let store = Arc::new(InstrumentedStore::new_slow(location.clone()).unwrap());
 
     let mut seq_version = 0;
     let t = SystemTime::now();
@@ -101,6 +270,19 @@ async fn test_log_buffering_success_explicit_version() {
             .unwrap();
         table.update_incremental(None).await.unwrap();
         assert_eq!(table.version(), Some(10));
+        let err = table.update_incremental(Some(0)).await.unwrap_err();
+        assert!(
+            matches!(err, DeltaTableError::Generic(_)),
+            "expected downgrade through update_incremental to fail with an existing error shape: {err}"
+        );
+        assert!(
+            err.to_string()
+                .contains("Cannot downgrade via update_incremental from version 10 to 0"),
+            "expected downgrade error message to direct callers to load_version: {err}"
+        );
+        assert_eq!(table.version(), Some(10));
+        table.load_version(0).await.unwrap();
+        assert_eq!(table.version(), Some(0));
 
         let mut table = DeltaTableBuilder::from_url(Url::from_directory_path(&path).unwrap())
             .unwrap()
@@ -146,6 +328,156 @@ async fn test_log_buffering_success_explicit_version() {
         table.update_incremental(None).await.unwrap();
         assert_eq!(table.version(), Some(10));
     }
+}
+
+#[tokio::test]
+async fn test_update_incremental_does_not_reread_initial_commit() {
+    let n_commits = 10;
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let path = tmp_dir.path().to_path_buf();
+    let mut table = fs_common::create_table(&path.to_string_lossy(), None).await;
+    for _ in 0..n_commits {
+        let add = fs_common::add(3 * 60 * 1000);
+        fs_common::commit_add(&mut table, &add).await;
+    }
+
+    let location = Url::from_directory_path(&path).unwrap();
+    let store_root = Url::from_directory_path(path.ancestors().last().unwrap()).unwrap();
+    let store = Arc::new(InstrumentedStore::new_recording(store_root).unwrap());
+    let mut table = DeltaTableBuilder::from_url(location.clone())
+        .unwrap()
+        .with_storage_backend(store.clone(), location)
+        .with_version(0)
+        .load()
+        .await
+        .unwrap();
+
+    store.clear_recorded_gets();
+    table.update_incremental(None).await.unwrap();
+
+    let recorded_gets = store.recorded_gets();
+    assert_eq!(table.version(), Some(n_commits));
+    assert!(
+        recorded_gets
+            .iter()
+            .any(|path| path.ends_with("_delta_log/00000000000000000001.json")),
+        "expected incremental update to read newer commits: {recorded_gets:?}"
+    );
+    assert!(
+        !recorded_gets
+            .iter()
+            .any(|path| path.ends_with("_delta_log/00000000000000000000.json")),
+        "update_incremental reread the initial commit instead of reusing loaded state: {recorded_gets:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_update_incremental_skips_last_checkpoint_lookup_when_current_checkpoint_loaded() {
+    let n_commits = 2;
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let path = tmp_dir.path().to_path_buf();
+    let mut table = fs_common::create_table(&path.to_string_lossy(), None).await;
+    for _ in 0..n_commits {
+        let add = fs_common::add(3 * 60 * 1000);
+        fs_common::commit_add(&mut table, &add).await;
+    }
+
+    let location = Url::from_directory_path(&path).unwrap();
+    let store_root = Url::from_directory_path(path.ancestors().last().unwrap()).unwrap();
+    let store = Arc::new(InstrumentedStore::new_recording(store_root).unwrap());
+
+    deltalake_core::checkpoints::create_checkpoint_from_table_url_and_cleanup(
+        location.clone(),
+        table.version().unwrap(),
+        Some(false),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let mut table = DeltaTableBuilder::from_url(location.clone())
+        .unwrap()
+        .with_storage_backend(store.clone(), location)
+        .load()
+        .await
+        .unwrap();
+
+    store.clear_recorded_gets();
+    table.update_incremental(None).await.unwrap();
+
+    let recorded_gets = store.recorded_gets();
+    assert_eq!(table.version(), Some(n_commits));
+    assert!(
+        !recorded_gets
+            .iter()
+            .any(|path| path.ends_with("_delta_log/_last_checkpoint")),
+        "expected no same-version checkpoint lookup when already loaded from the current checkpoint: {recorded_gets:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_delta_table_state_update_refreshes_same_version_checkpoint_base() {
+    let n_commits = 2;
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let path = tmp_dir.path().to_path_buf();
+    let mut table = fs_common::create_table(&path.to_string_lossy(), None).await;
+    for _ in 0..n_commits {
+        let add = fs_common::add(3 * 60 * 1000);
+        fs_common::commit_add(&mut table, &add).await;
+    }
+
+    let location = Url::from_directory_path(&path).unwrap();
+    let store_root = Url::from_directory_path(path.ancestors().last().unwrap()).unwrap();
+    let store = Arc::new(InstrumentedStore::new_recording(store_root).unwrap());
+    let instrumented_table = DeltaTableBuilder::from_url(location.clone())
+        .unwrap()
+        .with_storage_backend(store.clone(), location.clone())
+        .build()
+        .unwrap();
+    let mut state = DeltaTableState::try_new(
+        instrumented_table.log_store().as_ref(),
+        DeltaTableConfig::default(),
+        Some(n_commits),
+    )
+    .await
+    .unwrap();
+
+    deltalake_core::checkpoints::create_checkpoint_from_table_url_and_cleanup(
+        location,
+        n_commits,
+        Some(false),
+        None,
+    )
+    .await
+    .unwrap();
+
+    store.clear_recorded_gets();
+    state
+        .update(instrumented_table.log_store().as_ref(), Some(n_commits))
+        .await
+        .unwrap();
+
+    let recorded_gets = store.recorded_gets();
+    assert!(
+        recorded_gets
+            .iter()
+            .any(|path| path.ends_with("_delta_log/_last_checkpoint")),
+        "expected DeltaTableState::update to consult _last_checkpoint for a same-version refresh: {recorded_gets:?}"
+    );
+
+    store.clear_recorded_gets();
+    state
+        .update(instrumented_table.log_store().as_ref(), Some(n_commits))
+        .await
+        .unwrap();
+
+    let recorded_gets = store.recorded_gets();
+    assert!(
+        !recorded_gets
+            .iter()
+            .any(|path| path.ends_with("_delta_log/_last_checkpoint")),
+        "expected DeltaTableState::update to skip _last_checkpoint once refreshed from the current checkpoint: {recorded_gets:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description
Fixes #4276

Incremental update from a cached table state could fall off the reuse path and reread older log state from scratch.

The fix here is to route `DeltaTable::update_incremental` back through `DeltaTableState::update` and add a narrow same version checkpoint refresh when `_last_checkpoint` points at the current version but the state isn't checkpoint backed.

Since there is multiple things going on in this area, I intentionally scoped to the regression only. 

This PR does not touch:
- https://github.com/delta-io/delta-kernel-rs/issues/2103
- #4269

Tests cover the original reread bug and checkpoint refresh behavior

# Related Issue(s)
- #4276
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
