### PR TITLE
fix(tests): replace tempfile with tmp_path in date partitioned table test

### DIFF
--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1,6 +1,5 @@
 import multiprocessing
 import os
-import tempfile
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -1000,10 +999,10 @@ def test_partitions_filtering_partitioned_table():
 
 
 @pytest.mark.pyarrow
-def test_partitions_date_partitioned_table():
+def test_partitions_date_partitioned_table(tmp_path: Path):
     import pyarrow as pa
 
-    table_path = tempfile.gettempdir() + "/date_partition_table"
+    table_path = tmp_path / "date_partition_table"
     date_partitions = [
         date(2024, 8, 1),
         date(2024, 8, 2),


### PR DESCRIPTION
# Description
This test fails on local when run repeatedly. 

`tempfile.gettempdir()` always returns the same path and cauases test to fail on second run. 
Existing fixture for `tmp_path` returns unique path for each test

# Related Issue(s)

# Documentation
NA