### PR TITLE
docs: add missing page to toc, and fix links

### DIFF
--- a/docs/usage/working-with-partitions.md
+++ b/docs/usage/working-with-partitions.md
@@ -37,8 +37,7 @@ tmp/partitioned-table/
 
 ### Filtering by partition columns
 
-Because partition columns are part of the storage path, queries that filter on those columns can skip reading unneeded partitions. You can specify partition filters when reading data with [DeltaTable.to_pandas()](../../delta_table/#deltalake.DeltaTable.to_pandas).
-
+Because partition columns are part of the storage path, queries that filter on those columns can skip reading unneeded partitions. You can specify partition filters when reading data with [DeltaTable.to_pandas()](../api/delta_table/index.md#deltalake.DeltaTable.to_pandas).
 
 In this example we restrict our query to the `country="US"` partition.
 ```python
@@ -204,7 +203,7 @@ This command logically deletes the data by creating a new transaction.
 
 ### Optimize & Vacuum
 
-Partitioned tables can accumulate many small files if a partition is frequently appended to. You can compact these into larger files on a specific partition with [`optimize.compact`](../../delta_table/#deltalake.DeltaTable.optimize).
+Partitioned tables can accumulate many small files if a partition is frequently appended to. You can compact these into larger files on a specific partition with [`optimize.compact`](../api/delta_table/index.md#deltalake.DeltaTable.optimize).
 
 If we want to target compaction at specific partitions we can include partition filters.
 
@@ -212,7 +211,7 @@ If we want to target compaction at specific partitions we can include partition 
  dt.optimize.compact(partition_filters=[("country", "=", "CA")])
  ```
 
-Then optionally [`vacuum`](../../delta_table/#deltalake.DeltaTable.vacuum) the table to remove older, unreferenced files.
+Then optionally [`vacuum`](../api/delta_table/index.md#deltalake.DeltaTable.vacuum) the table to remove older, unreferenced files.
 
 ### Handling High-Cardinality Columns
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - Querying a table: usage/querying-delta-tables.md
       - Merging a table: usage/merging-tables.md
       - Managing a table: usage/managing-tables.md
+      - Working with partitions: usage/working-with-partitions.md
       - Writing a table:
           - usage/writing/index.md
           - usage/writing/writing-to-s3-with-locking-provider.md


### PR DESCRIPTION
# Description

Addresses warnings about page not present in `mkdocs.yml` and fixes 3 links in page.