### PR TITLE
perf(snapshot): short-circuit warm-cache to skip scan_metadata_from replay

### DIFF
--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -346,6 +346,14 @@ impl Snapshot {
         log_store: &dyn LogStore,
         predicate: Option<PredicateRef>,
     ) -> SendableRBStream {
+        // Avoid the `stats_parsed -> JSON -> stats_parsed` roundtrip that
+        // `scan_metadata_from` forces on a no-predicate cache replay.
+        if predicate.is_none()
+            && let Some(cached) = self.cached_parsed_batches()
+        {
+            return cached;
+        }
+
         match self
             .materialized_files()
             .and_then(|materialized_files| materialized_files.full_table_seed())
@@ -362,6 +370,22 @@ impl Snapshot {
                 )
             }
             None => self.files_with_engine(log_store.engine(None), predicate),
+        }
+    }
+
+    fn cached_parsed_batches(&self) -> Option<SendableRBStream> {
+        let materialized = self.materialized_files()?;
+        if materialized.existing_predicate.is_some() {
+            return None;
+        }
+        match materialized.scope {
+            MaterializedFilesScope::FullTable => {
+                let batches = Arc::clone(&materialized.batches);
+                Some(
+                    futures::stream::iter((0..batches.len()).map(move |i| Ok(batches[i].clone())))
+                        .boxed(),
+                )
+            }
         }
     }
 
@@ -1818,6 +1842,61 @@ mod tests {
                 .contains("Had a _last_checkpoint hint but didn't find any checkpoints"),
             "expected same-version checkpoint refresh to surface the kernel checkpoint error: {err}"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cached_parsed_batches_short_circuit_guards() -> TestResult {
+        let base = TestTables::Checkpoints.table_builder()?.build_storage()?;
+
+        let plain = Snapshot::try_new(base.as_ref(), Default::default(), Some(12)).await?;
+        assert!(plain.cached_parsed_batches().is_none());
+
+        let eager = EagerSnapshot::try_new(base.as_ref(), Default::default(), Some(12)).await?;
+        let cached_stream = eager
+            .snapshot()
+            .cached_parsed_batches()
+            .expect("materialized full-table cache -> Some");
+        let cached_batches: Vec<_> = cached_stream.try_collect().await?;
+        let direct_batches = eager
+            .snapshot()
+            .materialized_files()
+            .expect("materialized cache present")
+            .batches
+            .clone();
+        assert_eq!(cached_batches.len(), direct_batches.len());
+        for (a, b) in cached_batches.iter().zip(direct_batches.iter()) {
+            assert_eq!(a.num_rows(), b.num_rows());
+            assert_eq!(a.schema(), b.schema());
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_file_views_no_predicate_matches_fresh_replay() -> TestResult {
+        let base = TestTables::Checkpoints.table_builder()?.build_storage()?;
+
+        let eager = EagerSnapshot::try_new(base.as_ref(), Default::default(), Some(12)).await?;
+        let eager_paths: Vec<String> = eager
+            .file_views(base.as_ref(), None)
+            .map_ok(|view| view.path_raw().to_string())
+            .try_collect()
+            .await?;
+
+        let plain = Snapshot::try_new(base.as_ref(), Default::default(), Some(12)).await?;
+        let plain_paths: Vec<String> = plain
+            .file_views(base.as_ref(), None)
+            .map_ok(|view| view.path_raw().to_string())
+            .try_collect()
+            .await?;
+
+        assert_eq!(
+            eager_paths, plain_paths,
+            "short-circuit cache replay must yield the same files in the same \
+             order as a fresh kernel replay with predicate = None",
+        );
+
         Ok(())
     }
 }


### PR DESCRIPTION
# Description
Adds a short-circuit to `Snapshot::files()` that bypasses the kernel scan pipeline when the caller has already materialized the full-table file cache and is replaying it without a predicate. Delivers a speedup on warm-cache `files(log_store, None)` calls used by compaction planning, vacuum candidates, partition listing, CDF planning...

`DeltaTable::load()` materializes `EagerSnapshot::files` once -> already parsed, already filtered. Every subsequent call walks the same batches, but routes them through the full `scan_metadata_from` pipeline ([delta-io/delta-kernel-rs#829](https://github.com/delta-io/delta-kernel-rs/pull/829)): the whole chain (JSON round-trip) is avoidable: the caller already has the final parsed output.

On a 50k-file cached snapshot with `~1 KB` of stats JSON per file, the whole chain costs `~33 ms` on every call. Every `files(log_store, None)` call after load pays it.

## When it fires
The short-circuit is used only when all three of these hold. 
If anyone fails, the call falls through to the existing path unchanged:
1. `predicate` is `None`: no data skipping required
2. `MaterializedFiles.existing_predicate` is `None`: the cache was materialized without a predicate filter
3. `MaterializedFilesScope::FullTable`: the cache covers the whole table

## Benchmark
I measured on a local Delta table (benchmark done on laptop with local Delta Table, not committed): one commit with N `Add` actions (N = 1k / 10k / 50k below), a 20-column schema, `~1 KB` realistic stats JSON per file, and one parquet checkpoint. Each iteration lists every active file without a filter on a table whose cache has already been populated by the initial load. The measured cost is CPU-only, because the cache must be populated from object storage on the first call.

| Files  | Without short-circuit | With short-circuit | Speedup |
|-------:|----------------------:|-------------------:|--------:|
|  1,000 |  1.01 ms              |  28.62 us          | ~35x    |
| 10,000 |  6.86 ms              | 231.17 us          | ~30x    |
| 50,000 | 32.82 ms              |   1.18 ms          | ~28x    |