### PR TITLE
chore: bump object_store to 0.13.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ arrow-ord = { version = "58" }
 arrow-row = { version = "58" }
 arrow-schema = { version = "58" }
 arrow-select = { version = "58" }
-object_store = { version = "0.13.1" }
+object_store = { version = "0.13.2" }
 parquet = { version = "58" }
 
 # datafusion 53


### PR DESCRIPTION
# Description

Bumps the workspace `object_store` pin from 0.13.1 to 0.13.2. Fixes #4311.

#4346 moved the workspace to `object_store 0.13.1`, but the fix for the Fabric token overflow reported in #4311 only landed in `object_store 0.13.2` (apache/arrow-rs-object-store#641, released 2026-03-19).

When a Microsoft Fabric bearer token expires during a long-running write, the raw subtraction in `FabricTokenOAuthProvider::fetch_token` underflows and produces a multi-century duration, which then panics as `overflow when adding duration to instant` in `Instant::now() + Duration::from_secs(exp_in)`. Reported downstream at Eventual-Inc/Daft#6007.

`cargo check --workspace --all-features` passes against the bumped dep.

# Related Issue(s)

Closes #4311