### PR TITLE
fix(ci): remove `v` prefix from actions/labeler SHA pin

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -25,7 +25,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
             (github.event.action == 'opened' ||
              github.event.action == 'synchronize')
-        uses: actions/labeler@v634933edcd8ababfe52f92936142cc22ac488b1b
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/workflows/dev_pr/labeler.yml


### PR DESCRIPTION
# Description
Remove erroneous `v` prefix from `actions/labeler` SHA pin that broke the Process workflow. All other actions in the same file use raw SHA without prefix.

# Related Issue(s)
- Introduced in f7ec6c49 (`ci: pin all actions to sha1s rather than tags`)

# Documentation