### PR TITLE
fix: refine merge duplicate validation semantics

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -290,7 +290,7 @@ pub(crate) fn get_path_column<'a>(
     let err = || DeltaTableError::Generic("Unable to obtain Delta-rs path column".to_string());
     batch
         .column_by_name(path_column)
-        .unwrap()
+        .ok_or_else(err)?
         .as_any()
         .downcast_ref::<DictionaryArray<UInt16Type>>()
         .ok_or_else(err)?

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -29,7 +29,7 @@
 //! ````
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::ops::Deref;
+use std::ops::{Deref, Not};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -48,7 +48,7 @@ use datafusion::logical_expr::build_join_schema;
 use datafusion::logical_expr::simplify::SimplifyContext;
 use datafusion::logical_expr::utils::split_conjunction_owned;
 use datafusion::logical_expr::{
-    Expr, JoinType, col, conditional_expressions::CaseBuilder, lit, when,
+    Expr, ExprFunctionExt, JoinType, col, conditional_expressions::CaseBuilder, lit, when,
 };
 use datafusion::logical_expr::{
     Extension, LogicalPlan, LogicalPlanBuilder, UNNAMED_TABLE, UserDefinedLogicalNode,
@@ -110,7 +110,8 @@ const TARGET_COLUMN: &str = "__delta_rs_target";
 
 const OPERATION_COLUMN: &str = "__delta_rs_operation";
 const DELETE_COLUMN: &str = "__delta_rs_delete";
-const TARGET_ROW_INDEX_COLUMN: &str = "__delta_rs_target_row_index";
+const TARGET_ROW_ORDINAL_IN_FILE_COLUMN: &str = "__delta_rs_target_row_ordinal_in_file";
+const TARGET_MATCH_ROW_RANK_COLUMN: &str = "__delta_rs_target_match_row_rank";
 pub(crate) const TARGET_INSERT_COLUMN: &str = "__delta_rs_target_insert";
 pub(crate) const TARGET_UPDATE_COLUMN: &str = "__delta_rs_target_update";
 pub(crate) const TARGET_DELETE_COLUMN: &str = "__delta_rs_target_delete";
@@ -542,25 +543,15 @@ enum OperationType {
     Copy,
 }
 
-/// Duplicate-match validation class encoding.
+// This enum models whether a matched source/target pair participated in a duplicate relevant
+// WHEN MATCHED clause, not the final write path operation chosen for the row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
-enum CardinalityClass {
+enum MatchParticipationClass {
     Ignore = 0,
-    MatchedUnconditionalDelete = 1,
-    DuplicateInvalidating = 2,
-}
-
-impl CardinalityClass {
-    fn for_matched_operation(op_type: OperationType, is_unconditional: bool) -> Self {
-        match op_type {
-            OperationType::Delete if is_unconditional => Self::MatchedUnconditionalDelete,
-            OperationType::Delete | OperationType::Update | OperationType::Copy => {
-                Self::DuplicateInvalidating
-            }
-            OperationType::Insert | OperationType::SourceDelete => Self::Ignore,
-        }
-    }
+    MatchedNoop = 1,
+    MatchedUnconditionalDelete = 2,
+    MatchedAction = 3,
 }
 
 //Encapsute the User's Merge configuration for later processing
@@ -579,7 +570,7 @@ struct MergeOperation {
     operations: HashMap<Column, Expr>,
     r#type: OperationType,
     /// Duplicate-match validation class for this operation.
-    cardinality_class: CardinalityClass,
+    match_participation_class: MatchParticipationClass,
 }
 
 impl MergeOperation {
@@ -639,15 +630,19 @@ impl MergeOperation {
             predicate: maybe_into_expr(config.predicate, schema, state)?,
             operations: ops,
             r#type: config.r#type,
-            cardinality_class: CardinalityClass::Ignore,
+            match_participation_class: MatchParticipationClass::Ignore,
         })
     }
 
     fn into_matched(mut self) -> Self {
-        let is_unconditional =
-            matches!(self.r#type, OperationType::Delete) && self.predicate.is_none();
-        self.cardinality_class =
-            CardinalityClass::for_matched_operation(self.r#type, is_unconditional);
+        self.match_participation_class = match self.r#type {
+            OperationType::Delete if self.predicate.is_none() => {
+                MatchParticipationClass::MatchedUnconditionalDelete
+            }
+            OperationType::Delete | OperationType::Update => MatchParticipationClass::MatchedAction,
+            OperationType::Copy => MatchParticipationClass::MatchedNoop,
+            OperationType::Insert | OperationType::SourceDelete => MatchParticipationClass::Ignore,
+        };
         self
     }
 }
@@ -790,7 +785,9 @@ impl ExtensionPlanner for MergeMetricExtensionPlanner {
             let schema = validation.input.schema();
             return Ok(Some(Arc::new(MergeValidationExec::new(
                 physical_inputs.first().unwrap().clone(),
-                planner.create_physical_expr(&validation.expr, schema, session_state)?,
+                planner.create_physical_expr(&validation.file_expr, schema, session_state)?,
+                Arc::clone(&validation.file_column),
+                Arc::clone(&validation.row_ordinal_column),
             ))));
         }
 
@@ -996,7 +993,12 @@ async fn execute(
         }),
     });
     let target = DataFrame::new(state.clone(), target);
-    let target = target.with_column(TARGET_ROW_INDEX_COLUMN, row_number())?;
+    let target = target.with_column(
+        TARGET_ROW_ORDINAL_IN_FILE_COLUMN,
+        row_number()
+            .partition_by(vec![col(file_column.as_str())])
+            .build()?,
+    )?;
     let target = target.with_column(TARGET_COLUMN, lit(true))?;
 
     let join = source.join(target, JoinType::Full, &[], &[], Some(predicate.clone()))?;
@@ -1087,12 +1089,19 @@ async fn execute(
 
     let mut when_expr = Vec::with_capacity(operations_size);
     let mut then_expr = Vec::with_capacity(operations_size);
-    let mut ops: Vec<(HashMap<Column, Expr>, OperationType, CardinalityClass)> =
-        Vec::with_capacity(operations_size);
+    let mut ops: Vec<(
+        HashMap<Column, Expr>,
+        OperationType,
+        MatchParticipationClass,
+    )> = Vec::with_capacity(operations_size);
 
     fn update_case(
         operations: Vec<MergeOperation>,
-        ops: &mut Vec<(HashMap<Column, Expr>, OperationType, CardinalityClass)>,
+        ops: &mut Vec<(
+            HashMap<Column, Expr>,
+            OperationType,
+            MatchParticipationClass,
+        )>,
         when_expr: &mut Vec<Expr>,
         then_expr: &mut Vec<Expr>,
         base_expr: &Expr,
@@ -1108,7 +1117,7 @@ async fn execute(
             when_expr.push(predicate);
             then_expr.push(lit(ops.len() as i32));
 
-            ops.push((op.operations, op.r#type, op.cardinality_class));
+            ops.push((op.operations, op.r#type, op.match_participation_class));
 
             let action_type = match op.r#type {
                 OperationType::Update => "update",
@@ -1160,12 +1169,12 @@ async fn execute(
         &not_matched_source,
     )?;
 
-    when_expr.push(matched);
+    when_expr.push(matched.clone());
     then_expr.push(lit(ops.len() as i32));
     ops.push((
         HashMap::new(),
         OperationType::Copy,
-        CardinalityClass::DuplicateInvalidating,
+        MatchParticipationClass::MatchedNoop,
     ));
 
     when_expr.push(not_matched_target);
@@ -1173,7 +1182,7 @@ async fn execute(
     ops.push((
         HashMap::new(),
         OperationType::SourceDelete,
-        CardinalityClass::Ignore,
+        MatchParticipationClass::Ignore,
     ));
 
     when_expr.push(not_matched_source);
@@ -1181,7 +1190,7 @@ async fn execute(
     ops.push((
         HashMap::new(),
         OperationType::Copy,
-        CardinalityClass::Ignore,
+        MatchParticipationClass::Ignore,
     ));
 
     let case = CaseBuilder::new(None, when_expr, then_expr, None).end()?;
@@ -1407,16 +1416,37 @@ async fn execute(
         )
         .end()?;
 
+        let match_row_rank = row_number()
+            .partition_by(vec![
+                col(file_column.as_str()),
+                col(TARGET_ROW_ORDINAL_IN_FILE_COLUMN),
+            ])
+            .order_by(vec![
+                col(TARGET_MATCH_CARDINALITY_CLASS_COLUMN).sort(false, false),
+            ])
+            .build()?;
+
         let new_columns = DataFrame::new(state.clone(), new_columns)
             .with_column(TARGET_MATCH_CARDINALITY_CLASS_COLUMN, cardinality_class)?
+            .with_column(TARGET_MATCH_ROW_RANK_COLUMN, match_row_rank)?
             .into_unoptimized_plan();
 
-        LogicalPlan::Extension(Extension {
+        let validated = LogicalPlan::Extension(Extension {
             node: Arc::new(MergeValidation {
                 input: new_columns,
-                expr: col(TARGET_ROW_INDEX_COLUMN),
+                file_expr: col(file_column.as_str()),
+                file_column: Arc::clone(&file_column),
+                row_ordinal_column: Arc::new(TARGET_ROW_ORDINAL_IN_FILE_COLUMN.to_string()),
             }),
-        })
+        });
+
+        DataFrame::new(state.clone(), validated)
+            .filter(
+                matched
+                    .and(col(TARGET_MATCH_ROW_RANK_COLUMN).gt(lit(1_u64)))
+                    .not(),
+            )?
+            .into_unoptimized_plan()
     } else {
         new_columns
     };
@@ -3490,7 +3520,257 @@ mod tests {
             .unwrap()
             .await;
 
-        assert!(res.is_err());
+        let err = res.expect_err("expected duplicate validation failure");
+        assert!(
+            err.to_string()
+                .contains("duplicate relevant WHEN MATCHED clauses")
+        );
+        assert_eq!(table.version(), Some(1));
+
+        let actual = get_data(&table).await;
+        assert_batches_sorted_eq!(&expected, &actual);
+    }
+
+    #[tokio::test]
+    async fn test_merge_update_duplicate_with_noop_source_row_passes() {
+        let schema = get_arrow_schema(&None);
+        let table = setup_table(None).await;
+        let table = write_data(table, &schema).await;
+        let ctx = SessionContext::new();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["B", "B"])),
+                Arc::new(arrow::array::Int32Array::from(vec![11, 12])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "2023-07-04",
+                    "2023-07-05",
+                ])),
+            ],
+        )
+        .unwrap();
+        let source = ctx.read_batch(batch).unwrap();
+
+        let (table, metrics) = table
+            .merge(source, "target.id = source.id")
+            .with_source_alias("source")
+            .with_target_alias("target")
+            .when_matched_update(|update| {
+                update
+                    .predicate(col("source.value").gt(lit(11)))
+                    .update("value", "source.value")
+                    .update("modified", "source.modified")
+            })
+            .unwrap()
+            .await
+            .unwrap();
+
+        assert_eq!(table.version(), Some(2));
+        assert_eq!(metrics.num_source_rows, 2);
+        assert_eq!(metrics.num_target_rows_inserted, 0);
+        assert_eq!(metrics.num_target_rows_updated, 1);
+        assert_eq!(metrics.num_target_rows_deleted, 0);
+        assert_eq!(metrics.num_target_rows_copied, 3);
+        assert_eq!(metrics.num_output_rows, 4);
+
+        let expected = vec![
+            "+----+-------+------------+",
+            "| id | value | modified   |",
+            "+----+-------+------------+",
+            "| A  | 1     | 2021-02-01 |",
+            "| B  | 12    | 2023-07-05 |",
+            "| C  | 10    | 2021-02-02 |",
+            "| D  | 100   | 2021-02-02 |",
+            "+----+-------+------------+",
+        ];
+        let actual = get_data(&table).await;
+        assert_batches_sorted_eq!(&expected, &actual);
+    }
+
+    #[tokio::test]
+    async fn test_merge_cdf_enabled_update_duplicate_with_noop_source_row_passes() {
+        use crate::kernel::ProtocolInner;
+        use crate::operations::merge::Action;
+
+        let delta_schema = get_delta_schema();
+        let actions = vec![Action::Protocol(ProtocolInner::new(1, 4).as_kernel())];
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(delta_schema.fields().cloned())
+            .with_actions(actions)
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
+            .await
+            .unwrap();
+
+        let schema = get_arrow_schema(&None);
+        let table = write_data(table, &schema).await;
+        let ctx = SessionContext::new();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["B", "B"])),
+                Arc::new(arrow::array::Int32Array::from(vec![11, 12])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "2023-07-04",
+                    "2023-07-05",
+                ])),
+            ],
+        )
+        .unwrap();
+        let source = ctx.read_batch(batch).unwrap();
+
+        let (table, metrics) = table
+            .merge(source, "target.id = source.id")
+            .with_source_alias("source")
+            .with_target_alias("target")
+            .when_matched_update(|update| {
+                update
+                    .predicate(col("source.value").gt(lit(11)))
+                    .update("value", "source.value")
+                    .update("modified", "source.modified")
+            })
+            .unwrap()
+            .await
+            .unwrap();
+
+        assert_eq!(table.version(), Some(2));
+        assert_eq!(metrics.num_source_rows, 2);
+        assert_eq!(metrics.num_target_rows_inserted, 0);
+        assert_eq!(metrics.num_target_rows_updated, 1);
+        assert_eq!(metrics.num_target_rows_deleted, 0);
+        assert_eq!(metrics.num_target_rows_copied, 3);
+        assert_eq!(metrics.num_output_rows, 4);
+
+        let expected = vec![
+            "+----+-------+------------+",
+            "| id | value | modified   |",
+            "+----+-------+------------+",
+            "| A  | 1     | 2021-02-01 |",
+            "| B  | 12    | 2023-07-05 |",
+            "| C  | 10    | 2021-02-02 |",
+            "| D  | 100   | 2021-02-02 |",
+            "+----+-------+------------+",
+        ];
+        let actual = get_data(&table).await;
+        assert_batches_sorted_eq!(&expected, &actual);
+
+        let cdf = table
+            .scan_cdf()
+            .with_starting_version(0)
+            .build(&ctx.state(), None)
+            .await
+            .expect("Failed to load CDF");
+
+        let mut batches = collect(cdf, ctx.task_ctx())
+            .await
+            .expect("Failed to collect CDF batches");
+
+        let _: Vec<_> = batches.iter_mut().map(|b| b.remove_column(5)).collect();
+
+        let expected_cdf = vec![
+            "+----+-------+------------+------------------+-----------------+",
+            "| id | value | modified   | _change_type     | _commit_version |",
+            "+----+-------+------------+------------------+-----------------+",
+            "| A  | 1     | 2021-02-01 | insert           | 1               |",
+            "| B  | 10    | 2021-02-01 | insert           | 1               |",
+            "| B  | 10    | 2021-02-01 | update_preimage  | 2               |",
+            "| B  | 12    | 2023-07-05 | update_postimage | 2               |",
+            "| C  | 10    | 2021-02-02 | insert           | 1               |",
+            "| D  | 100   | 2021-02-02 | insert           | 1               |",
+            "+----+-------+------------+------------------+-----------------+",
+        ];
+        assert_batches_sorted_eq!(&expected_cdf, &batches);
+    }
+
+    #[tokio::test]
+    async fn test_merge_unconditional_delete_multiple_source_match_allowed() {
+        let schema = get_arrow_schema(&None);
+        let table = setup_table(None).await;
+        let table = write_data(table, &schema).await;
+        let ctx = SessionContext::new();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["B", "B"])),
+                Arc::new(arrow::array::Int32Array::from(vec![11, 12])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "2023-07-04",
+                    "2023-07-05",
+                ])),
+            ],
+        )
+        .unwrap();
+        let source = ctx.read_batch(batch).unwrap();
+
+        let (table, _) = table
+            .merge(source, "target.id = source.id")
+            .with_source_alias("source")
+            .with_target_alias("target")
+            .when_matched_delete(|delete| delete)
+            .unwrap()
+            .await
+            .unwrap();
+
+        assert_eq!(table.version(), Some(2));
+
+        let expected = vec![
+            "+----+-------+------------+",
+            "| id | value | modified   |",
+            "+----+-------+------------+",
+            "| A  | 1     | 2021-02-01 |",
+            "| C  | 10    | 2021-02-02 |",
+            "| D  | 100   | 2021-02-02 |",
+            "+----+-------+------------+",
+        ];
+        let actual = get_data(&table).await;
+        assert_batches_sorted_eq!(&expected, &actual);
+    }
+
+    #[tokio::test]
+    async fn test_merge_conditional_delete_multiple_source_match_error() {
+        let schema = get_arrow_schema(&None);
+        let table = setup_table(None).await;
+        let table = write_data(table, &schema).await;
+        let ctx = SessionContext::new();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["B", "B"])),
+                Arc::new(arrow::array::Int32Array::from(vec![11, 12])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "2023-07-04",
+                    "2023-07-05",
+                ])),
+            ],
+        )
+        .unwrap();
+        let source = ctx.read_batch(batch).unwrap();
+
+        let expected = vec![
+            "+----+-------+------------+",
+            "| id | value | modified   |",
+            "+----+-------+------------+",
+            "| A  | 1     | 2021-02-01 |",
+            "| B  | 10    | 2021-02-01 |",
+            "| C  | 10    | 2021-02-02 |",
+            "| D  | 100   | 2021-02-02 |",
+            "+----+-------+------------+",
+        ];
+
+        let res = table
+            .clone()
+            .merge(source, "target.id = source.id")
+            .with_source_alias("source")
+            .with_target_alias("target")
+            .when_matched_delete(|delete| delete.predicate(col("source.value").gt(lit(10))))
+            .unwrap()
+            .await;
+
+        let err = res.expect_err("expected duplicate validation failure");
+        assert!(
+            err.to_string()
+                .contains("duplicate relevant WHEN MATCHED clauses")
+        );
         assert_eq!(table.version(), Some(1));
 
         let actual = get_data(&table).await;

--- a/crates/core/src/operations/merge/validation.rs
+++ b/crates/core/src/operations/merge/validation.rs
@@ -15,21 +15,29 @@ use datafusion::physical_plan::{
 use futures::{Stream, StreamExt};
 
 use crate::DeltaTableError;
-use crate::operations::merge::{
-    CardinalityClass, TARGET_MATCH_CARDINALITY_CLASS_COLUMN, TARGET_ROW_INDEX_COLUMN,
-};
+use crate::delta_datafusion::get_path_column;
+use crate::operations::merge::{MatchParticipationClass, TARGET_MATCH_CARDINALITY_CLASS_COLUMN};
 
 #[derive(Debug)]
 pub(crate) struct MergeValidationExec {
     input: Arc<dyn ExecutionPlan>,
-    row_index_expr: Arc<dyn PhysicalExpr>,
+    file_expr: Arc<dyn PhysicalExpr>,
+    file_column: Arc<String>,
+    row_ordinal_column: Arc<String>,
 }
 
 impl MergeValidationExec {
-    pub fn new(input: Arc<dyn ExecutionPlan>, expr: Arc<dyn PhysicalExpr>) -> Self {
+    pub(super) fn new(
+        input: Arc<dyn ExecutionPlan>,
+        file_expr: Arc<dyn PhysicalExpr>,
+        file_column: Arc<String>,
+        row_ordinal_column: Arc<String>,
+    ) -> Self {
         Self {
             input,
-            row_index_expr: expr,
+            file_expr,
+            file_column,
+            row_ordinal_column,
         }
     }
 }
@@ -52,7 +60,7 @@ impl ExecutionPlan for MergeValidationExec {
     }
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
-        vec![Distribution::HashPartitioned(vec![self.row_index_expr.clone()]); 1]
+        vec![Distribution::HashPartitioned(vec![self.file_expr.clone()]); 1]
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
@@ -70,7 +78,9 @@ impl ExecutionPlan for MergeValidationExec {
         }
         Ok(Arc::new(Self::new(
             children[0].clone(),
-            self.row_index_expr.clone(),
+            self.file_expr.clone(),
+            Arc::clone(&self.file_column),
+            Arc::clone(&self.row_ordinal_column),
         )))
     }
 
@@ -80,7 +90,12 @@ impl ExecutionPlan for MergeValidationExec {
         context: Arc<datafusion::execution::TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
         let input = self.input.execute(partition, context)?;
-        Ok(Box::pin(MergeValidationStream::new(input, self.schema())))
+        Ok(Box::pin(MergeValidationStream::new(
+            input,
+            self.schema(),
+            Arc::clone(&self.file_column),
+            Arc::clone(&self.row_ordinal_column),
+        )))
     }
 }
 
@@ -97,38 +112,78 @@ impl DisplayAs for MergeValidationExec {
     }
 }
 
+#[derive(Default)]
+struct TargetMatchState {
+    matched_action_count: i32,
+    unconditional_delete_count: i32,
+}
+
 struct MergeValidationStream {
     schema: SchemaRef,
     input: SendableRecordBatchStream,
-    target_row_state: HashMap<u64, (i32, i32)>,
+    file_column: Arc<String>,
+    row_ordinal_column: Arc<String>,
+    file_id_by_path: HashMap<String, usize>,
+    file_paths: Vec<String>,
+    target_row_state: HashMap<(usize, u64), TargetMatchState>,
 }
 
 impl MergeValidationStream {
-    fn new(input: SendableRecordBatchStream, schema: SchemaRef) -> Self {
+    fn new(
+        input: SendableRecordBatchStream,
+        schema: SchemaRef,
+        file_column: Arc<String>,
+        row_ordinal_column: Arc<String>,
+    ) -> Self {
         Self {
             schema,
             input,
+            file_column,
+            row_ordinal_column,
+            file_id_by_path: HashMap::new(),
+            file_paths: Vec::new(),
             target_row_state: HashMap::new(),
         }
     }
 
-    fn validate_batch(&mut self, batch: &RecordBatch) -> DataFusionResult<()> {
-        let target_row_index_col =
-            batch
-                .column_by_name(TARGET_ROW_INDEX_COLUMN)
-                .ok_or_else(|| {
-                    DataFusionError::External(Box::new(DeltaTableError::Generic(
-                        "Required column __delta_rs_target_row_index is missing".to_string(),
-                    )))
-                })?;
+    fn intern_file_id(&mut self, file_path: &str) -> usize {
+        if let Some(file_id) = self.file_id_by_path.get(file_path) {
+            *file_id
+        } else {
+            let file_id = self.file_paths.len();
+            let file_path = file_path.to_string();
+            self.file_id_by_path.insert(file_path.clone(), file_id);
+            self.file_paths.push(file_path);
+            file_id
+        }
+    }
 
-        let target_row_index_array = target_row_index_col
+    fn validate_batch(&mut self, batch: &RecordBatch) -> DataFusionResult<()> {
+        let file_dictionary =
+            get_path_column(batch, self.file_column.as_str()).map_err(DataFusionError::from)?;
+        let file_keys = file_dictionary.keys();
+        let mut key_map = Vec::with_capacity(file_dictionary.values().len());
+        for file_name in file_dictionary.values().into_iter() {
+            key_map.push(file_name.map(|path| self.intern_file_id(path)));
+        }
+
+        let row_ordinal_col = batch
+            .column_by_name(self.row_ordinal_column.as_str())
+            .ok_or_else(|| {
+                DataFusionError::External(Box::new(DeltaTableError::Generic(format!(
+                    "Required column {} is missing",
+                    self.row_ordinal_column
+                ))))
+            })?;
+
+        let row_ordinal_array = row_ordinal_col
             .as_any()
             .downcast_ref::<UInt64Array>()
             .ok_or_else(|| {
-                DataFusionError::External(Box::new(DeltaTableError::Generic(
-                    "Column __delta_rs_target_row_index is not UInt64".to_string(),
-                )))
+                DataFusionError::External(Box::new(DeltaTableError::Generic(format!(
+                    "Column {} is not UInt64",
+                    self.row_ordinal_column
+                ))))
             })?;
 
         let cardinality_class_col = batch
@@ -149,31 +204,44 @@ impl MergeValidationStream {
             })?;
 
         for row in 0..batch.num_rows() {
-            if !target_row_index_array.is_null(row) && !cardinality_class_array.is_null(row) {
-                let target_row_index = target_row_index_array.value(row);
-                let cardinality_class = cardinality_class_array.value(row);
+            if file_keys.is_null(row)
+                || row_ordinal_array.is_null(row)
+                || cardinality_class_array.is_null(row)
+            {
+                continue;
+            }
 
-                let (candidate_count, invalidating_count) = self
-                    .target_row_state
-                    .entry(target_row_index)
-                    .or_insert((0, 0));
+            let file_key = file_keys.value(row) as usize;
+            let Some(file_id) = key_map[file_key] else {
+                continue;
+            };
 
-                if cardinality_class != CardinalityClass::Ignore as i32 {
-                    *candidate_count += 1;
-                }
+            let row_ordinal = row_ordinal_array.value(row);
+            let cardinality_class = cardinality_class_array.value(row);
 
-                if cardinality_class == CardinalityClass::DuplicateInvalidating as i32 {
-                    *invalidating_count += 1;
-                }
+            let state = self
+                .target_row_state
+                .entry((file_id, row_ordinal))
+                .or_default();
 
-                if *candidate_count > 1 && *invalidating_count > 0 {
-                    return Err(DataFusionError::External(Box::new(
-                        DeltaTableError::Generic(format!(
-                            "Merge matched a single target row (index: {}) with multiple source rows",
-                            target_row_index
-                        )),
-                    )));
-                }
+            if cardinality_class == MatchParticipationClass::MatchedAction as i32 {
+                state.matched_action_count += 1;
+            } else if cardinality_class
+                == MatchParticipationClass::MatchedUnconditionalDelete as i32
+            {
+                state.unconditional_delete_count += 1;
+            }
+
+            if state.matched_action_count > 1
+                || (state.matched_action_count > 0 && state.unconditional_delete_count > 0)
+            {
+                let file_path = self.file_paths[file_id].as_str();
+                return Err(DataFusionError::External(Box::new(
+                    DeltaTableError::Generic(format!(
+                        "MERGE matched a target row with multiple source rows that satisfy duplicate relevant WHEN MATCHED clauses (file: {}, row ordinal in file: {})",
+                        file_path, row_ordinal
+                    )),
+                )));
             }
         }
 
@@ -211,8 +279,10 @@ impl RecordBatchStream for MergeValidationStream {
 
 #[derive(Debug, Hash, Eq, PartialEq, PartialOrd)]
 pub(crate) struct MergeValidation {
-    pub input: LogicalPlan,
-    pub expr: Expr,
+    pub(super) input: LogicalPlan,
+    pub(super) file_expr: Expr,
+    pub(super) file_column: Arc<String>,
+    pub(super) row_ordinal_column: Arc<String>,
 }
 
 impl UserDefinedLogicalNodeCore for MergeValidation {
@@ -229,7 +299,7 @@ impl UserDefinedLogicalNodeCore for MergeValidation {
     }
 
     fn expressions(&self) -> Vec<Expr> {
-        vec![self.expr.clone()]
+        vec![self.file_expr.clone()]
     }
 
     fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -243,7 +313,9 @@ impl UserDefinedLogicalNodeCore for MergeValidation {
     ) -> DataFusionResult<Self> {
         Ok(Self {
             input: inputs[0].clone(),
-            expr: exprs[0].clone(),
+            file_expr: exprs[0].clone(),
+            file_column: Arc::clone(&self.file_column),
+            row_ordinal_column: Arc::clone(&self.row_ordinal_column),
         })
     }
 }
@@ -251,13 +323,40 @@ impl UserDefinedLogicalNodeCore for MergeValidation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Int32Array, RecordBatch, UInt64Array};
-    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::array::{DictionaryArray, Int32Array, RecordBatch, UInt64Array};
+    use arrow::datatypes::{DataType, Field, Schema, UInt16Type};
+    use arrow_array::builder::StringDictionaryBuilder;
     use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 
+    use crate::delta_datafusion::PATH_COLUMN;
+    use crate::operations::merge::TARGET_ROW_ORDINAL_IN_FILE_COLUMN;
+
     fn batch(target_indices: Vec<u64>, classes: Vec<i32>) -> RecordBatch {
+        batch_with_files(
+            vec!["a.parquet"; target_indices.len()],
+            target_indices,
+            classes,
+        )
+    }
+
+    fn batch_with_files(
+        file_paths: Vec<&str>,
+        target_ordinals: Vec<u64>,
+        classes: Vec<i32>,
+    ) -> RecordBatch {
+        let mut file_paths_builder = StringDictionaryBuilder::<UInt16Type>::new();
+        for file_path in file_paths {
+            file_paths_builder.append_value(file_path);
+        }
+        let file_paths: DictionaryArray<UInt16Type> = file_paths_builder.finish();
+
         let schema = Arc::new(Schema::new(vec![
-            Field::new(TARGET_ROW_INDEX_COLUMN, DataType::UInt64, false),
+            Field::new(
+                PATH_COLUMN,
+                DataType::Dictionary(DataType::UInt16.into(), DataType::Utf8.into()),
+                false,
+            ),
+            Field::new(TARGET_ROW_ORDINAL_IN_FILE_COLUMN, DataType::UInt64, false),
             Field::new(
                 TARGET_MATCH_CARDINALITY_CLASS_COLUMN,
                 DataType::Int32,
@@ -268,7 +367,8 @@ mod tests {
         RecordBatch::try_new(
             schema,
             vec![
-                Arc::new(UInt64Array::from(target_indices)),
+                Arc::new(file_paths),
+                Arc::new(UInt64Array::from(target_ordinals)),
                 Arc::new(Int32Array::from(classes)),
             ],
         )
@@ -281,8 +381,24 @@ mod tests {
     }
 
     fn validate(b: &RecordBatch) -> DataFusionResult<()> {
-        let mut s = MergeValidationStream::new(empty_stream(b.schema()), b.schema());
-        s.validate_batch(b)
+        validate_batches(std::slice::from_ref(b))
+    }
+
+    fn validate_batches(batches: &[RecordBatch]) -> DataFusionResult<()> {
+        let schema = batches
+            .first()
+            .expect("expected at least one batch")
+            .schema();
+        let mut s = MergeValidationStream::new(
+            empty_stream(schema.clone()),
+            schema,
+            Arc::new(PATH_COLUMN.to_string()),
+            Arc::new(TARGET_ROW_ORDINAL_IN_FILE_COLUMN.to_string()),
+        );
+        for batch in batches {
+            s.validate_batch(batch)?;
+        }
+        Ok(())
     }
 
     #[test]
@@ -290,16 +406,15 @@ mod tests {
         let b = batch(
             vec![10, 10],
             vec![
-                CardinalityClass::DuplicateInvalidating as i32,
-                CardinalityClass::DuplicateInvalidating as i32,
+                MatchParticipationClass::MatchedAction as i32,
+                MatchParticipationClass::MatchedAction as i32,
             ],
         );
 
         let err = validate(&b).expect_err("expected duplicate violation");
-        assert!(
-            err.to_string()
-                .contains("Merge matched a single target row (index: 10)")
-        );
+        assert!(err.to_string().contains(
+            "duplicate relevant WHEN MATCHED clauses (file: a.parquet, row ordinal in file: 10)"
+        ));
     }
 
     #[test]
@@ -307,8 +422,8 @@ mod tests {
         let b = batch(
             vec![10, 11],
             vec![
-                CardinalityClass::DuplicateInvalidating as i32,
-                CardinalityClass::DuplicateInvalidating as i32,
+                MatchParticipationClass::MatchedAction as i32,
+                MatchParticipationClass::MatchedAction as i32,
             ],
         );
 
@@ -320,8 +435,8 @@ mod tests {
         let b = batch(
             vec![30, 30],
             vec![
-                CardinalityClass::MatchedUnconditionalDelete as i32,
-                CardinalityClass::MatchedUnconditionalDelete as i32,
+                MatchParticipationClass::MatchedUnconditionalDelete as i32,
+                MatchParticipationClass::MatchedUnconditionalDelete as i32,
             ],
         );
 
@@ -333,16 +448,93 @@ mod tests {
         let b = batch(
             vec![40, 40],
             vec![
-                CardinalityClass::MatchedUnconditionalDelete as i32,
-                CardinalityClass::DuplicateInvalidating as i32,
+                MatchParticipationClass::MatchedUnconditionalDelete as i32,
+                MatchParticipationClass::MatchedAction as i32,
             ],
         );
 
         let err = validate(&b).expect_err("expected duplicate violation");
-        assert!(
-            err.to_string().contains(
-                "Merge matched a single target row (index: 40) with multiple source rows"
-            )
+        assert!(err.to_string().contains(
+            "duplicate relevant WHEN MATCHED clauses (file: a.parquet, row ordinal in file: 40)"
+        ));
+    }
+
+    #[test]
+    fn test_matched_noop_rows_do_not_count_as_duplicates() {
+        let b = batch(
+            vec![10, 10],
+            vec![
+                MatchParticipationClass::MatchedNoop as i32,
+                MatchParticipationClass::MatchedNoop as i32,
+            ],
         );
+
+        validate(&b).expect("matched no op rows should not be treated as duplicates");
+    }
+
+    #[test]
+    fn test_one_matched_action_and_one_matched_noop_passes() {
+        let b = batch(
+            vec![10, 10],
+            vec![
+                MatchParticipationClass::MatchedNoop as i32,
+                MatchParticipationClass::MatchedAction as i32,
+            ],
+        );
+
+        validate(&b).expect("matched noop + one matched action should pass");
+    }
+
+    #[test]
+    fn test_same_row_ordinal_in_different_files_does_not_collide() {
+        let b = batch_with_files(
+            vec!["a.parquet", "b.parquet"],
+            vec![1, 1],
+            vec![
+                MatchParticipationClass::MatchedAction as i32,
+                MatchParticipationClass::MatchedAction as i32,
+            ],
+        );
+
+        validate(&b).expect("row ordinals must be scoped by file");
+    }
+
+    #[test]
+    fn test_duplicate_across_batches_with_changed_dictionary_indices_fails() {
+        let first = batch_with_files(
+            vec!["a.parquet"],
+            vec![7],
+            vec![MatchParticipationClass::MatchedAction as i32],
+        );
+        let second = batch_with_files(
+            vec!["b.parquet", "a.parquet"],
+            vec![99, 7],
+            vec![
+                MatchParticipationClass::MatchedNoop as i32,
+                MatchParticipationClass::MatchedAction as i32,
+            ],
+        );
+
+        let err = validate_batches(&[first, second]).expect_err("expected duplicate violation");
+        assert!(err.to_string().contains(
+            "duplicate relevant WHEN MATCHED clauses (file: a.parquet, row ordinal in file: 7)"
+        ));
+    }
+
+    #[test]
+    fn test_different_files_across_batches_with_same_dictionary_index_do_not_collide() {
+        let first = batch_with_files(
+            vec!["a.parquet"],
+            vec![7],
+            vec![MatchParticipationClass::MatchedAction as i32],
+        );
+        let second = batch_with_files(
+            vec!["b.parquet"],
+            vec![7],
+            vec![MatchParticipationClass::MatchedAction as i32],
+        );
+
+        validate_batches(&[first, second])
+            .expect("dictionary keys must be remapped per batch before cross batch validation");
     }
 }

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -271,10 +271,183 @@ def test_merge_when_matched_update_duplicates(
             predicate="s.deleted = true",
         )
 
-    with pytest.raises(DeltaError):
+    with pytest.raises(DeltaError, match="duplicate relevant WHEN MATCHED"):
         merger.execute()
 
     dt = DeltaTable(tmp_path)
+    result = (
+        QueryBuilder()
+        .register("tbl", dt)
+        .execute("select * from tbl order by id asc")
+        .read_all()
+    )
+
+    assert dt.version() == 0
+    assert result == sample_table
+
+
+@pytest.mark.parametrize("streaming", (True, False))
+def test_merge_when_matched_update_duplicate_with_noop_source_row_passes(
+    tmp_path: pathlib.Path, sample_table: Table, streaming: bool
+):
+    write_deltalake(tmp_path, sample_table, mode="append")
+
+    dt = DeltaTable(tmp_path)
+
+    source_table = Table(
+        {
+            "id": Array(
+                ["4", "4"],
+                ArrowField("id", type=DataType.string_view(), nullable=True),
+            ),
+            "price": Array(
+                [10, 100],
+                ArrowField("price", type=DataType.int64(), nullable=True),
+            ),
+            "sold": Array(
+                [10, 20],
+                ArrowField("sold", type=DataType.int32(), nullable=True),
+            ),
+            "deleted": Array(
+                [False, True],
+                ArrowField("deleted", type=DataType.bool(), nullable=True),
+            ),
+        }
+    )
+
+    dt.merge(
+        source=source_table,
+        predicate="t.id = s.id",
+        source_alias="s",
+        target_alias="t",
+        streamed_exec=streaming,
+    ).when_matched_update({"price": "s.price"}, predicate="s.deleted = true").execute()
+
+    expected = Table(
+        {
+            "id": Array(
+                ["1", "2", "3", "4", "5"],
+                ArrowField("id", type=DataType.string_view(), nullable=True),
+            ),
+            "price": Array(
+                [0, 1, 2, 100, 4],
+                ArrowField("price", type=DataType.int64(), nullable=True),
+            ),
+            "sold": Array(
+                [0, 1, 2, 3, 4],
+                ArrowField("sold", type=DataType.int32(), nullable=True),
+            ),
+            "deleted": Array(
+                [False] * 5,
+                ArrowField("deleted", type=DataType.bool(), nullable=True),
+            ),
+        }
+    )
+
+    result = (
+        QueryBuilder()
+        .register("tbl", dt)
+        .execute("select * from tbl order by id asc")
+        .read_all()
+    )
+
+    assert dt.version() == 1
+    assert result == expected
+
+
+@pytest.mark.parametrize("streaming", (True, False))
+def test_merge_when_matched_delete_unconditional_duplicates_pass(
+    tmp_path: pathlib.Path, sample_table: Table, streaming: bool
+):
+    write_deltalake(tmp_path, sample_table, mode="append")
+
+    dt = DeltaTable(tmp_path)
+
+    source_table = Table(
+        {
+            "id": Array(
+                ["5", "5"],
+                ArrowField("id", type=DataType.string_view(), nullable=True),
+            ),
+            "weight": Array(
+                [105, 106],
+                ArrowField("weight", type=DataType.int32(), nullable=True),
+            ),
+        }
+    )
+
+    dt.merge(
+        source=source_table,
+        predicate="t.id = s.id",
+        source_alias="s",
+        target_alias="t",
+        streamed_exec=streaming,
+    ).when_matched_delete().execute()
+
+    expected = Table(
+        {
+            "id": Array(
+                ["1", "2", "3", "4"],
+                ArrowField("id", type=DataType.string_view(), nullable=True),
+            ),
+            "price": Array(
+                [0, 1, 2, 3],
+                ArrowField("price", type=DataType.int64(), nullable=True),
+            ),
+            "sold": Array(
+                [0, 1, 2, 3],
+                ArrowField("sold", type=DataType.int32(), nullable=True),
+            ),
+            "deleted": Array(
+                [False] * 4,
+                ArrowField("deleted", type=DataType.bool(), nullable=True),
+            ),
+        }
+    )
+
+    result = (
+        QueryBuilder()
+        .register("tbl", dt)
+        .execute("select * from tbl order by id asc")
+        .read_all()
+    )
+
+    assert dt.version() == 1
+    assert result == expected
+
+
+@pytest.mark.parametrize("streaming", (True, False))
+def test_merge_when_matched_delete_conditional_duplicates_fail(
+    tmp_path: pathlib.Path, sample_table: Table, streaming: bool
+):
+    write_deltalake(tmp_path, sample_table, mode="append")
+
+    dt = DeltaTable(tmp_path)
+
+    source_table = Table(
+        {
+            "id": Array(
+                ["4", "4"],
+                ArrowField("id", type=DataType.string_view(), nullable=True),
+            ),
+            "deleted": Array(
+                [True, True],
+                ArrowField("deleted", type=DataType.bool(), nullable=True),
+            ),
+        }
+    )
+
+    merger = dt.merge(
+        source=source_table,
+        predicate="t.id = s.id",
+        source_alias="s",
+        target_alias="t",
+        streamed_exec=streaming,
+    ).when_matched_delete("s.deleted = True")
+
+    with pytest.raises(DeltaError, match="duplicate relevant WHEN MATCHED"):
+        merger.execute()
+
     result = (
         QueryBuilder()
         .register("tbl", dt)


### PR DESCRIPTION
Previous validation treated every repeated match as ambiguous, even when a row didn't satisfy any WHEN MATCHED predicate. That rejected valid merges, for example two source rows match the same target, but only one actually hits the update/delete clause.

The fix is to classify matched rows by semantic participation instead of final operation shape.

- Matched no ops don't count as duplicates
- Unconditional matched deletes are allowed (deterministic)
- Duplicate conditional matched actions still fail
- Target row identity is now file & row ordinal (avoids cross file collisions)

Tests cover: no-op & update, unconditional delete, conditional delete rejection, cdc behavior. rust and python.