### PR TITLE
feat: support nested struct columns in Z-Order optimization (#2007)

### DIFF
--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -55,7 +55,9 @@ use crate::delta_datafusion::{
 };
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, DEFAULT_RETRIES, PROTOCOL};
-use crate::kernel::{Action, Add, PartitionsExt, Remove, Version, scalars::ScalarExt};
+use crate::kernel::{
+    Action, Add, DataType, PartitionsExt, Remove, StructType, Version, scalars::ScalarExt,
+};
 use crate::kernel::{EagerSnapshot, resolve_snapshot};
 use crate::logstore::{LogStore, LogStoreRef, ObjectStoreRef};
 use crate::parquet_utils::default_writer_properties;
@@ -727,6 +729,7 @@ impl MergePlan {
         table_provider: DeltaTableProvider,
     ) -> Result<BoxStream<'static, Result<RecordBatch, ParquetError>>, DeltaTableError> {
         use datafusion::common::Column;
+        use datafusion::functions::core::expr_ext::FieldAccessor;
         use datafusion::logical_expr::expr::ScalarFunction;
         use datafusion::logical_expr::{Expr, ScalarUDF};
 
@@ -736,7 +739,15 @@ impl MergePlan {
         let cols = context
             .columns
             .iter()
-            .map(|col| Expr::Column(Column::from_qualified_name_ignore_case(col)))
+            .map(|col_name| {
+                let mut segments = col_name.split('.');
+                let first = segments.next().expect("column name cannot be empty");
+                let mut expr = Expr::Column(Column::new_unqualified(first));
+                for segment in segments {
+                    expr = expr.field(segment);
+                }
+                expr
+            })
             .collect_vec();
         let expr = Expr::ScalarFunction(ScalarFunction::new_udf(
             Arc::new(ScalarUDF::from(zorder::datafusion::ZOrderUDF)),
@@ -1235,6 +1246,31 @@ async fn build_compaction_plan(
     ))
 }
 
+/// Validates that a z-order column path exists in the schema, supporting nested
+/// struct fields via dot notation (e.g., "meta.field_a").
+fn validate_zorder_column(schema: &StructType, column: &str) -> Result<(), DeltaTableError> {
+    let mut segments = column.split('.').peekable();
+    let mut current_struct = schema;
+    while let Some(segment) = segments.next() {
+        let field = current_struct.field(segment).ok_or_else(|| {
+            DeltaTableError::Generic(format!(
+                "Z-order column \"{column}\": field \"{segment}\" not found in schema"
+            ))
+        })?;
+        if segments.peek().is_some() {
+            match field.data_type() {
+                DataType::Struct(inner) => current_struct = inner,
+                _ => {
+                    return Err(DeltaTableError::Generic(format!(
+                        "Z-order column \"{column}\": \"{segment}\" is not a struct type"
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn build_zorder_plan(
     log_store: &dyn LogStore,
     zorder_columns: Vec<String>,
@@ -1257,19 +1293,8 @@ async fn build_zorder_plan(
             "Z-order columns cannot be partition columns. Found: {zorder_partition_cols:?}"
         )));
     }
-    let field_names = snapshot
-        .schema()
-        .fields()
-        .map(|field| field.name().to_string())
-        .collect_vec();
-    let unknown_columns = zorder_columns
-        .iter()
-        .filter(|col| !field_names.contains(col))
-        .collect_vec();
-    if !unknown_columns.is_empty() {
-        return Err(DeltaTableError::Generic(format!(
-            "Z-order columns must be present in the table schema. Unknown columns: {unknown_columns:?}"
-        )));
+    for col in &zorder_columns {
+        validate_zorder_column(snapshot.schema().as_ref(), col)?;
     }
 
     // For now, just be naive and optimize all files in each selected partition.

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -728,10 +728,9 @@ impl MergePlan {
         context: Arc<zorder::ZOrderExecContext>,
         table_provider: DeltaTableProvider,
     ) -> Result<BoxStream<'static, Result<RecordBatch, ParquetError>>, DeltaTableError> {
-        use datafusion::common::Column;
         use datafusion::functions::core::expr_ext::FieldAccessor;
         use datafusion::logical_expr::expr::ScalarFunction;
-        use datafusion::logical_expr::{Expr, ScalarUDF};
+        use datafusion::logical_expr::{Expr, ScalarUDF, ident};
 
         let provider = table_provider.with_files(files.files);
         let df = context.ctx.read_table(Arc::new(provider))?;
@@ -742,7 +741,7 @@ impl MergePlan {
             .map(|col_name| {
                 let mut segments = col_name.split('.');
                 let first = segments.next().expect("column name cannot be empty");
-                let mut expr = Expr::Column(Column::new_unqualified(first));
+                let mut expr = ident(first);
                 for segment in segments {
                     expr = expr.field(segment);
                 }

--- a/crates/core/tests/command_optimize.rs
+++ b/crates/core/tests/command_optimize.rs
@@ -1299,9 +1299,10 @@ async fn test_zorder_rejects_nonexistent_columns() -> Result<(), Box<dyn Error>>
         .with_type(OptimizeType::ZOrder(vec!["non-existent".to_string()]))
         .await;
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains(
-        "Z-order columns must be present in the table schema. Unknown columns: [\"non-existent\"]"
-    ));
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("field \"non-existent\" not found in schema"));
     Ok(())
 }
 
@@ -1495,6 +1496,123 @@ async fn test_zorder_respects_target_size() -> Result<(), Box<dyn Error>> {
 
     // Allow going a little over the target size
     assert!(metrics.files_added.max < 11_000_000);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_zorder_nested_columns() -> Result<(), Box<dyn Error>> {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        Field::new(
+            "meta",
+            ArrowDataType::Struct(
+                vec![Field::new("field_a", ArrowDataType::Int32, false)].into(),
+            ),
+            false,
+        ),
+        Field::new("value", ArrowDataType::Int32, false),
+    ]));
+
+    let batch1 = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(arrow_array::StructArray::from(vec![(
+                Arc::new(Field::new("field_a", ArrowDataType::Int32, false)),
+                Arc::new(Int32Array::from(vec![1, 2, 3])) as Arc<dyn arrow_array::Array>,
+            )])),
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+        ],
+    )?;
+
+    let batch2 = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(arrow_array::StructArray::from(vec![(
+                Arc::new(Field::new("field_a", ArrowDataType::Int32, false)),
+                Arc::new(Int32Array::from(vec![4, 5, 6])) as Arc<dyn arrow_array::Array>,
+            )])),
+            Arc::new(Int32Array::from(vec![40, 50, 60])),
+        ],
+    )?;
+
+    let table = DeltaTable::new_in_memory()
+        .write(vec![batch1])
+        .with_save_mode(deltalake_core::protocol::SaveMode::Append)
+        .await?;
+
+    let table = table
+        .write(vec![batch2])
+        .with_save_mode(deltalake_core::protocol::SaveMode::Append)
+        .await?;
+
+    let (_, metrics) = table
+        .optimize()
+        .with_type(OptimizeType::ZOrder(vec!["meta.field_a".to_string()]))
+        .await?;
+
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_zorder_rejects_invalid_nested_path() -> Result<(), Box<dyn Error>> {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        Field::new(
+            "meta",
+            ArrowDataType::Struct(
+                vec![Field::new("field_a", ArrowDataType::Int32, false)].into(),
+            ),
+            false,
+        ),
+        Field::new("value", ArrowDataType::Int32, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(arrow_array::StructArray::from(vec![(
+                Arc::new(Field::new("field_a", ArrowDataType::Int32, false)),
+                Arc::new(Int32Array::from(vec![1, 2, 3])) as Arc<dyn arrow_array::Array>,
+            )])),
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+        ],
+    )?;
+
+    // Non-existent nested field
+    let table = DeltaTable::new_in_memory()
+        .write(vec![batch.clone()])
+        .with_save_mode(deltalake_core::protocol::SaveMode::Append)
+        .await?;
+
+    let result = table
+        .optimize()
+        .with_type(OptimizeType::ZOrder(vec![
+            "meta.nonexistent".to_string(),
+        ]))
+        .await;
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("field \"nonexistent\" not found in schema"));
+
+    // Non-struct intermediate field
+    let table = DeltaTable::new_in_memory()
+        .write(vec![batch])
+        .with_save_mode(deltalake_core::protocol::SaveMode::Append)
+        .await?;
+
+    let result = table
+        .optimize()
+        .with_type(OptimizeType::ZOrder(vec!["value.sub".to_string()]))
+        .await;
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("\"value\" is not a struct type"));
 
     Ok(())
 }

--- a/crates/core/tests/command_optimize.rs
+++ b/crates/core/tests/command_optimize.rs
@@ -1299,10 +1299,12 @@ async fn test_zorder_rejects_nonexistent_columns() -> Result<(), Box<dyn Error>>
         .with_type(OptimizeType::ZOrder(vec!["non-existent".to_string()]))
         .await;
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("field \"non-existent\" not found in schema"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("field \"non-existent\" not found in schema")
+    );
     Ok(())
 }
 
@@ -1505,9 +1507,7 @@ async fn test_zorder_nested_columns() -> Result<(), Box<dyn Error>> {
     let schema = Arc::new(ArrowSchema::new(vec![
         Field::new(
             "meta",
-            ArrowDataType::Struct(
-                vec![Field::new("field_a", ArrowDataType::Int32, false)].into(),
-            ),
+            ArrowDataType::Struct(vec![Field::new("field_a", ArrowDataType::Int32, false)].into()),
             false,
         ),
         Field::new("value", ArrowDataType::Int32, false),
@@ -1561,9 +1561,7 @@ async fn test_zorder_rejects_invalid_nested_path() -> Result<(), Box<dyn Error>>
     let schema = Arc::new(ArrowSchema::new(vec![
         Field::new(
             "meta",
-            ArrowDataType::Struct(
-                vec![Field::new("field_a", ArrowDataType::Int32, false)].into(),
-            ),
+            ArrowDataType::Struct(vec![Field::new("field_a", ArrowDataType::Int32, false)].into()),
             false,
         ),
         Field::new("value", ArrowDataType::Int32, false),
@@ -1588,15 +1586,15 @@ async fn test_zorder_rejects_invalid_nested_path() -> Result<(), Box<dyn Error>>
 
     let result = table
         .optimize()
-        .with_type(OptimizeType::ZOrder(vec![
-            "meta.nonexistent".to_string(),
-        ]))
+        .with_type(OptimizeType::ZOrder(vec!["meta.nonexistent".to_string()]))
         .await;
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("field \"nonexistent\" not found in schema"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("field \"nonexistent\" not found in schema")
+    );
 
     // Non-struct intermediate field
     let table = DeltaTable::new_in_memory()
@@ -1609,10 +1607,12 @@ async fn test_zorder_rejects_invalid_nested_path() -> Result<(), Box<dyn Error>>
         .with_type(OptimizeType::ZOrder(vec!["value.sub".to_string()]))
         .await;
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("\"value\" is not a struct type"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("\"value\" is not a struct type")
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Z-Order now accepts dot-notation paths for nested struct fields (e.g., "meta.field_a").  Validation layer only checked top-level field names, so "meta.field_a" was rejected as an unknown column. And even if validation was bypassed, the execution layer treated the dot as a table qualifier instead of a struct field accessor, so it would fail there too.

# Description
- Fixes #2007: Z-Order now accepts dot-notation paths for nested struct fields (e.g., "meta.field_a")
- Adds validate_zorder_column() that walks the schema to verify each path segment exists and intermediate segments are struct types
- Fixes read_zorder() to build proper DataFusion nested field expressions instead of treating dots as table qualifiers

# Related Issue(s)

- closes #2007