### PR TITLE
refactor: migrate overwrite rewrites to matched file scans

### DIFF
--- a/crates/core/src/delta_datafusion/bench_support.rs
+++ b/crates/core/src/delta_datafusion/bench_support.rs
@@ -81,7 +81,7 @@ pub async fn scan_files_where_matches(
     predicate: Expr,
 ) -> DataFusionResult<Option<MatchedFilesScan>> {
     prepare_session(session, &log_store)?;
-    super::scan_files_where_matches(session, snapshot, predicate)
+    super::scan_files_where_matches(session, snapshot, log_store, predicate)
         .await
         .map(|scan| scan.map(MatchedFilesScan))
 }

--- a/crates/core/src/delta_datafusion/engine/expressions/to_kernel.rs
+++ b/crates/core/src/delta_datafusion/engine/expressions/to_kernel.rs
@@ -76,9 +76,7 @@ fn rewrite_in_list_expr_for_kernel(in_list: &InList) -> Option<Expr> {
 /// Converts a DataFusion expression to a Delta kernel expression.
 pub(crate) fn to_delta_expression(expr: &Expr) -> Result<Expression> {
     match expr {
-        Expr::Column(column) => Ok(Expression::Column(ColumnName::from_naive_str_split(
-            &column.name,
-        ))),
+        Expr::Column(column) => Ok(Expression::Column(ColumnName::new([column.name.as_str()]))),
         Expr::Literal(scalar, _meta) => {
             Ok(Expression::Literal(datafusion_scalar_to_scalar(scalar)?))
         }
@@ -198,7 +196,7 @@ pub(crate) fn to_delta_expression(expr: &Expr) -> Result<Expression> {
 
                 if let Expression::Column(ref col_name) = to_delta_expression(&scalar_fn.args[0])? {
                     return Ok(Expression::Column(
-                        col_name.join(&ColumnName::from_naive_str_split(field_name)),
+                        col_name.join(&ColumnName::new([field_name.as_str()])),
                     ));
                 }
             }
@@ -335,6 +333,7 @@ fn to_junction_op(op: Operator) -> JunctionPredicateOp {
 mod tests {
     use super::*;
     use datafusion::{
+        common::Column,
         functions::core::expr_ext::FieldAccessor,
         logical_expr::{col, lit},
     };
@@ -470,12 +469,12 @@ mod tests {
         let expr = col("a").field("b");
         assert_eq!(
             to_delta_expression(&expr).unwrap(),
-            Expression::Column(ColumnName::from_naive_str_split("a.b"))
+            Expression::Column(ColumnName::new(["a", "b"]))
         );
         let expr = col("a").field("b").field("c");
         assert_eq!(
             to_delta_expression(&expr).unwrap(),
-            Expression::Column(ColumnName::from_naive_str_split("a.b.c"))
+            Expression::Column(ColumnName::new(["a", "b", "c"]))
         );
 
         let expr = col("a").field("b").field("c").eq(lit(10));
@@ -611,6 +610,24 @@ mod tests {
             Expression::Column(name) => assert_eq!(&name.to_string(), "test_column"),
             _ => panic!("Expected Column expression, got {:?}", delta_expr),
         }
+    }
+
+    #[test]
+    fn test_column_expression_preserves_dots_in_name() {
+        let expr = Expr::Column(Column::from_name("a.b"));
+        assert_eq!(
+            to_delta_expression(&expr).unwrap(),
+            Expression::Column(ColumnName::new(["a.b"]))
+        );
+    }
+
+    #[test]
+    fn test_field_access_preserves_dots_in_field_name_segment() {
+        let expr = col("a").field("b.c");
+        assert_eq!(
+            to_delta_expression(&expr).unwrap(),
+            Expression::Column(ColumnName::new(["a", "b.c"]))
+        );
     }
 
     #[test]

--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -69,22 +69,16 @@ pub(crate) async fn find_files(
     session: &dyn Session,
     predicate: Option<Expr>,
 ) -> DeltaResult<FindFiles> {
-    let current_metadata = snapshot.metadata();
-
     match &predicate {
         Some(predicate) => {
-            // Validate the Predicate and determine if it only contains partition columns
-            let mut expr_properties = FindFilesExprProperties {
-                partition_only: true,
-                partition_columns: current_metadata.partition_columns().to_vec(),
-                result: Ok(()),
-            };
+            let analysis = analyze_predicate_for_find_files(
+                predicate.to_owned(),
+                snapshot.metadata().partition_columns(),
+            )?;
+            let predicate = analysis.predicate();
 
-            TreeNode::visit(predicate, &mut expr_properties)?;
-            expr_properties.result?;
-
-            if expr_properties.partition_only {
-                let candidates = scan_memory_table(snapshot, predicate).await?;
+            if analysis.partition_only {
+                let candidates = scan_memory_table(snapshot, &predicate).await?;
                 let result = FindFiles {
                     candidates,
                     partition_scan: true,
@@ -93,8 +87,7 @@ pub(crate) async fn find_files(
                 Span::current().record("candidate_count", result.candidates.len());
                 Ok(result)
             } else {
-                let candidates =
-                    find_files_scan(snapshot, log_store, session, predicate.to_owned()).await?;
+                let candidates = find_files_scan(snapshot, log_store, session, predicate).await?;
 
                 let result = FindFiles {
                     candidates,
@@ -135,6 +128,20 @@ impl Default for FindFilesExprProperties {
             partition_only: true,
             result: Ok(()),
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FindFilesPredicateAnalysis {
+    simplified_terms: Vec<Expr>,
+    pub(crate) partition_only: bool,
+    pub(crate) translated_pruning_term_count: usize,
+    pub(crate) dropped_pruning_term_count: usize,
+}
+
+impl FindFilesPredicateAnalysis {
+    fn predicate(&self) -> Expr {
+        conjunction(self.simplified_terms.clone()).unwrap_or(lit(true))
     }
 }
 
@@ -200,6 +207,37 @@ impl TreeNodeVisitor<'_> for FindFilesExprProperties {
     }
 }
 
+pub(crate) fn analyze_predicate_for_find_files(
+    predicate: Expr,
+    partition_columns: &[String],
+) -> DeltaResult<FindFilesPredicateAnalysis> {
+    let simplified_terms = simplify_predicates(split_conjunction_owned(predicate))?;
+    let mut visitor = FindFilesExprProperties {
+        partition_columns: partition_columns.to_vec(),
+        partition_only: true,
+        result: Ok(()),
+    };
+
+    for term in &simplified_terms {
+        term.visit(&mut visitor)?;
+        std::mem::replace(&mut visitor.result, Ok(()))?;
+    }
+
+    let translated_pruning_term_count = simplified_terms
+        .iter()
+        .filter(|term| to_delta_predicate(term).is_ok())
+        .count();
+
+    Ok(FindFilesPredicateAnalysis {
+        partition_only: visitor.partition_only,
+        translated_pruning_term_count,
+        dropped_pruning_term_count: simplified_terms
+            .len()
+            .saturating_sub(translated_pruning_term_count),
+        simplified_terms,
+    })
+}
+
 struct MatchingFilesScanSeed {
     valid_files: Vec<GenericByteViewArray<StringViewType>>,
     file_skipping_predicates: Vec<Expr>,
@@ -214,28 +252,20 @@ async fn collect_matching_files(
     predicate: Expr,
     file_column_name: &str,
 ) -> Result<Option<MatchingFilesScanSeed>> {
-    let skipping_pred = simplify_predicates(split_conjunction_owned(predicate))?;
-
-    let partition_columns = snapshot
-        .table_configuration()
-        .metadata()
-        .partition_columns();
-    let mut visitor = FindFilesExprProperties {
-        partition_columns: partition_columns.to_vec(),
-        partition_only: true,
-        result: Ok(()),
-    };
-    for term in &skipping_pred {
-        term.visit(&mut visitor)?;
-        std::mem::replace(&mut visitor.result, Ok(()))?;
-    }
-
+    let analysis = analyze_predicate_for_find_files(
+        predicate,
+        snapshot
+            .table_configuration()
+            .metadata()
+            .partition_columns(),
+    )?;
+    let skipping_pred = analysis.simplified_terms.clone();
     let delta_predicate = Arc::new(Predicate::and_from(
         skipping_pred
             .iter()
             .flat_map(|term| to_delta_predicate(term).ok()),
     ));
-    let predicate = conjunction(skipping_pred.clone()).unwrap_or(lit(true));
+    let predicate = analysis.predicate();
 
     let mut builder = DeltaScanNext::builder()
         .with_snapshot(snapshot.snapshot().clone())
@@ -603,7 +633,7 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use arrow_schema::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
     use datafusion::physical_plan::collect;
-    use datafusion::prelude::{col, lit};
+    use datafusion::prelude::{col, lit, when};
     use delta_kernel::schema::{DataType, PrimitiveType, StructField};
 
     use crate::{
@@ -923,6 +953,21 @@ mod tests {
         assert!(!data.is_empty());
 
         Ok(())
+    }
+
+    #[test]
+    fn test_analyze_predicate_for_find_files_counts_dropped_pruning_terms() {
+        let analysis = analyze_predicate_for_find_files(
+            when(lit(true), col("id").eq(lit("A")))
+                .otherwise(lit(false))
+                .unwrap(),
+            &["id".to_string()],
+        )
+        .unwrap();
+
+        assert!(analysis.partition_only);
+        assert_eq!(analysis.translated_pruning_term_count, 0);
+        assert_eq!(analysis.dropped_pruning_term_count, 1);
     }
 
     #[tokio::test]

--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -354,9 +354,13 @@ pub(in crate::delta_datafusion) async fn find_files_scan(
         .clone();
     let mut candidate_map: HashMap<_, _> = snapshot
         .file_views(log_store.as_ref(), None)
-        .map_ok(|view| view.to_add())
-        .try_fold(HashMap::new(), |mut candidate_map, add| {
-            let file_id = normalize_path_as_file_id(&add.path, &table_root, "find_files candidate");
+        .try_fold(HashMap::new(), |mut candidate_map, view| {
+            // The next-provider file-id column is derived from the raw log path representation.
+            // Key candidate lookup with that same representation, but keep decoded Add actions
+            // as values for downstream DML consumers.
+            let file_id =
+                normalize_path_as_file_id(view.path_raw(), &table_root, "find_files candidate");
+            let add = view.to_add();
 
             futures::future::ready(match file_id {
                 Ok(file_id) => {
@@ -595,8 +599,9 @@ pub(crate) async fn scan_files_where_matches(
 
 #[cfg(test)]
 mod tests {
+    use arrow::array::{Int64Array, StringArray};
     use arrow::record_batch::RecordBatch;
-    use arrow_schema::{DataType as ArrowDataType, Field};
+    use arrow_schema::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
     use datafusion::physical_plan::collect;
     use datafusion::prelude::{col, lit};
     use delta_kernel::schema::{DataType, PrimitiveType, StructField};
@@ -756,6 +761,50 @@ mod tests {
 
         assert_eq!(matches.len(), 1);
         assert!(matches[0].path.ends_with(".parquet"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_find_files_scan_matches_encoded_partition_paths_for_data_predicates() -> TestResult
+    {
+        let tmp_dir = tempfile::tempdir()?;
+        let table_path = std::fs::canonicalize(tmp_dir.path())?;
+        let table_url = url::Url::from_directory_path(&table_path)
+            .map_err(|_| DeltaTableError::InvalidTableLocation(table_path.display().to_string()))?;
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", ArrowDataType::Utf8, true),
+            Field::new("price", ArrowDataType::Int64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec![Some("1 2")])),
+                Arc::new(Int64Array::from(vec![Some(10)])),
+            ],
+        )?;
+
+        let table = DeltaTable::try_from_url(table_url)
+            .await?
+            .write(vec![batch])
+            .with_partition_columns(["id"])
+            .await?;
+
+        let ctx = create_session().into_inner();
+        let session = ctx.state();
+
+        let snapshot = table.snapshot()?.snapshot().clone();
+        let log_store = table.log_store();
+
+        let matches =
+            find_files_scan(&snapshot, log_store, &session, col("price").eq(lit(10i64))).await?;
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches[0].partition_values.get("id"),
+            Some(&Some("1 2".to_string()))
+        );
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use arrow::array::AsArray;
 use arrow::datatypes::StringViewType;
 use arrow_array::{Array, GenericByteViewArray, RecordBatch, StringArray};
-use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_schema::{DataType, Field, Schema};
 use datafusion::catalog::Session;
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion, TreeNodeVisitor};
 use datafusion::common::{HashSet, Result};
@@ -14,9 +14,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::utils::{conjunction, split_conjunction_owned};
 use datafusion::logical_expr::{Expr, LogicalPlan, LogicalPlanBuilder, Volatility, col};
 use datafusion::optimizer::simplify_expressions::simplify_predicates;
-use datafusion::physical_plan::filter::FilterExec;
-use datafusion::physical_plan::limit::LocalLimitExec;
-use datafusion::physical_plan::{ExecutionPlan, collect_partitioned};
+use datafusion::physical_plan::collect_partitioned;
 use datafusion::prelude::{cast, lit};
 use delta_kernel::Predicate;
 use futures::TryStreamExt as _;
@@ -28,8 +26,8 @@ use crate::delta_datafusion::engine::to_delta_predicate;
 use crate::delta_datafusion::logical::LogicalPlanBuilderExt as _;
 use crate::delta_datafusion::table_provider::next::{FileSelection, MissingFilePolicy};
 use crate::delta_datafusion::{
-    DataFusionMixins as _, DeltaScanBuilder, DeltaScanConfigBuilder, DeltaScanNext,
-    FILE_ID_COLUMN_DEFAULT, PATH_COLUMN, get_path_column,
+    DataFusionMixins as _, DeltaScanNext, FILE_ID_COLUMN_DEFAULT, PATH_COLUMN, get_path_column,
+    normalize_path_as_file_id, resolve_file_column_name,
 };
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::{Add, EagerSnapshot};
@@ -202,6 +200,85 @@ impl TreeNodeVisitor<'_> for FindFilesExprProperties {
     }
 }
 
+struct MatchingFilesScanSeed {
+    valid_files: Vec<GenericByteViewArray<StringViewType>>,
+    file_skipping_predicates: Vec<Expr>,
+    predicate: Expr,
+    delta_predicate: Arc<Predicate>,
+}
+
+async fn collect_matching_files(
+    session: &dyn Session,
+    snapshot: &EagerSnapshot,
+    log_store: Option<&LogStoreRef>,
+    predicate: Expr,
+    file_column_name: &str,
+) -> Result<Option<MatchingFilesScanSeed>> {
+    let skipping_pred = simplify_predicates(split_conjunction_owned(predicate))?;
+
+    let partition_columns = snapshot
+        .table_configuration()
+        .metadata()
+        .partition_columns();
+    let mut visitor = FindFilesExprProperties {
+        partition_columns: partition_columns.to_vec(),
+        partition_only: true,
+        result: Ok(()),
+    };
+    for term in &skipping_pred {
+        term.visit(&mut visitor)?;
+        std::mem::replace(&mut visitor.result, Ok(()))?;
+    }
+
+    let delta_predicate = Arc::new(Predicate::and_from(
+        skipping_pred
+            .iter()
+            .flat_map(|term| to_delta_predicate(term).ok()),
+    ));
+    let predicate = conjunction(skipping_pred.clone()).unwrap_or(lit(true));
+
+    let mut builder = DeltaScanNext::builder()
+        .with_snapshot(snapshot.snapshot().clone())
+        .with_file_skipping_predicates(skipping_pred.clone())
+        .with_file_column(file_column_name);
+    if let Some(log_store) = log_store {
+        builder = builder.with_log_store(log_store.clone());
+    }
+    let table_source = provider_as_source(builder.await?);
+
+    let files_plan = LogicalPlanBuilder::scan("files_scan", table_source, None)?
+        .filter(predicate.clone())?
+        .project([cast(col(file_column_name), DataType::Utf8View).alias(file_column_name)])?
+        .distinct()?
+        .build()?;
+
+    let files_exec = session.create_physical_plan(&files_plan).await?;
+    let files_data = collect_partitioned(files_exec, session.task_ctx()).await?;
+    let files_count = files_data
+        .iter()
+        .flat_map(|batches| batches.iter().map(|batch| batch.num_rows()))
+        .sum::<usize>();
+    if files_count == 0 {
+        return Ok(None);
+    }
+
+    let valid_files = files_data
+        .iter()
+        .flat_map(|batches| {
+            batches
+                .iter()
+                .map(|batch| batch.column(0).as_string_view().clone())
+        })
+        .collect_vec();
+
+    Ok(Some(MatchingFilesScanSeed {
+        valid_files,
+        file_skipping_predicates: skipping_pred,
+        predicate,
+        delta_predicate,
+    }))
+}
+
 fn join_batches_with_add_actions(
     batches: Vec<RecordBatch>,
     mut actions: HashMap<String, Add>,
@@ -268,63 +345,57 @@ pub(in crate::delta_datafusion) async fn find_files_scan(
     session: &dyn Session,
     expression: Expr,
 ) -> DeltaResult<Vec<Add>> {
-    // let kernel_predicate = to_predicate(&expression).ok().map(Arc::new);
-    let candidate_map: HashMap<_, _> = snapshot
-        .file_views(&log_store, None)
-        .map_ok(|f| {
-            let add = f.to_add();
-            (add.path.clone(), add)
+    let file_column_name = resolve_file_column_name(snapshot.input_schema().as_ref(), None)?;
+    let table_root = snapshot
+        .snapshot()
+        .scan_builder()
+        .build()?
+        .table_root()
+        .clone();
+    let mut candidate_map: HashMap<_, _> = snapshot
+        .file_views(log_store.as_ref(), None)
+        .map_ok(|view| view.to_add())
+        .try_fold(HashMap::new(), |mut candidate_map, add| {
+            let file_id = normalize_path_as_file_id(&add.path, &table_root, "find_files candidate");
+
+            futures::future::ready(match file_id {
+                Ok(file_id) => {
+                    candidate_map.insert(file_id, add);
+                    Ok(candidate_map)
+                }
+                Err(err) => Err(err),
+            })
         })
-        .try_collect()
         .await?;
 
     Span::current().record("total_files", candidate_map.len());
 
-    let scan_config = DeltaScanConfigBuilder::default()
-        .with_file_column(true)
-        .build(snapshot)?;
-    let file_column_name = scan_config
-        .file_column_name
-        .as_ref()
-        .ok_or(DeltaTableError::Generic(
-            "File column name must be set in scan config".to_string(),
-        ))?
-        .clone();
+    let Some(matches) = collect_matching_files(
+        session,
+        snapshot,
+        Some(&log_store),
+        expression,
+        &file_column_name,
+    )
+    .await?
+    else {
+        Span::current().record("matching_files", 0);
+        return Ok(vec![]);
+    };
 
-    let logical_schema = df_logical_schema(snapshot, &file_column_name)?;
-
-    // Identify which columns we need to project
-    let mut used_columns: Vec<_> = expression
-        .column_refs()
-        .into_iter()
-        .map(|column| logical_schema.index_of(&column.name))
-        .try_collect()?;
-    // Add path column
-    let path_column_idx = logical_schema.index_of(&file_column_name)?;
-    if !used_columns.contains(&path_column_idx) {
-        used_columns.push(path_column_idx);
+    let mut result = Vec::new();
+    for file_id in matches
+        .valid_files
+        .iter()
+        .flat_map(|arr| arr.iter().flatten().map(str::to_owned))
+    {
+        let add = candidate_map.remove(&file_id).ok_or_else(|| {
+            DeltaTableError::Generic(format!(
+                "Unable to map matched file id back to Add action: {file_id}"
+            ))
+        })?;
+        result.push(add);
     }
-
-    let scan = DeltaScanBuilder::new(snapshot, log_store, session)
-        .with_filter(Some(expression.clone()))
-        .with_projection(Some(&used_columns))
-        .with_scan_config(scan_config)
-        .build()
-        .await?;
-    let scan = Arc::new(scan);
-
-    let input_dfschema = scan.logical_schema.as_ref().to_owned().try_into()?;
-    let predicate_expr = session
-        .create_physical_expr(Expr::IsTrue(Box::new(expression.clone())), &input_dfschema)?;
-
-    let filter: Arc<dyn ExecutionPlan> =
-        Arc::new(FilterExec::try_new(predicate_expr, scan.clone())?);
-    let limit: Arc<dyn ExecutionPlan> = Arc::new(LocalLimitExec::new(filter, 1));
-
-    let path_batches = datafusion::physical_plan::collect(limit, session.task_ctx()).await?;
-
-    let result =
-        join_batches_with_add_actions(path_batches, candidate_map, &file_column_name, true, false)?;
 
     Span::current().record("matching_files", result.len());
     Ok(result)
@@ -414,37 +485,6 @@ async fn scan_memory_table(snapshot: &EagerSnapshot, predicate: &Expr) -> DeltaR
     join_batches_with_add_actions(batches, map, PATH_COLUMN, false, true)
 }
 
-/// The logical schema for a Deltatable is different from the protocol level schema since partition
-/// columns must appear at the end of the schema. This is to align with how partition are handled
-/// at the physical level
-fn df_logical_schema(
-    snapshot: &EagerSnapshot,
-    file_column_name: &String,
-) -> DeltaResult<SchemaRef> {
-    let input_schema = snapshot.input_schema();
-    let table_partition_cols = snapshot.metadata().partition_columns();
-
-    let mut fields: Vec<_> = input_schema
-        .fields()
-        .iter()
-        .filter(|f| !table_partition_cols.contains(f.name()))
-        .cloned()
-        .collect();
-
-    for partition_col in table_partition_cols.iter() {
-        fields.push(Arc::new(
-            input_schema
-                .field_with_name(partition_col)
-                .unwrap()
-                .to_owned(),
-        ));
-    }
-
-    fields.push(Arc::new(Field::new(file_column_name, DataType::Utf8, true)));
-
-    Ok(Arc::new(Schema::new(fields)))
-}
-
 pub(crate) struct MatchedFilesScan {
     /// A logical plan to perform a scan over all matched filed
     plan: LogicalPlan,
@@ -495,74 +535,26 @@ impl MatchedFilesScan {
 pub(crate) async fn scan_files_where_matches(
     session: &dyn Session,
     snapshot: &EagerSnapshot,
+    log_store: LogStoreRef,
     predicate: Expr,
 ) -> Result<Option<MatchedFilesScan>> {
-    let skipping_pred = simplify_predicates(split_conjunction_owned(predicate))?;
-
-    let partition_columns = snapshot
-        .table_configuration()
-        .metadata()
-        .partition_columns();
-    // validate that the expressions contain no illegal variants
-    // that are not eligible for file skipping, e.g. volatile functions.
-    let mut visitor = FindFilesExprProperties {
-        partition_columns: partition_columns.to_vec(),
-        partition_only: true,
-        result: Ok(()),
-    };
-    for term in &skipping_pred {
-        term.visit(&mut visitor)?;
-        std::mem::replace(&mut visitor.result, Ok(()))?;
-    }
-
-    // convert to a delta predicate that can be applied to kernel scans.
-    // This is a best effort predicate and downstream code needs to also
-    // apply the explicit file selection so we can ignore errors in the
-    // conversion.
-    let delta_predicate = Arc::new(Predicate::and_from(
-        skipping_pred
-            .iter()
-            .flat_map(|p| to_delta_predicate(p).ok()),
-    ));
-
-    let predicate = conjunction(skipping_pred.clone()).unwrap_or(lit(true));
-
-    // Scan the delta table with a dedicated predicate applied for file skipping
-    // and with the source file path exposed as column.
-    let table_source = provider_as_source(
-        DeltaScanNext::builder()
-            .with_snapshot(snapshot.snapshot().clone())
-            .with_file_skipping_predicates(skipping_pred.clone())
-            .with_file_column(FILE_ID_COLUMN_DEFAULT)
-            .await?,
-    );
-
-    // the kernel scan only provides a best effort file skipping, in this case
-    // we want to determine the file we certainly need to rewrite. For this
-    // we perform an initial aggregate scan to see if we can quickly find
-    // at least one matching record in the files.
-    let files_plan = LogicalPlanBuilder::scan("files_scan", table_source.clone(), None)?
-        .filter(predicate.clone())?
-        .project([
-            cast(col(FILE_ID_COLUMN_DEFAULT), DataType::Utf8View).alias(FILE_ID_COLUMN_DEFAULT)
-        ])?
-        .distinct()?
-        .build()?;
-
-    let files_exec = session.create_physical_plan(&files_plan).await?;
-    let files_data = collect_partitioned(files_exec, session.task_ctx()).await?;
-    let files_count = files_data
-        .iter()
-        .flat_map(|batches| batches.iter().map(|b| b.num_rows()))
-        .sum::<usize>();
-    if files_count == 0 {
+    let Some(matches) = collect_matching_files(
+        session,
+        snapshot,
+        Some(&log_store),
+        predicate,
+        FILE_ID_COLUMN_DEFAULT,
+    )
+    .await?
+    else {
         return Ok(None);
-    }
-
-    let valid_files = files_data
-        .iter()
-        .flat_map(|batches| batches.iter().map(|b| b.column(0).as_string_view().clone()))
-        .collect_vec();
+    };
+    let MatchingFilesScanSeed {
+        valid_files,
+        file_skipping_predicates,
+        predicate,
+        delta_predicate,
+    } = matches;
 
     // Create a table scan limited to the matched files by forwarding an explicit
     // file selection into the table provider.
@@ -581,8 +573,9 @@ pub(crate) async fn scan_files_where_matches(
     .with_missing_file_policy(MissingFilePolicy::Ignore);
     let selected_provider = DeltaScanNext::builder()
         .with_snapshot(snapshot.snapshot().clone())
-        .with_file_skipping_predicates(skipping_pred)
+        .with_file_skipping_predicates(file_skipping_predicates)
         .with_file_column(FILE_ID_COLUMN_DEFAULT)
+        .with_log_store(log_store)
         .build()
         .await?
         .with_file_selection(file_selection);
@@ -602,12 +595,17 @@ pub(crate) async fn scan_files_where_matches(
 
 #[cfg(test)]
 mod tests {
+    use arrow::record_batch::RecordBatch;
+    use arrow_schema::{DataType as ArrowDataType, Field};
     use datafusion::physical_plan::collect;
     use datafusion::prelude::{col, lit};
+    use delta_kernel::schema::{DataType, PrimitiveType, StructField};
 
     use crate::{
-        DeltaTable,
-        delta_datafusion::{DeltaSessionExt as _, create_session},
+        DeltaTable, DeltaTableBuilder,
+        delta_datafusion::{
+            DataFusionMixins as _, DeltaSessionExt as _, create_session, resolve_file_column_name,
+        },
         protocol::SaveMode,
         test_utils::{TestResult, multibatch_add_actions_for_partition, open_fs_path},
         writer::test_utils::{get_delta_schema, get_record_batch},
@@ -622,11 +620,12 @@ mod tests {
 
         let ctx = create_session().into_inner();
         let session = ctx.state();
-        table.update_datafusion_session(&session)?;
-
         let snapshot = table.snapshot()?.snapshot().clone();
+        let log_store = table.log_store();
         let predicate = col("id").gt(lit(-1i64));
-        let Some(scan) = scan_files_where_matches(&session, &snapshot, predicate).await? else {
+        let Some(scan) =
+            scan_files_where_matches(&session, &snapshot, log_store, predicate).await?
+        else {
             panic!("Expected at least one matching file");
         };
 
@@ -643,11 +642,12 @@ mod tests {
 
         let ctx = create_session().into_inner();
         let session = ctx.state();
-        table.update_datafusion_session(&session)?;
-
         let snapshot = table.snapshot()?.snapshot().clone();
+        let log_store = table.log_store();
         let predicate = col("id").gt(lit(-1i64));
-        let Some(scan) = scan_files_where_matches(&session, &snapshot, predicate).await? else {
+        let Some(scan) =
+            scan_files_where_matches(&session, &snapshot, log_store, predicate).await?
+        else {
             panic!("Expected at least one matching file");
         };
 
@@ -672,6 +672,7 @@ mod tests {
         let snapshot = table.snapshot()?.snapshot().clone();
         let log_store = table.log_store();
         session.ensure_log_store_registered(log_store.as_ref())?;
+        let file_column_name = resolve_file_column_name(snapshot.input_schema().as_ref(), None)?;
 
         let by_id = find_files_scan(
             &snapshot,
@@ -682,6 +683,17 @@ mod tests {
         .await?;
         assert!(!by_id.is_empty());
         let expected_path = by_id[0].path.clone();
+        let table_root = snapshot
+            .snapshot()
+            .scan_builder()
+            .build()?
+            .table_root()
+            .clone();
+        let expected_file_id = crate::delta_datafusion::normalize_path_as_file_id(
+            &expected_path,
+            &table_root,
+            "find_files test path",
+        )?;
         let matched_paths = by_id.iter().map(|add| add.path.as_str()).collect_vec();
 
         let matches = find_files_scan(
@@ -690,7 +702,7 @@ mod tests {
             &session,
             col("id")
                 .eq(lit(7i64))
-                .and(col(PATH_COLUMN).eq(lit(expected_path.clone()))),
+                .and(col(file_column_name.clone()).eq(lit(expected_file_id))),
         )
         .await?;
         assert_eq!(
@@ -704,16 +716,162 @@ mod tests {
             .map(|add| add.path().to_string())
             .find(|path| !matched_paths.contains(&path.as_str()))
             .expect("expected a non-matching file path");
+        let other_file_id = crate::delta_datafusion::normalize_path_as_file_id(
+            &other_path,
+            &table_root,
+            "find_files test path",
+        )?;
         let no_matches = find_files_scan(
             &snapshot,
             log_store,
             &session,
             col("id")
                 .eq(lit(7i64))
-                .and(col(PATH_COLUMN).eq(lit(other_path))),
+                .and(col(file_column_name).eq(lit(other_file_id))),
         )
         .await?;
         assert!(no_matches.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_find_files_scan_prepares_fresh_session_and_snapshot_without_files() -> TestResult
+    {
+        let mut base = open_fs_path("../test/tests/data/simple_table");
+        base.load().await?;
+
+        let table = DeltaTableBuilder::from_url(base.table_url().clone())?
+            .without_files()
+            .load()
+            .await?;
+        let snapshot = table.snapshot()?.snapshot().clone();
+        let log_store = table.log_store();
+
+        let ctx = create_session().into_inner();
+        let session = ctx.state();
+
+        let matches =
+            find_files_scan(&snapshot, log_store, &session, col("id").eq(lit(7i64))).await?;
+
+        assert_eq!(matches.len(), 1);
+        assert!(matches[0].path.ends_with(".parquet"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_find_files_scan_uses_collision_safe_file_column_namespace() -> TestResult {
+        let delta_schema = vec![
+            StructField::new(
+                "id".to_string(),
+                DataType::Primitive(PrimitiveType::String),
+                false,
+            ),
+            StructField::new(
+                "value".to_string(),
+                DataType::Primitive(PrimitiveType::Integer),
+                true,
+            ),
+            StructField::new(
+                "modified".to_string(),
+                DataType::Primitive(PrimitiveType::String),
+                true,
+            ),
+            StructField::new(
+                PATH_COLUMN.to_string(),
+                DataType::Primitive(PrimitiveType::String),
+                true,
+            ),
+            StructField::new(
+                format!("{PATH_COLUMN}_1"),
+                DataType::Primitive(PrimitiveType::String),
+                true,
+            ),
+        ];
+
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(delta_schema)
+            .await?;
+        let schema = Arc::new(arrow_schema::Schema::new(vec![
+            Field::new("id", ArrowDataType::Utf8, false),
+            Field::new("value", ArrowDataType::Int32, true),
+            Field::new("modified", ArrowDataType::Utf8, true),
+            Field::new(PATH_COLUMN, ArrowDataType::Utf8, true),
+            Field::new(format!("{PATH_COLUMN}_1"), ArrowDataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["B"])),
+                Arc::new(arrow::array::Int32Array::from(vec![20])),
+                Arc::new(arrow::array::StringArray::from(vec!["2021-03-01"])),
+                Arc::new(arrow::array::StringArray::from(vec!["beta-src"])),
+                Arc::new(arrow::array::StringArray::from(vec!["beta-src-1"])),
+            ],
+        )?;
+        let table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let ctx = create_session().into_inner();
+        let session = ctx.state();
+        table.update_datafusion_session(&session)?;
+
+        let snapshot = table.snapshot()?.snapshot().clone();
+        let log_store = table.log_store();
+        session.ensure_log_store_registered(log_store.as_ref())?;
+
+        let file_column_name = resolve_file_column_name(snapshot.input_schema().as_ref(), None)?;
+        assert_eq!(file_column_name, format!("{PATH_COLUMN}_2"));
+
+        let matches = find_files_scan(
+            &snapshot,
+            log_store,
+            &session,
+            col("id")
+                .eq(lit("B"))
+                .and(col(file_column_name).is_not_null()),
+        )
+        .await?;
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches[0].path,
+            snapshot.log_data().iter().next().unwrap().path()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_files_where_matches_prepares_fresh_session_and_snapshot_without_files()
+    -> TestResult {
+        let mut base = open_fs_path("../test/tests/data/simple_table");
+        base.load().await?;
+
+        let table = DeltaTableBuilder::from_url(base.table_url().clone())?
+            .without_files()
+            .load()
+            .await?;
+        let snapshot = table.snapshot()?.snapshot().clone();
+        let log_store = table.log_store();
+
+        let ctx = create_session().into_inner();
+        let session = ctx.state();
+
+        let Some(scan) =
+            scan_files_where_matches(&session, &snapshot, log_store, col("id").eq(lit(7i64)))
+                .await?
+        else {
+            panic!("Expected at least one matching file");
+        };
+
+        let plan = session.create_physical_plan(scan.scan()).await?;
+        let data = collect(plan, session.task_ctx()).await?;
+        assert!(!data.is_empty());
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -300,7 +300,10 @@ pub(in crate::delta_datafusion) async fn find_files_scan(
         .map(|column| logical_schema.index_of(&column.name))
         .try_collect()?;
     // Add path column
-    used_columns.push(logical_schema.index_of(&file_column_name)?);
+    let path_column_idx = logical_schema.index_of(&file_column_name)?;
+    if !used_columns.contains(&path_column_idx) {
+        used_columns.push(path_column_idx);
+    }
 
     let scan = DeltaScanBuilder::new(snapshot, log_store, session)
         .with_filter(Some(expression.clone()))
@@ -604,7 +607,7 @@ mod tests {
 
     use crate::{
         DeltaTable,
-        delta_datafusion::create_session,
+        delta_datafusion::{DeltaSessionExt as _, create_session},
         protocol::SaveMode,
         test_utils::{TestResult, multibatch_add_actions_for_partition, open_fs_path},
         writer::test_utils::{get_delta_schema, get_record_batch},
@@ -653,6 +656,64 @@ mod tests {
             !(plan_debug.contains("InList(") && plan_debug.contains(FILE_ID_COLUMN_DEFAULT)),
             "unexpected plan with file-id IN filter: {plan_debug}"
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_find_files_scan_honors_data_and_file_column_predicate() -> TestResult {
+        let mut table = open_fs_path("../test/tests/data/simple_table");
+        table.load().await?;
+
+        let ctx = create_session().into_inner();
+        let session = ctx.state();
+        table.update_datafusion_session(&session)?;
+
+        let snapshot = table.snapshot()?.snapshot().clone();
+        let log_store = table.log_store();
+        session.ensure_log_store_registered(log_store.as_ref())?;
+
+        let by_id = find_files_scan(
+            &snapshot,
+            log_store.clone(),
+            &session,
+            col("id").eq(lit(7i64)),
+        )
+        .await?;
+        assert!(!by_id.is_empty());
+        let expected_path = by_id[0].path.clone();
+        let matched_paths = by_id.iter().map(|add| add.path.as_str()).collect_vec();
+
+        let matches = find_files_scan(
+            &snapshot,
+            log_store.clone(),
+            &session,
+            col("id")
+                .eq(lit(7i64))
+                .and(col(PATH_COLUMN).eq(lit(expected_path.clone()))),
+        )
+        .await?;
+        assert_eq!(
+            matches.iter().map(|add| add.path.as_str()).collect_vec(),
+            vec![expected_path.as_str()]
+        );
+
+        let other_path = snapshot
+            .log_data()
+            .iter()
+            .map(|add| add.path().to_string())
+            .find(|path| !matched_paths.contains(&path.as_str()))
+            .expect("expected a non-matching file path");
+        let no_matches = find_files_scan(
+            &snapshot,
+            log_store,
+            &session,
+            col("id")
+                .eq(lit(7i64))
+                .and(col(PATH_COLUMN).eq(lit(other_path))),
+        )
+        .await?;
+        assert!(no_matches.is_empty());
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -77,8 +77,7 @@ pub use table_provider::{
     next::DeltaScanExec,
 };
 pub(crate) use table_provider::{
-    DeltaScanBuilder, next::FILE_ID_COLUMN_DEFAULT, resolve_file_column_name,
-    update_datafusion_session,
+    next::FILE_ID_COLUMN_DEFAULT, resolve_file_column_name, update_datafusion_session,
 };
 
 pub(crate) const PATH_COLUMN: &str = "__delta_rs_path";
@@ -1282,7 +1281,7 @@ mod tests {
 
         let ctx = SessionContext::new();
         let state = ctx.state();
-        let scan = DeltaScanBuilder::new(
+        let scan = table_provider::DeltaScanBuilder::new(
             table.snapshot().unwrap().snapshot(),
             table.log_store(),
             &state,
@@ -1311,17 +1310,18 @@ mod tests {
         let snapshot = table.snapshot().unwrap();
         let ctx = SessionContext::new();
         let state = ctx.state();
-        let scan = DeltaScanBuilder::new(snapshot.snapshot(), table.log_store(), &state)
-            .with_filter(Some(col("a").eq(lit("s"))))
-            .with_scan_config(
-                DeltaScanConfigBuilder::new()
-                    .with_parquet_pushdown(false)
-                    .build(snapshot.snapshot())
-                    .unwrap(),
-            )
-            .build()
-            .await
-            .unwrap();
+        let scan =
+            table_provider::DeltaScanBuilder::new(snapshot.snapshot(), table.log_store(), &state)
+                .with_filter(Some(col("a").eq(lit("s"))))
+                .with_scan_config(
+                    DeltaScanConfigBuilder::new()
+                        .with_parquet_pushdown(false)
+                        .build(snapshot.snapshot())
+                        .unwrap(),
+                )
+                .build()
+                .await
+                .unwrap();
 
         let mut visitor = ParquetVisitor::default();
         visit_execution_plan(&scan, &mut visitor).unwrap();
@@ -1346,10 +1346,11 @@ mod tests {
         let ctx = SessionContext::new_with_config(config);
         let state = ctx.state();
 
-        let scan = DeltaScanBuilder::new(snapshot.snapshot(), table.log_store(), &state)
-            .build()
-            .await
-            .unwrap();
+        let scan =
+            table_provider::DeltaScanBuilder::new(snapshot.snapshot(), table.log_store(), &state)
+                .build()
+                .await
+                .unwrap();
 
         let mut visitor = ParquetVisitor::default();
         visit_execution_plan(&scan, &mut visitor).unwrap();

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -40,6 +40,7 @@ use datafusion::{
     physical_plan::ExecutionPlan,
 };
 use delta_kernel::{Engine, table_configuration::TableConfiguration, table_features::TableFeature};
+use object_store::path::Path;
 use serde::{Deserialize, Serialize};
 use url::Url;
 use uuid::Uuid;
@@ -148,7 +149,14 @@ impl FileSelection {
         adds: impl IntoIterator<Item = crate::kernel::Add>,
         table_root_url: &Url,
     ) -> crate::DeltaResult<Self> {
-        Self::from_file_paths(adds.into_iter().map(|a| a.path), table_root_url)
+        Self::from_file_paths(
+            adds.into_iter()
+                // Add.path is URI-decoded once, while scan file IDs are keyed by the
+                // object-store/raw path form. Route through Path so literal '%' bytes in
+                // partition directories are escaped back to the canonical file-id form.
+                .map(|add| String::from(Path::from(add.path))),
+            table_root_url,
+        )
     }
 }
 
@@ -565,7 +573,7 @@ pub(crate) fn test_multi_partitioned_override_schema() -> SchemaRef {
 #[cfg(test)]
 mod tests {
     use arrow::{
-        array::{Date32Array, Int64Array, TimestampMillisecondArray},
+        array::{Date32Array, Int32Array, Int64Array, StringArray, TimestampMillisecondArray},
         datatypes::{
             DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema, TimeUnit,
         },
@@ -1362,6 +1370,78 @@ mod tests {
         let mut visitor = DeltaScanVisitor::default();
         visit_execution_plan(plan.as_ref(), &mut visitor).unwrap();
         assert_eq!(visitor.num_scanned, Some(1));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_with_selected_adds_reads_file_with_encoded_partition_path() -> TestResult {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("modified", ArrowDataType::Utf8, true),
+            ArrowField::new("country", ArrowDataType::Utf8, true),
+            ArrowField::new("value", ArrowDataType::Int32, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![
+                    "2021-02-01",
+                    "2021-02-01",
+                    "2021-02-02",
+                    "2021-02-02",
+                ])),
+                Arc::new(StringArray::from(vec![
+                    "Germany",
+                    "China",
+                    "Canada",
+                    "Dominican Republic",
+                ])),
+                Arc::new(Int32Array::from(vec![1, 10, 20, 100])),
+            ],
+        )?;
+        let table = crate::DeltaTable::new_in_memory()
+            .write(vec![batch])
+            .with_partition_columns(vec!["country"])
+            .with_save_mode(crate::protocol::SaveMode::Overwrite)
+            .await?;
+        let log_store = table.log_store();
+        let snapshot = Arc::new(Snapshot::try_new(&log_store, Default::default(), None).await?);
+
+        let views = snapshot
+            .file_views(log_store.as_ref(), None)
+            .try_collect::<Vec<_>>()
+            .await?;
+        let selected_add = views
+            .into_iter()
+            .find_map(|view| {
+                let add = view.to_add();
+                (add.partition_values.get("country") == Some(&Some("Dominican Republic".into())))
+                    .then_some(add)
+            })
+            .expect("expected a file in the Dominican Republic partition");
+
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+        let provider = DeltaScan::builder()
+            .with_snapshot(snapshot)
+            .with_file_column(FILE_ID_COLUMN_DEFAULT)
+            .build()
+            .await?
+            .with_log_store(log_store)
+            .with_selected_adds([selected_add])?;
+
+        let plan = provider.scan(&state, None, &[], None).await?;
+        let mut visitor = DeltaScanVisitor::default();
+        visit_execution_plan(plan.as_ref(), &mut visitor).unwrap();
+        assert_eq!(visitor.num_scanned, Some(1));
+
+        let batches: Vec<_> = collect_partitioned(plan, session.task_ctx())
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
+        let returned_rows = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
+        assert_eq!(returned_rows, 1);
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -323,7 +323,7 @@ impl DeltaScan {
         self
     }
 
-    /// Attach the runtime log store handle required for write operations.
+    /// Attach the runtime log store handle required for session setup on read paths and writes.
     pub(crate) fn with_log_store(mut self, log_store: impl Into<LogStoreRef>) -> Self {
         self.log_store = Some(log_store.into());
         self

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -39,7 +39,7 @@ use datafusion::{
     logical_expr::LogicalPlan,
     physical_plan::ExecutionPlan,
 };
-use delta_kernel::{Engine, table_configuration::TableConfiguration};
+use delta_kernel::{Engine, table_configuration::TableConfiguration, table_features::TableFeature};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -51,6 +51,7 @@ use crate::DeltaTableError;
 use crate::delta_datafusion::DeltaScanConfig;
 use crate::delta_datafusion::engine::DataFusionEngine;
 use crate::delta_datafusion::table_provider::TableProviderBuilder;
+use crate::kernel::transaction::{PROTOCOL, TransactionError};
 use crate::kernel::{EagerSnapshot, SendableScanMetadataStream, Snapshot};
 use crate::logstore::LogStoreRef;
 use crate::protocol::SaveMode;
@@ -329,7 +330,25 @@ impl DeltaScan {
         self
     }
 
-    fn ensure_read_session_ready(&self, session: &dyn Session) -> Result<()> {
+    fn ensure_supported_reader_features(&self) -> std::result::Result<(), TransactionError> {
+        match PROTOCOL.can_read_from_protocol(self.snapshot.snapshot().protocol()) {
+            Ok(()) => Ok(()),
+            Err(TransactionError::UnsupportedTableFeatures(features))
+                if features.as_slice() == [TableFeature::ColumnMapping]
+                    && self
+                        .snapshot
+                        .table_configuration()
+                        .is_feature_enabled(&TableFeature::ColumnMapping) =>
+            {
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn ensure_read_ready(&self, session: &dyn Session) -> Result<()> {
+        self.ensure_supported_reader_features()
+            .map_err(crate::DeltaTableError::from)?;
         if let Some(log_store) = &self.log_store {
             super::update_datafusion_session(session, log_store.as_ref(), None)?;
         }
@@ -346,7 +365,7 @@ impl DeltaScan {
         &self,
         session: &dyn Session,
     ) -> Result<Vec<DeletionVectorSelection>> {
-        self.ensure_read_session_ready(session)?;
+        self.ensure_read_ready(session)?;
         let engine = DataFusionEngine::new_from_session(session);
 
         let scan_plan = KernelScanPlan::try_new(
@@ -406,10 +425,11 @@ impl TableProvider for DeltaScan {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        self.ensure_read_session_ready(session)?;
+        self.ensure_read_ready(session)?;
         let engine = DataFusionEngine::new_from_session(session);
         let contract = ProjectedScanContract::try_new(
             self.scan_schema.clone(),
+            self.full_schema.clone(),
             &self.config,
             projection,
             filters,
@@ -554,7 +574,8 @@ mod tests {
         assert_batches_sorted_eq,
         delta_datafusion::{DeltaScanConfig, session::create_session},
         kernel::{
-            Action, DataType, EagerSnapshot, PrimitiveType, Snapshot, StructField, StructType,
+            Action, DataType, EagerSnapshot, PrimitiveType, ProtocolInner, Snapshot, StructField,
+            StructType,
         },
         logstore::get_actions,
         operations::create::CreateBuilder,
@@ -653,6 +674,23 @@ mod tests {
             vec![Arc::new(Int64Array::from(values))],
         )?;
         table.write(vec![batch]).await
+    }
+
+    async fn create_in_memory_id_table_with_reader_protocol(
+        min_reader_version: i32,
+    ) -> crate::DeltaResult<crate::DeltaTable> {
+        let schema = StructType::try_new(vec![StructField::new(
+            "id".to_string(),
+            DataType::Primitive(PrimitiveType::Long),
+            true,
+        )])?;
+        crate::DeltaTable::new_in_memory()
+            .create()
+            .with_columns(schema.fields().cloned())
+            .with_actions(vec![Action::Protocol(
+                ProtocolInner::new(min_reader_version, 2).as_kernel(),
+            )])
+            .await
     }
 
     async fn build_insert_input(
@@ -1049,6 +1087,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_direct_scan_with_log_store_registers_fresh_session() -> TestResult {
+        let table = create_in_memory_id_table_with_rows(vec![11, 13]).await?;
+        let provider = DeltaScan::new(
+            table.snapshot()?.snapshot().snapshot().clone(),
+            DeltaScanConfig::default(),
+        )?
+        .with_log_store(table.log_store());
+
+        let session = Arc::new(create_session().into_inner());
+        session.register_table("delta_table", Arc::new(provider))?;
+
+        let batches = session
+            .sql("SELECT id FROM delta_table ORDER BY id")
+            .await?
+            .collect()
+            .await?;
+        let expected = vec!["+----+", "| id |", "+----+", "| 11 |", "| 13 |", "+----+"];
+        assert_batches_sorted_eq!(&expected, &batches);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_direct_scan_rejects_unsupported_reader_protocol() -> TestResult {
+        let table = create_in_memory_id_table_with_reader_protocol(2).await?;
+        let provider = DeltaScan::new(
+            table.snapshot()?.snapshot().snapshot().clone(),
+            DeltaScanConfig::default(),
+        )?;
+
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+        let err = provider
+            .scan(&state, None, &[], None)
+            .await
+            .expect_err("unsupported reader protocol should fail before scan planning");
+        assert!(
+            err.to_string().contains("Unsupported"),
+            "unexpected error: {err}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_scan_with_file_selection_reads_only_selected_files() -> TestResult {
         let log_store = TestTables::Simple.table_builder()?.build_storage()?;
         let snapshot = Arc::new(Snapshot::try_new(&log_store, Default::default(), None).await?);
@@ -1436,6 +1519,28 @@ mod tests {
 
         let deletion_vectors = provider.deletion_vectors(&state).await?;
         assert!(deletion_vectors.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_deletion_vectors_reject_unsupported_reader_protocol() -> TestResult {
+        let table = create_in_memory_id_table_with_reader_protocol(2).await?;
+        let provider = DeltaScan::new(
+            table.snapshot()?.snapshot().snapshot().clone(),
+            DeltaScanConfig::default(),
+        )?;
+
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+        let err = provider
+            .deletion_vectors(&state)
+            .await
+            .expect_err("unsupported reader protocol should fail before deletion-vector reads");
+        assert!(
+            err.to_string().contains("Unsupported"),
+            "unexpected error: {err}"
+        );
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -45,6 +45,7 @@ use url::Url;
 
 pub use self::scan::DeltaScanExec;
 pub(crate) use self::scan::KernelScanPlan;
+use self::scan::ProjectedScanContract;
 use super::data_sink::DeltaDataSink;
 use crate::DeltaTableError;
 use crate::delta_datafusion::DeltaScanConfig;
@@ -327,6 +328,14 @@ impl DeltaScan {
         self.log_store = Some(log_store.into());
         self
     }
+
+    fn ensure_read_session_ready(&self, session: &dyn Session) -> Result<()> {
+        if let Some(log_store) = &self.log_store {
+            super::update_datafusion_session(session, log_store.as_ref(), None)?;
+        }
+        Ok(())
+    }
+
     /// Materialize deletion vector keep masks for files in this scan.
     ///
     /// The result is sorted lexicographically by filepath for deterministic ordering and includes
@@ -337,6 +346,7 @@ impl DeltaScan {
         &self,
         session: &dyn Session,
     ) -> Result<Vec<DeletionVectorSelection>> {
+        self.ensure_read_session_ready(session)?;
         let engine = DataFusionEngine::new_from_session(session);
 
         let scan_plan = KernelScanPlan::try_new(
@@ -396,24 +406,18 @@ impl TableProvider for DeltaScan {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.ensure_read_session_ready(session)?;
         let engine = DataFusionEngine::new_from_session(session);
-
-        // Filter out file_id column from projection if present
-        let file_id_idx = self
-            .config
-            .file_column_name
-            .as_ref()
-            .map(|_| self.scan_schema.fields().len());
-        let kernel_projection = projection.map(|proj| {
-            proj.iter()
-                .copied()
-                .filter(|&idx| Some(idx) != file_id_idx)
-                .collect::<Vec<_>>()
-        });
-
-        let scan_plan = KernelScanPlan::try_new(
+        let contract = ProjectedScanContract::try_new(
+            self.scan_schema.clone(),
+            self.full_schema.clone(),
+            &self.config,
+            projection,
+            filters,
+        )?;
+        let scan_plan = KernelScanPlan::try_new_with_contract(
             self.snapshot.snapshot(),
-            kernel_projection.as_ref(),
+            contract,
             filters,
             &self.config,
             self.file_skipping_predicate.clone(),
@@ -424,7 +428,6 @@ impl TableProvider for DeltaScan {
         scan::execution_plan(
             &self.config,
             session,
-            projection,
             scan_plan,
             stream,
             engine,
@@ -604,6 +607,21 @@ mod tests {
             .create()
             .with_columns(schema.fields().cloned())
             .await
+    }
+
+    async fn create_in_memory_id_table_with_rows(
+        values: Vec<i64>,
+    ) -> crate::DeltaResult<crate::DeltaTable> {
+        let table = create_in_memory_id_table().await?;
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                "id",
+                ArrowDataType::Int64,
+                true,
+            )])),
+            vec![Arc::new(Int64Array::from(values))],
+        )?;
+        table.write(vec![batch]).await
     }
 
     async fn build_insert_input(
@@ -972,6 +990,28 @@ mod tests {
             "+----+", "| id |", "+----+", "| 5  |", "| 7  |", "| 9  |", "+----+",
         ];
 
+        assert_batches_sorted_eq!(&expected, &batches);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_registers_log_store_for_fresh_session() -> TestResult {
+        let table = create_in_memory_id_table_with_rows(vec![11, 13]).await?;
+        let provider = DeltaScan::builder()
+            .with_log_store(table.log_store())
+            .build()
+            .await?;
+
+        let session = Arc::new(create_session().into_inner());
+        session.register_table("delta_table", Arc::new(provider))?;
+
+        let batches = session
+            .sql("SELECT id FROM delta_table ORDER BY id")
+            .await?
+            .collect()
+            .await?;
+        let expected = vec!["+----+", "| id |", "+----+", "| 11 |", "| 13 |", "+----+"];
         assert_batches_sorted_eq!(&expected, &batches);
 
         Ok(())
@@ -1347,6 +1387,23 @@ mod tests {
 
         let deletion_vectors = provider.deletion_vectors(&state).await?;
 
+        assert!(deletion_vectors.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_deletion_vectors_registers_log_store_for_fresh_session() -> TestResult {
+        let table = create_in_memory_id_table_with_rows(vec![11, 13]).await?;
+        let provider = DeltaScan::builder()
+            .with_log_store(table.log_store())
+            .build()
+            .await?;
+
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+
+        let deletion_vectors = provider.deletion_vectors(&state).await?;
         assert!(deletion_vectors.is_empty());
 
         Ok(())

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -265,7 +265,7 @@ pub struct DeltaScan {
     snapshot: SnapshotWrapper,
     config: DeltaScanConfig,
     scan_schema: SchemaRef,
-    /// Full schema including file_id column if configured
+    /// Provider/public schema, including configured file id capability when enabled.
     full_schema: SchemaRef,
     #[serde(skip)]
     file_skipping_predicate: Option<Vec<Expr>>,
@@ -289,7 +289,7 @@ impl DeltaScan {
         let snapshot = snapshot.into();
         let scan_schema = config.table_schema(snapshot.table_configuration())?;
         let full_schema = if let Some(file_id_column) =
-            config.projected_file_id_column(None, scan_schema.as_ref())
+            config.provider_file_id_column(None, scan_schema.as_ref())
         {
             let mut fields = scan_schema.fields().to_vec();
             fields.push(crate::delta_datafusion::file_id::file_id_field(Some(
@@ -410,7 +410,6 @@ impl TableProvider for DeltaScan {
         let engine = DataFusionEngine::new_from_session(session);
         let contract = ProjectedScanContract::try_new(
             self.scan_schema.clone(),
-            self.full_schema.clone(),
             &self.config,
             projection,
             filters,
@@ -487,6 +486,38 @@ impl TableProvider for DeltaScan {
             &self.config,
         ))
     }
+}
+
+#[cfg(test)]
+pub(crate) fn test_multi_partitioned_override_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Arc::new(arrow::datatypes::Field::new(
+            "letter",
+            arrow::datatypes::DataType::Dictionary(
+                Box::new(arrow::datatypes::DataType::UInt16),
+                Box::new(arrow::datatypes::DataType::Utf8),
+            ),
+            true,
+        )),
+        Arc::new(arrow::datatypes::Field::new(
+            "date",
+            arrow::datatypes::DataType::Date32,
+            true,
+        )),
+        Arc::new(arrow::datatypes::Field::new(
+            "data",
+            arrow::datatypes::DataType::Dictionary(
+                Box::new(arrow::datatypes::DataType::UInt16),
+                Box::new(arrow::datatypes::DataType::Binary),
+            ),
+            true,
+        )),
+        Arc::new(arrow::datatypes::Field::new(
+            "number",
+            arrow::datatypes::DataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),
+            true,
+        )),
+    ]))
 }
 
 #[cfg(test)]
@@ -1425,33 +1456,6 @@ mod tests {
         Ok(())
     }
 
-    fn multi_partitioned_override_schema() -> Arc<ArrowSchema> {
-        Arc::new(ArrowSchema::new(vec![
-            ArrowField::new(
-                "letter",
-                ArrowDataType::Dictionary(
-                    Box::new(ArrowDataType::UInt16),
-                    Box::new(ArrowDataType::Utf8),
-                ),
-                true,
-            ),
-            ArrowField::new("date", ArrowDataType::Date32, true),
-            ArrowField::new(
-                "data",
-                ArrowDataType::Dictionary(
-                    Box::new(ArrowDataType::UInt16),
-                    Box::new(ArrowDataType::Binary),
-                ),
-                true,
-            ),
-            ArrowField::new(
-                "number",
-                ArrowDataType::Timestamp(TimeUnit::Millisecond, None),
-                true,
-            ),
-        ]))
-    }
-
     async fn provider_for_partitioned_table() -> TestResult<(
         crate::DeltaTable,
         Arc<crate::delta_datafusion::table_provider::next::DeltaScan>,
@@ -1462,7 +1466,7 @@ mod tests {
 
         let provider = crate::delta_datafusion::table_provider::next::DeltaScan::new(
             table.snapshot().unwrap().snapshot().clone(),
-            DeltaScanConfig::default().with_schema(multi_partitioned_override_schema()),
+            DeltaScanConfig::default().with_schema(test_multi_partitioned_override_schema()),
         )?
         .with_log_store(table.log_store());
 
@@ -1569,7 +1573,7 @@ mod tests {
         let provider = Arc::new(
             crate::delta_datafusion::table_provider::next::DeltaScan::new(
                 table.snapshot().unwrap().snapshot().clone(),
-                DeltaScanConfig::default().with_schema(multi_partitioned_override_schema()),
+                DeltaScanConfig::default().with_schema(test_multi_partitioned_override_schema()),
             )?
             .with_log_store(table.log_store()),
         );
@@ -1617,6 +1621,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_delta_scan_provider_schema_keeps_configured_file_id_capability() -> TestResult {
+        let mut table =
+            open_fs_path("../../dat/v0.0.3/reader_tests/generated/multi_partitioned/delta");
+        table.load().await?;
+        let provider = crate::delta_datafusion::table_provider::next::DeltaScan::new(
+            table.snapshot()?.snapshot().clone(),
+            DeltaScanConfig::default().with_file_column_name("my_files"),
+        )?;
+
+        let schema = provider.schema();
+        assert!(schema.column_with_name("my_files").is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_delta_scan_config_file_column_projection() -> TestResult {
         let mut table =
             open_fs_path("../../dat/v0.0.3/reader_tests/generated/multi_partitioned/delta");
@@ -1625,7 +1644,7 @@ mod tests {
             crate::delta_datafusion::table_provider::next::DeltaScan::new(
                 table.snapshot()?.snapshot().clone(),
                 DeltaScanConfig::default()
-                    .with_schema(multi_partitioned_override_schema())
+                    .with_schema(test_multi_partitioned_override_schema())
                     .with_file_column_name("my_files"),
             )?
             .with_log_store(table.log_store()),

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -42,6 +42,7 @@ use datafusion::{
 use delta_kernel::{Engine, table_configuration::TableConfiguration, table_features::TableFeature};
 use serde::{Deserialize, Serialize};
 use url::Url;
+use uuid::Uuid;
 
 pub use self::scan::DeltaScanExec;
 pub(crate) use self::scan::KernelScanPlan;
@@ -272,6 +273,8 @@ pub struct DeltaScan {
     file_skipping_predicate: Option<Vec<Expr>>,
     #[serde(skip)]
     log_store: Option<LogStoreRef>,
+    #[serde(skip)]
+    read_operation_id: Option<Uuid>,
     file_selection: Option<FileSelection>,
 }
 
@@ -307,6 +310,7 @@ impl DeltaScan {
             full_schema,
             file_skipping_predicate: None,
             log_store: None,
+            read_operation_id: None,
             file_selection: None,
         })
     }
@@ -324,9 +328,27 @@ impl DeltaScan {
         self
     }
 
+    /// Restrict reads to the provided add actions by normalizing them into a
+    /// [`FileSelection`], so callers can pass kernel `Add`s directly.
+    pub(crate) fn with_selected_adds(
+        mut self,
+        adds: impl IntoIterator<Item = crate::kernel::Add>,
+    ) -> crate::DeltaResult<Self> {
+        let table_root = self.snapshot.table_configuration().table_root().clone();
+        self.file_selection = Some(FileSelection::from_adds(adds, &table_root)?);
+        Ok(self)
+    }
+
     /// Attach the runtime log store handle required for session setup on read paths and writes.
     pub(crate) fn with_log_store(mut self, log_store: impl Into<LogStoreRef>) -> Self {
         self.log_store = Some(log_store.into());
+        self
+    }
+
+    /// Scope runtime object store registration to a specific operation's temporary copy when
+    /// the caller needs operation local reads.
+    pub(crate) fn with_operation_id(mut self, operation_id: Uuid) -> Self {
+        self.read_operation_id = Some(operation_id);
         self
     }
 
@@ -350,7 +372,7 @@ impl DeltaScan {
         self.ensure_supported_reader_features()
             .map_err(crate::DeltaTableError::from)?;
         if let Some(log_store) = &self.log_store {
-            super::update_datafusion_session(session, log_store.as_ref(), None)?;
+            super::update_datafusion_session(session, log_store.as_ref(), self.read_operation_id)?;
         }
         Ok(())
     }
@@ -468,7 +490,7 @@ impl TableProvider for DeltaScan {
             )
         })?;
 
-        super::update_datafusion_session(state, log_store.as_ref(), None)?;
+        super::update_datafusion_session(state, log_store.as_ref(), self.read_operation_id)?;
 
         let snapshot = match &self.snapshot {
             SnapshotWrapper::EagerSnapshot(esnap) => esnap.as_ref().clone(),
@@ -566,7 +588,10 @@ mod tests {
     use futures::{StreamExt as _, TryStreamExt as _};
     use parquet::file::reader::FileReader as _;
     use parquet::file::serialized_reader::SerializedFileReader;
-    use std::{fs::File, sync::Arc};
+    use std::{
+        fs::File,
+        sync::{Arc, Mutex},
+    };
     use url::Url;
 
     use super::*;
@@ -701,6 +726,75 @@ mod tests {
         let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(values))])?;
         let mem_table = MemTable::try_new(schema, vec![vec![batch]])?;
         mem_table.scan(state, None, &[], None).await
+    }
+
+    #[derive(Debug)]
+    struct RootRegistrationTrackingLogStore {
+        inner: LogStoreRef,
+        root_calls: Arc<Mutex<Vec<Option<Uuid>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::logstore::LogStore for RootRegistrationTrackingLogStore {
+        fn name(&self) -> String {
+            self.inner.name()
+        }
+
+        async fn refresh(&self) -> crate::DeltaResult<()> {
+            self.inner.refresh().await
+        }
+
+        async fn read_commit_entry(
+            &self,
+            version: crate::kernel::Version,
+        ) -> crate::DeltaResult<Option<bytes::Bytes>> {
+            self.inner.read_commit_entry(version).await
+        }
+
+        async fn write_commit_entry(
+            &self,
+            version: crate::kernel::Version,
+            commit_or_bytes: crate::logstore::CommitOrBytes,
+            operation_id: Uuid,
+        ) -> std::result::Result<(), TransactionError> {
+            self.inner
+                .write_commit_entry(version, commit_or_bytes, operation_id)
+                .await
+        }
+
+        async fn abort_commit_entry(
+            &self,
+            version: crate::kernel::Version,
+            commit_or_bytes: crate::logstore::CommitOrBytes,
+            operation_id: Uuid,
+        ) -> std::result::Result<(), TransactionError> {
+            self.inner
+                .abort_commit_entry(version, commit_or_bytes, operation_id)
+                .await
+        }
+
+        async fn get_latest_version(
+            &self,
+            start_version: crate::kernel::Version,
+        ) -> crate::DeltaResult<crate::kernel::Version> {
+            self.inner.get_latest_version(start_version).await
+        }
+
+        fn object_store(&self, operation_id: Option<Uuid>) -> Arc<dyn object_store::ObjectStore> {
+            self.inner.object_store(operation_id)
+        }
+
+        fn root_object_store(
+            &self,
+            operation_id: Option<Uuid>,
+        ) -> Arc<dyn object_store::ObjectStore> {
+            self.root_calls.lock().unwrap().push(operation_id);
+            self.inner.root_object_store(operation_id)
+        }
+
+        fn config(&self) -> &crate::logstore::LogStoreConfig {
+            self.inner.config()
+        }
     }
 
     #[tokio::test]
@@ -896,6 +990,37 @@ mod tests {
             .unwrap_err();
         let err_str = err.to_string();
         assert!(err_str.contains("log_store"), "unexpected error: {err_str}");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_registers_operation_scoped_root_object_store() -> TestResult {
+        let table = create_in_memory_id_table().await?;
+        let root_calls = Arc::new(Mutex::new(Vec::new()));
+        let operation_id = Uuid::new_v4();
+        let tracked_log_store: LogStoreRef = Arc::new(RootRegistrationTrackingLogStore {
+            inner: table.log_store(),
+            root_calls: root_calls.clone(),
+        });
+        let provider = DeltaScan::builder()
+            .with_log_store(tracked_log_store)
+            .build()
+            .await?
+            .with_operation_id(operation_id);
+
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+        let input = build_insert_input(&state, provider.schema(), vec![1]).await?;
+
+        let _write_plan = provider
+            .insert_into(&state, input, InsertOp::Append)
+            .await?;
+
+        assert!(
+            root_calls.lock().unwrap().contains(&Some(operation_id)),
+            "expected insert path to register the root object store with operation id {operation_id}",
+        );
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -153,7 +153,7 @@ impl DeltaScanExec {
         let input_file_id_column = scan_plan.contract.file_id_field.name().to_owned();
         let file_id_column = scan_plan
             .contract
-            .scan_must_return_file_id
+            .retain_file_id
             .then(|| scan_plan.contract.file_id_field.name().to_owned());
         let output_schema = scan_plan.effective_schema(file_id_column.is_some());
         let properties = Arc::new(PlanProperties::new(

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -17,18 +17,19 @@ use arrow_array::{Array, BooleanArray};
 use dashmap::DashMap;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::error::{DataFusionError, Result};
-use datafusion::common::tree_node::TreeNode;
 use datafusion::common::{
     ColumnStatistics, HashMap, internal_datafusion_err, internal_err, plan_err,
 };
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
-use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, PlanProperties};
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, Statistics,
+};
+use datafusion_physical_expr_adapter::{
+    DefaultPhysicalExprAdapterFactory, PhysicalExprAdapterFactory,
 };
 use delta_kernel::schema::DataType as KernelDataType;
 use delta_kernel::table_features::TableFeature;
@@ -344,49 +345,42 @@ impl ExecutionPlan for DeltaScanExec {
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
         _config: &ConfigOptions,
     ) -> Result<FilterDescription> {
-        // With schema overrides, DataFusion builds a FilterExec above DeltaScanExec and then
-        // re-pushes that physical predicate into the child scan. If an overridden column's
-        // output type differs from the child input type, simplification/coercion runs against
-        // incompatible physical types and the pushed-down predicate can fail to plan.
-        if parent_filters.iter().any(|filter| {
-            filter_references_type_mismatch(
-                filter,
-                &self.scan_plan.contract.result_schema,
-                &self.input.schema(),
-            )
-        }) {
+        // Parent filters are bound against the logical output schema. For column mapped tables
+        // the child parquet schema uses physical column names, so pushing the parent filter
+        // through this exec again can rewrite it against the wrong child field. Provider level
+        // predicate planning already handles the safe parquet pushdown path for these tables.
+        if self
+            .scan_plan
+            .table_configuration()
+            .is_feature_enabled(&TableFeature::ColumnMapping)
+        {
             return Ok(FilterDescription::all_unsupported(
                 &parent_filters,
                 &self.children(),
             ));
         }
 
-        // TODO(roeap): this will likely not do much for column mapping enabled tables
-        // since the default methods determines this based on existence of columns in child
-        // schemas. In the case of column mapping all columns will have a different name.
-        FilterDescription::from_children(parent_filters, &self.children())
-    }
-}
-
-fn filter_references_type_mismatch(
-    filter: &Arc<dyn PhysicalExpr>,
-    result_schema: &SchemaRef,
-    input_schema: &SchemaRef,
-) -> bool {
-    filter
-        .exists(|expr| {
-            Ok(
-                if let Some(column) = expr.as_any().downcast_ref::<Column>()
-                    && let Ok(result_field) = result_schema.field_with_name(column.name())
-                    && let Ok(input_field) = input_schema.field_with_name(column.name())
-                {
-                    result_field.data_type() != input_field.data_type()
-                } else {
-                    false
-                },
+        let adapter_factory = DefaultPhysicalExprAdapterFactory {};
+        let adapted_filters = adapter_factory
+            .create(
+                Arc::clone(&self.scan_plan.contract.result_schema),
+                self.input.schema(),
             )
-        })
-        .unwrap_or(false)
+            .and_then(|adapter| {
+                parent_filters
+                    .iter()
+                    .map(|filter| adapter.rewrite(Arc::clone(filter)))
+                    .collect::<Result<Vec<_>>>()
+            });
+
+        match adapted_filters {
+            Ok(filters) => FilterDescription::from_children(filters, &self.children()),
+            Err(_) => Ok(FilterDescription::all_unsupported(
+                &parent_filters,
+                &self.children(),
+            )),
+        }
+    }
 }
 
 /// Stream that produces logical RecordBatches from a Delta table scan.
@@ -661,19 +655,26 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::array::AsArray;
-    use arrow::datatypes::DataType;
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use arrow_array::Array;
     use arrow_array::ArrayAccessor;
     use datafusion::{
-        common::stats::Precision,
-        physical_plan::{collect, collect_partitioned},
+        common::{ToDFSchema, stats::Precision},
+        datasource::TableProvider,
+        physical_plan::{
+            collect, collect_partitioned,
+            filter_pushdown::{FilterPushdownPhase, PushedDown},
+        },
         prelude::{col, lit},
+        scalar::ScalarValue,
     };
 
     use super::*;
     use crate::{
         assert_batches_sorted_eq,
-        delta_datafusion::{session::create_session, table_provider::next::FILE_ID_COLUMN_DEFAULT},
+        delta_datafusion::{
+            DeltaScanConfig, session::create_session, table_provider::next::FILE_ID_COLUMN_DEFAULT,
+        },
         test_utils::{TestResult, TestTables, open_fs_path},
     };
 
@@ -773,6 +774,131 @@ mod tests {
         assert_eq!(data[0].num_columns(), 2);
         assert!(data[0].schema().column_with_name("data").is_some());
         assert!(data[0].schema().column_with_name("file_id").is_some());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_with_file_id_provider_does_not_force_output_when_unprojected() -> TestResult
+    {
+        let table = TestTables::Simple.table_builder()?.load().await?;
+        let provider = table.table_provider().with_file_column("file_id").await?;
+        let session = Arc::new(create_session().into_inner());
+        let id_idx = provider.schema().index_of("id").unwrap();
+
+        let scan = provider
+            .scan(&session.state(), Some(&vec![id_idx]), &[], None)
+            .await?;
+
+        let downcast = scan.as_any().downcast_ref::<DeltaScanExec>();
+        assert!(downcast.is_some());
+        assert!(downcast.unwrap().file_id_column.is_none());
+
+        let data = collect_partitioned(scan, session.task_ctx())
+            .await?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+        assert!(!data.is_empty());
+        assert_eq!(data[0].num_columns(), 1);
+        assert!(data[0].schema().column_with_name("id").is_some());
+        assert!(data[0].schema().column_with_name("file_id").is_none());
+
+        Ok(())
+    }
+
+    fn multi_partitioned_override_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new(
+                "letter",
+                DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
+                true,
+            ),
+            Field::new("date", DataType::Date32, true),
+            Field::new(
+                "data",
+                DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Binary)),
+                true,
+            ),
+            Field::new(
+                "number",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                true,
+            ),
+        ]))
+    }
+
+    #[tokio::test]
+    async fn test_gather_filters_for_pushdown_adapts_override_schema_predicates() -> TestResult {
+        let mut table =
+            open_fs_path("../../dat/v0.0.3/reader_tests/generated/multi_partitioned/delta");
+        table.load().await?;
+
+        let provider = crate::delta_datafusion::table_provider::next::DeltaScan::new(
+            table.snapshot()?.snapshot().clone(),
+            DeltaScanConfig::default().with_schema(multi_partitioned_override_schema()),
+        )?
+        .with_log_store(table.log_store());
+
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .as_any()
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        let filter = session.state().create_physical_expr(
+            col("number").lt(lit(ScalarValue::TimestampMillisecond(Some(7), None))),
+            &exec.schema().clone().to_dfschema()?,
+        )?;
+
+        let description = exec.gather_filters_for_pushdown(
+            FilterPushdownPhase::Pre,
+            vec![filter],
+            session.state().config().options(),
+        )?;
+
+        let child_filters = description.parent_filters();
+        assert_eq!(child_filters.len(), 1);
+        assert_eq!(child_filters[0].len(), 1);
+        assert!(matches!(child_filters[0][0].discriminant, PushedDown::Yes));
+
+        let input_batches = collect(Arc::clone(&exec.input), session.task_ctx()).await?;
+        assert!(!input_batches.is_empty());
+        child_filters[0][0].predicate.evaluate(&input_batches[0])?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_gather_filters_for_pushdown_skips_column_mapping_parent_filters() -> TestResult {
+        let mut table = open_fs_path("../test/tests/data/table_with_column_mapping");
+        table.load().await?;
+
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .as_any()
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        let filter = session.state().create_physical_expr(
+            col(r#""Super Name""#).eq(lit(ScalarValue::Utf8View(Some("Timothy Lamb".to_string())))),
+            &exec.schema().clone().to_dfschema()?,
+        )?;
+
+        let description = exec.gather_filters_for_pushdown(
+            FilterPushdownPhase::Pre,
+            vec![filter],
+            session.state().config().options(),
+        )?;
+
+        let child_filters = description.parent_filters();
+        assert_eq!(child_filters.len(), 1);
+        assert_eq!(child_filters[0].len(), 1);
+        assert!(matches!(child_filters[0][0].discriminant, PushedDown::No));
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -36,7 +36,7 @@ use delta_kernel::{EvaluationHandler, ExpressionRef};
 use futures::stream::{Stream, StreamExt};
 
 use super::plan::KernelScanPlan;
-use crate::delta_datafusion::file_id::{FILE_ID_COLUMN_DEFAULT, file_id_field};
+use crate::delta_datafusion::file_id::file_id_field;
 use crate::kernel::ARROW_HANDLER;
 use crate::kernel::arrow::engine_ext::ExpressionEvaluatorExt;
 
@@ -101,7 +101,7 @@ pub(crate) fn consume_dv_mask(
 /// 1. Inner [`input`](Self::input) plan reads raw Parquet data
 /// 2. Per-file [`transforms`](Self::transforms) convert physical to logical schema
 /// 3. [`selection_vectors`](Self::selection_vectors) filter deleted rows
-/// 4. Result is cast to [`result_schema`](KernelScanPlan::result_schema)
+/// 4. Result is cast to the projected scan contract's result schema
 #[derive(Clone, Debug)]
 pub struct DeltaScanExec {
     scan_plan: Arc<KernelScanPlan>,
@@ -113,6 +113,8 @@ pub struct DeltaScanExec {
     selection_vectors: Arc<DashMap<String, Vec<bool>>>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
+    /// File id column name carried by the input batches for per file correlation.
+    input_file_id_column: String,
     /// User-visible file-id column name when projected in the output.
     file_id_column: Option<String>,
     /// plan properties
@@ -145,9 +147,13 @@ impl DeltaScanExec {
         transforms: Arc<HashMap<String, ExpressionRef>>,
         selection_vectors: Arc<DashMap<String, Vec<bool>>>,
         partition_stats: HashMap<String, ColumnStatistics>,
-        file_id_column: Option<String>,
         metrics: ExecutionPlanMetricsSet,
     ) -> Self {
+        let input_file_id_column = scan_plan.contract.file_id_field.name().to_owned();
+        let file_id_column = scan_plan
+            .contract
+            .retain_file_id
+            .then(|| scan_plan.contract.file_id_field.name().to_owned());
         let output_schema = scan_plan.effective_schema(file_id_column.is_some());
         let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema),
@@ -162,6 +168,7 @@ impl DeltaScanExec {
             selection_vectors,
             partition_stats,
             metrics,
+            input_file_id_column,
             file_id_column,
             properties,
         }
@@ -262,7 +269,6 @@ impl ExecutionPlan for DeltaScanExec {
             self.transforms.clone(),
             self.selection_vectors.clone(),
             self.partition_stats.clone(),
-            self.file_id_column.clone(),
             self.metrics.clone(),
         )))
     }
@@ -294,9 +300,12 @@ impl ExecutionPlan for DeltaScanExec {
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
             transforms: Arc::clone(&self.transforms),
             selection_vectors: Arc::clone(&self.selection_vectors),
+            input_file_id_column: self.input_file_id_column.clone(),
             file_id_column: self.file_id_column.clone(),
             pending: VecDeque::new(),
-            schema_adapter: super::SchemaAdapter::new(Arc::clone(&self.scan_plan.result_schema)),
+            schema_adapter: super::SchemaAdapter::new(Arc::clone(
+                &self.scan_plan.contract.result_schema,
+            )),
         }))
     }
 
@@ -342,7 +351,7 @@ impl ExecutionPlan for DeltaScanExec {
         if parent_filters.iter().any(|filter| {
             filter_references_type_mismatch(
                 filter,
-                &self.scan_plan.result_schema,
+                &self.scan_plan.contract.result_schema,
                 &self.input.schema(),
             )
         }) {
@@ -404,6 +413,8 @@ struct DeltaScanStream {
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Selection vectors to be applied to data read from individual files
     selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+    /// File id column name carried by the input batches for per file correlation.
+    input_file_id_column: String,
     /// User-visible file-id column name when projected in the output.
     file_id_column: Option<String>,
     pending: VecDeque<RecordBatch>,
@@ -422,7 +433,7 @@ impl DeltaScanStream {
             return Ok(vec![RecordBatch::new_empty(self.schema())]);
         }
 
-        let file_id_idx = file_id_column_idx(&batch, FILE_ID_COLUMN_DEFAULT)?;
+        let file_id_idx = file_id_column_idx(&batch, &self.input_file_id_column)?;
         let file_runs = split_by_file_id_runs(&batch, file_id_idx)?;
 
         let mut results = Vec::with_capacity(file_runs.len());
@@ -663,7 +674,7 @@ mod tests {
     use crate::{
         assert_batches_sorted_eq,
         delta_datafusion::{session::create_session, table_provider::next::FILE_ID_COLUMN_DEFAULT},
-        test_utils::{TestResult, open_fs_path},
+        test_utils::{TestResult, TestTables, open_fs_path},
     };
 
     #[tokio::test]
@@ -844,6 +855,41 @@ mod tests {
         // Verify file_id column has a value (full file path)
         let file_id_col = batches[0].column_by_name("file_id").unwrap();
         assert_eq!(file_id_col.len(), 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_with_file_id_filter_omits_unprojected_file_id_from_final_output()
+    -> TestResult {
+        let table = TestTables::Simple.table_builder()?.load().await?;
+        let provider = table.table_provider().with_file_column("file_id").await?;
+        let session = Arc::new(create_session().into_inner());
+
+        session
+            .register_table("delta_table", provider.clone())
+            .unwrap();
+
+        let file_id_batches = session
+            .sql("SELECT CAST(file_id AS STRING) AS file_id FROM delta_table LIMIT 1")
+            .await
+            .unwrap()
+            .collect()
+            .await?;
+        let file_id = file_id_batches[0].column(0).as_string_view().value(0);
+        let file_id = file_id.replace('\'', "''");
+
+        let df = session
+            .sql(&format!(
+                "SELECT id FROM delta_table WHERE file_id = '{file_id}'"
+            ))
+            .await
+            .unwrap();
+        let batches = df.collect().await?;
+
+        assert_eq!(batches[0].num_columns(), 1);
+        assert!(batches[0].schema().column_with_name("id").is_some());
+        assert!(batches[0].schema().column_with_name("file_id").is_none());
 
         Ok(())
     }
@@ -1143,14 +1189,14 @@ mod tests {
         let kernel_type = Arc::clone(exec.scan_plan.scan.logical_schema()).into();
 
         let mut scan_plan = exec.scan_plan.as_ref().clone();
-        scan_plan.result_schema = Arc::new(Schema::new(vec![Field::new(
+        scan_plan.contract.result_schema = Arc::new(Schema::new(vec![Field::new(
             "value",
             DataType::Int32,
             false,
         )]));
-        scan_plan.output_schema = Arc::clone(&scan_plan.result_schema);
-        scan_plan.result_projection = None;
-        scan_plan.parquet_read_schema = Arc::clone(&scan_plan.result_schema);
+        scan_plan.contract.output_schema = Arc::clone(&scan_plan.contract.result_schema);
+        scan_plan.contract.result_projection = None;
+        scan_plan.parquet_read_schema = Arc::clone(&scan_plan.contract.result_schema);
 
         Ok((kernel_type, Arc::new(scan_plan)))
     }
@@ -1212,14 +1258,16 @@ mod tests {
         let input_schema = input_batches
             .first()
             .map(|b| b.schema())
-            .unwrap_or_else(|| Arc::clone(&scan_plan.output_schema));
+            .unwrap_or_else(|| Arc::clone(&scan_plan.contract.output_schema));
+        let input_file_id_column = scan_plan.contract.file_id_field.name().clone();
 
         let input = Box::pin(RecordBatchStreamAdapter::new(
             input_schema,
             futures::stream::iter(input_batches.into_iter().map(Ok)),
         ));
 
-        let schema_adapter = super::super::SchemaAdapter::new(Arc::clone(&scan_plan.result_schema));
+        let schema_adapter =
+            super::super::SchemaAdapter::new(Arc::clone(&scan_plan.contract.result_schema));
         DeltaScanStream {
             scan_plan,
             kernel_type,
@@ -1227,6 +1275,7 @@ mod tests {
             baseline_metrics: BaselineMetrics::new(&ExecutionPlanMetricsSet::new(), 0),
             transforms: Arc::new(HashMap::new()),
             selection_vectors,
+            input_file_id_column,
             file_id_column,
             pending: VecDeque::new(),
             schema_adapter,
@@ -1353,7 +1402,7 @@ mod tests {
 
         // set any fake schema different to result_schema and no desired file_id
         let output_schema = Arc::new(Schema::empty());
-        scan_plan.output_schema = output_schema.clone();
+        scan_plan.contract.output_schema = output_schema.clone();
         let mut stream = test_scan_stream(
             Arc::new(scan_plan),
             kernel_type,

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -153,7 +153,7 @@ impl DeltaScanExec {
         let input_file_id_column = scan_plan.contract.file_id_field.name().to_owned();
         let file_id_column = scan_plan
             .contract
-            .retain_file_id
+            .scan_must_return_file_id
             .then(|| scan_plan.contract.file_id_field.name().to_owned());
         let output_schema = scan_plan.effective_schema(file_id_column.is_some());
         let properties = Arc::new(PlanProperties::new(
@@ -655,7 +655,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::array::AsArray;
-    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use arrow::datatypes::DataType;
     use arrow_array::Array;
     use arrow_array::ArrayAccessor;
     use datafusion::{
@@ -808,27 +808,6 @@ mod tests {
         Ok(())
     }
 
-    fn multi_partitioned_override_schema() -> Arc<Schema> {
-        Arc::new(Schema::new(vec![
-            Field::new(
-                "letter",
-                DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
-                true,
-            ),
-            Field::new("date", DataType::Date32, true),
-            Field::new(
-                "data",
-                DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Binary)),
-                true,
-            ),
-            Field::new(
-                "number",
-                DataType::Timestamp(TimeUnit::Millisecond, None),
-                true,
-            ),
-        ]))
-    }
-
     #[tokio::test]
     async fn test_gather_filters_for_pushdown_adapts_override_schema_predicates() -> TestResult {
         let mut table =
@@ -837,7 +816,9 @@ mod tests {
 
         let provider = crate::delta_datafusion::table_provider::next::DeltaScan::new(
             table.snapshot()?.snapshot().clone(),
-            DeltaScanConfig::default().with_schema(multi_partitioned_override_schema()),
+            DeltaScanConfig::default().with_schema(
+                crate::delta_datafusion::table_provider::next::test_multi_partitioned_override_schema(),
+            ),
         )?
         .with_log_store(table.log_store());
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -261,7 +261,9 @@ impl ExecutionPlan for DeltaScanMetaExec {
             transforms: Arc::clone(&self.transforms),
             selection_vectors: Arc::clone(&self.selection_vectors),
             file_id_field: self.file_id_field.clone(),
-            schema_adapter: super::SchemaAdapter::new(Arc::clone(&self.scan_plan.result_schema)),
+            schema_adapter: super::SchemaAdapter::new(Arc::clone(
+                &self.scan_plan.contract.result_schema,
+            )),
         }))
     }
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -53,7 +53,7 @@ use url::Url;
 
 pub use self::exec::DeltaScanExec;
 use self::exec_meta::DeltaScanMetaExec;
-pub(crate) use self::plan::{KernelScanPlan, supports_filters_pushdown};
+pub(crate) use self::plan::{KernelScanPlan, ProjectedScanContract, supports_filters_pushdown};
 use self::replay::{ScanFileContext, ScanFileStream};
 use super::FileSelection;
 use crate::{
@@ -61,7 +61,7 @@ use crate::{
     delta_datafusion::{
         DeltaScanConfig,
         engine::{AsObjectStoreUrl as _, to_datafusion_scalar},
-        file_id::{FILE_ID_COLUMN_DEFAULT, file_id_field, wrap_file_id_value},
+        file_id::wrap_file_id_value,
         table_provider::next::DeletionVectorSelection,
     },
 };
@@ -76,7 +76,6 @@ type ScanMetadataStream = Pin<Box<dyn Stream<Item = Result<ScanMetadata, DeltaTa
 pub(super) async fn execution_plan(
     config: &DeltaScanConfig,
     session: &dyn Session,
-    projection: Option<&Vec<usize>>,
     scan_plan: KernelScanPlan,
     stream: ScanMetadataStream,
     engine: Arc<dyn Engine>,
@@ -86,9 +85,7 @@ pub(super) async fn execution_plan(
     let (files, transforms, dvs, metrics) =
         replay_files(engine, &scan_plan, config.clone(), stream, file_selection).await?;
 
-    let table_schema = config.table_schema(scan_plan.table_configuration())?;
-    let projected_file_id_column =
-        config.projected_file_id_column(projection, table_schema.as_ref());
+    let file_id_field = scan_plan.contract.file_id_field.clone();
     if scan_plan.is_metadata_only() {
         let map_file = |f: &ScanFileContext| {
             Ok((
@@ -110,29 +107,20 @@ pub(super) async fn execution_plan(
             .map(map_file)
             .try_collect::<_, VecDeque<_>, _>();
         if let Ok(file_rows) = maybe_file_rows {
+            let retain_file_id = scan_plan.contract.retain_file_id;
             let exec = DeltaScanMetaExec::new(
                 Arc::new(scan_plan),
                 vec![file_rows],
                 Arc::new(transforms),
                 Arc::new(dvs),
-                projected_file_id_column.map(|name| file_id_field(Some(name))),
+                retain_file_id.then_some(file_id_field),
                 metrics,
             );
             return Ok(Arc::new(exec) as _);
         }
     }
 
-    get_data_scan_plan(
-        session,
-        scan_plan,
-        files,
-        transforms,
-        dvs,
-        metrics,
-        limit,
-        projected_file_id_column,
-    )
-    .await
+    get_data_scan_plan(session, scan_plan, files, transforms, dvs, metrics, limit).await
 }
 
 /// Materialize deletion vector keep masks for every file in the scan that has one.
@@ -301,7 +289,6 @@ async fn get_data_scan_plan(
     dvs: DashMap<String, Vec<bool>>,
     metrics: ExecutionPlanMetricsSet,
     limit: Option<usize>,
-    projected_file_id_column: Option<&str>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut partition_stats = HashMap::new();
 
@@ -352,12 +339,13 @@ async fn get_data_scan_plan(
     } else {
         scan_plan.parquet_predicate.as_ref()
     };
+    let file_id_field = scan_plan.contract.file_id_field.clone();
     let pq_plan = get_read_plan(
         session,
         files_by_store,
         &scan_plan.parquet_read_schema,
         limit,
-        &file_id_field(Some(FILE_ID_COLUMN_DEFAULT)),
+        &file_id_field,
         predicate,
     )
     .await?;
@@ -368,7 +356,6 @@ async fn get_data_scan_plan(
         Arc::new(transforms),
         Arc::new(dvs),
         partition_stats,
-        projected_file_id_column.map(ToOwned::to_owned),
         metrics,
     );
 
@@ -514,14 +501,14 @@ fn finalize_transformed_batch(
     file_id_col: Option<(ArrayRef, FieldRef)>,
     schema_adapter: &mut SchemaAdapter,
 ) -> Result<RecordBatch> {
-    let result = if let Some(projection) = scan_plan.result_projection.as_ref() {
+    let result = if let Some(projection) = scan_plan.contract.result_projection.as_ref() {
         batch.project(projection)?
     } else {
         batch
     };
     // NOTE: most data is read properly typed already, however columns added via
     // literals in the transformations may need to be cast to the physical expected type.
-    let result = if result.schema_ref().eq(&scan_plan.result_schema) {
+    let result = if result.schema_ref().eq(&scan_plan.contract.result_schema) {
         result
     } else {
         schema_adapter.adapt(result)?

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -111,13 +111,13 @@ pub(super) async fn execution_plan(
             .map(map_file)
             .try_collect::<_, VecDeque<_>, _>();
         if let Ok(file_rows) = maybe_file_rows {
-            let retain_file_id = scan_plan.contract.retain_file_id;
+            let scan_must_return_file_id = scan_plan.contract.scan_must_return_file_id;
             let exec = DeltaScanMetaExec::new(
                 Arc::new(scan_plan),
                 vec![file_rows],
                 Arc::new(transforms),
                 Arc::new(dvs),
-                retain_file_id.then_some(file_id_field),
+                scan_must_return_file_id.then_some(file_id_field),
                 metrics,
             );
             return Ok(Arc::new(exec) as _);

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -42,13 +42,17 @@ use datafusion_datasource::{
     PartitionedFile, TableSchema, compute_all_files_statistics, file_groups::FileGroup,
     file_scan_config::FileScanConfigBuilder, source::DataSourceExec,
 };
-use datafusion_physical_expr_adapter::{BatchAdapter, BatchAdapterFactory};
+use datafusion_physical_expr_adapter::{
+    BatchAdapter, BatchAdapterFactory, DefaultPhysicalExprAdapterFactory,
+    PhysicalExprAdapterFactory,
+};
 use delta_kernel::{
     Engine, Expression, expressions::StructData, scan::ScanMetadata, table_features::TableFeature,
 };
 use futures::{Stream, TryStreamExt as _, future::ready};
 use itertools::Itertools as _;
 use object_store::{ObjectMeta, path::Path};
+use tracing::debug;
 use url::Url;
 
 pub use self::exec::DeltaScanExec;
@@ -344,6 +348,7 @@ async fn get_data_scan_plan(
         session,
         files_by_store,
         &scan_plan.parquet_read_schema,
+        &scan_plan.parquet_predicate_schema,
         limit,
         &file_id_field,
         predicate,
@@ -428,6 +433,9 @@ async fn get_read_plan(
     // This is also the schema used for Parquet pruning/pushdown. It may include view types
     // (e.g. Utf8View/BinaryView) depending on `DeltaScanConfig`.
     parquet_read_schema: &SchemaRef,
+    // Predicate binding schema used to bind Parquet predicates, including the synthetic file id
+    // column when the provider exposes it.
+    parquet_predicate_schema: &SchemaRef,
     limit: Option<usize>,
     file_id_field: &FieldRef,
     predicate: Option<&Expr>,
@@ -442,7 +450,8 @@ async fn get_read_plan(
     let mut full_read_schema = SchemaBuilder::from(parquet_read_schema.as_ref().clone());
     full_read_schema.push(file_id_field.as_ref().clone().with_nullable(true));
     let full_read_schema = Arc::new(full_read_schema.finish());
-    let full_read_df_schema = full_read_schema.clone().to_dfschema()?;
+    let parquet_predicate_df_schema = parquet_predicate_schema.clone().to_dfschema()?;
+    let adapter_factory = Arc::new(DefaultPhysicalExprAdapterFactory {});
 
     for (store_url, files) in files_by_store.into_iter() {
         let reader_factory = Arc::new(CachedParquetFileReaderFactory::new(
@@ -465,13 +474,43 @@ async fn get_read_plan(
         // interfere with other delta features like row ids.
         let has_selection_vectors = files.iter().any(|(_, sv)| sv.is_some());
         if !has_selection_vectors && let Some(pred) = predicate {
-            // Predicate pushdown can reference the synthetic file-id partition column.
-            // Use the full read schema (data columns + file-id) when planning.
-            let physical = state.create_physical_expr(pred.clone(), &full_read_df_schema)?;
-
-            file_source = file_source
-                .with_predicate(physical)
-                .with_pushdown_filters(true);
+            match state.create_physical_expr(pred.clone(), &parquet_predicate_df_schema) {
+                Ok(physical) => match adapter_factory
+                    .create(parquet_predicate_schema.clone(), full_read_schema.clone())
+                {
+                    Ok(adapter) => match adapter.rewrite(physical) {
+                        Ok(rewritten) => {
+                            file_source = file_source
+                                .with_predicate(rewritten)
+                                .with_pushdown_filters(true);
+                        }
+                        Err(err) => {
+                            debug!(
+                                predicate = ?pred,
+                                schema = ?parquet_predicate_schema,
+                                error = %err,
+                                "Skipping parquet predicate pushdown because predicate adaptation to the read schema failed"
+                            );
+                        }
+                    },
+                    Err(err) => {
+                        debug!(
+                            predicate = ?pred,
+                            schema = ?parquet_predicate_schema,
+                            error = %err,
+                            "Skipping parquet predicate pushdown because predicate adapter creation failed"
+                        );
+                    }
+                },
+                Err(err) => {
+                    debug!(
+                        predicate = ?pred,
+                        schema = ?parquet_predicate_schema,
+                        error = %err,
+                        "Skipping parquet predicate pushdown because predicate binding failed"
+                    );
+                }
+            }
         }
 
         let file_groups = partitioned_files_to_file_groups(files.into_iter().map(|file| file.0));
@@ -482,6 +521,7 @@ async fn get_read_plan(
             .with_file_groups(file_groups)
             .with_statistics(statistics)
             .with_limit(limit)
+            .with_expr_adapter(Some(adapter_factory.clone() as _))
             .build();
 
         plans.push(DataSourceExec::from_data_source(config) as Arc<dyn ExecutionPlan>);
@@ -584,7 +624,7 @@ mod tests {
     use arrow_array::Array;
     use arrow_array::{
         BinaryArray, BinaryViewArray, Int32Array, Int64Array, RecordBatch, RecordBatchOptions,
-        StringArray, StructArray,
+        StringArray, StringViewArray, StructArray,
     };
     use arrow_schema::{ArrowError, DataType, Field, Fields, Schema};
     use datafusion::{
@@ -602,7 +642,7 @@ mod tests {
         test_utils::TestResult,
     };
 
-    use super::*;
+    use super::{plan::build_parquet_predicate_schema, *};
 
     #[test]
     fn test_partitioned_files_to_file_groups_respects_dictionary_cardinality_limit() {
@@ -885,11 +925,14 @@ mod tests {
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+        let parquet_predicate_schema =
+            build_parquet_predicate_schema(&arrow_schema, &file_id_field);
 
         let plan = get_read_plan(
             &session.state(),
             files_by_store.clone(),
             &arrow_schema,
+            &parquet_predicate_schema,
             None,
             &file_id_field,
             None,
@@ -912,6 +955,7 @@ mod tests {
             &session.state(),
             files_by_store.clone(),
             &arrow_schema,
+            &parquet_predicate_schema,
             Some(1),
             &file_id_field,
             None,
@@ -933,10 +977,13 @@ mod tests {
             Field::new("value", DataType::Utf8, true),
             Field::new("value2", DataType::Utf8, true),
         ]));
+        let parquet_predicate_schema_extended =
+            build_parquet_predicate_schema(&arrow_schema_extended, &file_id_field);
         let plan = get_read_plan(
             &session.state(),
             files_by_store.clone(),
             &arrow_schema_extended,
+            &parquet_predicate_schema_extended,
             Some(1),
             &file_id_field,
             None,
@@ -1006,11 +1053,14 @@ mod tests {
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+        let parquet_predicate_schema =
+            build_parquet_predicate_schema(&arrow_schema, &file_id_field);
 
         let plan = get_read_plan(
             &session.state(),
             files_by_store.clone(),
             &arrow_schema,
+            &parquet_predicate_schema,
             None,
             &file_id_field,
             None,
@@ -1042,10 +1092,13 @@ mod tests {
                 true,
             ),
         ]));
+        let parquet_predicate_schema_extended =
+            build_parquet_predicate_schema(&arrow_schema_extended, &file_id_field);
         let plan = get_read_plan(
             &session.state(),
             files_by_store.clone(),
             &arrow_schema_extended,
+            &parquet_predicate_schema_extended,
             None,
             &file_id_field,
             None,
@@ -1136,11 +1189,14 @@ mod tests {
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+        let parquet_predicate_schema =
+            build_parquet_predicate_schema(&arrow_schema, &file_id_field);
 
         let plan = get_read_plan(
             &session.state(),
             files_by_store.clone(),
             &arrow_schema,
+            &parquet_predicate_schema,
             None,
             &file_id_field,
             None,
@@ -1199,12 +1255,15 @@ mod tests {
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+        let parquet_predicate_schema =
+            build_parquet_predicate_schema(&arrow_schema, &file_id_field);
 
         let predicate = col("id").eq(lit(2i32));
         let plan = get_read_plan(
             &session.state(),
             files_by_store.clone(),
             &arrow_schema,
+            &parquet_predicate_schema,
             None,
             &file_id_field,
             Some(&predicate),
@@ -1222,6 +1281,75 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_predicate_pushdown_skips_pushdown_when_logical_rewrite_fails() -> TestResult {
+        let store = Arc::new(InMemory::new());
+        let store_url = Url::parse("memory:///")?;
+        let session = Arc::new(create_session().into_inner());
+        session
+            .runtime_env()
+            .register_object_store(&store_url, store.clone());
+
+        let parquet_read_schema =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let logical_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("missing", DataType::Int32, false),
+        ]));
+        let data = RecordBatch::try_new(
+            parquet_read_schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )?;
+
+        let mut buffer = Vec::new();
+        let mut arrow_writer =
+            ArrowWriter::try_new(&mut buffer, parquet_read_schema.clone(), None)?;
+        arrow_writer.write(&data)?;
+        arrow_writer.close()?;
+
+        let path = Path::from("test_rewrite_failure.parquet");
+        store.put(&path, buffer.into()).await?;
+        let mut file: PartitionedFile = store.head(&path).await?.into();
+        file.partition_values
+            .push(wrap_file_id_value("memory:///test_rewrite_failure.parquet"));
+
+        let files_by_store = vec![(
+            store_url.as_object_store_url(),
+            vec![(file, None::<Vec<bool>>)],
+        )];
+
+        let file_id_field =
+            crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+        let parquet_predicate_schema =
+            build_parquet_predicate_schema(&logical_schema, &file_id_field);
+        let predicate = col("missing").eq(lit(1i32));
+
+        let plan = get_read_plan(
+            &session.state(),
+            files_by_store,
+            &parquet_read_schema,
+            &parquet_predicate_schema,
+            None,
+            &file_id_field,
+            Some(&predicate),
+        )
+        .await?;
+        let batches = collect(plan, session.task_ctx()).await?;
+        let expected = vec![
+            "+----+----------------------------------------+",
+            "| id | __delta_rs_file_id__                   |",
+            "+----+----------------------------------------+",
+            "| 1  | memory:///test_rewrite_failure.parquet |",
+            "| 2  | memory:///test_rewrite_failure.parquet |",
+            "| 3  | memory:///test_rewrite_failure.parquet |",
+            "+----+----------------------------------------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &batches);
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_predicate_pushdown_allows_view_literal_against_base_parquet_file() -> TestResult {
         use datafusion::scalar::ScalarValue;
@@ -1272,12 +1400,15 @@ mod tests {
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+        let parquet_predicate_schema =
+            build_parquet_predicate_schema(&parquet_read_schema, &file_id_field);
 
         let predicate = col("name").eq(lit(ScalarValue::Utf8View(Some("bob".to_string()))));
         let plan = get_read_plan(
             &session.state(),
             files_by_store,
             &parquet_read_schema,
+            &parquet_predicate_schema,
             None,
             &file_id_field,
             Some(&predicate),
@@ -1345,12 +1476,15 @@ mod tests {
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+        let parquet_predicate_schema =
+            build_parquet_predicate_schema(&parquet_read_schema, &file_id_field);
 
         let predicate = col("name").eq(lit("bob"));
         let plan = get_read_plan(
             &session.state(),
             files_by_store,
             &parquet_read_schema,
+            &parquet_predicate_schema,
             None,
             &file_id_field,
             Some(&predicate),
@@ -1366,6 +1500,94 @@ mod tests {
             "+----+------+------------------------------------+",
         ];
         assert_batches_sorted_eq!(&expected, &batches);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_predicate_pushdown_allows_physical_column_mapping_names() -> TestResult {
+        let store = Arc::new(InMemory::new());
+        let store_url = Url::parse("memory:///")?;
+        let session = Arc::new(create_session().into_inner());
+        session
+            .runtime_env()
+            .register_object_store(&store_url, store.clone());
+
+        let physical_name = "col-3877fd94-0973-4941-ac6b-646849a1ff65";
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(physical_name, DataType::Utf8, true),
+        ]));
+        let parquet_read_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(physical_name, DataType::Utf8View, true),
+        ]));
+        let data = RecordBatch::try_new(
+            file_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec![
+                    Some("alice"),
+                    Some("bob"),
+                    Some("charlie"),
+                ])),
+            ],
+        )?;
+
+        let mut buffer = Vec::new();
+        let mut arrow_writer = ArrowWriter::try_new(&mut buffer, file_schema.clone(), None)?;
+        arrow_writer.write(&data)?;
+        arrow_writer.close()?;
+
+        let path = Path::from("test_column_mapping_pushdown.parquet");
+        store.put(&path, buffer.into()).await?;
+        let mut file: PartitionedFile = store.head(&path).await?.into();
+        file.partition_values.push(wrap_file_id_value(
+            "memory:///test_column_mapping_pushdown.parquet",
+        ));
+
+        let files_by_store = vec![(
+            store_url.as_object_store_url(),
+            vec![(file, None::<Vec<bool>>)],
+        )];
+
+        let file_id_field =
+            crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+        let parquet_predicate_schema =
+            build_parquet_predicate_schema(&parquet_read_schema, &file_id_field);
+
+        let predicate = col(physical_name).eq(lit("bob"));
+        let plan = get_read_plan(
+            &session.state(),
+            files_by_store,
+            &parquet_read_schema,
+            &parquet_predicate_schema,
+            None,
+            &file_id_field,
+            Some(&predicate),
+        )
+        .await?;
+        let batches = collect(plan, session.task_ctx()).await?;
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 1);
+        assert_eq!(batches[0].num_columns(), 3);
+
+        let id_col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(id_col.value(0), 2);
+
+        let name_col = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .unwrap();
+        assert_eq!(name_col.value(0), "bob");
+
+        assert_eq!(batches[0].schema().field(1).name(), physical_name);
+        assert_eq!(batches[0].schema().field(2).name(), FILE_ID_COLUMN_DEFAULT);
 
         Ok(())
     }
@@ -1420,12 +1642,15 @@ mod tests {
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+        let parquet_predicate_schema =
+            build_parquet_predicate_schema(&parquet_read_schema, &file_id_field);
 
         let predicate = col("data").eq(lit(ScalarValue::BinaryView(Some(b"bbb".to_vec()))));
         let plan = get_read_plan(
             &session.state(),
             files_by_store,
             &parquet_read_schema,
+            &parquet_predicate_schema,
             None,
             &file_id_field,
             Some(&predicate),

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -111,13 +111,13 @@ pub(super) async fn execution_plan(
             .map(map_file)
             .try_collect::<_, VecDeque<_>, _>();
         if let Ok(file_rows) = maybe_file_rows {
-            let scan_must_return_file_id = scan_plan.contract.scan_must_return_file_id;
+            let retain_file_id = scan_plan.contract.retain_file_id;
             let exec = DeltaScanMetaExec::new(
                 Arc::new(scan_plan),
                 vec![file_rows],
                 Arc::new(transforms),
                 Arc::new(dvs),
-                scan_must_return_file_id.then_some(file_id_field),
+                retain_file_id.then_some(file_id_field),
                 metrics,
             );
             return Ok(Arc::new(exec) as _);

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
@@ -185,6 +185,9 @@ pub(crate) struct KernelScanPlan {
     pub(crate) contract: ProjectedScanContract,
     /// Physical schema used for Parquet reads and predicate evaluation.
     pub(crate) parquet_read_schema: SchemaRef,
+    /// Predicate binding schema used to plan Parquet pushdown, including the synthetic file id
+    /// column.
+    pub(crate) parquet_predicate_schema: SchemaRef,
     /// If set, indicates a predicate to apply at the Parquet scan level
     pub(crate) parquet_predicate: Option<Expr>,
 }
@@ -265,10 +268,13 @@ impl KernelScanPlan {
             scan.snapshot().table_configuration(),
             &scan.physical_schema().as_ref().try_into_arrow()?,
         )?;
+        let parquet_predicate_schema =
+            build_parquet_predicate_schema(&parquet_read_schema, &contract.file_id_field);
         Ok(Self {
             scan,
             contract,
             parquet_read_schema,
+            parquet_predicate_schema,
             parquet_predicate,
         })
     }
@@ -293,6 +299,15 @@ impl KernelScanPlan {
             self.contract.result_schema.clone()
         }
     }
+}
+
+pub(crate) fn build_parquet_predicate_schema(
+    predicate_schema: &SchemaRef,
+    file_id_field: &FieldRef,
+) -> SchemaRef {
+    let mut schema_builder = SchemaBuilder::from(predicate_schema.as_ref().clone());
+    schema_builder.push(file_id_field.as_ref().clone().with_nullable(true));
+    Arc::new(schema_builder.finish())
 }
 
 impl DeltaScanConfig {
@@ -661,6 +676,7 @@ mod tests {
     use datafusion::logical_expr::and;
     use datafusion::{
         assert_batches_sorted_eq,
+        common::ToDFSchema,
         physical_plan::collect,
         prelude::{col, lit},
         scalar::ScalarValue,
@@ -816,6 +832,32 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_column_mapping_direct_provider_scan_for_data_column_filter() -> TestResult {
+        let mut table = open_fs_path("../test/tests/data/table_with_column_mapping");
+        table.load().await?;
+
+        let provider = table.table_provider().await?;
+        let ctx = create_session().into_inner();
+
+        let filter =
+            col(r#""Super Name""#).eq(lit(ScalarValue::Utf8View(Some("Timothy Lamb".to_string()))));
+        let scan = provider.scan(&ctx.state(), None, &[filter], None).await?;
+        let batches = collect(scan, ctx.task_ctx()).await?;
+
+        let expected = vec![
+            "+--------------------+--------------+",
+            "| Company Very Short | Super Name   |",
+            "+--------------------+--------------+",
+            "| BME                | Timothy Lamb |",
+            "+--------------------+--------------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &batches);
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_scan_schema_contract() -> TestResult {
         let mut table = open_fs_path("../test/tests/data/table_with_column_mapping");
@@ -1004,6 +1046,46 @@ mod tests {
         assert_eq!(contract.kernel_projection, Some(vec![0, 1]));
         assert_eq!(contract.result_projection, Some(vec![0]));
         assert!(contract.retain_file_id);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_kernel_scan_plan_carries_explicit_parquet_predicate_schema() -> TestResult {
+        let mut table = open_fs_path("../test/tests/data/table_with_column_mapping");
+        table.load().await?;
+
+        let snapshot = table.snapshot()?.snapshot().snapshot();
+        let config = DeltaScanConfig::default().with_file_column_name("file_id");
+        let filter = col(r#""Super Name""#).eq(lit("Anthony Johnson"));
+        let scan_plan = KernelScanPlan::try_new(snapshot, None, &[filter], &config, None)?;
+
+        assert!(
+            scan_plan
+                .parquet_predicate_schema
+                .field_with_name("col-3877fd94-0973-4941-ac6b-646849a1ff65")
+                .is_ok()
+        );
+        assert!(
+            scan_plan
+                .parquet_predicate_schema
+                .field_with_name("file_id")
+                .is_ok()
+        );
+        assert!(
+            scan_plan
+                .parquet_predicate_schema
+                .field_with_name("Super Name")
+                .is_err()
+        );
+        let session = create_session().into_inner();
+        session.state().create_physical_expr(
+            scan_plan
+                .parquet_predicate
+                .clone()
+                .expect("expected parquet predicate for column-mapped filter"),
+            &scan_plan.parquet_predicate_schema.clone().to_dfschema()?,
+        )?;
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
@@ -40,35 +40,149 @@ use crate::delta_datafusion::engine::{
 use crate::delta_datafusion::table_provider::next::FILE_ID_COLUMN_DEFAULT;
 use crate::kernel::{Scan, Snapshot};
 
+/// Query scoped contract between the provider, logical planner, and scan execs.
+///
+/// This centralizes all schema and file id visibility decisions for a single
+/// `TableProvider::scan` request so planning and execution do not rederive them independently.
+#[derive(Clone, Debug)]
+pub(crate) struct ProjectedScanContract {
+    /// Schema advertised by the provider for this table, including any public file id column.
+    #[allow(dead_code)]
+    pub(crate) provider_schema: SchemaRef,
+    /// Schema explicitly requested by the parent plan through the provider projection.
+    #[allow(dead_code)]
+    pub(crate) requested_schema: SchemaRef,
+    /// Logical data schema after removing temporary predicate only columns and internal metadata.
+    pub(crate) result_schema: SchemaRef,
+    /// Logical schema produced by the kernel scan before dropping filter only columns.
+    #[allow(dead_code)]
+    pub(crate) scan_schema: SchemaRef,
+    /// Actual schema the scan must return to its parent for this query.
+    pub(crate) output_schema: SchemaRef,
+    /// Projection against the logical table schema used to build the kernel scan.
+    pub(crate) kernel_projection: Option<Vec<usize>>,
+    /// Projection from the kernel scan result into [`result_schema`](Self::result_schema) when
+    /// filter only columns were added to the kernel projection.
+    pub(crate) result_projection: Option<Vec<usize>>,
+    /// Synthetic file id field used internally to correlate batches with their source files.
+    pub(crate) file_id_field: FieldRef,
+    /// Whether this particular scan must return the file id column to its parent plan.
+    pub(crate) retain_file_id: bool,
+}
+
+impl ProjectedScanContract {
+    pub(crate) fn try_new(
+        table_schema: SchemaRef,
+        provider_schema: SchemaRef,
+        config: &DeltaScanConfig,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+    ) -> Result<Self> {
+        let file_id_field = config.file_id_field();
+        let file_id_idx = config.has_file_id().then_some(table_schema.fields().len());
+
+        let requested_schema = match projection {
+            Some(projection) => Arc::new(provider_schema.project(projection)?),
+            None => provider_schema.clone(),
+        };
+
+        let retain_file_id = config.has_file_id()
+            && match projection {
+                None => true,
+                Some(projection) => {
+                    projection.iter().any(|idx| Some(*idx) == file_id_idx)
+                        || filters.iter().any(|filter| {
+                            filter
+                                .column_refs()
+                                .iter()
+                                .any(|column| column.name == file_id_field.name().as_str())
+                        })
+                }
+            };
+
+        let requested_data_projection = projection.map(|projection| {
+            projection
+                .iter()
+                .filter(|&&idx| Some(idx) != file_id_idx)
+                .copied()
+                .collect_vec()
+        });
+
+        let result_schema = match requested_data_projection.as_ref() {
+            Some(projection) => Arc::new(table_schema.project(projection)?),
+            None => table_schema.clone(),
+        };
+
+        let columns_in_filters: HashSet<String> = filters
+            .iter()
+            .flat_map(|f| f.column_refs().iter().map(|c| c.name.clone()).collect_vec())
+            .collect();
+        let columns_in_result: HashSet<String> = result_schema
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        let missing_columns: Vec<_> = columns_in_filters
+            .difference(&columns_in_result)
+            .filter(|column| column.as_str() != file_id_field.name().as_str())
+            .cloned()
+            .sorted()
+            .collect();
+
+        let kernel_projection = requested_data_projection
+            .as_ref()
+            .map(|projection| {
+                let mut projection = projection.clone();
+                for column in &missing_columns {
+                    projection.push(table_schema.index_of(column)?);
+                }
+                Ok::<_, datafusion::common::DataFusionError>(projection)
+            })
+            .transpose()?;
+
+        let scan_schema = match kernel_projection.as_ref() {
+            Some(projection) => Arc::new(table_schema.project(projection)?),
+            None => table_schema.clone(),
+        };
+
+        let result_projection = kernel_projection.as_ref().and_then(|projection| {
+            let projected_len = requested_data_projection.as_ref()?.len();
+            (projection.len() > projected_len).then(|| (0..projected_len).collect())
+        });
+
+        let output_schema = if retain_file_id {
+            let mut schema_builder = SchemaBuilder::from(result_schema.as_ref());
+            schema_builder.push(file_id_field.clone());
+            Arc::new(schema_builder.finish())
+        } else {
+            result_schema.clone()
+        };
+
+        Ok(Self {
+            provider_schema,
+            requested_schema,
+            result_schema,
+            scan_schema,
+            output_schema,
+            kernel_projection,
+            result_projection,
+            file_id_field,
+            retain_file_id,
+        })
+    }
+}
+
 /// Logical scan plan for Delta tables using Delta Kernel.
 ///
 /// This structure bridges DataFusion's query planning with Delta Kernel's scan capabilities.
-/// It handles schema projection, predicate translation, and determines which predicates can
+/// It finalizes the query scoped scan contract and determines which predicates can
 /// be pushed to kernel file skipping vs. Parquet readers.
-///
-/// # Schema Handling
-///
-/// Manages three schemas:
-/// - **result_schema**: Logical schema exposed to query after all transformations
-/// - **output_schema**: Final schema including metadata columns (e.g., file_id)
-/// - **parquet_read_schema**: Physical schema for Parquet reads + predicate evaluation
-///
-/// # Predicate Pushdown
-///
-/// Predicates are assigned to two levels:
-/// - Kernel scan: File-level skipping using table statistics (pushed to [`scan`])
-/// - Parquet scan: File/Row-level filtering within files ([`parquet_predicate`])
 #[derive(Clone, Debug)]
 pub(crate) struct KernelScanPlan {
     /// Wrapped kernel scan to produce logical file stream
     pub(crate) scan: Arc<Scan>,
-    /// The resulting schema exposed to the caller (used for expression evaluation)
-    pub(crate) result_schema: SchemaRef,
-    /// The final output schema (includes file_id column if configured)
-    pub(crate) output_schema: SchemaRef,
-    /// If set, indicates a projection to apply to the
-    /// scan output to obtain the result schema
-    pub(crate) result_projection: Option<Vec<usize>>,
+    /// Query scoped contract shared across planning and execution.
+    pub(crate) contract: ProjectedScanContract,
     /// Physical schema used for Parquet reads and predicate evaluation.
     pub(crate) parquet_read_schema: SchemaRef,
     /// If set, indicates a predicate to apply at the Parquet scan level
@@ -83,9 +197,33 @@ impl KernelScanPlan {
         config: &DeltaScanConfig,
         skipping_predicate: Option<Vec<Expr>>,
     ) -> Result<Self> {
+        let table_schema = config.table_schema(snapshot.table_configuration())?;
+        let provider_schema = if config.has_file_id() {
+            let mut schema_builder = SchemaBuilder::from(table_schema.as_ref());
+            schema_builder.push(config.file_id_field());
+            Arc::new(schema_builder.finish())
+        } else {
+            table_schema.clone()
+        };
+        let contract = ProjectedScanContract::try_new(
+            table_schema,
+            provider_schema,
+            config,
+            projection,
+            filters,
+        )?;
+        Self::try_new_with_contract(snapshot, contract, filters, config, skipping_predicate)
+    }
+
+    pub(crate) fn try_new_with_contract(
+        snapshot: &Snapshot,
+        contract: ProjectedScanContract,
+        filters: &[Expr],
+        config: &DeltaScanConfig,
+        skipping_predicate: Option<Vec<Expr>>,
+    ) -> Result<Self> {
         let table_config = snapshot.table_configuration();
         let kernel_logical_schema = table_config.logical_schema();
-        let table_schema = config.table_schema(table_config)?;
 
         // At this point we should only have supported predicates, but we decide where
         // when can handle them (kernel scan and/or parquet scan)
@@ -110,101 +248,18 @@ impl KernelScanPlan {
             .scan_builder()
             .with_predicate(scan_predicate.clone());
 
-        let Some(projection) = projection else {
-            let scan = Arc::new(scan_builder.build()?);
-            return Self::try_new_with_scan(scan, config, table_schema, None, parquet_predicate);
-        };
-
-        // The table projection may not include all columns referenced in filters,
-        // Specifically, if a filter references a partition column that is not
-        // part of the projection, we need to add it to the scan projection.
-        // This is because may not include columns that are handled Exact by a provider.
-        let result_schema = Arc::new(table_schema.project(projection)?);
-        let columns_in_filters: HashSet<_> = filters
-            .iter()
-            .flat_map(|f| f.column_refs().iter().map(|c| c.name()).collect_vec())
-            .collect();
-        let columns_in_scan: HashSet<_> = result_schema
-            .fields()
-            .iter()
-            .map(|f| f.name().as_str())
-            .collect();
-        let missing_columns: Vec<_> = columns_in_filters
-            .difference(&columns_in_scan)
-            .cloned()
-            .sorted() // Prevent non-deterministic ordering from HashSet
-            .collect();
-
-        let file_id_field = config.file_id_field();
-        let mut projection = projection.clone();
-        for col in missing_columns {
-            // the file id field is not part of the table schema here, as
-            // it is managed on the table provider level.
-            if col == file_id_field.name() {
-                continue;
-            }
-            projection.push(table_schema.index_of(col)?);
-        }
-
-        // With the updated projection, build the scan
-        let kernel_projection_names = projection
-            .iter()
-            .map(|idx| table_schema.field(*idx).name().as_str())
-            .collect_vec();
-        let kernel_scan_schema = kernel_logical_schema
-            .project(&kernel_projection_names)
-            .map_err(crate::DeltaTableError::from)?;
-        let scan = Arc::new(scan_builder.with_schema(kernel_scan_schema).build()?);
-
-        // We may have read columns in the scan that are purely for predicate processing.
-        // We need to project them out of the final result schema
-        let logical_columns: HashSet<_> = scan
-            .logical_schema()
-            .fields()
-            .map(|f| f.name().as_str())
-            .collect();
-        let excess_columns = logical_columns.difference(&columns_in_scan).collect_vec();
-        let result_projection = if !excess_columns.is_empty() {
-            let mut result_projection = Vec::with_capacity(result_schema.fields().len());
-            for (i, field) in scan.logical_schema().fields().enumerate() {
-                if columns_in_scan.contains(field.name().as_str()) {
-                    result_projection.push(i);
-                }
-            }
-            Some(result_projection)
+        let scan = if let Some(projection) = contract.kernel_projection.as_ref() {
+            let table_schema = config.table_schema(table_config)?;
+            let kernel_projection_names = projection
+                .iter()
+                .map(|idx| table_schema.field(*idx).name().as_str())
+                .collect_vec();
+            let kernel_scan_schema = kernel_logical_schema
+                .project(&kernel_projection_names)
+                .map_err(crate::DeltaTableError::from)?;
+            Arc::new(scan_builder.with_schema(kernel_scan_schema).build()?)
         } else {
-            None
-        };
-
-        drop(columns_in_scan);
-        drop(logical_columns);
-
-        Self::try_new_with_scan(
-            scan,
-            config,
-            result_schema,
-            result_projection,
-            parquet_predicate,
-        )
-    }
-
-    fn try_new_with_scan(
-        scan: Arc<Scan>,
-        config: &DeltaScanConfig,
-        result_schema: SchemaRef,
-        result_projection: Option<Vec<usize>>,
-        parquet_predicate: Option<Expr>,
-    ) -> Result<Self> {
-        let output_schema = if let Some(file_id_column) =
-            config.projected_file_id_column(None, result_schema.as_ref())
-        {
-            let mut schema_builder = SchemaBuilder::from(result_schema.as_ref());
-            schema_builder.push(crate::delta_datafusion::file_id::file_id_field(Some(
-                file_id_column,
-            )));
-            Arc::new(schema_builder.finish())
-        } else {
-            result_schema.clone()
+            Arc::new(scan_builder.build()?)
         };
         let parquet_read_schema = config.physical_arrow_schema(
             scan.snapshot().table_configuration(),
@@ -212,9 +267,7 @@ impl KernelScanPlan {
         )?;
         Ok(Self {
             scan,
-            result_schema,
-            output_schema,
-            result_projection,
+            contract,
             parquet_read_schema,
             parquet_predicate,
         })
@@ -235,9 +288,9 @@ impl KernelScanPlan {
     // Projected schema depending on if execution preserves file column
     pub(crate) fn effective_schema(&self, include_file_id: bool) -> SchemaRef {
         if include_file_id {
-            self.output_schema.clone()
+            self.contract.output_schema.clone()
         } else {
-            self.result_schema.clone()
+            self.contract.result_schema.clone()
         }
     }
 }
@@ -245,6 +298,10 @@ impl KernelScanPlan {
 impl DeltaScanConfig {
     pub(crate) fn file_id_field(&self) -> FieldRef {
         crate::delta_datafusion::file_id::file_id_field(self.file_column_name.as_deref())
+    }
+
+    pub(crate) fn has_file_id(&self) -> bool {
+        self.file_column_name.is_some()
     }
 
     pub(crate) fn projected_file_id_column<'a>(
@@ -766,10 +823,30 @@ mod tests {
 
         let snapshot = table.snapshot()?.snapshot().snapshot();
 
+        let override_schema = Arc::new(Schema::new(vec![
+            Arc::new(arrow_schema::Field::new(
+                "Company Very Short",
+                DataType::Utf8,
+                true,
+            )),
+            Arc::new(arrow_schema::Field::new("Super Name", DataType::Utf8, true)),
+        ]));
+        let config = DeltaScanConfig::default().with_schema(override_schema.clone());
+        let scan_plan = KernelScanPlan::try_new(snapshot, None, &[], &config, None)?;
+        assert_eq!(
+            scan_plan.contract.result_schema.as_ref(),
+            override_schema.as_ref()
+        );
+        assert!(!schema_has_view_types(
+            scan_plan.contract.result_schema.as_ref()
+        ));
+
         let mut config = DeltaScanConfig::default();
         config.schema_force_view_types = true;
         let scan_plan = KernelScanPlan::try_new(snapshot, None, &[], &config, None)?;
-        assert!(schema_has_view_types(scan_plan.result_schema.as_ref()));
+        assert!(schema_has_view_types(
+            scan_plan.contract.result_schema.as_ref()
+        ));
         assert!(schema_has_view_types(
             scan_plan.parquet_read_schema.as_ref()
         ));
@@ -800,6 +877,7 @@ mod tests {
         // Column-mapped tables use logical names in the result schema, but physical names for Parquet reads.
         assert!(
             scan_plan
+                .contract
                 .result_schema
                 .field_with_name("Super Name")
                 .is_ok()
@@ -827,7 +905,9 @@ mod tests {
         let mut config = DeltaScanConfig::default();
         config.schema_force_view_types = false;
         let scan_plan = KernelScanPlan::try_new(snapshot, None, &[], &config, None)?;
-        assert!(!schema_has_view_types(scan_plan.result_schema.as_ref()));
+        assert!(!schema_has_view_types(
+            scan_plan.contract.result_schema.as_ref()
+        ));
         assert!(!schema_has_view_types(
             scan_plan.parquet_read_schema.as_ref()
         ));
@@ -864,6 +944,70 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_projected_scan_contract_tracks_internal_and_output_file_id_requirements() -> TestResult
+    {
+        let config = DeltaScanConfig::default().with_file_column_name("file_id");
+        let table_schema = Arc::new(Schema::new(vec![
+            Arc::new(arrow_schema::Field::new("data", DataType::Utf8, true)),
+            Arc::new(arrow_schema::Field::new("letter", DataType::Utf8, true)),
+        ]));
+
+        let mut provider_fields = table_schema.fields().to_vec();
+        provider_fields.push(config.file_id_field());
+        let provider_schema = Arc::new(Schema::new(provider_fields));
+
+        let projection = vec![0];
+        let filters = vec![
+            col("letter").eq(lit("b")),
+            col("file_id").eq(lit("file:///tmp/part-0000.parquet")),
+        ];
+        let contract = ProjectedScanContract::try_new(
+            table_schema.clone(),
+            provider_schema.clone(),
+            &config,
+            Some(&projection),
+            &filters,
+        )?;
+
+        assert_eq!(contract.provider_schema.as_ref(), provider_schema.as_ref());
+        assert_eq!(
+            contract.requested_schema.as_ref(),
+            &Schema::new(vec![Arc::new(arrow_schema::Field::new(
+                "data",
+                DataType::Utf8,
+                true,
+            ))])
+        );
+        assert_eq!(
+            contract.result_schema.as_ref(),
+            contract.requested_schema.as_ref()
+        );
+        assert_eq!(
+            contract
+                .scan_schema
+                .fields()
+                .iter()
+                .map(|f| f.name())
+                .collect_vec(),
+            vec!["data", "letter"]
+        );
+        assert_eq!(
+            contract
+                .output_schema
+                .fields()
+                .iter()
+                .map(|f| f.name())
+                .collect_vec(),
+            vec!["data", "file_id"]
+        );
+        assert_eq!(contract.kernel_projection, Some(vec![0, 1]));
+        assert_eq!(contract.result_projection, Some(vec![0]));
+        assert!(contract.retain_file_id);
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_projected_scan_plan_preserves_column_mapping_annotations() -> TestResult {
         let mut table = open_fs_path("../test/tests/data/table_with_column_mapping");
@@ -891,7 +1035,7 @@ mod tests {
             field.metadata().get("delta.columnMapping.physicalName"),
             Some(delta_kernel::schema::MetadataValue::String(_))
         ));
-        assert_eq!(scan_plan.result_projection, Some(vec![0]));
+        assert_eq!(scan_plan.contract.result_projection, Some(vec![0]));
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
@@ -46,17 +46,8 @@ use crate::kernel::{Scan, Snapshot};
 /// `TableProvider::scan` request so planning and execution do not rederive them independently.
 #[derive(Clone, Debug)]
 pub(crate) struct ProjectedScanContract {
-    /// Schema advertised by the provider for this table, including any public file id column.
-    #[allow(dead_code)]
-    pub(crate) provider_schema: SchemaRef,
-    /// Schema explicitly requested by the parent plan through the provider projection.
-    #[allow(dead_code)]
-    pub(crate) requested_schema: SchemaRef,
     /// Logical data schema after removing temporary predicate only columns and internal metadata.
     pub(crate) result_schema: SchemaRef,
-    /// Logical schema produced by the kernel scan before dropping filter only columns.
-    #[allow(dead_code)]
-    pub(crate) scan_schema: SchemaRef,
     /// Actual schema the scan must return to its parent for this query.
     pub(crate) output_schema: SchemaRef,
     /// Projection against the logical table schema used to build the kernel scan.
@@ -66,39 +57,37 @@ pub(crate) struct ProjectedScanContract {
     pub(crate) result_projection: Option<Vec<usize>>,
     /// Synthetic file id field used internally to correlate batches with their source files.
     pub(crate) file_id_field: FieldRef,
-    /// Whether this particular scan must return the file id column to its parent plan.
-    pub(crate) retain_file_id: bool,
+    /// Whether the scan must preserve file id in its output for projection or filter semantics.
+    pub(crate) scan_must_return_file_id: bool,
 }
 
 impl ProjectedScanContract {
     pub(crate) fn try_new(
         table_schema: SchemaRef,
-        provider_schema: SchemaRef,
         config: &DeltaScanConfig,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
     ) -> Result<Self> {
         let file_id_field = config.file_id_field();
-        let file_id_idx = config.has_file_id().then_some(table_schema.fields().len());
+        let provider_exposes_file_id = config.has_file_id();
+        let file_id_idx = provider_exposes_file_id.then_some(table_schema.fields().len());
 
-        let requested_schema = match projection {
-            Some(projection) => Arc::new(provider_schema.project(projection)?),
-            None => provider_schema.clone(),
+        let query_projects_file_id = if provider_exposes_file_id {
+            match projection {
+                None => true,
+                Some(projection) => projection.iter().any(|idx| Some(*idx) == file_id_idx),
+            }
+        } else {
+            false
         };
 
-        let retain_file_id = config.has_file_id()
-            && match projection {
-                None => true,
-                Some(projection) => {
-                    projection.iter().any(|idx| Some(*idx) == file_id_idx)
-                        || filters.iter().any(|filter| {
-                            filter
-                                .column_refs()
-                                .iter()
-                                .any(|column| column.name == file_id_field.name().as_str())
-                        })
-                }
-            };
+        let filters_reference_file_id = filters.iter().any(|filter| {
+            filter
+                .column_refs()
+                .iter()
+                .any(|column| column.name == file_id_field.name().as_str())
+        });
+        let scan_must_return_file_id = query_projects_file_id || filters_reference_file_id;
 
         let requested_data_projection = projection.map(|projection| {
             projection
@@ -140,17 +129,12 @@ impl ProjectedScanContract {
             })
             .transpose()?;
 
-        let scan_schema = match kernel_projection.as_ref() {
-            Some(projection) => Arc::new(table_schema.project(projection)?),
-            None => table_schema.clone(),
-        };
-
         let result_projection = kernel_projection.as_ref().and_then(|projection| {
             let projected_len = requested_data_projection.as_ref()?.len();
             (projection.len() > projected_len).then(|| (0..projected_len).collect())
         });
 
-        let output_schema = if retain_file_id {
+        let output_schema = if scan_must_return_file_id {
             let mut schema_builder = SchemaBuilder::from(result_schema.as_ref());
             schema_builder.push(file_id_field.clone());
             Arc::new(schema_builder.finish())
@@ -159,15 +143,12 @@ impl ProjectedScanContract {
         };
 
         Ok(Self {
-            provider_schema,
-            requested_schema,
             result_schema,
-            scan_schema,
             output_schema,
             kernel_projection,
             result_projection,
             file_id_field,
-            retain_file_id,
+            scan_must_return_file_id,
         })
     }
 }
@@ -201,20 +182,7 @@ impl KernelScanPlan {
         skipping_predicate: Option<Vec<Expr>>,
     ) -> Result<Self> {
         let table_schema = config.table_schema(snapshot.table_configuration())?;
-        let provider_schema = if config.has_file_id() {
-            let mut schema_builder = SchemaBuilder::from(table_schema.as_ref());
-            schema_builder.push(config.file_id_field());
-            Arc::new(schema_builder.finish())
-        } else {
-            table_schema.clone()
-        };
-        let contract = ProjectedScanContract::try_new(
-            table_schema,
-            provider_schema,
-            config,
-            projection,
-            filters,
-        )?;
+        let contract = ProjectedScanContract::try_new(table_schema, config, projection, filters)?;
         Self::try_new_with_contract(snapshot, contract, filters, config, skipping_predicate)
     }
 
@@ -291,7 +259,7 @@ impl KernelScanPlan {
         self.scan.snapshot().table_configuration()
     }
 
-    // Projected schema depending on if execution preserves file column
+    // Scan output schema depends on whether execution must preserve file id for this request.
     pub(crate) fn effective_schema(&self, include_file_id: bool) -> SchemaRef {
         if include_file_id {
             self.contract.output_schema.clone()
@@ -319,7 +287,7 @@ impl DeltaScanConfig {
         self.file_column_name.is_some()
     }
 
-    pub(crate) fn projected_file_id_column<'a>(
+    pub(crate) fn provider_file_id_column<'a>(
         &'a self,
         projection: Option<&Vec<usize>>,
         result_schema: &Schema,
@@ -987,6 +955,58 @@ mod tests {
     }
 
     #[test]
+    fn test_projected_scan_contract_separates_provider_capability_from_scan_output_requirement()
+    -> TestResult {
+        let table_schema = Arc::new(Schema::new(vec![
+            Arc::new(arrow_schema::Field::new("data", DataType::Utf8, true)),
+            Arc::new(arrow_schema::Field::new("letter", DataType::Utf8, true)),
+        ]));
+        let config = DeltaScanConfig::default().with_file_column_name("file_id");
+        let projection = vec![0];
+
+        let contract =
+            ProjectedScanContract::try_new(table_schema, &config, Some(&projection), &[])?;
+
+        assert!(!contract.scan_must_return_file_id);
+        assert_eq!(
+            contract
+                .output_schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect_vec(),
+            vec!["data"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_projected_scan_contract_keeps_file_id_for_filter_only_queries() -> TestResult {
+        let table_schema = Arc::new(Schema::new(vec![
+            Arc::new(arrow_schema::Field::new("data", DataType::Utf8, true)),
+            Arc::new(arrow_schema::Field::new("letter", DataType::Utf8, true)),
+        ]));
+        let config = DeltaScanConfig::default().with_file_column_name("file_id");
+        let projection = vec![0];
+        let filters = vec![col("file_id").eq(lit("file:///tmp/part-0000.parquet"))];
+
+        let contract =
+            ProjectedScanContract::try_new(table_schema, &config, Some(&projection), &filters)?;
+
+        assert!(contract.scan_must_return_file_id);
+        assert_eq!(
+            contract
+                .output_schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect_vec(),
+            vec!["data", "file_id"]
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_projected_scan_contract_tracks_internal_and_output_file_id_requirements() -> TestResult
     {
         let config = DeltaScanConfig::default().with_file_column_name("file_id");
@@ -994,46 +1014,20 @@ mod tests {
             Arc::new(arrow_schema::Field::new("data", DataType::Utf8, true)),
             Arc::new(arrow_schema::Field::new("letter", DataType::Utf8, true)),
         ]));
-
-        let mut provider_fields = table_schema.fields().to_vec();
-        provider_fields.push(config.file_id_field());
-        let provider_schema = Arc::new(Schema::new(provider_fields));
-
         let projection = vec![0];
         let filters = vec![
             col("letter").eq(lit("b")),
             col("file_id").eq(lit("file:///tmp/part-0000.parquet")),
         ];
-        let contract = ProjectedScanContract::try_new(
-            table_schema.clone(),
-            provider_schema.clone(),
-            &config,
-            Some(&projection),
-            &filters,
-        )?;
+        let contract =
+            ProjectedScanContract::try_new(table_schema, &config, Some(&projection), &filters)?;
+        let expected_result_schema = Schema::new(vec![Arc::new(arrow_schema::Field::new(
+            "data",
+            DataType::Utf8,
+            true,
+        ))]);
 
-        assert_eq!(contract.provider_schema.as_ref(), provider_schema.as_ref());
-        assert_eq!(
-            contract.requested_schema.as_ref(),
-            &Schema::new(vec![Arc::new(arrow_schema::Field::new(
-                "data",
-                DataType::Utf8,
-                true,
-            ))])
-        );
-        assert_eq!(
-            contract.result_schema.as_ref(),
-            contract.requested_schema.as_ref()
-        );
-        assert_eq!(
-            contract
-                .scan_schema
-                .fields()
-                .iter()
-                .map(|f| f.name())
-                .collect_vec(),
-            vec!["data", "letter"]
-        );
+        assert_eq!(contract.result_schema.as_ref(), &expected_result_schema);
         assert_eq!(
             contract
                 .output_schema
@@ -1045,7 +1039,7 @@ mod tests {
         );
         assert_eq!(contract.kernel_projection, Some(vec![0, 1]));
         assert_eq!(contract.result_projection, Some(vec![0]));
-        assert!(contract.retain_file_id);
+        assert!(contract.scan_must_return_file_id);
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
@@ -48,6 +48,8 @@ use crate::kernel::{Scan, Snapshot};
 pub(crate) struct ProjectedScanContract {
     /// Logical data schema after removing temporary predicate only columns and internal metadata.
     pub(crate) result_schema: SchemaRef,
+    /// Logical schema produced by the kernel scan before dropping filter-only columns.
+    pub(crate) scan_schema: SchemaRef,
     /// Actual schema the scan must return to its parent for this query.
     pub(crate) output_schema: SchemaRef,
     /// Projection against the logical table schema used to build the kernel scan.
@@ -57,37 +59,42 @@ pub(crate) struct ProjectedScanContract {
     pub(crate) result_projection: Option<Vec<usize>>,
     /// Synthetic file id field used internally to correlate batches with their source files.
     pub(crate) file_id_field: FieldRef,
-    /// Whether the scan must preserve file id in its output for projection or filter semantics.
-    pub(crate) scan_must_return_file_id: bool,
+    /// Whether the scan must preserve file-id in its output for projection or filter semantics.
+    pub(crate) retain_file_id: bool,
 }
 
 impl ProjectedScanContract {
     pub(crate) fn try_new(
         table_schema: SchemaRef,
+        provider_schema: SchemaRef,
         config: &DeltaScanConfig,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
     ) -> Result<Self> {
         let file_id_field = config.file_id_field();
         let provider_exposes_file_id = config.has_file_id();
-        let file_id_idx = provider_exposes_file_id.then_some(table_schema.fields().len());
+        let file_id_idx = provider_exposes_file_id
+            .then(|| provider_schema.index_of(file_id_field.name()).ok())
+            .flatten();
 
-        let query_projects_file_id = if provider_exposes_file_id {
+        let query_projects_file_id = if let Some(file_id_idx) = file_id_idx {
             match projection {
                 None => true,
-                Some(projection) => projection.iter().any(|idx| Some(*idx) == file_id_idx),
+                Some(projection) => projection.iter().any(|idx| *idx == file_id_idx),
             }
         } else {
             false
         };
 
-        let filters_reference_file_id = filters.iter().any(|filter| {
-            filter
-                .column_refs()
-                .iter()
-                .any(|column| column.name == file_id_field.name().as_str())
-        });
-        let scan_must_return_file_id = query_projects_file_id || filters_reference_file_id;
+        let filters_reference_file_id = provider_exposes_file_id
+            && filters.iter().any(|filter| {
+                filter
+                    .column_refs()
+                    .iter()
+                    .any(|column| column.name == file_id_field.name().as_str())
+            });
+        let retain_file_id =
+            provider_exposes_file_id && (query_projects_file_id || filters_reference_file_id);
 
         let requested_data_projection = projection.map(|projection| {
             projection
@@ -129,12 +136,17 @@ impl ProjectedScanContract {
             })
             .transpose()?;
 
+        let scan_schema = match kernel_projection.as_ref() {
+            Some(projection) => Arc::new(table_schema.project(projection)?),
+            None => table_schema.clone(),
+        };
+
         let result_projection = kernel_projection.as_ref().and_then(|projection| {
             let projected_len = requested_data_projection.as_ref()?.len();
             (projection.len() > projected_len).then(|| (0..projected_len).collect())
         });
 
-        let output_schema = if scan_must_return_file_id {
+        let output_schema = if retain_file_id {
             let mut schema_builder = SchemaBuilder::from(result_schema.as_ref());
             schema_builder.push(file_id_field.clone());
             Arc::new(schema_builder.finish())
@@ -144,11 +156,12 @@ impl ProjectedScanContract {
 
         Ok(Self {
             result_schema,
+            scan_schema,
             output_schema,
             kernel_projection,
             result_projection,
             file_id_field,
-            scan_must_return_file_id,
+            retain_file_id,
         })
     }
 }
@@ -182,7 +195,20 @@ impl KernelScanPlan {
         skipping_predicate: Option<Vec<Expr>>,
     ) -> Result<Self> {
         let table_schema = config.table_schema(snapshot.table_configuration())?;
-        let contract = ProjectedScanContract::try_new(table_schema, config, projection, filters)?;
+        let provider_schema = if config.has_file_id() {
+            let mut schema_builder = SchemaBuilder::from(table_schema.as_ref());
+            schema_builder.push(config.file_id_field());
+            Arc::new(schema_builder.finish())
+        } else {
+            table_schema.clone()
+        };
+        let contract = ProjectedScanContract::try_new(
+            table_schema,
+            provider_schema,
+            config,
+            projection,
+            filters,
+        )?;
         Self::try_new_with_contract(snapshot, contract, filters, config, skipping_predicate)
     }
 
@@ -219,11 +245,12 @@ impl KernelScanPlan {
             .scan_builder()
             .with_predicate(scan_predicate.clone());
 
-        let scan = if let Some(projection) = contract.kernel_projection.as_ref() {
-            let table_schema = config.table_schema(table_config)?;
-            let kernel_projection_names = projection
+        let scan = if contract.kernel_projection.is_some() {
+            let kernel_projection_names = contract
+                .scan_schema
+                .fields()
                 .iter()
-                .map(|idx| table_schema.field(*idx).name().as_str())
+                .map(|field| field.name().as_str())
                 .collect_vec();
             let kernel_scan_schema = kernel_logical_schema
                 .project(&kernel_projection_names)
@@ -963,11 +990,32 @@ mod tests {
         ]));
         let config = DeltaScanConfig::default().with_file_column_name("file_id");
         let projection = vec![0];
+        let provider_schema = Arc::new(Schema::new(vec![
+            Arc::new(arrow_schema::Field::new("data", DataType::Utf8, true)),
+            Arc::new(arrow_schema::Field::new("letter", DataType::Utf8, true)),
+            config.file_id_field(),
+        ]));
 
-        let contract =
-            ProjectedScanContract::try_new(table_schema, &config, Some(&projection), &[])?;
+        let contract = ProjectedScanContract::try_new(
+            table_schema,
+            provider_schema,
+            &config,
+            Some(&projection),
+            &[],
+        )?;
 
-        assert!(!contract.scan_must_return_file_id);
+        assert!(!contract.retain_file_id);
+        assert_eq!(
+            contract
+                .scan_schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect_vec(),
+            vec!["data"]
+        );
+        assert_eq!(contract.kernel_projection, Some(vec![0]));
+        assert_eq!(contract.result_projection, None);
         assert_eq!(
             contract
                 .output_schema
@@ -989,11 +1037,32 @@ mod tests {
         let config = DeltaScanConfig::default().with_file_column_name("file_id");
         let projection = vec![0];
         let filters = vec![col("file_id").eq(lit("file:///tmp/part-0000.parquet"))];
+        let provider_schema = Arc::new(Schema::new(vec![
+            Arc::new(arrow_schema::Field::new("data", DataType::Utf8, true)),
+            Arc::new(arrow_schema::Field::new("letter", DataType::Utf8, true)),
+            config.file_id_field(),
+        ]));
 
-        let contract =
-            ProjectedScanContract::try_new(table_schema, &config, Some(&projection), &filters)?;
+        let contract = ProjectedScanContract::try_new(
+            table_schema,
+            provider_schema,
+            &config,
+            Some(&projection),
+            &filters,
+        )?;
 
-        assert!(contract.scan_must_return_file_id);
+        assert!(contract.retain_file_id);
+        assert_eq!(contract.kernel_projection, Some(vec![0]));
+        assert_eq!(contract.result_projection, None);
+        assert_eq!(
+            contract
+                .scan_schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect_vec(),
+            vec!["data"]
+        );
         assert_eq!(
             contract
                 .output_schema
@@ -1019,8 +1088,18 @@ mod tests {
             col("letter").eq(lit("b")),
             col("file_id").eq(lit("file:///tmp/part-0000.parquet")),
         ];
-        let contract =
-            ProjectedScanContract::try_new(table_schema, &config, Some(&projection), &filters)?;
+        let provider_schema = Arc::new(Schema::new(vec![
+            Arc::new(arrow_schema::Field::new("data", DataType::Utf8, true)),
+            Arc::new(arrow_schema::Field::new("letter", DataType::Utf8, true)),
+            config.file_id_field(),
+        ]));
+        let contract = ProjectedScanContract::try_new(
+            table_schema,
+            provider_schema,
+            &config,
+            Some(&projection),
+            &filters,
+        )?;
         let expected_result_schema = Schema::new(vec![Arc::new(arrow_schema::Field::new(
             "data",
             DataType::Utf8,
@@ -1039,7 +1118,16 @@ mod tests {
         );
         assert_eq!(contract.kernel_projection, Some(vec![0, 1]));
         assert_eq!(contract.result_projection, Some(vec![0]));
-        assert!(contract.scan_must_return_file_id);
+        assert_eq!(
+            contract
+                .scan_schema
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect_vec(),
+            vec!["data", "letter"]
+        );
+        assert!(contract.retain_file_id);
 
         Ok(())
     }

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -441,7 +441,8 @@ async fn execute(
         return Ok((removes, metrics));
     }
 
-    let maybe_scan_plan = scan_files_where_matches(session, &snapshot, predicate).await?;
+    let maybe_scan_plan =
+        scan_files_where_matches(session, &snapshot, log_store.clone(), predicate).await?;
     metrics.scan_time_ms = Instant::now().duration_since(scan_start).as_millis() as u64;
 
     let Some(files_scan) = maybe_scan_plan else {

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1558,7 +1558,7 @@ async fn execute(
         writer_stats_config.clone(),
         None,
         should_cdc, // if true, write execution plan splits batches in [normal, cdc] data before writing
-        false,
+        None,
     )
     .await?;
     if let Some(schema_metadata) = schema_action {

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1885,9 +1885,7 @@ mod tests {
     use std::sync::Arc;
     use url::Url;
 
-    use crate::delta_datafusion::{
-        DataFusionMixins, DeltaScanNext, PATH_COLUMN, resolve_file_column_name,
-    };
+    use crate::delta_datafusion::{DataFusionMixins, PATH_COLUMN, resolve_file_column_name};
 
     use super::MergeMetrics;
 
@@ -2715,49 +2713,6 @@ mod tests {
             "+----+-------+------------+",
         ];
         assert_batches_sorted_eq!(&expected, &actual);
-    }
-
-    #[tokio::test]
-    async fn test_merge_target_scan_provider_exposes_resolved_file_column() {
-        let table = setup_table(None).await;
-        let table = write_data(table, &get_arrow_schema(&None)).await;
-        let snapshot = table.snapshot().unwrap().snapshot().clone();
-        let file_column_name =
-            resolve_file_column_name(snapshot.input_schema().as_ref(), None).unwrap();
-
-        let provider = DeltaScanNext::builder()
-            .with_eager_snapshot(snapshot.clone())
-            .with_log_store(table.log_store())
-            .with_file_column(file_column_name.as_str())
-            .await
-            .unwrap();
-
-        let provider_schema = provider.schema();
-        let input_schema = snapshot.input_schema();
-        let expected_names = input_schema
-            .fields()
-            .iter()
-            .map(|field| field.name().as_str())
-            .chain(std::iter::once(file_column_name.as_str()))
-            .collect_vec();
-
-        assert_eq!(
-            provider_schema
-                .fields()
-                .iter()
-                .map(|field| field.name().as_str())
-                .collect_vec(),
-            expected_names
-        );
-        assert_eq!(
-            provider_schema.fields().len(),
-            input_schema.fields().len() + 1
-        );
-        assert!(
-            provider_schema
-                .column_with_name(&file_column_name)
-                .is_some()
-        );
     }
 
     #[tokio::test]

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1558,6 +1558,7 @@ async fn execute(
         writer_stats_config.clone(),
         None,
         should_cdc, // if true, write execution plan splits batches in [normal, cdc] data before writing
+        false,
     )
     .await?;
     if let Some(schema_metadata) = schema_action {

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -2603,7 +2603,8 @@ mod tests {
     async fn test_merge_metrics_select_target_scan_when_source_is_delta_with_same_file_column_name()
     {
         let target_dir = tempfile::tempdir().unwrap();
-        let target_url = Url::from_directory_path(target_dir.path()).unwrap();
+        let target_path = std::fs::canonicalize(target_dir.path()).unwrap();
+        let target_url = Url::from_directory_path(&target_path).unwrap();
         let target_table = DeltaTable::try_from_url(target_url)
             .await
             .unwrap()
@@ -2615,7 +2616,8 @@ mod tests {
         assert_eq!(target_table.snapshot().unwrap().log_data().num_files(), 1);
 
         let source_dir = tempfile::tempdir().unwrap();
-        let source_url = Url::from_directory_path(source_dir.path()).unwrap();
+        let source_path = std::fs::canonicalize(source_dir.path()).unwrap();
+        let source_url = Url::from_directory_path(&source_path).unwrap();
         let source_table = DeltaTable::try_from_url(source_url)
             .await
             .unwrap()
@@ -2673,7 +2675,7 @@ mod tests {
             .await
             .unwrap();
 
-        let (_table, metrics) = target_table
+        let (table, metrics) = target_table
             .merge(source, col("target.id").eq(col("source.id")))
             .with_source_alias("source")
             .with_target_alias("target")
@@ -2694,6 +2696,23 @@ mod tests {
             .unwrap();
 
         assert_eq!(metrics.num_target_files_scanned, 1);
+        assert_eq!(metrics.num_target_files_skipped_during_scan, 0);
+        assert_eq!(metrics.num_target_rows_updated, 1);
+        assert_eq!(metrics.num_target_rows_inserted, 1);
+
+        let actual = get_data_sorted(&table, "id, value, modified").await;
+        let expected = vec![
+            "+----+-------+------------+",
+            "| id | value | modified   |",
+            "+----+-------+------------+",
+            "| A  | 1     | 2021-02-01 |",
+            "| B  | 20    | 2021-03-01 |",
+            "| C  | 10    | 2021-02-02 |",
+            "| D  | 100   | 2021-02-02 |",
+            "| X  | 30    | 2021-03-02 |",
+            "+----+-------+------------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &actual);
     }
 
     #[tokio::test]

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -2614,6 +2614,17 @@ mod tests {
             .unwrap();
         let target_table = write_data(target_table, &get_arrow_schema(&None)).await;
         assert_eq!(target_table.snapshot().unwrap().log_data().num_files(), 1);
+        let target_file_column = resolve_file_column_name(
+            target_table
+                .snapshot()
+                .unwrap()
+                .snapshot()
+                .input_schema()
+                .as_ref(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(target_file_column, PATH_COLUMN);
 
         let source_dir = tempfile::tempdir().unwrap();
         let source_path = std::fs::canonicalize(source_dir.path()).unwrap();

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1855,7 +1855,7 @@ mod tests {
     use crate::kernel::{Action, DataType, PrimitiveType, StructField};
     use crate::operations::merge::filter::generalize_filter;
     use crate::protocol::*;
-    use crate::writer::test_utils::datafusion::get_data;
+    use crate::writer::test_utils::datafusion::{get_data, get_data_sorted};
     use crate::writer::test_utils::get_arrow_schema;
     use crate::writer::test_utils::get_delta_schema;
     use crate::writer::test_utils::setup_table_with_configuration;
@@ -1885,7 +1885,9 @@ mod tests {
     use std::sync::Arc;
     use url::Url;
 
-    use crate::delta_datafusion::{DataFusionMixins, PATH_COLUMN, resolve_file_column_name};
+    use crate::delta_datafusion::{
+        DataFusionMixins, DeltaScanNext, PATH_COLUMN, resolve_file_column_name,
+    };
 
     use super::MergeMetrics;
 
@@ -2713,6 +2715,49 @@ mod tests {
             "+----+-------+------------+",
         ];
         assert_batches_sorted_eq!(&expected, &actual);
+    }
+
+    #[tokio::test]
+    async fn test_merge_target_scan_provider_exposes_resolved_file_column() {
+        let table = setup_table(None).await;
+        let table = write_data(table, &get_arrow_schema(&None)).await;
+        let snapshot = table.snapshot().unwrap().snapshot().clone();
+        let file_column_name =
+            resolve_file_column_name(snapshot.input_schema().as_ref(), None).unwrap();
+
+        let provider = DeltaScanNext::builder()
+            .with_eager_snapshot(snapshot.clone())
+            .with_log_store(table.log_store())
+            .with_file_column(file_column_name.as_str())
+            .await
+            .unwrap();
+
+        let provider_schema = provider.schema();
+        let input_schema = snapshot.input_schema();
+        let expected_names = input_schema
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .chain(std::iter::once(file_column_name.as_str()))
+            .collect_vec();
+
+        assert_eq!(
+            provider_schema
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect_vec(),
+            expected_names
+        );
+        assert_eq!(
+            provider_schema.fields().len(),
+            input_schema.fields().len() + 1
+        );
+        assert!(
+            provider_schema
+                .column_with_name(&file_column_name)
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -29,7 +29,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use datafusion::catalog::Session;
-use datafusion::execution::context::SessionState;
+use datafusion::execution::context::{SessionContext, SessionState};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::Scalar;
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
@@ -39,7 +39,6 @@ use futures::{Future, StreamExt, TryStreamExt};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use num_cpus;
-use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 use parquet::basic::{Compression, ZstdLevel};
 use parquet::errors::ParquetError;
 use parquet::file::properties::WriterProperties;
@@ -50,14 +49,12 @@ use uuid::Uuid;
 use super::write::writer::{PartitionWriter, PartitionWriterConfig};
 use super::{CustomExecuteHandler, Operation};
 use crate::delta_datafusion::{
-    DeltaTableProvider, SessionFallbackPolicy, SessionResolveContext,
-    create_session_state_with_spill_config, resolve_session_state,
+    DataFusionMixins, DeltaScanConfig, DeltaScanNext, SessionFallbackPolicy, SessionResolveContext,
+    create_session_state_with_spill_config, resolve_session_state, update_datafusion_session,
 };
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, DEFAULT_RETRIES, PROTOCOL};
-use crate::kernel::{
-    Action, Add, DataType, PartitionsExt, Remove, StructType, Version, scalars::ScalarExt,
-};
+use crate::kernel::{Action, Add, DataType, PartitionsExt, Remove, StructType, Version};
 use crate::kernel::{EagerSnapshot, resolve_snapshot};
 use crate::logstore::{LogStore, LogStoreRef, ObjectStoreRef};
 use crate::parquet_utils::default_writer_properties;
@@ -499,41 +496,23 @@ impl TryFrom<OptimizeInput> for DeltaOperation {
 }
 
 /// Generate an appropriate remove action for the optimization task
-fn create_remove(
-    path: &str,
-    partitions: &IndexMap<String, Scalar>,
-    size: i64,
-) -> Result<Action, DeltaTableError> {
+fn create_remove(add: &Add) -> Action {
     // NOTE unwrap is safe since UNIX_EPOCH will always be earlier then now.
     let deletion_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
     let deletion_time = deletion_time.as_millis() as i64;
 
-    Ok(Action::Remove(Remove {
-        path: path.to_string(),
+    Action::Remove(Remove {
+        path: add.path.clone(),
         deletion_timestamp: Some(deletion_time),
         data_change: false,
-        extended_file_metadata: None,
-        partition_values: Some(
-            partitions
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        k.clone(),
-                        if v.is_null() {
-                            None
-                        } else {
-                            Some(ScalarExt::serialize(v))
-                        },
-                    )
-                })
-                .collect(),
-        ),
-        size: Some(size),
-        deletion_vector: None,
-        tags: None,
-        base_row_id: None,
-        default_row_commit_version: None,
-    }))
+        extended_file_metadata: Some(true),
+        partition_values: Some(add.partition_values.clone()),
+        size: Some(add.size),
+        deletion_vector: add.deletion_vector.clone(),
+        tags: add.tags.clone(),
+        base_row_id: add.base_row_id,
+        default_row_commit_version: add.default_row_commit_version,
+    })
 }
 
 /// Layout for optimizing a plan
@@ -551,7 +530,6 @@ enum OptimizeOperations {
     ZOrder(
         Vec<String>,
         HashMap<String, (IndexMap<String, Scalar>, MergeBin)>,
-        Box<SessionState>,
     ),
     // TODO: Sort
 }
@@ -574,6 +552,8 @@ pub struct MergePlan {
     task_parameters: Arc<MergeTaskParameters>,
     /// Version of the table at beginning of optimization. Used for conflict resolution.
     read_table_version: Version,
+    /// Session state used for provider owned rewrite scans.
+    read_session: Arc<SessionState>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -623,6 +603,47 @@ pub struct MergeTaskParameters {
 /// A stream of record batches, with a ParquetError on failure.
 type ParquetReadStream = BoxStream<'static, Result<RecordBatch, ParquetError>>;
 
+#[derive(Clone)]
+struct SelectedFileScanFactory {
+    snapshot: EagerSnapshot,
+    log_store: LogStoreRef,
+    scan_config: DeltaScanConfig,
+    read_operation_id: Option<Uuid>,
+}
+
+impl SelectedFileScanFactory {
+    fn try_new(
+        snapshot: &EagerSnapshot,
+        log_store: LogStoreRef,
+        session: &dyn Session,
+        read_operation_id: Option<Uuid>,
+    ) -> Result<Self, DeltaTableError> {
+        Ok(Self {
+            snapshot: snapshot.clone(),
+            log_store,
+            // Mirror the caller's DataFusion session flags so rewrite scans keep
+            // the same parquet/view type behavior as the rest of optimize.
+            scan_config: DeltaScanConfig::new_from_session(session)
+                .with_schema(snapshot.input_schema()),
+            read_operation_id,
+        })
+    }
+
+    fn provider_for(
+        &self,
+        adds: impl IntoIterator<Item = Add>,
+    ) -> Result<DeltaScanNext, DeltaTableError> {
+        let provider = DeltaScanNext::new(self.snapshot.clone(), self.scan_config.clone())?
+            .with_log_store(self.log_store.clone());
+        let provider = if let Some(operation_id) = self.read_operation_id {
+            provider.with_operation_id(operation_id)
+        } else {
+            provider
+        };
+        provider.with_selected_adds(adds)
+    }
+}
+
 impl MergePlan {
     /// Rewrites files in a single partition.
     ///
@@ -641,12 +662,7 @@ impl MergePlan {
     {
         debug!("Rewriting files in partition: {partition_values:?}");
         // First, initialize metrics
-        let mut partial_actions = files
-            .iter()
-            .map(|file_meta| {
-                create_remove(file_meta.path.as_ref(), &partition_values, file_meta.size)
-            })
-            .collect::<Result<Vec<_>, DeltaTableError>>()?;
+        let mut partial_actions = files.iter().map(create_remove).collect::<Vec<_>>();
 
         let files_removed = files
             .iter()
@@ -722,17 +738,36 @@ impl MergePlan {
         Ok((partial_actions, partial_metrics))
     }
 
+    async fn read_selected_files(
+        files: MergeBin,
+        context: Arc<SessionContext>,
+        scan_factory: SelectedFileScanFactory,
+    ) -> Result<ParquetReadStream, DeltaTableError> {
+        let provider = scan_factory.provider_for(files.iter().cloned())?;
+        let df = context.read_table(Arc::new(provider))?;
+        let stream = df
+            .execute_stream()
+            .await?
+            .map_err(|err| {
+                ParquetError::General(format!(
+                    "Optimize selected-file scan failed while scanning data: {err}"
+                ))
+            })
+            .boxed();
+        Ok(stream)
+    }
+
     /// Datafusion-based z-order read.
     async fn read_zorder(
         files: MergeBin,
         context: Arc<zorder::ZOrderExecContext>,
-        table_provider: DeltaTableProvider,
+        scan_factory: SelectedFileScanFactory,
     ) -> Result<BoxStream<'static, Result<RecordBatch, ParquetError>>, DeltaTableError> {
         use datafusion::functions::core::expr_ext::FieldAccessor;
         use datafusion::logical_expr::expr::ScalarFunction;
         use datafusion::logical_expr::{Expr, ScalarUDF, ident};
 
-        let provider = table_provider.with_files(files.files);
+        let provider = scan_factory.provider_for(files.iter().cloned())?;
         let df = context.ctx.read_table(Arc::new(provider))?;
 
         let cols = context
@@ -758,7 +793,7 @@ impl MergePlan {
             .execute_stream()
             .await?
             .map_err(|err| {
-                ParquetError::General(format!("Z-order failed while scanning data: {err:?}"))
+                ParquetError::General(format!("Z-order failed while scanning data: {err}"))
             })
             .boxed();
 
@@ -779,69 +814,75 @@ impl MergePlan {
         handle: Option<&Arc<dyn CustomExecuteHandler>>,
     ) -> Result<Metrics, DeltaTableError> {
         let operations = std::mem::take(&mut self.operations);
+        let read_session = self.read_session.clone();
         info!("starting optimize execution");
         let object_store = log_store.object_store(Some(operation_id));
+        update_datafusion_session(
+            read_session.as_ref(),
+            log_store.as_ref(),
+            Some(operation_id),
+        )?;
 
         let mut stream = match operations {
-            OptimizeOperations::Compact(bins) => futures::stream::iter(bins)
-                .flat_map(|(_, (partition, bins))| {
-                    futures::stream::iter(bins).map(move |bin| (partition.clone(), bin))
-                })
-                .map(|(partition, files)| {
-                    debug!(
-                        "merging a group of {} files in partition {partition:?}",
-                        files.len(),
-                    );
-                    for file in files.iter() {
-                        debug!("  file {}", file.path);
-                    }
-                    let object_store_ref = object_store.clone();
-                    let batch_stream = futures::stream::iter(files.clone())
-                        .then(move |file| {
-                            let object_store_ref = object_store_ref.clone();
-                            let meta = ObjectMeta::try_from(file).unwrap();
-                            async move {
-                                let file_reader =
-                                    ParquetObjectReader::new(object_store_ref, meta.location)
-                                        .with_file_size(meta.size);
-                                ParquetRecordBatchStreamBuilder::new(file_reader)
-                                    .await?
-                                    .build()
-                            }
-                        })
-                        .try_flatten()
-                        .boxed();
+            OptimizeOperations::Compact(bins) => {
+                let read_context = Arc::new(SessionContext::new_with_state(
+                    read_session.as_ref().clone(),
+                ));
+                let scan_factory = SelectedFileScanFactory::try_new(
+                    snapshot,
+                    log_store.clone(),
+                    read_session.as_ref(),
+                    Some(operation_id),
+                )?;
+                let task_parameters = self.task_parameters.clone();
 
-                    let rewrite_result = tokio::task::spawn(Self::rewrite_files(
-                        self.task_parameters.clone(),
-                        partition,
-                        files,
-                        object_store.clone(),
-                        futures::future::ready(Ok(batch_stream)),
-                        true,
-                    ));
-                    util::flatten_join_error(rewrite_result)
-                })
-                .buffered(max_concurrent_tasks)
-                .boxed(),
-            OptimizeOperations::ZOrder(zorder_columns, bins, state) => {
+                futures::stream::iter(bins)
+                    .flat_map(|(_, (partition, bins))| {
+                        futures::stream::iter(bins).map(move |bin| (partition.clone(), bin))
+                    })
+                    .map(move |(partition, files)| {
+                        debug!(
+                            "merging a group of {} files in partition {partition:?}",
+                            files.len(),
+                        );
+                        for file in files.iter() {
+                            debug!("  file {}", file.path);
+                        }
+
+                        let batch_stream = Self::read_selected_files(
+                            files.clone(),
+                            read_context.clone(),
+                            scan_factory.clone(),
+                        );
+
+                        let rewrite_result = tokio::task::spawn(Self::rewrite_files(
+                            task_parameters.clone(),
+                            partition,
+                            files,
+                            object_store.clone(),
+                            batch_stream,
+                            true,
+                        ));
+                        util::flatten_join_error(rewrite_result)
+                    })
+                    .buffered(max_concurrent_tasks)
+                    .boxed()
+            }
+            OptimizeOperations::ZOrder(zorder_columns, bins) => {
                 debug!("Starting zorder with the columns: {zorder_columns:?} {bins:?}");
 
                 let exec_context = Arc::new(zorder::ZOrderExecContext::new(
                     zorder_columns,
-                    *state,
+                    read_session.as_ref().clone(),
                     object_store,
                 )?);
                 let task_parameters = self.task_parameters.clone();
-
-                use crate::delta_datafusion::DataFusionMixins;
-                use crate::delta_datafusion::DeltaScanConfigBuilder;
-                use crate::delta_datafusion::DeltaTableProvider;
-
-                let scan_config = DeltaScanConfigBuilder::default()
-                    .with_file_column(false)
-                    .with_schema(snapshot.input_schema())
-                    .build(snapshot)?;
+                let scan_factory = SelectedFileScanFactory::try_new(
+                    snapshot,
+                    log_store.clone(),
+                    read_session.as_ref(),
+                    Some(operation_id),
+                )?;
 
                 // For each rewrite evaluate the predicate and then modify each expression
                 // to either compute the new value or obtain the old one then write these batches
@@ -851,12 +892,7 @@ impl MergePlan {
                         let batch_stream = Self::read_zorder(
                             files.clone(),
                             exec_context.clone(),
-                            DeltaTableProvider::try_new(
-                                snapshot.clone(),
-                                log_store.clone(),
-                                scan_config.clone(),
-                            )
-                            .unwrap(),
+                            scan_factory.clone(),
                         );
                         let rewrite_result = tokio::task::spawn(Self::rewrite_files(
                             task_parameters.clone(),
@@ -988,7 +1024,6 @@ pub async fn create_merge_plan(
                 snapshot,
                 partitions_keys,
                 filters,
-                session,
             )
             .await?
         }
@@ -1025,6 +1060,7 @@ pub async fn create_merge_plan(
                 .map(|v| v.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
         }),
         read_table_version: snapshot.version(),
+        read_session: Arc::new(session),
     })
 }
 
@@ -1276,7 +1312,6 @@ async fn build_zorder_plan(
     snapshot: &EagerSnapshot,
     partition_keys: &[String],
     filters: &[PartitionFilter],
-    session: SessionState,
 ) -> Result<(OptimizeOperations, Metrics, PlannerStats), DeltaTableError> {
     if zorder_columns.is_empty() {
         return Err(DeltaTableError::Generic(
@@ -1337,7 +1372,7 @@ async fn build_zorder_plan(
         .map(|(_, bin)| bin.len())
         .max()
         .unwrap_or(0);
-    let operation = OptimizeOperations::ZOrder(zorder_columns, partition_files, Box::new(session));
+    let operation = OptimizeOperations::ZOrder(zorder_columns, partition_files);
     Ok((
         operation,
         metrics,

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -307,7 +307,8 @@ async fn execute(
 
     let scan_start = Instant::now();
 
-    let maybe_scan_plan = scan_files_where_matches(session, snapshot, predicate).await?;
+    let maybe_scan_plan =
+        scan_files_where_matches(session, snapshot, log_store.clone(), predicate).await?;
     metrics.scan_time_ms = Instant::now().duration_since(scan_start).as_millis() as u64;
 
     let Some(files_scan) = maybe_scan_plan else {

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -25,7 +25,6 @@ use tokio::task::JoinSet;
 use tracing::log::*;
 use uuid::Uuid;
 
-use super::plan::WRITE_INSERT_MARKER_COLUMN;
 use super::writer::{DeltaWriter, WriterConfig};
 use crate::DeltaTableError;
 use crate::delta_datafusion::{
@@ -358,7 +357,7 @@ pub(crate) async fn write_execution_plan(
         writer_stats_config,
         None,
         false,
-        false,
+        None,
     )
     .await?;
     Ok(actions)
@@ -377,7 +376,7 @@ pub(crate) async fn write_execution_plan_v2(
     writer_stats_config: WriterStatsConfig,
     predicate: Option<Expr>,
     contains_cdc: bool,
-    contains_insert_marker: bool,
+    insert_marker_column: Option<String>,
 ) -> DeltaResult<(Vec<Action>, WriteExecutionPlanMetrics)> {
     // We always take the plan Schema since the data may contain Large/View arrow types,
     // the schema and batches were prior constructed with this in mind.
@@ -398,9 +397,10 @@ pub(crate) async fn write_execution_plan_v2(
     };
 
     if let Some(mut pred) = predicate {
-        if contains_insert_marker {
-            pred =
-                when(col(WRITE_INSERT_MARKER_COLUMN).eq(lit(true)), pred).otherwise(lit(true))?;
+        // DataRescue uses an internal insert-marker column; CDC-only plans rely on `_change_type`.
+        // A rewrite plan never needs both paths at once.
+        if let Some(insert_marker_column) = insert_marker_column.as_ref() {
+            pred = when(col(insert_marker_column).eq(lit(true)), pred).otherwise(lit(true))?;
         } else if contains_cdc {
             pred = when(col(CDC_COLUMN_NAME).eq(lit("insert")), pred).otherwise(lit(true))?;
         }
@@ -408,8 +408,8 @@ pub(crate) async fn write_execution_plan_v2(
     }
 
     let mut plan = DataValidationExec::try_new_with_predicates(session, plan, validations)?;
-    if contains_insert_marker {
-        plan = drop_internal_column(plan, WRITE_INSERT_MARKER_COLUMN)?;
+    if let Some(insert_marker_column) = insert_marker_column.as_ref() {
+        plan = drop_internal_column(plan, insert_marker_column)?;
     }
 
     let sink_config = WriteSinkConfig {

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -5,10 +5,11 @@ use arrow::datatypes::Schema;
 use arrow_array::RecordBatch;
 use datafusion::catalog::{Session, TableProvider};
 use datafusion::common::ToDFSchema;
-use datafusion::datasource::{MemTable, provider_as_source};
+use datafusion::datasource::MemTable;
 use datafusion::execution::context::SessionContext;
-use datafusion::logical_expr::{Expr, LogicalPlan, LogicalPlanBuilder, col, lit, when};
+use datafusion::logical_expr::{Expr, col, lit, when};
 use datafusion::physical_expr::expressions::col as physical_col;
+use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{
     ExecutionPlan, ExecutionPlanProperties, Partitioning, SendableRecordBatchStream,
@@ -24,20 +25,17 @@ use tokio::task::JoinSet;
 use tracing::log::*;
 use uuid::Uuid;
 
+use super::plan::WRITE_INSERT_MARKER_COLUMN;
 use super::writer::{DeltaWriter, WriterConfig};
 use crate::DeltaTableError;
 use crate::delta_datafusion::{
-    DataFusionMixins, DataValidationExec, DeltaScanConfigBuilder, DeltaTableProvider, find_files,
-    generated_columns_to_exprs,
-    logical::{LogicalPlanBuilderExt as _, LogicalPlanExt as _},
-    validation_predicates,
+    DataValidationExec, generated_columns_to_exprs, validation_predicates,
 };
 use crate::errors::DeltaResult;
-use crate::kernel::{Action, Add, AddCDCFile, EagerSnapshot, Remove, StructType, StructTypeExt};
-use crate::logstore::{LogStore, LogStoreRef, ObjectStoreRef};
-use crate::operations::cdc::{CDC_COLUMN_NAME, should_write_cdc};
+use crate::kernel::{Action, Add, AddCDCFile, EagerSnapshot, StructType, StructTypeExt};
+use crate::logstore::{LogStore, ObjectStoreRef};
+use crate::operations::cdc::CDC_COLUMN_NAME;
 use crate::operations::write::WriterStatsConfig;
-use crate::table::config::TablePropertiesExt as _;
 
 const DEFAULT_WRITER_BATCH_CHANNEL_SIZE: usize = 10;
 const WRITER_TASK_CLOSED_UNEXPECTEDLY_MSG: &str = "Writer task closed unexpectedly";
@@ -273,6 +271,15 @@ pub(crate) struct WriteExecutionPlanMetrics {
     pub write_time_ms: u64,
 }
 
+struct WriteSinkConfig {
+    partition_columns: Vec<String>,
+    object_store: ObjectStoreRef,
+    target_file_size: Option<NonZeroU64>,
+    write_batch_size: Option<usize>,
+    writer_properties: Option<WriterProperties>,
+    writer_stats_config: WriterStatsConfig,
+}
+
 /// Metrics captured from draining streams through a writer.
 #[derive(Debug, Default)]
 pub(crate) struct WriteStreamMetrics {
@@ -351,139 +358,10 @@ pub(crate) async fn write_execution_plan(
         writer_stats_config,
         None,
         false,
+        false,
     )
     .await?;
     Ok(actions)
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn execute_non_empty_expr(
-    snapshot: &EagerSnapshot,
-    log_store: LogStoreRef,
-    session: &dyn Session,
-    partition_columns: Vec<String>,
-    expression: &Expr,
-    rewrite: &[Add],
-    writer_properties: Option<WriterProperties>,
-    writer_stats_config: WriterStatsConfig,
-    partition_scan: bool,
-    operation_id: Uuid,
-) -> DeltaResult<(Vec<Action>, Option<LogicalPlan>)> {
-    // For each identified file perform a parquet scan + filter + limit (1) + count.
-    // If returned count is not zero then append the file to be rewritten and removed from the log. Otherwise do nothing to the file.
-    let mut actions: Vec<Action> = Vec::new();
-
-    // Take the insert plan schema since it might have been schema evolved, if its not
-    // it is simply the table schema
-    let scan_config = DeltaScanConfigBuilder::new()
-        .with_schema(snapshot.input_schema())
-        .build(snapshot)?;
-
-    let target_provider = Arc::new(
-        DeltaTableProvider::try_new(snapshot.clone(), log_store.clone(), scan_config.clone())?
-            .with_files(rewrite.to_vec()),
-    );
-
-    let source = Arc::new(
-        LogicalPlanBuilder::scan("target", provider_as_source(target_provider), None)?.build()?,
-    );
-
-    let cdf_df = if !partition_scan {
-        // Apply the negation of the filter and rewrite files
-        let negated_expression = Expr::Not(Box::new(Expr::IsTrue(Box::new(expression.clone()))));
-        let filter = LogicalPlanBuilder::from(source.clone())
-            .filter(negated_expression)?
-            .build()?;
-        let filter = session.create_physical_plan(&filter).await?;
-
-        let add_actions: Vec<Action> = write_execution_plan(
-            Some(snapshot),
-            session,
-            filter,
-            partition_columns.clone(),
-            log_store.object_store(Some(operation_id)),
-            Some(snapshot.table_properties().target_file_size()),
-            None,
-            writer_properties.clone(),
-            writer_stats_config.clone(),
-        )
-        .await?;
-
-        actions.extend(add_actions);
-
-        // CDC logic, simply filters data with predicate and adds the _change_type="delete" as literal column
-        // Only write when CDC actions when it was not a partition scan, load_cdf can deduce the deletes in that case
-        // based on the remove actions if a partition got deleted
-        if should_write_cdc(snapshot)? {
-            Some(
-                source
-                    .into_builder()
-                    .filter(expression.clone())?
-                    .with_column(CDC_COLUMN_NAME, lit("delete"))?
-                    .build()?,
-            )
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-
-    Ok((actions, cdf_df))
-}
-
-// This should only be called with a valid predicate
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn prepare_predicate_actions(
-    predicate: Expr,
-    log_store: LogStoreRef,
-    snapshot: &EagerSnapshot,
-    session: &dyn Session,
-    partition_columns: Vec<String>,
-    writer_properties: Option<WriterProperties>,
-    deletion_timestamp: i64,
-    writer_stats_config: WriterStatsConfig,
-    operation_id: Uuid,
-) -> DeltaResult<(Vec<Action>, Option<LogicalPlan>)> {
-    let candidates = find_files(
-        snapshot,
-        log_store.clone(),
-        session,
-        Some(predicate.clone()),
-    )
-    .await?;
-
-    let (mut actions, cdf_df) = execute_non_empty_expr(
-        snapshot,
-        log_store,
-        session,
-        partition_columns,
-        &predicate,
-        &candidates.candidates,
-        writer_properties,
-        writer_stats_config,
-        candidates.partition_scan,
-        operation_id,
-    )
-    .await?;
-
-    let remove = candidates.candidates;
-
-    for action in remove {
-        actions.push(Action::Remove(Remove {
-            path: action.path,
-            deletion_timestamp: Some(deletion_timestamp),
-            data_change: true,
-            extended_file_metadata: Some(true),
-            partition_values: Some(action.partition_values),
-            size: Some(action.size),
-            deletion_vector: action.deletion_vector,
-            tags: None,
-            base_row_id: action.base_row_id,
-            default_row_commit_version: action.default_row_commit_version,
-        }))
-    }
-    Ok((actions, cdf_df))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -499,6 +377,7 @@ pub(crate) async fn write_execution_plan_v2(
     writer_stats_config: WriterStatsConfig,
     predicate: Option<Expr>,
     contains_cdc: bool,
+    contains_insert_marker: bool,
 ) -> DeltaResult<(Vec<Action>, WriteExecutionPlanMetrics)> {
     // We always take the plan Schema since the data may contain Large/View arrow types,
     // the schema and batches were prior constructed with this in mind.
@@ -519,39 +398,57 @@ pub(crate) async fn write_execution_plan_v2(
     };
 
     if let Some(mut pred) = predicate {
-        if contains_cdc {
+        if contains_insert_marker {
+            pred =
+                when(col(WRITE_INSERT_MARKER_COLUMN).eq(lit(true)), pred).otherwise(lit(true))?;
+        } else if contains_cdc {
             pred = when(col(CDC_COLUMN_NAME).eq(lit("insert")), pred).otherwise(lit(true))?;
         }
         validations.push(pred);
     }
 
-    let plan = DataValidationExec::try_new_with_predicates(session, plan, validations)?;
+    let mut plan = DataValidationExec::try_new_with_predicates(session, plan, validations)?;
+    if contains_insert_marker {
+        plan = drop_internal_column(plan, WRITE_INSERT_MARKER_COLUMN)?;
+    }
+
+    let sink_config = WriteSinkConfig {
+        partition_columns,
+        object_store,
+        target_file_size,
+        write_batch_size,
+        writer_properties,
+        writer_stats_config,
+    };
 
     if !contains_cdc {
-        write_data_plan(
-            session,
-            plan,
-            partition_columns,
-            object_store,
-            target_file_size,
-            write_batch_size,
-            writer_properties,
-            writer_stats_config,
-        )
-        .await
+        write_data_plan(session, plan, sink_config).await
     } else {
-        write_cdc_plan(
-            session,
-            plan,
-            partition_columns,
-            object_store,
-            target_file_size,
-            write_batch_size,
-            writer_properties,
-            writer_stats_config,
-        )
-        .await
+        write_cdc_plan(session, plan, sink_config).await
     }
+}
+
+fn drop_internal_column(
+    plan: Arc<dyn ExecutionPlan>,
+    column: &str,
+) -> DeltaResult<Arc<dyn ExecutionPlan>> {
+    let schema = plan.schema();
+    let expressions: Vec<_> = schema
+        .fields()
+        .iter()
+        .filter(|field| field.name() != column)
+        .map(|field| {
+            physical_col(field.name(), &schema)
+                .map(|expr| (expr, field.name().clone()))
+                .map_err(DeltaTableError::from)
+        })
+        .collect::<DeltaResult<_>>()?;
+
+    if expressions.len() == schema.fields().len() {
+        return Ok(plan);
+    }
+
+    Ok(Arc::new(ProjectionExec::try_new(expressions, plan)?))
 }
 
 pub(crate) async fn write_exec_plan(
@@ -571,32 +468,19 @@ pub(crate) async fn write_exec_plan(
         .build();
     let stats_config = WriterStatsConfig::from_config(table_config);
     let object_store = log_store.object_store(operation_id);
-    let partition_columns = table_config.metadata().partition_columns().to_vec();
+    let sink_config = WriteSinkConfig {
+        partition_columns: table_config.metadata().partition_columns().to_vec(),
+        object_store,
+        target_file_size,
+        write_batch_size: None,
+        writer_properties: Some(writer_properties),
+        writer_stats_config: stats_config,
+    };
 
     if write_as_cdc {
-        write_cdc_plan(
-            session,
-            exec,
-            partition_columns,
-            object_store,
-            target_file_size,
-            None,
-            Some(writer_properties),
-            stats_config,
-        )
-        .await
+        write_cdc_plan(session, exec, sink_config).await
     } else {
-        write_data_plan(
-            session,
-            exec,
-            partition_columns,
-            object_store,
-            target_file_size,
-            None,
-            Some(writer_properties),
-            stats_config,
-        )
-        .await
+        write_data_plan(session, exec, sink_config).await
     }
 }
 
@@ -771,13 +655,16 @@ fn repartition_by_partition_columns(
 async fn write_data_plan(
     session: &dyn Session,
     plan: Arc<dyn ExecutionPlan>,
-    partition_columns: Vec<String>,
-    object_store: ObjectStoreRef,
-    target_file_size: Option<NonZeroU64>,
-    write_batch_size: Option<usize>,
-    writer_properties: Option<WriterProperties>,
-    writer_stats_config: WriterStatsConfig,
+    sink_config: WriteSinkConfig,
 ) -> DeltaResult<(Vec<Action>, WriteExecutionPlanMetrics)> {
+    let WriteSinkConfig {
+        partition_columns,
+        object_store,
+        target_file_size,
+        write_batch_size,
+        writer_properties,
+        writer_stats_config,
+    } = sink_config;
     let config = WriterConfig::new(
         plan.schema().clone(),
         partition_columns.clone(),
@@ -863,13 +750,16 @@ async fn write_data_plan(
 async fn write_cdc_plan(
     session: &dyn Session,
     plan: Arc<dyn ExecutionPlan>,
-    partition_columns: Vec<String>,
-    object_store: ObjectStoreRef,
-    target_file_size: Option<NonZeroU64>,
-    write_batch_size: Option<usize>,
-    writer_properties: Option<WriterProperties>,
-    writer_stats_config: WriterStatsConfig,
+    sink_config: WriteSinkConfig,
 ) -> DeltaResult<(Vec<Action>, WriteExecutionPlanMetrics)> {
+    let WriteSinkConfig {
+        partition_columns,
+        object_store,
+        target_file_size,
+        write_batch_size,
+        writer_properties,
+        writer_stats_config,
+    } = sink_config;
     let cdf_store = Arc::new(PrefixStore::new(object_store.clone(), "_change_data"));
 
     let write_schema = Arc::new(Schema::new(

--- a/crates/core/src/operations/write/generated_columns.rs
+++ b/crates/core/src/operations/write/generated_columns.rs
@@ -166,6 +166,7 @@ mod tests {
     use arrow::array::Int32Array;
     use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField};
     use arrow_array::RecordBatch;
+    use datafusion::assert_batches_eq;
     use datafusion::catalog::MemTable;
     use datafusion::datasource::provider_as_source;
     use datafusion::execution::SessionState;
@@ -316,6 +317,55 @@ mod tests {
                 .schema()
                 .field_with_unqualified_name("product")
                 .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generated_column_is_cast_back_to_target_type() {
+        let session = create_test_session();
+        let plan = create_test_plan();
+        let ctx = SessionContext::new();
+
+        let table_schema = Schema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, false),
+            ArrowField::new("value", ArrowDataType::Int32, false),
+            ArrowField::new("computed", ArrowDataType::Int64, false),
+        ]);
+
+        let generated_cols = vec![GeneratedColumn::new(
+            "computed",
+            "id + value",
+            &KernelDataType::LONG,
+        )];
+
+        let result = with_generated_columns(&session, plan, &table_schema, &generated_cols);
+        assert!(result.is_ok());
+
+        let result_plan = result.unwrap();
+        let computed = result_plan
+            .schema()
+            .field_with_unqualified_name("computed")
+            .unwrap();
+        assert_eq!(computed.data_type(), &ArrowDataType::Int64);
+
+        let actual = ctx
+            .execute_logical_plan(result_plan)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_batches_eq!(
+            &[
+                "+----+-------+----------+",
+                "| id | value | computed |",
+                "+----+-------+----------+",
+                "| 1  | 10    | 11       |",
+                "| 2  | 20    | 22       |",
+                "| 3  | 30    | 33       |",
+                "+----+-------+----------+",
+            ],
+            &actual
         );
     }
 

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -259,7 +259,7 @@ impl WriteBuilder {
         self
     }
 
-    /// Control how delta rs resolves the provided session when it is not a concrete `SessionState`.
+    /// Control how delta-rs resolves the provided session when it is not a concrete `SessionState`.
     ///
     /// Defaults to `SessionFallbackPolicy::InternalDefaults` to preserve existing behavior.
     pub fn with_session_fallback_policy(mut self, policy: SessionFallbackPolicy) -> Self {
@@ -492,6 +492,7 @@ impl std::future::IntoFuture for WriteBuilder {
                     &session,
                     this.mode,
                     &prepared_write,
+                    operation_id,
                 )
                 .await?;
 
@@ -525,7 +526,7 @@ impl std::future::IntoFuture for WriteBuilder {
                     writer_stats_config,
                 } = exec_options;
                 let predicate_sql = exact_validation.as_ref().map(fmt_expr_to_sql).transpose()?;
-                let (sink_plan, contains_cdc, contains_insert_marker) =
+                let (sink_plan, contains_cdc, insert_marker_column) =
                     overwrite_plan.build_sink_plan()?;
                 let source_plan = session.create_physical_plan(&sink_plan).await?;
 
@@ -542,7 +543,7 @@ impl std::future::IntoFuture for WriteBuilder {
                     writer_stats_config,
                     exact_validation,
                     contains_cdc,
-                    contains_insert_marker,
+                    insert_marker_column,
                 )
                 .await?;
 
@@ -624,12 +625,16 @@ mod tests {
         get_arrow_schema, get_delta_schema, get_delta_schema_with_nested_struct, get_record_batch,
         get_record_batch_with_nested_struct, setup_table_with_configuration,
     };
-    use arrow_array::{Int32Array, StringArray, TimestampMicrosecondArray};
+    use arrow_array::{
+        Float64Array, Int32Array, Int64Array, StringArray, TimestampMicrosecondArray,
+    };
     use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema, TimeUnit};
     use datafusion::physical_plan::collect;
     use datafusion::prelude::*;
     use datafusion::{assert_batches_eq, assert_batches_sorted_eq};
     use delta_kernel::engine::arrow_conversion::TryIntoArrow;
+    use delta_kernel::schema::MetadataValue;
+    use futures::TryStreamExt;
     use itertools::Itertools;
     use serde_json::{Value, json};
 
@@ -642,6 +647,86 @@ mod tests {
             .remove("operationMetrics")
             .unwrap();
         serde_json::from_value(metrics).unwrap()
+    }
+
+    async fn query_table(table: &DeltaTable, sql: &str) -> TestResult<Vec<RecordBatch>> {
+        let table = DeltaTable::new_with_state(
+            table.log_store.clone(),
+            table.state.as_ref().unwrap().clone(),
+        );
+        let ctx = SessionContext::new();
+        table.update_datafusion_session(&ctx.state()).unwrap();
+        ctx.register_table("test", table.table_provider().await.unwrap())
+            .unwrap();
+
+        Ok(ctx.sql(sql).await?.collect().await?)
+    }
+
+    async fn query_single_i64_row(table: &DeltaTable, sql: &str) -> TestResult<Vec<i64>> {
+        let batches = query_table(table, sql).await?;
+        let batch = batches
+            .first()
+            .expect("expected aggregate query to return a single batch");
+
+        Ok(batch
+            .columns()
+            .iter()
+            .map(|column| {
+                column
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("expected Int64 aggregate column")
+                    .value(0)
+            })
+            .collect())
+    }
+
+    async fn query_i32_rows(table: &DeltaTable, sql: &str, column: &str) -> TestResult<Vec<i32>> {
+        let mut values = Vec::new();
+        for batch in query_table(table, sql).await? {
+            let array = batch
+                .column_by_name(column)
+                .expect("expected query column")
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("expected Int32 query column");
+            values.extend(
+                array
+                    .iter()
+                    .map(|value| value.expect("expected non-null Int32 value")),
+            );
+        }
+        Ok(values)
+    }
+
+    async fn open_copied_table_fixture(
+        fixture_source: &std::path::Path,
+        table_dir_name: &str,
+    ) -> TestResult<(tempfile::TempDir, DeltaTable)> {
+        let temp_dir = tempfile::tempdir()?;
+        fs_extra::dir::copy(fixture_source, temp_dir.path(), &Default::default())?;
+        let table_url =
+            url::Url::from_directory_path(temp_dir.path().join(table_dir_name).canonicalize()?)
+                .unwrap();
+        Ok((temp_dir, crate::open_table(table_url).await?))
+    }
+
+    async fn latest_remove_actions(table: &DeltaTable) -> TestResult<Vec<crate::kernel::Remove>> {
+        let version = table
+            .version()
+            .expect("expected committed version for latest remove actions");
+        let snapshot_bytes = table
+            .log_store
+            .read_commit_entry(version)
+            .await?
+            .expect("failed to get snapshot bytes");
+        Ok(get_actions(version, &snapshot_bytes)?
+            .into_iter()
+            .filter_map(|action| match action {
+                Action::Remove(remove) => Some(remove),
+                _ => None,
+            })
+            .collect())
     }
 
     fn assert_common_write_metrics(write_metrics: WriteMetrics) {
@@ -1185,6 +1270,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_merge_schema_preserves_existing_field_metadata() {
+        let schema: StructType = serde_json::from_value(json!({
+            "type": "struct",
+            "fields": [
+                {"name": "id", "type": "string", "nullable": true, "metadata": {}},
+                {"name": "value", "type": "integer", "nullable": true, "metadata": {
+                    "delta.invariants": "{\"expression\": { \"expression\": \"value < 12\"} }",
+                    "delta.userMetadata": "preserve-me"
+                }},
+                {"name": "modified", "type": "string", "nullable": true, "metadata": {}},
+            ]
+        }))
+        .unwrap();
+
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_save_mode(SaveMode::ErrorIfExists)
+            .with_columns(schema.fields().cloned())
+            .await
+            .unwrap()
+            .write(vec![get_record_batch(None, false)])
+            .await
+            .unwrap();
+
+        let batch = get_record_batch(None, false);
+        let evolved_schema = Arc::new(ArrowSchema::new(vec![
+            batch.schema().field(0).as_ref().clone(),
+            batch.schema().field(1).as_ref().clone(),
+            batch.schema().field(2).as_ref().clone(),
+            Field::new("inserted_by", DataType::Utf8, true),
+        ]));
+        let evolved_batch = RecordBatch::try_new(
+            evolved_schema,
+            vec![
+                batch.column(0).clone(),
+                batch.column(1).clone(),
+                batch.column(2).clone(),
+                Arc::new(StringArray::from(vec![
+                    Some("A1"),
+                    Some("B1"),
+                    None,
+                    Some("B2"),
+                    Some("A3"),
+                    Some("A4"),
+                    None,
+                    None,
+                    Some("B4"),
+                    Some("A5"),
+                    Some("A7"),
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let table = table
+            .write(vec![evolved_batch])
+            .with_save_mode(SaveMode::Append)
+            .with_schema_mode(SchemaMode::Merge)
+            .await
+            .unwrap();
+
+        let schema = table.snapshot().unwrap().metadata().parse_schema().unwrap();
+        let value = schema.field("value").unwrap();
+        assert_eq!(
+            value.metadata.get("delta.invariants"),
+            Some(&MetadataValue::String(
+                "{\"expression\": { \"expression\": \"value < 12\"} }".to_string()
+            ))
+        );
+        assert_eq!(
+            value.metadata.get("delta.userMetadata"),
+            Some(&MetadataValue::String("preserve-me".to_string()))
+        );
+    }
+
+    #[tokio::test]
     async fn test_overwrite_schema() {
         let batch = get_record_batch(None, false);
         let table = DeltaTable::new_in_memory()
@@ -1636,7 +1797,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_replace_where_rejects_insert_marker_column_collision() {
+    async fn test_replace_where_preserves_user_insert_marker_column() {
         let schema = Arc::new(ArrowSchema::new(vec![
             Field::new("id", DataType::Utf8, true),
             Field::new("value", DataType::Int32, true),
@@ -1684,17 +1845,33 @@ mod tests {
         )
         .unwrap();
 
-        let err = table
+        let table = table
             .write(vec![replacement_batch])
             .with_save_mode(SaveMode::Overwrite)
             .with_replace_where(col("value").eq(lit(3)))
             .await
-            .expect_err("replaceWhere should reject internal marker column collisions");
+            .expect("replaceWhere should preserve user columns named like internal markers");
 
-        assert!(
-            err.to_string()
-                .contains("internal write marker column '__delta_rs_write_insert'"),
-            "unexpected error: {err:#}"
+        let actual = get_data_sorted(
+            &table,
+            format!(
+                "id,value,modified,{}",
+                super::plan::WRITE_INSERT_MARKER_COLUMN
+            )
+            .as_str(),
+        )
+        .await;
+        assert_batches_sorted_eq!(
+            &[
+                "+----+-------+------------+-------------------------+",
+                "| id | value | modified   | __delta_rs_write_insert |",
+                "+----+-------+------------+-------------------------+",
+                "| A  | 1     | 2021-02-02 | false                   |",
+                "| B  | 2     | 2021-02-03 | false                   |",
+                "| C  | 3     | 2023-01-01 | false                   |",
+                "+----+-------+------------+-------------------------+",
+            ],
+            &actual
         );
     }
 
@@ -1758,6 +1935,246 @@ mod tests {
                 "+----+-------+------------+-------------+",
             ],
             &actual
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_replace_where_preserves_live_rows_with_deletion_vectors() -> TestResult {
+        let (_temp_dir, table) = open_copied_table_fixture(
+            &crate::test_utils::TestTables::WithDvSmall.as_path(),
+            "table-with-dv-small",
+        )
+        .await?;
+
+        let source_files = table
+            .get_active_add_actions_by_partitions(&[])
+            .try_collect::<Vec<_>>()
+            .await?;
+        assert_eq!(source_files.len(), 1);
+        let source_path = source_files[0].path().to_string();
+        let source_deletion_vector = source_files[0].deletion_vector_descriptor();
+        assert!(
+            source_deletion_vector.is_some(),
+            "expected DV-backed source file"
+        );
+        assert_eq!(
+            query_i32_rows(&table, "SELECT value FROM test ORDER BY value", "value").await?,
+            vec![1, 2, 3, 4, 5, 6, 7, 8]
+        );
+
+        let replacement_batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "value",
+                DataType::Int32,
+                true,
+            )])),
+            vec![Arc::new(Int32Array::from(vec![Some(50)]))],
+        )?;
+
+        let table = table
+            .write(vec![replacement_batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_replace_where("value = 5 OR value = 50")
+            .await?;
+        assert_eq!(table.version(), Some(2));
+
+        assert_eq!(
+            query_i32_rows(&table, "SELECT value FROM test ORDER BY value", "value").await?,
+            vec![1, 2, 3, 4, 6, 7, 8, 50]
+        );
+
+        let remove_actions = latest_remove_actions(&table).await?;
+
+        assert_eq!(remove_actions.len(), 1);
+        let remove = &remove_actions[0];
+        assert_eq!(remove.path, source_path);
+        assert_eq!(remove.deletion_vector, source_deletion_vector);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_replace_where_rewrites_multiple_files_with_deletion_vectors() -> TestResult {
+        let (_temp_dir, table) = open_copied_table_fixture(
+            &crate::test_utils::TestTables::WithDvSmall.as_path(),
+            "table-with-dv-small",
+        )
+        .await?;
+
+        let source_files = table
+            .get_active_add_actions_by_partitions(&[])
+            .try_collect::<Vec<_>>()
+            .await?;
+        assert_eq!(source_files.len(), 1);
+        let dv_source = source_files
+            .into_iter()
+            .next()
+            .expect("expected DV-backed source file");
+        assert!(
+            dv_source.deletion_vector_descriptor().is_some(),
+            "expected DV-backed source file"
+        );
+
+        let append_batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "value",
+                DataType::Int32,
+                true,
+            )])),
+            vec![Arc::new(Int32Array::from(vec![Some(0), Some(9)]))],
+        )?;
+
+        let table = table
+            .write(vec![append_batch])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let source_files = table
+            .get_active_add_actions_by_partitions(&[])
+            .try_collect::<Vec<_>>()
+            .await?;
+        assert_eq!(source_files.len(), 2);
+        let appended_source = source_files
+            .iter()
+            .find(|file| file.path() != dv_source.path())
+            .expect("expected appended source file");
+        assert!(
+            appended_source.deletion_vector_descriptor().is_none(),
+            "expected appended source without DV metadata"
+        );
+
+        let replacement_batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "value",
+                DataType::Int32,
+                true,
+            )])),
+            vec![Arc::new(Int32Array::from(vec![Some(50)]))],
+        )?;
+
+        let table = table
+            .write(vec![replacement_batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_replace_where("value >= 5")
+            .await?;
+        assert_eq!(table.version(), Some(3));
+
+        assert_eq!(
+            query_i32_rows(&table, "SELECT value FROM test ORDER BY value", "value").await?,
+            vec![0, 1, 2, 3, 4, 50]
+        );
+
+        let remove_actions = latest_remove_actions(&table).await?;
+
+        assert_eq!(remove_actions.len(), 2);
+        assert!(
+            remove_actions.iter().any(|remove| {
+                remove.path == dv_source.path().to_string()
+                    && remove.deletion_vector == dv_source.deletion_vector_descriptor()
+            }),
+            "expected tombstone for DV-backed source file"
+        );
+        assert!(
+            remove_actions.iter().any(|remove| {
+                remove.path == appended_source.path().to_string()
+                    && remove.deletion_vector.is_none()
+            }),
+            "expected tombstone for appended non-DV source file"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_replace_where_real_world_deletion_logs_preserve_live_rows() -> TestResult {
+        let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../test/tests/data/table_with_deletion_logs");
+        let (_temp_dir, table) =
+            open_copied_table_fixture(&fixture_path, "table_with_deletion_logs").await?;
+
+        let source_files = table
+            .get_active_add_actions_by_partitions(&[])
+            .try_collect::<Vec<_>>()
+            .await?;
+        let dv_sources = source_files
+            .iter()
+            .filter_map(|file| {
+                file.deletion_vector_descriptor()
+                    .map(|descriptor| (file.path().to_string(), descriptor))
+            })
+            .collect::<std::collections::HashMap<_, _>>();
+        assert!(
+            !dv_sources.is_empty(),
+            "expected at least one active DV-backed source file"
+        );
+
+        let initial_counts = query_single_i64_row(
+            &table,
+            "SELECT \
+                SUM(CASE WHEN id < 100 THEN 1 ELSE 0 END) AS matching_rows, \
+                SUM(CASE WHEN id >= 100 THEN 1 ELSE 0 END) AS preserved_rows \
+             FROM test",
+        )
+        .await?;
+        let matching_rows = initial_counts[0];
+        let preserved_rows = initial_counts[1];
+        assert!(matching_rows > 0, "expected fixture rows matching id < 100");
+        assert!(preserved_rows > 0, "expected fixture rows with id >= 100");
+
+        let replacement_batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                Field::new("address", DataType::Utf8, true),
+                Field::new("age", DataType::Float64, true),
+                Field::new("company", DataType::Utf8, true),
+                Field::new("id", DataType::Int64, true),
+                Field::new("name", DataType::Utf8, true),
+                Field::new("nbr", DataType::Int64, true),
+                Field::new("phone_number", DataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec![Some("Replacement Ave")])),
+                Arc::new(Float64Array::from(vec![Some(42.0)])),
+                Arc::new(StringArray::from(vec![Some("delta-rs")])),
+                Arc::new(Int64Array::from(vec![Some(42)])),
+                Arc::new(StringArray::from(vec![Some("replacement")])),
+                Arc::new(Int64Array::from(vec![Some(4242)])),
+                Arc::new(StringArray::from(vec![Some("555-4242")])),
+            ],
+        )?;
+
+        let table = table
+            .write(vec![replacement_batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_replace_where("id < 100")
+            .await?;
+
+        let final_counts = query_single_i64_row(
+            &table,
+            "SELECT \
+                COUNT(*) AS total_rows, \
+                SUM(CASE WHEN id < 100 THEN 1 ELSE 0 END) AS matching_rows, \
+                SUM(CASE WHEN id >= 100 THEN 1 ELSE 0 END) AS preserved_rows, \
+                SUM(CASE WHEN id = 42 AND name = 'replacement' THEN 1 ELSE 0 END) AS replacement_rows \
+             FROM test",
+        )
+        .await?;
+
+        assert_eq!(final_counts[0], preserved_rows + 1);
+        assert_eq!(final_counts[1], 1);
+        assert_eq!(final_counts[2], preserved_rows);
+        assert_eq!(final_counts[3], 1);
+
+        let remove_actions = latest_remove_actions(&table).await?;
+
+        assert!(
+            remove_actions.iter().any(|remove| {
+                dv_sources
+                    .get(&remove.path)
+                    .is_some_and(|descriptor| remove.deletion_vector.as_ref() == Some(descriptor))
+            }),
+            "expected at least one DV-backed tombstone preserving its deletion vector"
         );
 
         Ok(())

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -48,6 +48,7 @@ use self::metrics::{SOURCE_COUNT_ID, SOURCE_COUNT_METRIC};
 use super::{CreateBuilder, CustomExecuteHandler, Operation};
 use crate::DeltaTable;
 use crate::delta_datafusion::Expression;
+use crate::delta_datafusion::expr::fmt_expr_to_sql;
 use crate::delta_datafusion::physical::{find_metric_node, get_metric};
 use crate::delta_datafusion::{
     DeltaSessionExt, SessionFallbackPolicy, SessionResolveContext, create_session,
@@ -64,7 +65,7 @@ pub mod configs;
 pub(crate) mod execution;
 pub(crate) mod generated_columns;
 pub(crate) mod metrics;
-pub(crate) mod plan;
+mod plan;
 pub(crate) mod schema_evolution;
 pub mod writer;
 
@@ -258,7 +259,7 @@ impl WriteBuilder {
         self
     }
 
-    /// Control how delta-rs resolves the provided session when it is not a concrete `SessionState`.
+    /// Control how delta rs resolves the provided session when it is not a concrete `SessionState`.
     ///
     /// Defaults to `SessionFallbackPolicy::InternalDefaults` to preserve existing behavior.
     pub fn with_session_fallback_policy(mut self, policy: SessionFallbackPolicy) -> Self {
@@ -485,9 +486,6 @@ impl std::future::IntoFuture for WriteBuilder {
                     configuration: &this.configuration,
                 })?;
 
-                actions.extend(prepared_write.schema_delta.actions());
-
-                let predicate_str = prepared_write.predicate_sql.clone();
                 let overwrite_plan = plan::plan_overwrite_rewrite(
                     this.snapshot.as_ref(),
                     &this.log_store,
@@ -498,11 +496,25 @@ impl std::future::IntoFuture for WriteBuilder {
                 )
                 .await?;
 
+                let plan::PreparedWrite {
+                    schema_delta,
+                    exact_validation,
+                    exec_options,
+                    ..
+                } = prepared_write;
+                actions.extend(schema_delta.into_actions());
+
                 metrics.num_removed_files = overwrite_plan.num_removed_files();
                 actions.extend(overwrite_plan.actions);
 
-                let exec_options = prepared_write.exec_options.clone();
-                let predicate = prepared_write.exact_validation_predicate();
+                let plan::WriteExecOptions {
+                    partition_columns,
+                    target_file_size,
+                    write_batch_size,
+                    writer_properties,
+                    writer_stats_config,
+                } = exec_options;
+                let predicate_sql = exact_validation.as_ref().map(fmt_expr_to_sql).transpose()?;
                 let source_plan = session
                     .create_physical_plan(&overwrite_plan.sink_plan)
                     .await?;
@@ -512,13 +524,13 @@ impl std::future::IntoFuture for WriteBuilder {
                     this.snapshot.as_ref(),
                     &session,
                     source_plan.clone(),
-                    exec_options.partition_columns.clone(),
+                    partition_columns.clone(),
                     this.log_store.object_store(Some(operation_id)).clone(),
-                    exec_options.target_file_size,
-                    exec_options.write_batch_size,
-                    exec_options.writer_properties.clone(),
-                    exec_options.writer_stats_config,
-                    predicate,
+                    target_file_size,
+                    write_batch_size,
+                    writer_properties,
+                    writer_stats_config,
+                    exact_validation,
                     overwrite_plan.contains_cdc,
                 )
                 .await?;
@@ -539,12 +551,12 @@ impl std::future::IntoFuture for WriteBuilder {
 
                 let operation = DeltaOperation::Write {
                     mode: this.mode,
-                    partition_by: if !exec_options.partition_columns.is_empty() {
-                        Some(exec_options.partition_columns)
+                    partition_by: if !partition_columns.is_empty() {
+                        Some(partition_columns)
                     } else {
                         None
                     },
-                    predicate: predicate_str,
+                    predicate: predicate_sql,
                 };
 
                 let mut commit_properties = this.commit_properties.clone();
@@ -618,66 +630,6 @@ mod tests {
     fn assert_common_write_metrics(write_metrics: WriteMetrics) {
         // assert!(write_metrics.execution_time_ms > 0);
         assert!(write_metrics.num_added_files > 0);
-    }
-
-    #[test]
-    fn test_prepare_write_carries_exact_validations_and_exec_options() {
-        let batch = get_record_batch(None, false);
-        let source = LogicalPlanBuilder::scan(
-            UNNAMED_TABLE,
-            provider_as_source(Arc::new(
-                MemTable::try_new(batch.schema(), vec![vec![batch]]).unwrap(),
-            )),
-            None,
-        )
-        .unwrap()
-        .build()
-        .unwrap();
-
-        let writer_properties = WriterProperties::builder()
-            .set_max_row_group_row_count(Some(42))
-            .build();
-        let target_file_size = NonZeroU64::new(123).unwrap();
-        let session = create_session().state();
-
-        let prepared = super::plan::prepare_write(super::plan::WritePreparationInput {
-            snapshot: None,
-            session: &session,
-            source,
-            mode: SaveMode::Append,
-            schema_mode: None,
-            safe_cast: false,
-            partition_columns: vec![],
-            predicate: Some(col("id").eq(lit("A")).into()),
-            target_file_size: Some(Some(target_file_size)),
-            write_batch_size: Some(456),
-            writer_properties: Some(writer_properties.clone()),
-            configuration: &HashMap::new(),
-        })
-        .unwrap();
-
-        assert_eq!(prepared.exact_validations.len(), 1);
-        assert!(prepared.predicate_sql.is_some());
-        assert!(prepared.exact_validation_predicate().is_some());
-        assert!(prepared.schema_delta.is_empty());
-        assert_eq!(
-            prepared.exec_options.partition_columns,
-            Vec::<String>::new()
-        );
-        assert_eq!(
-            prepared.exec_options.target_file_size,
-            Some(target_file_size)
-        );
-        assert_eq!(prepared.exec_options.write_batch_size, Some(456));
-        assert_eq!(
-            prepared
-                .exec_options
-                .writer_properties
-                .as_ref()
-                .unwrap()
-                .max_row_group_row_count(),
-            writer_properties.max_row_group_row_count()
-        );
     }
 
     #[tokio::test]
@@ -1208,13 +1160,8 @@ mod tests {
         let mut names = fields.map(|f| f.name()).collect::<Vec<_>>();
         names.sort();
         assert_eq!(names, vec!["id", "inserted_by", "modified", "value"]);
-        let part_cols = table
-            .snapshot()
-            .unwrap()
-            .metadata()
-            .partition_columns()
-            .clone();
-        assert_eq!(part_cols, vec!["id", "value"]); // we want to preserve partitions
+        let part_cols = table.snapshot().unwrap().metadata().partition_columns();
+        assert_eq!(part_cols, ["id".to_string(), "value".to_string()]); // we want to preserve partitions
 
         let write_metrics: WriteMetrics = get_write_metrics(&table).await;
         assert_common_write_metrics(write_metrics);
@@ -2589,7 +2536,7 @@ mod tests {
             Field::new("id", DataType::Int32, false),
             Field::new("sales_date", DataType::Date64, true),
         ]));
-        let millis = 1760918400000i64; // 2025-10-20 in ms since epoch
+        let millis = 1760918400000i64; // 2025 10 20 in ms since epoch
         let batch = RecordBatch::try_new(
             schema,
             vec![

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -492,9 +492,20 @@ impl std::future::IntoFuture for WriteBuilder {
                     &session,
                     this.mode,
                     &prepared_write,
-                    operation_id,
                 )
                 .await?;
+
+                if overwrite_plan.diagnostics.dropped_pruning_term_count > 0 {
+                    tracing::warn!(
+                        rewrite_kind = ?overwrite_plan.kind,
+                        matched_file_count = overwrite_plan.diagnostics.matched_file_count,
+                        translated_pruning_term_count =
+                            overwrite_plan.diagnostics.translated_pruning_term_count,
+                        dropped_pruning_term_count =
+                            overwrite_plan.diagnostics.dropped_pruning_term_count,
+                        "overwrite rewrite predicate was only partially translated for pruning; exact validation remains enabled"
+                    );
+                }
 
                 let plan::PreparedWrite {
                     schema_delta,
@@ -505,7 +516,6 @@ impl std::future::IntoFuture for WriteBuilder {
                 actions.extend(schema_delta.into_actions());
 
                 metrics.num_removed_files = overwrite_plan.num_removed_files();
-                actions.extend(overwrite_plan.actions);
 
                 let plan::WriteExecOptions {
                     partition_columns,
@@ -515,9 +525,9 @@ impl std::future::IntoFuture for WriteBuilder {
                     writer_stats_config,
                 } = exec_options;
                 let predicate_sql = exact_validation.as_ref().map(fmt_expr_to_sql).transpose()?;
-                let source_plan = session
-                    .create_physical_plan(&overwrite_plan.sink_plan)
-                    .await?;
+                let (sink_plan, contains_cdc, contains_insert_marker) =
+                    overwrite_plan.build_sink_plan()?;
+                let source_plan = session.create_physical_plan(&sink_plan).await?;
 
                 // Here we need to validate if the new data conforms to a predicate if one is provided
                 let (add_actions, _) = write_execution_plan_v2(
@@ -531,9 +541,16 @@ impl std::future::IntoFuture for WriteBuilder {
                     writer_properties,
                     writer_stats_config,
                     exact_validation,
-                    overwrite_plan.contains_cdc,
+                    contains_cdc,
+                    contains_insert_marker,
                 )
                 .await?;
+
+                actions.extend(
+                    overwrite_plan
+                        .matched_existing
+                        .into_actions(overwrite_plan.deletion_timestamp)?,
+                );
 
                 let source_count =
                     find_metric_node(SOURCE_COUNT_ID, &source_plan).ok_or_else(|| {
@@ -1555,6 +1572,230 @@ mod tests {
 
         let table = DeltaTable::new_with_state(table_logstore, table_state);
         assert_eq!(table.get_latest_version().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_write_preserves_user_insert_marker_column_outside_rewrite() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Utf8, true),
+            Field::new("value", DataType::Int32, true),
+            Field::new("modified", DataType::Utf8, true),
+            Field::new(
+                super::plan::WRITE_INSERT_MARKER_COLUMN,
+                DataType::Boolean,
+                true,
+            ),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("A"), Some("B"), Some("C")])),
+                Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3)])),
+                Arc::new(StringArray::from(vec![
+                    Some("2021-02-02"),
+                    Some("2021-02-03"),
+                    Some("2021-02-04"),
+                ])),
+                Arc::new(arrow::array::BooleanArray::from(vec![
+                    Some(false),
+                    Some(true),
+                    Some(false),
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let table = DeltaTable::new_in_memory()
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .await
+            .unwrap();
+
+        let actual = get_data_sorted(
+            &table,
+            format!(
+                "id,value,modified,{}",
+                super::plan::WRITE_INSERT_MARKER_COLUMN
+            )
+            .as_str(),
+        )
+        .await;
+        assert_batches_sorted_eq!(
+            &[
+                "+----+-------+------------+-------------------------+",
+                "| id | value | modified   | __delta_rs_write_insert |",
+                "+----+-------+------------+-------------------------+",
+                "| A  | 1     | 2021-02-02 | false                   |",
+                "| B  | 2     | 2021-02-03 | true                    |",
+                "| C  | 3     | 2021-02-04 | false                   |",
+                "+----+-------+------------+-------------------------+",
+            ],
+            &actual
+        );
+    }
+
+    #[tokio::test]
+    async fn test_replace_where_rejects_insert_marker_column_collision() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Utf8, true),
+            Field::new("value", DataType::Int32, true),
+            Field::new("modified", DataType::Utf8, true),
+            Field::new(
+                super::plan::WRITE_INSERT_MARKER_COLUMN,
+                DataType::Boolean,
+                true,
+            ),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec![Some("A"), Some("B"), Some("C")])),
+                Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3)])),
+                Arc::new(StringArray::from(vec![
+                    Some("2021-02-02"),
+                    Some("2021-02-03"),
+                    Some("2021-02-04"),
+                ])),
+                Arc::new(arrow::array::BooleanArray::from(vec![
+                    Some(false),
+                    Some(false),
+                    Some(true),
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let table = DeltaTable::new_in_memory()
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .await
+            .unwrap();
+
+        let replacement_batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("C")])),
+                Arc::new(Int32Array::from(vec![Some(3)])),
+                Arc::new(StringArray::from(vec![Some("2023-01-01")])),
+                Arc::new(arrow::array::BooleanArray::from(vec![Some(false)])),
+            ],
+        )
+        .unwrap();
+
+        let err = table
+            .write(vec![replacement_batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_replace_where(col("value").eq(lit(3)))
+            .await
+            .expect_err("replaceWhere should reject internal marker column collisions");
+
+        assert!(
+            err.to_string()
+                .contains("internal write marker column '__delta_rs_write_insert'"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_replace_where_merge_schema_rescues_existing_rows() -> TestResult {
+        let base_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Utf8, true),
+            Field::new("value", DataType::Int32, true),
+            Field::new("modified", DataType::Utf8, true),
+        ]));
+        let base_batch = RecordBatch::try_new(
+            Arc::clone(&base_schema),
+            vec![
+                Arc::new(StringArray::from(vec![Some("A"), Some("B"), Some("C")])),
+                Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3)])),
+                Arc::new(StringArray::from(vec![
+                    Some("2021-02-02"),
+                    Some("2021-02-03"),
+                    Some("2021-02-04"),
+                ])),
+            ],
+        )?;
+
+        let table = DeltaTable::new_in_memory()
+            .write(vec![base_batch])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let merge_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Utf8, true),
+            Field::new("value", DataType::Int32, true),
+            Field::new("modified", DataType::Utf8, true),
+            Field::new("inserted_by", DataType::Utf8, true),
+        ]));
+        let replacement_batch = RecordBatch::try_new(
+            merge_schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("C")])),
+                Arc::new(Int32Array::from(vec![Some(3)])),
+                Arc::new(StringArray::from(vec![Some("2023-01-01")])),
+                Arc::new(StringArray::from(vec![Some("rewrite")])),
+            ],
+        )?;
+
+        let table = table
+            .write(vec![replacement_batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_schema_mode(SchemaMode::Merge)
+            .with_replace_where(col("value").eq(lit(3)))
+            .await?;
+
+        let actual = get_data_sorted(&table, "id,value,modified,inserted_by").await;
+        assert_batches_sorted_eq!(
+            &[
+                "+----+-------+------------+-------------+",
+                "| id | value | modified   | inserted_by |",
+                "+----+-------+------------+-------------+",
+                "| A  | 1     | 2021-02-02 |             |",
+                "| B  | 2     | 2021-02-03 |             |",
+                "| C  | 3     | 2023-01-01 | rewrite     |",
+                "+----+-------+------------+-------------+",
+            ],
+            &actual
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_without_files_is_rejected() -> TestResult {
+        let temp_dir = tempfile::tempdir()?;
+        let table_path = temp_dir.path().join("without_files_overwrite");
+        std::fs::create_dir(&table_path)?;
+        let table_uri = ensure_table_uri(table_path.to_str().unwrap())?;
+
+        DeltaTable::try_from_url(table_uri.clone())
+            .await?
+            .write(vec![get_record_batch(None, false)])
+            .await?;
+
+        let table = crate::DeltaTableBuilder::from_url(table_uri)?
+            .without_files()
+            .load()
+            .await?;
+
+        assert_eq!(table.version(), Some(0));
+
+        // Phase 3 now routes overwrite planning through matched-file discovery, so this guard
+        // stays covered here to ensure we still fail before any rewrite planning starts.
+        let err = table
+            .write(vec![get_record_batch(None, false)])
+            .with_save_mode(SaveMode::Overwrite)
+            .await
+            .expect_err("overwrite should fail when table was loaded without files");
+
+        assert!(matches!(
+            err,
+            DeltaTableError::NotInitializedWithFiles(operation) if operation == "WRITE"
+        ));
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -27,50 +27,36 @@ use std::collections::HashMap;
 use std::num::NonZeroU64;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::Instant;
 use std::vec;
 
 use arrow::array::RecordBatch;
-use arrow_schema::Schema;
 use datafusion::catalog::{Session, TableProvider};
-use datafusion::common::{Column, Result, ScalarValue};
+use datafusion::common::Result;
 use datafusion::datasource::{MemTable, provider_as_source};
-use datafusion::logical_expr::{
-    Expr, Extension, LogicalPlan, LogicalPlanBuilder, UNNAMED_TABLE, cast, lit, try_cast,
-};
-use datafusion::prelude::col;
+use datafusion::logical_expr::{LogicalPlan, LogicalPlanBuilder, UNNAMED_TABLE};
 use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
-use futures::{TryStreamExt as _, future::BoxFuture};
-use itertools::Itertools as _;
+use futures::future::BoxFuture;
 use parquet::file::properties::WriterProperties;
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use url::Url;
 
 pub use self::configs::WriterStatsConfig;
-use self::execution::{prepare_predicate_actions, write_execution_plan_v2};
-use self::generated_columns::{gc_is_enabled, with_generated_columns};
+use self::execution::write_execution_plan_v2;
 use self::metrics::{SOURCE_COUNT_ID, SOURCE_COUNT_METRIC};
-use self::schema_evolution::try_cast_schema;
-use super::cdc::CDC_COLUMN_NAME;
 use super::{CreateBuilder, CustomExecuteHandler, Operation};
 use crate::DeltaTable;
-use crate::delta_datafusion::DataFusionMixins;
 use crate::delta_datafusion::Expression;
-use crate::delta_datafusion::expr::fmt_expr_to_sql;
-use crate::delta_datafusion::logical::MetricObserver;
 use crate::delta_datafusion::physical::{find_metric_node, get_metric};
 use crate::delta_datafusion::{
     DeltaSessionExt, SessionFallbackPolicy, SessionResolveContext, create_session,
     resolve_session_state, update_datafusion_session,
 };
 use crate::errors::{DeltaResult, DeltaTableError};
-use crate::kernel::schema::cast::{merge_arrow_schema, normalize_for_delta};
+use crate::kernel::schema::cast::normalize_for_delta;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL, TableReference};
-use crate::kernel::{
-    Action, EagerSnapshot, MetadataExt as _, ProtocolExt as _, StructType, StructTypeExt,
-    new_metadata,
-};
+use crate::kernel::{Action, EagerSnapshot, StructType};
 use crate::logstore::LogStoreRef;
 use crate::protocol::{DeltaOperation, SaveMode};
 
@@ -78,6 +64,7 @@ pub mod configs;
 pub(crate) mod execution;
 pub(crate) mod generated_columns;
 pub(crate) mod metrics;
+pub(crate) mod plan;
 pub(crate) mod schema_evolution;
 pub mod writer;
 
@@ -465,7 +452,7 @@ impl std::future::IntoFuture for WriteBuilder {
 
                 let partition_columns = this.get_partition_columns()?;
 
-                let Some(mut source) = this.input.take() else {
+                let Some(source) = this.input.take() else {
                     return Err(WriteError::MissingData.into());
                 };
 
@@ -483,281 +470,56 @@ impl std::future::IntoFuture for WriteBuilder {
                 update_datafusion_session(&session, &this.log_store, Some(operation_id))?;
                 session.ensure_log_store_registered(this.log_store.as_ref())?;
 
-                let mut schema_drift = false;
+                let prepared_write = plan::prepare_write(plan::WritePreparationInput {
+                    snapshot: this.snapshot.as_ref(),
+                    session: &session,
+                    source,
+                    mode: this.mode,
+                    schema_mode: this.schema_mode,
+                    safe_cast: this.safe_cast,
+                    partition_columns: partition_columns.clone(),
+                    predicate: this.predicate,
+                    target_file_size: this.target_file_size,
+                    write_batch_size: this.write_batch_size,
+                    writer_properties: this.writer_properties.clone(),
+                    configuration: &this.configuration,
+                })?;
 
-                let table_schema = if let Some(snapshot) = this.snapshot.as_ref() {
-                    snapshot.arrow_schema()
-                } else {
-                    normalize_for_delta(source.schema().inner())
-                };
+                actions.extend(prepared_write.schema_delta.actions());
 
-                if let Some(snapshot) = &this.snapshot
-                    && gc_is_enabled(snapshot)
-                {
-                    source = with_generated_columns(
-                        &session,
-                        source,
-                        &table_schema,
-                        &snapshot.schema().get_generated_columns()?,
-                    )?;
-                }
+                let predicate_str = prepared_write.predicate_sql.clone();
+                let overwrite_plan = plan::plan_overwrite_rewrite(
+                    this.snapshot.as_ref(),
+                    &this.log_store,
+                    &session,
+                    this.mode,
+                    &prepared_write,
+                    operation_id,
+                )
+                .await?;
 
-                let source_schema: Arc<Schema> = normalize_for_delta(source.schema().inner());
+                metrics.num_removed_files = overwrite_plan.num_removed_files();
+                actions.extend(overwrite_plan.actions);
 
-                if !Arc::ptr_eq(&source_schema, source.schema().inner()) {
-                    let original_schema = source.schema().inner();
-                    let cast_projection: Vec<Expr> = source_schema
-                        .fields()
-                        .iter()
-                        .zip(original_schema.fields().iter())
-                        .map(|(target, original)| {
-                            if target.data_type() != original.data_type() {
-                                let cast_fn = if this.safe_cast { try_cast } else { cast };
-                                cast_fn(
-                                    Expr::Column(Column::from_name(target.name())),
-                                    target.data_type().clone(),
-                                )
-                                .alias(target.name())
-                            } else {
-                                Expr::Column(Column::from_name(target.name()))
-                            }
-                        })
-                        .collect();
-                    source = LogicalPlanBuilder::new(source)
-                        .project(cast_projection)?
-                        .build()?;
-                }
-
-                // Schema merging code should be aware of columns that can be generated during write
-                // so they might be empty in the batch, but the will exist in the input_schema()
-                // in this case we have to insert the generated column and it's type in the schema of the batch
-                let mut new_schema = None;
-                if let Some(snapshot) = &this.snapshot {
-                    let table_schema = snapshot.input_schema();
-
-                    if let Err(schema_err) =
-                        try_cast_schema(source_schema.fields(), table_schema.fields())
-                    {
-                        schema_drift = true;
-                        if this.mode == SaveMode::Overwrite
-                            && this.schema_mode == Some(SchemaMode::Overwrite)
-                        {
-                            new_schema = None // we overwrite anyway, so no need to cast
-                        } else if this.schema_mode == Some(SchemaMode::Merge) {
-                            new_schema = Some(merge_arrow_schema(
-                                table_schema.clone(),
-                                source_schema.clone(),
-                                schema_drift,
-                            )?);
-                        } else {
-                            return Err(schema_err.into());
-                        }
-                    } else if this.mode == SaveMode::Overwrite
-                        && this.schema_mode == Some(SchemaMode::Overwrite)
-                    {
-                        new_schema = None // we overwrite anyway, so no need to cast
-                    } else {
-                        // Schema needs to be merged so that utf8/binary/list types are preserved from the batch side if both table
-                        // and batch contains such type. Other types are preserved from the table side.
-                        // At this stage it will never introduce more fields since try_cast_batch passed correctly.
-                        new_schema = Some(merge_arrow_schema(
-                            table_schema.clone(),
-                            source_schema.clone(),
-                            schema_drift,
-                        )?);
-                    }
-                }
-
-                if let Some(new_schema) = new_schema.as_ref() {
-                    let mut schema_evolution_projection =
-                        Vec::with_capacity(new_schema.fields().len());
-                    for field in new_schema.fields() {
-                        // If field exist in source data, we cast to new datatype
-                        if source_schema.index_of(field.name()).is_ok() {
-                            let cast_fn = if this.safe_cast { try_cast } else { cast };
-                            let cast_expr = cast_fn(
-                                Expr::Column(Column::from_name(field.name())),
-                                // col(field.name()),
-                                field.data_type().clone(),
-                            )
-                            .alias(field.name());
-                            schema_evolution_projection.push(cast_expr)
-                        // If field doesn't exist in source data, we insert the column
-                        // with null values
-                        } else {
-                            schema_evolution_projection.push(
-                                cast(
-                                    lit(ScalarValue::Null).alias(field.name()),
-                                    field.data_type().clone(),
-                                )
-                                .alias(field.name()),
-                            );
-                        }
-                    }
-                    source = LogicalPlanBuilder::new(source)
-                        .project(schema_evolution_projection)?
-                        .build()?;
-                }
-
-                let mut source = LogicalPlan::Extension(Extension {
-                    node: Arc::new(MetricObserver {
-                        id: "write_source_count".into(),
-                        input: source,
-                        enable_pushdown: false,
-                    }),
-                });
-
-                // Maybe create schema action based on schema_mode
-                if let Some(snapshot) = &this.snapshot {
-                    let should_update_schema = match this.schema_mode {
-                        Some(SchemaMode::Merge) if schema_drift => true,
-                        Some(SchemaMode::Overwrite) if this.mode == SaveMode::Overwrite => {
-                            let delta_schema: StructType =
-                                source.schema().as_arrow().try_into_kernel()?;
-                            &delta_schema != snapshot.schema().as_ref()
-                        }
-                        _ => false,
-                    };
-
-                    if should_update_schema {
-                        // Use the merged Arrow schema (not the DataFusion plan schema) when
-                        // performing schema evolution. DataFusion expressions do not reliably
-                        // preserve Arrow field metadata, which would otherwise strip column
-                        // metadata such as generated column expressions.
-                        let schema_struct: StructType =
-                            match (this.schema_mode, schema_drift, new_schema.as_deref()) {
-                                (Some(SchemaMode::Merge), true, Some(schema)) => {
-                                    schema.try_into_kernel()?
-                                }
-                                _ => source.schema().as_arrow().try_into_kernel()?,
-                            };
-                        // Verify if delta schema changed
-                        if &schema_struct != snapshot.schema().as_ref() {
-                            let current_protocol = snapshot.protocol();
-                            let configuration = snapshot.metadata().configuration().clone();
-                            let new_protocol = current_protocol
-                                .clone()
-                                .apply_column_metadata_to_protocol(&schema_struct)?
-                                .move_table_properties_into_features(&configuration);
-
-                            let mut metadata =
-                                new_metadata(&schema_struct, &partition_columns, configuration)?;
-                            let existing_metadata_id = snapshot.metadata().id().to_string();
-
-                            if !existing_metadata_id.is_empty() {
-                                metadata = metadata.with_table_id(existing_metadata_id)?;
-                            }
-                            let schema_action = Action::Metadata(metadata);
-                            actions.push(schema_action);
-                            if current_protocol != &new_protocol {
-                                actions.push(new_protocol.into())
-                            }
-                        }
-                    }
-                }
-
-                let df_schema = source
-                    .schema()
-                    .as_ref()
-                    .clone()
-                    .replace_qualifier(UNNAMED_TABLE);
-                let predicate = this
-                    .predicate
-                    .map(|p| p.resolve(&session, Arc::new(df_schema)))
-                    .transpose()?;
-                let predicate_str = predicate.as_ref().map(fmt_expr_to_sql).transpose()?;
-
-                let config = this
-                    .snapshot
-                    .as_ref()
-                    .map(|snapshot| snapshot.table_properties());
-
-                let target_file_size = this.target_file_size.unwrap_or_else(|| {
-                    Some(super::get_target_file_size(config, &this.configuration))
-                });
-
-                let (num_indexed_cols, stats_columns) =
-                    super::get_num_idx_cols_and_stats_columns(config, this.configuration);
-
-                let writer_stats_config = WriterStatsConfig {
-                    num_indexed_cols,
-                    stats_columns,
-                };
-
-                let mut contains_cdc = false;
-
-                // Collect remove actions if we are overwriting the table
-                if let Some(snapshot) = &this.snapshot {
-                    if matches!(this.mode, SaveMode::Overwrite) {
-                        let deletion_timestamp = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_millis() as i64;
-
-                        match &predicate {
-                            Some(pred) => {
-                                let (predicate_actions, cdf_df) = prepare_predicate_actions(
-                                    pred.clone(),
-                                    this.log_store.clone(),
-                                    snapshot,
-                                    &session,
-                                    partition_columns.clone(),
-                                    this.writer_properties.clone(),
-                                    deletion_timestamp,
-                                    writer_stats_config.clone(),
-                                    operation_id,
-                                )
-                                .await?;
-
-                                if let Some(cdf_df) = cdf_df {
-                                    contains_cdc = true;
-                                    let mut projection = source
-                                        .schema()
-                                        .iter()
-                                        .map(|(_, field)| col(field.name()))
-                                        .collect_vec();
-                                    projection.push(lit("insert").alias(CDC_COLUMN_NAME));
-                                    source = LogicalPlanBuilder::new(source)
-                                        .project(projection)?
-                                        .union(cdf_df)?
-                                        .build()?;
-                                }
-
-                                if !predicate_actions.is_empty() {
-                                    actions.extend(predicate_actions);
-                                }
-                            }
-                            _ => {
-                                let remove_actions = snapshot
-                                    .file_views(&this.log_store, None)
-                                    .map_ok(|p| p.remove_action(true).into())
-                                    .try_collect::<Vec<_>>()
-                                    .await?;
-                                actions.extend(remove_actions);
-                            }
-                        };
-                    }
-                    metrics.num_removed_files = actions
-                        .iter()
-                        .filter(|a| matches!(a, Action::Remove(_)))
-                        .count();
-                }
-
-                let source_plan = session.create_physical_plan(&source).await?;
+                let exec_options = prepared_write.exec_options.clone();
+                let predicate = prepared_write.exact_validation_predicate();
+                let source_plan = session
+                    .create_physical_plan(&overwrite_plan.sink_plan)
+                    .await?;
 
                 // Here we need to validate if the new data conforms to a predicate if one is provided
                 let (add_actions, _) = write_execution_plan_v2(
                     this.snapshot.as_ref(),
                     &session,
                     source_plan.clone(),
-                    partition_columns.clone(),
+                    exec_options.partition_columns.clone(),
                     this.log_store.object_store(Some(operation_id)).clone(),
-                    target_file_size,
-                    this.write_batch_size,
-                    this.writer_properties,
-                    writer_stats_config.clone(),
-                    predicate.clone(),
-                    contains_cdc,
+                    exec_options.target_file_size,
+                    exec_options.write_batch_size,
+                    exec_options.writer_properties.clone(),
+                    exec_options.writer_stats_config,
+                    predicate,
+                    overwrite_plan.contains_cdc,
                 )
                 .await?;
 
@@ -777,8 +539,8 @@ impl std::future::IntoFuture for WriteBuilder {
 
                 let operation = DeltaOperation::Write {
                     mode: this.mode,
-                    partition_by: if !partition_columns.is_empty() {
-                        Some(partition_columns)
+                    partition_by: if !exec_options.partition_columns.is_empty() {
+                        Some(exec_options.partition_columns)
                     } else {
                         None
                     },
@@ -856,6 +618,66 @@ mod tests {
     fn assert_common_write_metrics(write_metrics: WriteMetrics) {
         // assert!(write_metrics.execution_time_ms > 0);
         assert!(write_metrics.num_added_files > 0);
+    }
+
+    #[test]
+    fn test_prepare_write_carries_exact_validations_and_exec_options() {
+        let batch = get_record_batch(None, false);
+        let source = LogicalPlanBuilder::scan(
+            UNNAMED_TABLE,
+            provider_as_source(Arc::new(
+                MemTable::try_new(batch.schema(), vec![vec![batch]]).unwrap(),
+            )),
+            None,
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+        let writer_properties = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(42))
+            .build();
+        let target_file_size = NonZeroU64::new(123).unwrap();
+        let session = create_session().state();
+
+        let prepared = super::plan::prepare_write(super::plan::WritePreparationInput {
+            snapshot: None,
+            session: &session,
+            source,
+            mode: SaveMode::Append,
+            schema_mode: None,
+            safe_cast: false,
+            partition_columns: vec![],
+            predicate: Some(col("id").eq(lit("A")).into()),
+            target_file_size: Some(Some(target_file_size)),
+            write_batch_size: Some(456),
+            writer_properties: Some(writer_properties.clone()),
+            configuration: &HashMap::new(),
+        })
+        .unwrap();
+
+        assert_eq!(prepared.exact_validations.len(), 1);
+        assert!(prepared.predicate_sql.is_some());
+        assert!(prepared.exact_validation_predicate().is_some());
+        assert!(prepared.schema_delta.is_empty());
+        assert_eq!(
+            prepared.exec_options.partition_columns,
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            prepared.exec_options.target_file_size,
+            Some(target_file_size)
+        );
+        assert_eq!(prepared.exec_options.write_batch_size, Some(456));
+        assert_eq!(
+            prepared
+                .exec_options
+                .writer_properties
+                .as_ref()
+                .unwrap()
+                .max_row_group_row_count(),
+            writer_properties.max_row_group_row_count()
+        );
     }
 
     #[tokio::test]
@@ -1737,6 +1559,53 @@ mod tests {
         assert!(table.is_err());
 
         // Verify that table state hasn't changed
+        let table = DeltaTable::new_with_state(table_logstore, table_state);
+        assert_eq!(table.get_latest_version().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_replace_where_no_matching_files_still_validates_input() {
+        let schema = get_arrow_schema(&None);
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["A", "B"])),
+                Arc::new(arrow::array::Int32Array::from(vec![10, 20])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "2021-02-02",
+                    "2021-02-03",
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let table = DeltaTable::new_in_memory()
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .await
+            .unwrap();
+        assert_eq!(table.version(), Some(0));
+
+        let table_logstore = table.log_store();
+        let table_state = table.state.clone().unwrap();
+
+        let batch_fail = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["D"])),
+                Arc::new(arrow::array::Int32Array::from(vec![1000])),
+                Arc::new(arrow::array::StringArray::from(vec!["2023-01-01"])),
+            ],
+        )
+        .unwrap();
+
+        let result = table
+            .write(vec![batch_fail])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_replace_where(col("id").eq(lit("Z")))
+            .await;
+        assert!(result.is_err());
+
         let table = DeltaTable::new_with_state(table_logstore, table_state);
         assert_eq!(table.get_latest_version().await.unwrap(), 0);
     }

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -20,6 +20,7 @@ use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
 use futures::TryStreamExt as _;
 use itertools::Itertools as _;
 use parquet::file::properties::WriterProperties;
+use uuid::Uuid;
 
 use super::SchemaMode;
 use super::configs::WriterStatsConfig;
@@ -100,6 +101,8 @@ pub(super) struct WritePreparationInput<'a> {
     pub(super) configuration: &'a HashMap<String, Option<String>>,
 }
 
+/// Prefix for per-operation internal marker columns injected during overwrite rewrite
+/// to distinguish insert rows from rescued existing rows.
 pub(super) const WRITE_INSERT_MARKER_COLUMN: &str = "__delta_rs_write_insert";
 
 /// High-level rewrite strategy chosen for an overwrite flow.
@@ -206,6 +209,7 @@ pub(super) struct MatchedFilesRewritePlan {
     pub(super) matched_existing: MatchedExistingFiles,
     pub(super) data_plan: LogicalPlan,
     pub(super) cdc_plan: Option<LogicalPlan>,
+    insert_marker_column: Option<String>,
     pub(super) diagnostics: RewriteDiagnostics,
 }
 
@@ -217,6 +221,7 @@ impl MatchedFilesRewritePlan {
             matched_existing: MatchedExistingFiles::default(),
             data_plan: insert_plan,
             cdc_plan: None,
+            insert_marker_column: None,
             diagnostics: RewriteDiagnostics::default(),
         }
     }
@@ -225,15 +230,16 @@ impl MatchedFilesRewritePlan {
         self.matched_existing.num_files()
     }
 
-    pub(super) fn build_sink_plan(&self) -> DeltaResult<(LogicalPlan, bool, bool)> {
-        let contains_insert_marker = matches!(self.kind, RewriteKind::DataRescue);
-        let data_plan = if self.cdc_plan.is_some() {
+    pub(super) fn build_sink_plan(&self) -> DeltaResult<(LogicalPlan, bool, Option<String>)> {
+        let data_plan = if let (Some(_), Some(insert_marker_column)) =
+            (self.cdc_plan.as_ref(), self.insert_marker_column.as_ref())
+        {
             // Empty-string rows are rescued table data: they must bypass CDF output while still
             // flowing through the normal parquet write path.
             LogicalPlanBuilder::new(self.data_plan.clone())
                 .with_column(
                     CDC_COLUMN_NAME,
-                    when(col(WRITE_INSERT_MARKER_COLUMN).eq(lit(true)), lit("insert"))
+                    when(col(insert_marker_column).eq(lit(true)), lit("insert"))
                         .otherwise(lit(""))?,
                 )?
                 .build()?
@@ -249,10 +255,10 @@ impl MatchedFilesRewritePlan {
                         .union(cdc_plan)?
                         .build()?,
                     true,
-                    contains_insert_marker,
+                    self.insert_marker_column.clone(),
                 ))
             }
-            None => Ok((data_plan, false, contains_insert_marker)),
+            None => Ok((data_plan, false, self.insert_marker_column.clone())),
         }
     }
 }
@@ -414,6 +420,7 @@ pub(super) async fn plan_overwrite_rewrite(
     session: &dyn Session,
     mode: SaveMode,
     prepared_write: &PreparedWrite,
+    operation_id: Uuid,
 ) -> DeltaResult<MatchedFilesRewritePlan> {
     let Some(snapshot) = snapshot else {
         return Ok(MatchedFilesRewritePlan::passthrough(
@@ -453,6 +460,7 @@ pub(super) async fn plan_overwrite_rewrite(
                     matched_existing: MatchedExistingFiles::default(),
                     data_plan: prepared_write.insert_plan.clone(),
                     cdc_plan: None,
+                    insert_marker_column: None,
                     diagnostics,
                 });
             };
@@ -470,26 +478,32 @@ pub(super) async fn plan_overwrite_rewrite(
             if analysis.partition_only {
                 return Ok(MatchedFilesRewritePlan {
                     kind: RewriteKind::PartitionOnly,
-                    deletion_timestamp: Some(planned_deletion_timestamp_ms()),
+                    deletion_timestamp: Some(planned_deletion_timestamp_ms()?),
                     matched_existing,
                     data_plan: prepared_write.insert_plan.clone(),
                     cdc_plan: None,
+                    insert_marker_column: None,
                     diagnostics,
                 });
             }
 
-            ensure_internal_write_marker_available(&[
-                &prepared_write.insert_plan,
-                files_scan.scan(),
-            ])?;
+            let insert_marker_column = reserve_internal_write_marker_column(
+                &[&prepared_write.insert_plan, files_scan.scan()],
+                operation_id,
+            );
 
-            let validated_inserts = mark_insert_rows(prepared_write.insert_plan.clone(), true)?;
+            let validated_inserts = mark_insert_rows(
+                prepared_write.insert_plan.clone(),
+                &insert_marker_column,
+                true,
+            )?;
             let rescued_data = mark_insert_rows(
                 LogicalPlanBuilder::new(files_scan.scan().clone())
                     // `IS NOT TRUE` keeps rows where the predicate is FALSE or NULL so nullable
                     // predicate columns are rescued instead of being rewritten.
                     .filter(files_scan.predicate.clone().is_not_true())?
                     .build()?,
+                &insert_marker_column,
                 false,
             )?;
             let rescued_data = align_plan_to_schema(rescued_data, &validated_inserts)?;
@@ -501,7 +515,7 @@ pub(super) async fn plan_overwrite_rewrite(
                 Some(
                     LogicalPlanBuilder::new(files_scan.scan().clone())
                         .filter(files_scan.predicate.clone())?
-                        .with_column(WRITE_INSERT_MARKER_COLUMN, lit(false))?
+                        .with_column(insert_marker_column.as_str(), lit(false))?
                         .with_column(CDC_COLUMN_NAME, lit("delete"))?
                         .build()?,
                 )
@@ -511,10 +525,11 @@ pub(super) async fn plan_overwrite_rewrite(
 
             Ok(MatchedFilesRewritePlan {
                 kind: RewriteKind::DataRescue,
-                deletion_timestamp: Some(planned_deletion_timestamp_ms()),
+                deletion_timestamp: Some(planned_deletion_timestamp_ms()?),
                 matched_existing,
                 data_plan,
                 cdc_plan,
+                insert_marker_column: Some(insert_marker_column),
                 diagnostics,
             })
         }
@@ -524,25 +539,35 @@ pub(super) async fn plan_overwrite_rewrite(
                 matched_file_count: matched_existing.num_files(),
                 ..RewriteDiagnostics::default()
             };
+            let deletion_timestamp = if matched_existing.is_empty() {
+                None
+            } else {
+                Some(planned_deletion_timestamp_ms()?)
+            };
 
             Ok(MatchedFilesRewritePlan {
                 kind: RewriteKind::FullTable,
-                deletion_timestamp: (!matched_existing.is_empty())
-                    .then_some(planned_deletion_timestamp_ms()),
+                deletion_timestamp,
                 matched_existing,
                 data_plan: prepared_write.insert_plan.clone(),
                 cdc_plan: None,
+                insert_marker_column: None,
                 diagnostics,
             })
         }
     }
 }
 
-fn planned_deletion_timestamp_ms() -> i64 {
-    SystemTime::now()
+fn planned_deletion_timestamp_ms() -> DeltaResult<i64> {
+    let duration = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as i64
+        .map_err(|err| {
+            DeltaTableError::generic(format!(
+                "System clock returned a pre-epoch timestamp while planning overwrite deletions: {err}"
+            ))
+        })?;
+    i64::try_from(duration.as_millis())
+        .map_err(|_| DeltaTableError::generic("Overwrite deletion timestamp overflowed i64"))
 }
 
 async fn collect_all_existing_files(
@@ -585,9 +610,28 @@ async fn collect_matched_existing_files(
     Ok(MatchedExistingFiles::new(files))
 }
 
-fn mark_insert_rows(plan: LogicalPlan, is_insert: bool) -> DeltaResult<LogicalPlan> {
+fn reserve_internal_write_marker_column(plans: &[&LogicalPlan], operation_id: Uuid) -> String {
+    let base = format!("{WRITE_INSERT_MARKER_COLUMN}_{operation_id}");
+    let mut candidate = base.clone();
+    let mut suffix = 0usize;
+    while plans.iter().any(|plan| {
+        plan.schema()
+            .iter()
+            .any(|(_, field)| field.name() == &candidate)
+    }) {
+        suffix += 1;
+        candidate = format!("{base}_{suffix}");
+    }
+    candidate
+}
+
+fn mark_insert_rows(
+    plan: LogicalPlan,
+    insert_marker_column: &str,
+    is_insert: bool,
+) -> DeltaResult<LogicalPlan> {
     Ok(LogicalPlanBuilder::new(plan)
-        .with_column(WRITE_INSERT_MARKER_COLUMN, lit(is_insert))?
+        .with_column(insert_marker_column, lit(is_insert))?
         .build()?)
 }
 
@@ -613,20 +657,6 @@ fn align_plan_to_schema(plan: LogicalPlan, target_plan: &LogicalPlan) -> DeltaRe
         .collect::<DeltaResult<Vec<_>>>()?;
 
     Ok(LogicalPlanBuilder::new(plan).project(projection)?.build()?)
-}
-
-fn ensure_internal_write_marker_available(plans: &[&LogicalPlan]) -> DeltaResult<()> {
-    if plans.iter().any(|plan| {
-        plan.schema()
-            .iter()
-            .any(|(_, field)| field.name() == WRITE_INSERT_MARKER_COLUMN)
-    }) {
-        return Err(DeltaTableError::Generic(format!(
-            "Cannot execute overwrite rewrite because input or matched data contains internal write marker column '{WRITE_INSERT_MARKER_COLUMN}'"
-        )));
-    }
-
-    Ok(())
 }
 
 fn build_exec_options(
@@ -736,6 +766,7 @@ mod tests {
     use datafusion::datasource::{MemTable, provider_as_source};
     use datafusion::logical_expr::{LogicalPlanBuilder, UNNAMED_TABLE};
     use datafusion::prelude::{col, lit};
+    use uuid::Uuid;
 
     use crate::DeltaTable;
     use crate::TableProperty;
@@ -757,6 +788,19 @@ mod tests {
         .unwrap()
         .build()
         .unwrap()
+    }
+
+    fn assert_passthrough_overwrite_plan(
+        overwrite_plan: &MatchedFilesRewritePlan,
+        prepared: &PreparedWrite,
+    ) {
+        assert_eq!(overwrite_plan.kind, RewriteKind::Passthrough);
+        assert!(overwrite_plan.matched_existing.is_empty());
+        assert!(overwrite_plan.cdc_plan.is_none());
+        assert_eq!(
+            overwrite_plan.data_plan.schema().as_arrow(),
+            prepared.insert_plan.schema().as_arrow()
+        );
     }
 
     #[tokio::test]
@@ -848,11 +892,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_plan_overwrite_rewrite_passthrough_without_snapshot() {
-        let table = DeltaTable::new_in_memory();
+    async fn test_plan_overwrite_rewrite_passthrough_cases() {
         let session = create_session().state();
         let configuration = HashMap::new();
-        let prepared = prepare_write(WritePreparationInput {
+        let table_without_snapshot = DeltaTable::new_in_memory();
+        let prepared_without_snapshot = prepare_write(WritePreparationInput {
             snapshot: None,
             session: &session,
             source: source_plan_for_batch(get_record_batch(None, false)),
@@ -868,36 +912,28 @@ mod tests {
         })
         .unwrap();
 
-        let overwrite_plan = plan_overwrite_rewrite(
+        let overwrite_plan_without_snapshot = plan_overwrite_rewrite(
             None,
-            &table.log_store(),
+            &table_without_snapshot.log_store(),
             &session,
             SaveMode::Overwrite,
-            &prepared,
+            &prepared_without_snapshot,
+            Uuid::new_v4(),
         )
         .await
         .unwrap();
-
-        assert_eq!(overwrite_plan.kind, RewriteKind::Passthrough);
-        assert!(overwrite_plan.matched_existing.is_empty());
-        assert!(overwrite_plan.cdc_plan.is_none());
-        assert_eq!(
-            overwrite_plan.data_plan.schema().as_arrow(),
-            prepared.insert_plan.schema().as_arrow()
+        assert_passthrough_overwrite_plan(
+            &overwrite_plan_without_snapshot,
+            &prepared_without_snapshot,
         );
-    }
 
-    #[tokio::test]
-    async fn test_plan_overwrite_rewrite_passthrough_for_append_mode() {
-        let table = DeltaTable::new_in_memory()
+        let table_with_snapshot = DeltaTable::new_in_memory()
             .write(vec![get_record_batch(None, false)])
             .await
             .unwrap();
 
-        let session = create_session().state();
-        let configuration = HashMap::new();
-        let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot()),
+        let prepared_append = prepare_write(WritePreparationInput {
+            snapshot: Some(table_with_snapshot.snapshot().unwrap().snapshot()),
             session: &session,
             source: source_plan_for_batch(get_record_batch(None, false)),
             mode: SaveMode::Append,
@@ -912,23 +948,17 @@ mod tests {
         })
         .unwrap();
 
-        let overwrite_plan = plan_overwrite_rewrite(
-            Some(table.snapshot().unwrap().snapshot()),
-            &table.log_store(),
+        let overwrite_plan_append = plan_overwrite_rewrite(
+            Some(table_with_snapshot.snapshot().unwrap().snapshot()),
+            &table_with_snapshot.log_store(),
             &session,
             SaveMode::Append,
-            &prepared,
+            &prepared_append,
+            Uuid::new_v4(),
         )
         .await
         .unwrap();
-
-        assert_eq!(overwrite_plan.kind, RewriteKind::Passthrough);
-        assert!(overwrite_plan.matched_existing.is_empty());
-        assert!(overwrite_plan.cdc_plan.is_none());
-        assert_eq!(
-            overwrite_plan.data_plan.schema().as_arrow(),
-            prepared.insert_plan.schema().as_arrow()
-        );
+        assert_passthrough_overwrite_plan(&overwrite_plan_append, &prepared_append);
     }
 
     #[tokio::test]
@@ -963,6 +993,7 @@ mod tests {
             &session,
             SaveMode::Overwrite,
             &prepared,
+            Uuid::new_v4(),
         )
         .await;
     }
@@ -1008,6 +1039,7 @@ mod tests {
             &session,
             SaveMode::Overwrite,
             &prepared,
+            Uuid::new_v4(),
         )
         .await
         .unwrap();
@@ -1063,16 +1095,17 @@ mod tests {
             &session,
             SaveMode::Overwrite,
             &prepared,
+            Uuid::new_v4(),
         )
         .await
         .unwrap();
 
         assert_eq!(overwrite_plan.kind, RewriteKind::PartitionOnly);
         assert!(overwrite_plan.cdc_plan.is_none());
-        let (sink_plan, contains_cdc, contains_insert_marker) =
+        let (sink_plan, contains_cdc, insert_marker_column) =
             overwrite_plan.build_sink_plan().unwrap();
         assert!(!contains_cdc);
-        assert!(!contains_insert_marker);
+        assert!(insert_marker_column.is_none());
         assert_eq!(
             sink_plan.schema().as_arrow(),
             prepared.insert_plan.schema().as_arrow()
@@ -1128,6 +1161,7 @@ mod tests {
             &session,
             SaveMode::Overwrite,
             &prepared,
+            Uuid::new_v4(),
         )
         .await
         .unwrap();
@@ -1189,6 +1223,7 @@ mod tests {
             &session,
             SaveMode::Overwrite,
             &prepared,
+            Uuid::new_v4(),
         )
         .await
         .unwrap();

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -1,8 +1,8 @@
 //! Write planning has two stages.
 //! `prepare_write` normalizes incoming rows into table shaped insert data and resolves exact
 //! validations against that prepared schema.
-//! `plan_overwrite_rewrite` adjusts the sink plan for overwrite flows and returns any
-//! overwrite side actions the caller must commit before add actions.
+//! `plan_overwrite_rewrite` builds a typed overwrite rewrite plan that keeps matched existing
+//! files, rescue planning, and CDC composition explicit until commit assembly.
 
 use std::collections::HashMap;
 use std::num::NonZeroU64;
@@ -13,32 +13,31 @@ use arrow_schema::Schema;
 use datafusion::catalog::Session;
 use datafusion::common::{Column, ScalarValue};
 use datafusion::logical_expr::{
-    Expr, Extension, LogicalPlan, LogicalPlanBuilder, UNNAMED_TABLE, cast, lit, try_cast,
+    Expr, Extension, LogicalPlan, LogicalPlanBuilder, UNNAMED_TABLE, cast, lit, try_cast, when,
 };
 use datafusion::prelude::col;
 use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
 use futures::TryStreamExt as _;
 use itertools::Itertools as _;
 use parquet::file::properties::WriterProperties;
-use uuid::Uuid;
 
 use super::SchemaMode;
 use super::configs::WriterStatsConfig;
-use super::execution::prepare_predicate_actions;
 use super::generated_columns::{gc_is_enabled, with_generated_columns};
 use super::metrics::SOURCE_COUNT_ID;
 use super::schema_evolution::try_cast_schema;
-use crate::delta_datafusion::DataFusionMixins;
-use crate::delta_datafusion::Expression;
-use crate::delta_datafusion::logical::MetricObserver;
-use crate::errors::DeltaResult;
+use crate::delta_datafusion::logical::{LogicalPlanBuilderExt as _, MetricObserver};
+use crate::delta_datafusion::{
+    DataFusionMixins, Expression, analyze_predicate_for_find_files, scan_files_where_matches,
+};
+use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::schema::cast::{merge_arrow_schema, normalize_for_delta};
 use crate::kernel::{
-    Action, EagerSnapshot, MetadataExt as _, ProtocolExt as _, StructType, StructTypeExt,
-    new_metadata,
+    Action, Add, DeletionVectorDescriptor, EagerSnapshot, MetadataExt as _, ProtocolExt as _,
+    Remove, StructType, StructTypeExt, new_metadata,
 };
 use crate::logstore::LogStoreRef;
-use crate::operations::cdc::CDC_COLUMN_NAME;
+use crate::operations::cdc::{CDC_COLUMN_NAME, should_write_cdc};
 use crate::operations::{get_num_idx_cols_and_stats_columns, get_target_file_size};
 use crate::protocol::SaveMode;
 
@@ -101,27 +100,160 @@ pub(super) struct WritePreparationInput<'a> {
     pub(super) configuration: &'a HashMap<String, Option<String>>,
 }
 
-/// Planner output for overwrite flows before the sink materializes new files.
-pub(super) struct OverwritePlan {
-    pub(super) sink_plan: LogicalPlan,
-    pub(super) actions: Vec<Action>,
-    pub(super) contains_cdc: bool,
+pub(super) const WRITE_INSERT_MARKER_COLUMN: &str = "__delta_rs_write_insert";
+
+/// High-level rewrite strategy chosen for an overwrite flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RewriteKind {
+    Passthrough,
+    NoMatch,
+    FullTable,
+    PartitionOnly,
+    DataRescue,
 }
 
-impl OverwritePlan {
+/// Planner diagnostics for overwrite / replaceWhere rewrites.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct RewriteDiagnostics {
+    pub(super) matched_file_count: usize,
+    pub(super) translated_pruning_term_count: usize,
+    pub(super) dropped_pruning_term_count: usize,
+}
+
+/// A matched existing file kept as a typed removal candidate until commit assembly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MatchedExistingFile {
+    path: String,
+    partition_values: HashMap<String, Option<String>>,
+    size: i64,
+    deletion_vector: Option<DeletionVectorDescriptor>,
+    base_row_id: Option<i64>,
+    default_row_commit_version: Option<i64>,
+}
+
+impl From<Add> for MatchedExistingFile {
+    fn from(add: Add) -> Self {
+        Self {
+            path: add.path,
+            partition_values: add.partition_values,
+            size: add.size,
+            deletion_vector: add.deletion_vector,
+            base_row_id: add.base_row_id,
+            default_row_commit_version: add.default_row_commit_version,
+        }
+    }
+}
+
+impl MatchedExistingFile {
+    fn into_remove(self, deletion_timestamp: i64) -> Remove {
+        Remove {
+            path: self.path,
+            deletion_timestamp: Some(deletion_timestamp),
+            data_change: true,
+            extended_file_metadata: Some(true),
+            partition_values: Some(self.partition_values),
+            size: Some(self.size),
+            deletion_vector: self.deletion_vector,
+            tags: None,
+            base_row_id: self.base_row_id,
+            default_row_commit_version: self.default_row_commit_version,
+        }
+    }
+}
+
+/// The typed set of files that this overwrite will remove if the sink succeeds.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct MatchedExistingFiles {
+    files: Vec<MatchedExistingFile>,
+}
+
+impl MatchedExistingFiles {
+    fn new(files: Vec<MatchedExistingFile>) -> Self {
+        Self { files }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    pub(super) fn num_files(&self) -> usize {
+        self.files.len()
+    }
+
+    pub(super) fn into_actions(self, deletion_timestamp: Option<i64>) -> DeltaResult<Vec<Action>> {
+        if self.files.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let deletion_timestamp = deletion_timestamp.ok_or_else(|| {
+            DeltaTableError::generic(
+                "Matched existing files are missing a planner-owned deletion timestamp",
+            )
+        })?;
+
+        Ok(self
+            .files
+            .into_iter()
+            .map(|file| Action::Remove(file.into_remove(deletion_timestamp)))
+            .collect())
+    }
+}
+
+/// Planner output for overwrite flows before the sink materializes new files.
+pub(super) struct MatchedFilesRewritePlan {
+    pub(super) kind: RewriteKind,
+    pub(super) deletion_timestamp: Option<i64>,
+    pub(super) matched_existing: MatchedExistingFiles,
+    pub(super) data_plan: LogicalPlan,
+    pub(super) cdc_plan: Option<LogicalPlan>,
+    pub(super) diagnostics: RewriteDiagnostics,
+}
+
+impl MatchedFilesRewritePlan {
     fn passthrough(insert_plan: LogicalPlan) -> Self {
         Self {
-            sink_plan: insert_plan,
-            actions: Vec::new(),
-            contains_cdc: false,
+            kind: RewriteKind::Passthrough,
+            deletion_timestamp: None,
+            matched_existing: MatchedExistingFiles::default(),
+            data_plan: insert_plan,
+            cdc_plan: None,
+            diagnostics: RewriteDiagnostics::default(),
         }
     }
 
     pub(super) fn num_removed_files(&self) -> usize {
-        self.actions
-            .iter()
-            .filter(|action| matches!(action, Action::Remove(_)))
-            .count()
+        self.matched_existing.num_files()
+    }
+
+    pub(super) fn build_sink_plan(&self) -> DeltaResult<(LogicalPlan, bool, bool)> {
+        let contains_insert_marker = matches!(self.kind, RewriteKind::DataRescue);
+        let data_plan = if self.cdc_plan.is_some() {
+            // Empty-string rows are rescued table data: they must bypass CDF output while still
+            // flowing through the normal parquet write path.
+            LogicalPlanBuilder::new(self.data_plan.clone())
+                .with_column(
+                    CDC_COLUMN_NAME,
+                    when(col(WRITE_INSERT_MARKER_COLUMN).eq(lit(true)), lit("insert"))
+                        .otherwise(lit(""))?,
+                )?
+                .build()?
+        } else {
+            self.data_plan.clone()
+        };
+
+        match self.cdc_plan.clone() {
+            Some(cdc_plan) => {
+                let cdc_plan = align_plan_to_schema(cdc_plan, &data_plan)?;
+                Ok((
+                    LogicalPlanBuilder::new(data_plan)
+                        .union(cdc_plan)?
+                        .build()?,
+                    true,
+                    contains_insert_marker,
+                ))
+            }
+            None => Ok((data_plan, false, contains_insert_marker)),
+        }
     }
 }
 
@@ -282,10 +414,9 @@ pub(super) async fn plan_overwrite_rewrite(
     session: &dyn Session,
     mode: SaveMode,
     prepared_write: &PreparedWrite,
-    operation_id: Uuid,
-) -> DeltaResult<OverwritePlan> {
+) -> DeltaResult<MatchedFilesRewritePlan> {
     let Some(snapshot) = snapshot else {
-        return Ok(OverwritePlan::passthrough(
+        return Ok(MatchedFilesRewritePlan::passthrough(
             prepared_write.insert_plan.clone(),
         ));
     };
@@ -296,66 +427,206 @@ pub(super) async fn plan_overwrite_rewrite(
     );
 
     if !matches!(prepared_write.mode, SaveMode::Overwrite) {
-        return Ok(OverwritePlan::passthrough(
+        return Ok(MatchedFilesRewritePlan::passthrough(
             prepared_write.insert_plan.clone(),
         ));
     }
 
-    let mut sink_plan = prepared_write.insert_plan.clone();
-    let mut actions = Vec::new();
-    let mut contains_cdc = false;
-
     match prepared_write.exact_validation.clone() {
         Some(predicate) => {
-            let deletion_timestamp = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as i64;
+            let analysis = analyze_predicate_for_find_files(
+                predicate.clone(),
+                &prepared_write.exec_options.partition_columns,
+            )?;
+            let mut diagnostics = RewriteDiagnostics {
+                matched_file_count: 0,
+                translated_pruning_term_count: analysis.translated_pruning_term_count,
+                dropped_pruning_term_count: analysis.dropped_pruning_term_count,
+            };
 
-            let (predicate_actions, cdf_df) = prepare_predicate_actions(
-                predicate,
-                log_store.clone(),
-                snapshot,
-                session,
-                prepared_write.exec_options.partition_columns.clone(),
-                prepared_write.exec_options.writer_properties.clone(),
-                deletion_timestamp,
-                prepared_write.exec_options.writer_stats_config.clone(),
-                operation_id,
-            )
-            .await?;
+            let Some(files_scan) =
+                scan_files_where_matches(session, snapshot, log_store.clone(), predicate).await?
+            else {
+                return Ok(MatchedFilesRewritePlan {
+                    kind: RewriteKind::NoMatch,
+                    deletion_timestamp: None,
+                    matched_existing: MatchedExistingFiles::default(),
+                    data_plan: prepared_write.insert_plan.clone(),
+                    cdc_plan: None,
+                    diagnostics,
+                });
+            };
 
-            if let Some(cdf_df) = cdf_df {
-                contains_cdc = true;
-                let mut projection = sink_plan
-                    .schema()
-                    .iter()
-                    .map(|(_, field)| col(field.name()))
-                    .collect_vec();
-                projection.push(lit("insert").alias(CDC_COLUMN_NAME));
-                sink_plan = LogicalPlanBuilder::new(sink_plan)
-                    .project(projection)?
-                    .union(cdf_df)?
-                    .build()?;
+            let matched_existing =
+                collect_matched_existing_files(snapshot, log_store, &files_scan).await?;
+            diagnostics.matched_file_count = matched_existing.num_files();
+
+            if matched_existing.is_empty() {
+                return Err(DeltaTableError::Generic(
+                    "Matched-file scan returned rows but no existing files to rewrite".into(),
+                ));
             }
 
-            actions.extend(predicate_actions);
+            if analysis.partition_only {
+                return Ok(MatchedFilesRewritePlan {
+                    kind: RewriteKind::PartitionOnly,
+                    deletion_timestamp: Some(planned_deletion_timestamp_ms()),
+                    matched_existing,
+                    data_plan: prepared_write.insert_plan.clone(),
+                    cdc_plan: None,
+                    diagnostics,
+                });
+            }
+
+            ensure_internal_write_marker_available(&[
+                &prepared_write.insert_plan,
+                files_scan.scan(),
+            ])?;
+
+            let validated_inserts = mark_insert_rows(prepared_write.insert_plan.clone(), true)?;
+            let rescued_data = mark_insert_rows(
+                LogicalPlanBuilder::new(files_scan.scan().clone())
+                    // `IS NOT TRUE` keeps rows where the predicate is FALSE or NULL so nullable
+                    // predicate columns are rescued instead of being rewritten.
+                    .filter(files_scan.predicate.clone().is_not_true())?
+                    .build()?,
+                false,
+            )?;
+            let rescued_data = align_plan_to_schema(rescued_data, &validated_inserts)?;
+            let data_plan = LogicalPlanBuilder::new(validated_inserts)
+                .union(rescued_data)?
+                .build()?;
+
+            let cdc_plan = if should_write_cdc(snapshot)? {
+                Some(
+                    LogicalPlanBuilder::new(files_scan.scan().clone())
+                        .filter(files_scan.predicate.clone())?
+                        .with_column(WRITE_INSERT_MARKER_COLUMN, lit(false))?
+                        .with_column(CDC_COLUMN_NAME, lit("delete"))?
+                        .build()?,
+                )
+            } else {
+                None
+            };
+
+            Ok(MatchedFilesRewritePlan {
+                kind: RewriteKind::DataRescue,
+                deletion_timestamp: Some(planned_deletion_timestamp_ms()),
+                matched_existing,
+                data_plan,
+                cdc_plan,
+                diagnostics,
+            })
         }
         None => {
-            let remove_actions = snapshot
-                .file_views(log_store, None)
-                .map_ok(|file| file.remove_action(true).into())
-                .try_collect::<Vec<_>>()
-                .await?;
-            actions.extend(remove_actions);
+            let matched_existing = collect_all_existing_files(snapshot, log_store).await?;
+            let diagnostics = RewriteDiagnostics {
+                matched_file_count: matched_existing.num_files(),
+                ..RewriteDiagnostics::default()
+            };
+
+            Ok(MatchedFilesRewritePlan {
+                kind: RewriteKind::FullTable,
+                deletion_timestamp: (!matched_existing.is_empty())
+                    .then_some(planned_deletion_timestamp_ms()),
+                matched_existing,
+                data_plan: prepared_write.insert_plan.clone(),
+                cdc_plan: None,
+                diagnostics,
+            })
         }
     }
+}
 
-    Ok(OverwritePlan {
-        sink_plan,
-        actions,
-        contains_cdc,
-    })
+fn planned_deletion_timestamp_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64
+}
+
+async fn collect_all_existing_files(
+    snapshot: &EagerSnapshot,
+    log_store: &LogStoreRef,
+) -> DeltaResult<MatchedExistingFiles> {
+    Ok(MatchedExistingFiles::new(
+        snapshot
+            .file_views(log_store.as_ref(), None)
+            .map_ok(|file| MatchedExistingFile::from(file.to_add()))
+            .try_collect()
+            .await?,
+    ))
+}
+
+async fn collect_matched_existing_files(
+    snapshot: &EagerSnapshot,
+    log_store: &LogStoreRef,
+    files_scan: &crate::delta_datafusion::MatchedFilesScan,
+) -> DeltaResult<MatchedExistingFiles> {
+    let table_root = Arc::new(snapshot.table_configuration().table_root().clone());
+    let valid_files = Arc::new(files_scan.files_set());
+    let files = snapshot
+        .file_views(log_store.as_ref(), Some(files_scan.delta_predicate.clone()))
+        .try_filter_map(|file| {
+            let table_root = Arc::clone(&table_root);
+            let valid_files = Arc::clone(&valid_files);
+            async move {
+                let file_url = table_root
+                    .join(file.path_raw())
+                    .map_err(|err| DeltaTableError::Generic(format!("{err}")))?;
+                Ok(valid_files
+                    .contains(file_url.as_ref())
+                    .then(|| MatchedExistingFile::from(file.to_add())))
+            }
+        })
+        .try_collect()
+        .await?;
+
+    Ok(MatchedExistingFiles::new(files))
+}
+
+fn mark_insert_rows(plan: LogicalPlan, is_insert: bool) -> DeltaResult<LogicalPlan> {
+    Ok(LogicalPlanBuilder::new(plan)
+        .with_column(WRITE_INSERT_MARKER_COLUMN, lit(is_insert))?
+        .build()?)
+}
+
+fn align_plan_to_schema(plan: LogicalPlan, target_plan: &LogicalPlan) -> DeltaResult<LogicalPlan> {
+    let source_schema = plan.schema();
+    let target_schema = target_plan.schema();
+    let projection = target_schema
+        .fields()
+        .iter()
+        .map(|target_field| {
+            let name = target_field.name();
+            let expr = match source_schema.field_with_unqualified_name(name) {
+                Ok(source_field) if source_field.data_type() != target_field.data_type() => {
+                    cast(col(name), target_field.data_type().clone()).alias(name)
+                }
+                Ok(_) => col(name).alias(name),
+                Err(_) => {
+                    cast(lit(ScalarValue::Null), target_field.data_type().clone()).alias(name)
+                }
+            };
+            Ok(expr)
+        })
+        .collect::<DeltaResult<Vec<_>>>()?;
+
+    Ok(LogicalPlanBuilder::new(plan).project(projection)?.build()?)
+}
+
+fn ensure_internal_write_marker_available(plans: &[&LogicalPlan]) -> DeltaResult<()> {
+    if plans.iter().any(|plan| {
+        plan.schema()
+            .iter()
+            .any(|(_, field)| field.name() == WRITE_INSERT_MARKER_COLUMN)
+    }) {
+        return Err(DeltaTableError::Generic(format!(
+            "Cannot execute overwrite rewrite because input or matched data contains internal write marker column '{WRITE_INSERT_MARKER_COLUMN}'"
+        )));
+    }
+
+    Ok(())
 }
 
 fn build_exec_options(
@@ -465,11 +736,11 @@ mod tests {
     use datafusion::datasource::{MemTable, provider_as_source};
     use datafusion::logical_expr::{LogicalPlanBuilder, UNNAMED_TABLE};
     use datafusion::prelude::{col, lit};
-    use uuid::Uuid;
 
     use crate::DeltaTable;
     use crate::TableProperty;
     use crate::delta_datafusion::create_session;
+    use crate::operations::cdc::CDC_COLUMN_NAME;
     use crate::protocol::SaveMode;
     use crate::writer::test_utils::{
         get_arrow_schema, get_record_batch, setup_table_with_configuration,
@@ -603,15 +874,15 @@ mod tests {
             &session,
             SaveMode::Overwrite,
             &prepared,
-            Uuid::new_v4(),
         )
         .await
         .unwrap();
 
-        assert!(overwrite_plan.actions.is_empty());
-        assert!(!overwrite_plan.contains_cdc);
+        assert_eq!(overwrite_plan.kind, RewriteKind::Passthrough);
+        assert!(overwrite_plan.matched_existing.is_empty());
+        assert!(overwrite_plan.cdc_plan.is_none());
         assert_eq!(
-            overwrite_plan.sink_plan.schema().as_arrow(),
+            overwrite_plan.data_plan.schema().as_arrow(),
             prepared.insert_plan.schema().as_arrow()
         );
     }
@@ -647,15 +918,15 @@ mod tests {
             &session,
             SaveMode::Append,
             &prepared,
-            Uuid::new_v4(),
         )
         .await
         .unwrap();
 
-        assert!(overwrite_plan.actions.is_empty());
-        assert!(!overwrite_plan.contains_cdc);
+        assert_eq!(overwrite_plan.kind, RewriteKind::Passthrough);
+        assert!(overwrite_plan.matched_existing.is_empty());
+        assert!(overwrite_plan.cdc_plan.is_none());
         assert_eq!(
-            overwrite_plan.sink_plan.schema().as_arrow(),
+            overwrite_plan.data_plan.schema().as_arrow(),
             prepared.insert_plan.schema().as_arrow()
         );
     }
@@ -692,7 +963,6 @@ mod tests {
             &session,
             SaveMode::Overwrite,
             &prepared,
-            Uuid::new_v4(),
         )
         .await;
     }
@@ -738,21 +1008,87 @@ mod tests {
             &session,
             SaveMode::Overwrite,
             &prepared,
-            Uuid::new_v4(),
         )
         .await
         .unwrap();
 
-        assert!(overwrite_plan.actions.is_empty());
-        assert!(!overwrite_plan.contains_cdc);
+        assert_eq!(overwrite_plan.kind, RewriteKind::NoMatch);
+        assert!(overwrite_plan.matched_existing.is_empty());
+        assert!(overwrite_plan.cdc_plan.is_none());
         assert_eq!(
-            overwrite_plan.sink_plan.schema().as_arrow(),
+            overwrite_plan.data_plan.schema().as_arrow(),
             prepared.insert_plan.schema().as_arrow()
         );
     }
 
     #[tokio::test]
-    async fn test_plan_overwrite_rewrite_full_overwrite_collects_remove_actions() {
+    async fn test_plan_overwrite_rewrite_partition_only_avoids_rescue_scan() {
+        let table = DeltaTable::new_in_memory()
+            .write(vec![get_record_batch(None, false)])
+            .with_partition_columns(["id"])
+            .await
+            .unwrap();
+
+        let batch = RecordBatch::try_new(
+            get_arrow_schema(&None),
+            vec![
+                Arc::new(StringArray::from(vec![Some("A")])),
+                Arc::new(Int32Array::from(vec![Some(999)])),
+                Arc::new(StringArray::from(vec![Some("2026-04-16")])),
+            ],
+        )
+        .unwrap();
+
+        let session = create_session().state();
+        let configuration = HashMap::new();
+        let prepared = prepare_write(WritePreparationInput {
+            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            session: &session,
+            source: source_plan_for_batch(batch),
+            mode: SaveMode::Overwrite,
+            schema_mode: None,
+            safe_cast: false,
+            partition_columns: vec!["id".to_string()],
+            predicate: Some(col("id").eq(lit("A")).into()),
+            target_file_size: None,
+            write_batch_size: None,
+            writer_properties: None,
+            configuration: &configuration,
+        })
+        .unwrap();
+
+        let overwrite_plan = plan_overwrite_rewrite(
+            Some(table.snapshot().unwrap().snapshot()),
+            &table.log_store(),
+            &session,
+            SaveMode::Overwrite,
+            &prepared,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(overwrite_plan.kind, RewriteKind::PartitionOnly);
+        assert!(overwrite_plan.cdc_plan.is_none());
+        let (sink_plan, contains_cdc, contains_insert_marker) =
+            overwrite_plan.build_sink_plan().unwrap();
+        assert!(!contains_cdc);
+        assert!(!contains_insert_marker);
+        assert_eq!(
+            sink_plan.schema().as_arrow(),
+            prepared.insert_plan.schema().as_arrow()
+        );
+        assert!(
+            sink_plan
+                .schema()
+                .iter()
+                .all(|(_, field)| field.name() != CDC_COLUMN_NAME
+                    && field.name() != WRITE_INSERT_MARKER_COLUMN)
+        );
+        assert!(overwrite_plan.matched_existing.num_files() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_plan_overwrite_rewrite_full_overwrite_collects_matched_existing_files() {
         let table = DeltaTable::new_in_memory()
             .write(vec![get_record_batch(None, false)])
             .await
@@ -792,17 +1128,21 @@ mod tests {
             &session,
             SaveMode::Overwrite,
             &prepared,
-            Uuid::new_v4(),
         )
         .await
         .unwrap();
 
-        assert!(!overwrite_plan.contains_cdc);
+        assert_eq!(overwrite_plan.kind, RewriteKind::FullTable);
+        assert!(overwrite_plan.cdc_plan.is_none());
+        assert!(overwrite_plan.deletion_timestamp.is_some());
         assert!(
             overwrite_plan
-                .actions
-                .iter()
-                .any(|action| matches!(action, Action::Remove(_)))
+                .matched_existing
+                .clone()
+                .into_actions(Some(1_713_398_400_000))
+                .unwrap()
+                .into_iter()
+                .all(|action| matches!(action, Action::Remove(_)))
         );
     }
 
@@ -849,18 +1189,19 @@ mod tests {
             &session,
             SaveMode::Overwrite,
             &prepared,
-            Uuid::new_v4(),
         )
         .await
         .unwrap();
 
-        assert!(overwrite_plan.contains_cdc);
+        assert_eq!(overwrite_plan.kind, RewriteKind::DataRescue);
+        assert!(overwrite_plan.matched_existing.num_files() > 0);
+        assert!(overwrite_plan.cdc_plan.is_some());
         assert!(
             overwrite_plan
-                .sink_plan
+                .data_plan
                 .schema()
                 .iter()
-                .any(|(_, field)| field.name() == CDC_COLUMN_NAME)
+                .all(|(_, field)| field.name() != CDC_COLUMN_NAME)
         );
     }
 }

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -1,0 +1,906 @@
+//! Write planning is split into two stages:
+//! - `prepare_write` normalizes incoming rows into table-shaped insert data and resolves exact
+//!   validations against that prepared schema.
+//! - `plan_overwrite_rewrite` adjusts the sink plan for overwrite flows and returns any
+//!   overwrite-side actions the caller must commit before add actions.
+
+use std::collections::HashMap;
+use std::num::NonZeroU64;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use arrow_schema::Schema;
+use datafusion::catalog::Session;
+use datafusion::common::{Column, ScalarValue};
+use datafusion::logical_expr::utils::conjunction;
+use datafusion::logical_expr::{
+    Expr, Extension, LogicalPlan, LogicalPlanBuilder, UNNAMED_TABLE, cast, lit, try_cast,
+};
+use datafusion::prelude::col;
+use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
+use futures::TryStreamExt as _;
+use itertools::Itertools as _;
+use parquet::file::properties::WriterProperties;
+use uuid::Uuid;
+
+use super::SchemaMode;
+use super::configs::WriterStatsConfig;
+use super::execution::prepare_predicate_actions;
+use super::generated_columns::{gc_is_enabled, with_generated_columns};
+use super::metrics::SOURCE_COUNT_ID;
+use super::schema_evolution::try_cast_schema;
+use crate::delta_datafusion::DataFusionMixins;
+use crate::delta_datafusion::Expression;
+use crate::delta_datafusion::expr::fmt_expr_to_sql;
+use crate::delta_datafusion::logical::MetricObserver;
+use crate::errors::DeltaResult;
+use crate::kernel::schema::cast::{merge_arrow_schema, normalize_for_delta};
+use crate::kernel::{
+    Action, EagerSnapshot, MetadataExt as _, ProtocolExt as _, StructType, StructTypeExt,
+    new_metadata,
+};
+use crate::logstore::LogStoreRef;
+use crate::operations::cdc::CDC_COLUMN_NAME;
+use crate::operations::{get_num_idx_cols_and_stats_columns, get_target_file_size};
+use crate::protocol::SaveMode;
+
+/// Schema and protocol actions required before the sink executes the write.
+#[derive(Clone, Default)]
+pub(crate) struct SchemaDelta {
+    metadata: Option<Action>,
+    protocol: Option<Action>,
+}
+
+impl SchemaDelta {
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.metadata.is_none() && self.protocol.is_none()
+    }
+
+    pub(crate) fn actions(&self) -> Vec<Action> {
+        let mut actions = Vec::with_capacity(2);
+        if let Some(metadata) = &self.metadata {
+            actions.push(metadata.clone());
+        }
+        if let Some(protocol) = &self.protocol {
+            actions.push(protocol.clone());
+        }
+        actions
+    }
+}
+
+/// Sink-only knobs that must survive planning unchanged.
+#[derive(Clone)]
+pub(crate) struct WriteExecOptions {
+    pub partition_columns: Vec<String>,
+    pub target_file_size: Option<NonZeroU64>,
+    pub write_batch_size: Option<usize>,
+    pub writer_properties: Option<WriterProperties>,
+    pub writer_stats_config: WriterStatsConfig,
+}
+
+/// Prepared insert input plus the exact validations the sink must enforce.
+pub(crate) struct PreparedWrite {
+    pub insert_plan: LogicalPlan,
+    pub schema_delta: SchemaDelta,
+    pub exact_validations: Vec<Expr>,
+    pub predicate_sql: Option<String>,
+    pub exec_options: WriteExecOptions,
+}
+
+impl PreparedWrite {
+    pub(crate) fn exact_validation_predicate(&self) -> Option<Expr> {
+        conjunction(self.exact_validations.clone())
+    }
+}
+
+/// Inputs required to normalize source rows into table-shaped insert data.
+pub(crate) struct WritePreparationInput<'a> {
+    pub snapshot: Option<&'a EagerSnapshot>,
+    pub session: &'a dyn Session,
+    pub source: LogicalPlan,
+    pub mode: SaveMode,
+    pub schema_mode: Option<SchemaMode>,
+    pub safe_cast: bool,
+    pub partition_columns: Vec<String>,
+    pub predicate: Option<Expression>,
+    pub target_file_size: Option<Option<NonZeroU64>>,
+    pub write_batch_size: Option<usize>,
+    pub writer_properties: Option<WriterProperties>,
+    pub configuration: &'a HashMap<String, Option<String>>,
+}
+
+/// Planner output for overwrite flows before the sink materializes new files.
+pub(crate) struct OverwritePlan {
+    pub sink_plan: LogicalPlan,
+    pub actions: Vec<Action>,
+    pub contains_cdc: bool,
+}
+
+impl OverwritePlan {
+    fn passthrough(insert_plan: LogicalPlan) -> Self {
+        Self {
+            sink_plan: insert_plan,
+            actions: Vec::new(),
+            contains_cdc: false,
+        }
+    }
+
+    pub(crate) fn num_removed_files(&self) -> usize {
+        self.actions
+            .iter()
+            .filter(|action| matches!(action, Action::Remove(_)))
+            .count()
+    }
+}
+
+pub(crate) fn prepare_write(input: WritePreparationInput<'_>) -> DeltaResult<PreparedWrite> {
+    let WritePreparationInput {
+        snapshot,
+        session,
+        mut source,
+        mode,
+        schema_mode,
+        safe_cast,
+        partition_columns,
+        predicate,
+        target_file_size,
+        write_batch_size,
+        writer_properties,
+        configuration,
+    } = input;
+
+    let mut schema_drift = false;
+
+    let table_schema = if let Some(snapshot) = snapshot {
+        snapshot.arrow_schema()
+    } else {
+        normalize_for_delta(source.schema().inner())
+    };
+
+    if let Some(snapshot) = snapshot
+        && gc_is_enabled(snapshot)
+    {
+        source = with_generated_columns(
+            session,
+            source,
+            &table_schema,
+            &snapshot.schema().get_generated_columns()?,
+        )?;
+    }
+
+    let source_schema: Arc<Schema> = normalize_for_delta(source.schema().inner());
+    if !Arc::ptr_eq(&source_schema, source.schema().inner()) {
+        let original_schema = source.schema().inner();
+        let cast_projection = source_schema
+            .fields()
+            .iter()
+            .zip(original_schema.fields().iter())
+            .map(|(target, original)| {
+                if target.data_type() != original.data_type() {
+                    let cast_fn = if safe_cast { try_cast } else { cast };
+                    cast_fn(
+                        Expr::Column(Column::from_name(target.name())),
+                        target.data_type().clone(),
+                    )
+                    .alias(target.name())
+                } else {
+                    Expr::Column(Column::from_name(target.name()))
+                }
+            })
+            .collect_vec();
+        source = LogicalPlanBuilder::new(source)
+            .project(cast_projection)?
+            .build()?;
+    }
+
+    let mut new_schema = None;
+    if let Some(snapshot) = snapshot {
+        let table_schema = snapshot.input_schema();
+
+        if let Err(schema_err) = try_cast_schema(source_schema.fields(), table_schema.fields()) {
+            schema_drift = true;
+            if mode == SaveMode::Overwrite && schema_mode == Some(SchemaMode::Overwrite) {
+                new_schema = None;
+            } else if schema_mode == Some(SchemaMode::Merge) {
+                new_schema = Some(merge_arrow_schema(
+                    table_schema.clone(),
+                    source_schema.clone(),
+                    schema_drift,
+                )?);
+            } else {
+                return Err(schema_err.into());
+            }
+        } else if mode == SaveMode::Overwrite && schema_mode == Some(SchemaMode::Overwrite) {
+            new_schema = None;
+        } else {
+            new_schema = Some(merge_arrow_schema(
+                table_schema.clone(),
+                source_schema.clone(),
+                schema_drift,
+            )?);
+        }
+    }
+
+    if let Some(new_schema) = new_schema.as_ref() {
+        let mut schema_evolution_projection = Vec::with_capacity(new_schema.fields().len());
+        for field in new_schema.fields() {
+            if source_schema.index_of(field.name()).is_ok() {
+                let cast_fn = if safe_cast { try_cast } else { cast };
+                schema_evolution_projection.push(
+                    cast_fn(
+                        Expr::Column(Column::from_name(field.name())),
+                        field.data_type().clone(),
+                    )
+                    .alias(field.name()),
+                );
+            } else {
+                schema_evolution_projection.push(
+                    cast(
+                        lit(ScalarValue::Null).alias(field.name()),
+                        field.data_type().clone(),
+                    )
+                    .alias(field.name()),
+                );
+            }
+        }
+        source = LogicalPlanBuilder::new(source)
+            .project(schema_evolution_projection)?
+            .build()?;
+    }
+
+    let insert_plan = LogicalPlan::Extension(Extension {
+        node: Arc::new(MetricObserver {
+            id: SOURCE_COUNT_ID.into(),
+            input: source,
+            enable_pushdown: false,
+        }),
+    });
+
+    let schema_delta = schema_delta_for_prepared_source(
+        snapshot,
+        &insert_plan,
+        &partition_columns,
+        mode,
+        schema_mode,
+        schema_drift,
+        new_schema.as_deref(),
+    )?;
+
+    let exact_validations = resolve_exact_validations(session, &insert_plan, predicate)?;
+    let predicate_sql = exact_validations.first().map(fmt_expr_to_sql).transpose()?;
+
+    Ok(PreparedWrite {
+        insert_plan,
+        schema_delta,
+        exact_validations,
+        predicate_sql,
+        exec_options: build_exec_options(
+            snapshot,
+            partition_columns,
+            target_file_size,
+            write_batch_size,
+            writer_properties,
+            configuration,
+        ),
+    })
+}
+
+pub(crate) async fn plan_overwrite_rewrite(
+    snapshot: Option<&EagerSnapshot>,
+    log_store: &LogStoreRef,
+    session: &dyn Session,
+    mode: SaveMode,
+    prepared_write: &PreparedWrite,
+    operation_id: Uuid,
+) -> DeltaResult<OverwritePlan> {
+    let Some(snapshot) = snapshot else {
+        return Ok(OverwritePlan::passthrough(
+            prepared_write.insert_plan.clone(),
+        ));
+    };
+
+    if !matches!(mode, SaveMode::Overwrite) {
+        return Ok(OverwritePlan::passthrough(
+            prepared_write.insert_plan.clone(),
+        ));
+    }
+
+    let mut sink_plan = prepared_write.insert_plan.clone();
+    let mut actions = Vec::new();
+    let mut contains_cdc = false;
+
+    match prepared_write.exact_validation_predicate() {
+        Some(predicate) => {
+            let deletion_timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as i64;
+
+            let (predicate_actions, cdf_df) = prepare_predicate_actions(
+                predicate,
+                log_store.clone(),
+                snapshot,
+                session,
+                prepared_write.exec_options.partition_columns.clone(),
+                prepared_write.exec_options.writer_properties.clone(),
+                deletion_timestamp,
+                prepared_write.exec_options.writer_stats_config.clone(),
+                operation_id,
+            )
+            .await?;
+
+            if let Some(cdf_df) = cdf_df {
+                contains_cdc = true;
+                let mut projection = sink_plan
+                    .schema()
+                    .iter()
+                    .map(|(_, field)| col(field.name()))
+                    .collect_vec();
+                projection.push(lit("insert").alias(CDC_COLUMN_NAME));
+                sink_plan = LogicalPlanBuilder::new(sink_plan)
+                    .project(projection)?
+                    .union(cdf_df)?
+                    .build()?;
+            }
+
+            actions.extend(predicate_actions);
+        }
+        None => {
+            let remove_actions = snapshot
+                .file_views(log_store, None)
+                .map_ok(|file| file.remove_action(true).into())
+                .try_collect::<Vec<_>>()
+                .await?;
+            actions.extend(remove_actions);
+        }
+    }
+
+    Ok(OverwritePlan {
+        sink_plan,
+        actions,
+        contains_cdc,
+    })
+}
+
+fn build_exec_options(
+    snapshot: Option<&EagerSnapshot>,
+    partition_columns: Vec<String>,
+    target_file_size: Option<Option<NonZeroU64>>,
+    write_batch_size: Option<usize>,
+    writer_properties: Option<WriterProperties>,
+    configuration: &HashMap<String, Option<String>>,
+) -> WriteExecOptions {
+    let config = snapshot.map(|snapshot| snapshot.table_properties());
+    let target_file_size =
+        target_file_size.unwrap_or_else(|| Some(get_target_file_size(config, configuration)));
+    let (num_indexed_cols, stats_columns) =
+        get_num_idx_cols_and_stats_columns(config, configuration.clone());
+
+    WriteExecOptions {
+        partition_columns,
+        target_file_size,
+        write_batch_size,
+        writer_properties,
+        writer_stats_config: WriterStatsConfig {
+            num_indexed_cols,
+            stats_columns,
+        },
+    }
+}
+
+fn resolve_exact_validations(
+    session: &dyn Session,
+    insert_plan: &LogicalPlan,
+    predicate: Option<Expression>,
+) -> DeltaResult<Vec<Expr>> {
+    let df_schema = insert_plan
+        .schema()
+        .as_ref()
+        .clone()
+        .replace_qualifier(UNNAMED_TABLE);
+    Ok(predicate
+        .map(|predicate| predicate.resolve(session, Arc::new(df_schema)))
+        .transpose()?
+        .into_iter()
+        .collect())
+}
+
+fn schema_delta_for_prepared_source(
+    snapshot: Option<&EagerSnapshot>,
+    insert_plan: &LogicalPlan,
+    partition_columns: &[String],
+    mode: SaveMode,
+    schema_mode: Option<SchemaMode>,
+    schema_drift: bool,
+    new_schema: Option<&Schema>,
+) -> DeltaResult<SchemaDelta> {
+    let Some(snapshot) = snapshot else {
+        return Ok(SchemaDelta::default());
+    };
+
+    let should_update_schema = match schema_mode {
+        Some(SchemaMode::Merge) if schema_drift => true,
+        Some(SchemaMode::Overwrite) if mode == SaveMode::Overwrite => {
+            let delta_schema: StructType = insert_plan.schema().as_arrow().try_into_kernel()?;
+            &delta_schema != snapshot.schema().as_ref()
+        }
+        _ => false,
+    };
+
+    if !should_update_schema {
+        return Ok(SchemaDelta::default());
+    }
+
+    let schema_struct: StructType = match (schema_mode, schema_drift, new_schema) {
+        (Some(SchemaMode::Merge), true, Some(schema)) => schema.try_into_kernel()?,
+        _ => insert_plan.schema().as_arrow().try_into_kernel()?,
+    };
+
+    if &schema_struct == snapshot.schema().as_ref() {
+        return Ok(SchemaDelta::default());
+    }
+
+    let current_protocol = snapshot.protocol();
+    let configuration = snapshot.metadata().configuration().clone();
+    let new_protocol = current_protocol
+        .clone()
+        .apply_column_metadata_to_protocol(&schema_struct)?
+        .move_table_properties_into_features(&configuration);
+
+    let mut metadata = new_metadata(&schema_struct, partition_columns, configuration.clone())?;
+    let existing_metadata_id = snapshot.metadata().id().to_string();
+    if !existing_metadata_id.is_empty() {
+        metadata = metadata.with_table_id(existing_metadata_id)?;
+    }
+
+    Ok(SchemaDelta {
+        metadata: Some(metadata.into()),
+        protocol: (current_protocol != &new_protocol).then_some(new_protocol.into()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use arrow::array::RecordBatch;
+    use arrow_array::{Int32Array, StringArray};
+    use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+    use datafusion::datasource::{MemTable, provider_as_source};
+    use datafusion::logical_expr::{LogicalPlanBuilder, UNNAMED_TABLE};
+    use datafusion::prelude::{col, lit};
+    use delta_kernel::table_properties::DataSkippingNumIndexedCols;
+    use uuid::Uuid;
+
+    use crate::DeltaTable;
+    use crate::TableProperty;
+    use crate::delta_datafusion::create_session;
+    use crate::protocol::SaveMode;
+    use crate::writer::test_utils::{
+        get_arrow_schema, get_record_batch, setup_table_with_configuration,
+    };
+
+    fn source_plan_for_batch(batch: RecordBatch) -> LogicalPlan {
+        LogicalPlanBuilder::scan(
+            UNNAMED_TABLE,
+            provider_as_source(Arc::new(
+                MemTable::try_new(batch.schema(), vec![vec![batch]]).unwrap(),
+            )),
+            None,
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+    }
+
+    fn remove_action(path: &str) -> Action {
+        Action::Remove(crate::kernel::Remove {
+            path: path.to_string(),
+            data_change: true,
+            deletion_timestamp: Some(1),
+            extended_file_metadata: Some(true),
+            partition_values: Some(HashMap::new()),
+            size: Some(1),
+            tags: None,
+            deletion_vector: None,
+            base_row_id: None,
+            default_row_commit_version: None,
+        })
+    }
+
+    #[tokio::test]
+    async fn test_prepare_write_emits_schema_delta_for_merge() {
+        let table = DeltaTable::new_in_memory()
+            .write(vec![get_record_batch(None, false)])
+            .await
+            .unwrap();
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Utf8, true),
+            Field::new("value", DataType::Int32, true),
+            Field::new("modified", DataType::Utf8, true),
+            Field::new("extra", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("A")])),
+                Arc::new(Int32Array::from(vec![Some(100)])),
+                Arc::new(StringArray::from(vec![Some("2026-04-16")])),
+                Arc::new(StringArray::from(vec![Some("extra")])),
+            ],
+        )
+        .unwrap();
+
+        let session = create_session().state();
+        let configuration = HashMap::new();
+        let prepared = prepare_write(WritePreparationInput {
+            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            session: &session,
+            source: source_plan_for_batch(batch),
+            mode: SaveMode::Append,
+            schema_mode: Some(SchemaMode::Merge),
+            safe_cast: false,
+            partition_columns: vec![],
+            predicate: None,
+            target_file_size: None,
+            write_batch_size: None,
+            writer_properties: None,
+            configuration: &configuration,
+        })
+        .unwrap();
+
+        assert!(
+            prepared
+                .schema_delta
+                .actions()
+                .iter()
+                .any(|action| matches!(action, Action::Metadata(_)))
+        );
+        assert!(
+            prepared
+                .insert_plan
+                .schema()
+                .iter()
+                .any(|(_, field)| field.name() == "extra")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prepare_write_schema_overwrite_noop_has_no_schema_delta() {
+        let batch = get_record_batch(None, false);
+        let table = DeltaTable::new_in_memory()
+            .write(vec![batch.clone()])
+            .await
+            .unwrap();
+
+        let session = create_session().state();
+        let configuration = HashMap::new();
+        let prepared = prepare_write(WritePreparationInput {
+            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            session: &session,
+            source: source_plan_for_batch(batch),
+            mode: SaveMode::Overwrite,
+            schema_mode: Some(SchemaMode::Overwrite),
+            safe_cast: false,
+            partition_columns: vec![],
+            predicate: None,
+            target_file_size: None,
+            write_batch_size: None,
+            writer_properties: None,
+            configuration: &configuration,
+        })
+        .unwrap();
+
+        assert!(prepared.schema_delta.is_empty());
+    }
+
+    #[test]
+    fn test_exact_validation_predicate_returns_none_without_predicate() {
+        let prepared = PreparedWrite {
+            insert_plan: source_plan_for_batch(get_record_batch(None, false)),
+            schema_delta: SchemaDelta::default(),
+            exact_validations: Vec::new(),
+            predicate_sql: None,
+            exec_options: WriteExecOptions {
+                partition_columns: vec![],
+                target_file_size: None,
+                write_batch_size: None,
+                writer_properties: None,
+                writer_stats_config: WriterStatsConfig {
+                    num_indexed_cols: DataSkippingNumIndexedCols::NumColumns(32),
+                    stats_columns: None,
+                },
+            },
+        };
+
+        assert!(prepared.exact_validation_predicate().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_schema_delta_actions_preserve_metadata_then_protocol_order() {
+        let table = DeltaTable::new_in_memory()
+            .write(vec![get_record_batch(None, false)])
+            .await
+            .unwrap();
+        let snapshot = table.snapshot().unwrap().snapshot();
+
+        let schema_delta = SchemaDelta {
+            metadata: Some(Action::Metadata(snapshot.metadata().clone())),
+            protocol: Some(Action::Protocol(snapshot.protocol().clone())),
+        };
+
+        let actions = schema_delta.actions();
+        assert!(matches!(actions.first(), Some(Action::Metadata(_))));
+        assert!(matches!(actions.get(1), Some(Action::Protocol(_))));
+    }
+
+    #[test]
+    fn test_overwrite_plan_num_removed_files_counts_only_remove_actions() {
+        let overwrite_plan = OverwritePlan {
+            sink_plan: source_plan_for_batch(get_record_batch(None, false)),
+            actions: vec![
+                remove_action("part-000.parquet"),
+                Action::Protocol(Default::default()),
+                remove_action("part-001.parquet"),
+            ],
+            contains_cdc: false,
+        };
+
+        assert_eq!(overwrite_plan.num_removed_files(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_plan_overwrite_rewrite_passthrough_without_snapshot() {
+        let table = DeltaTable::new_in_memory();
+        let session = create_session().state();
+        let configuration = HashMap::new();
+        let prepared = prepare_write(WritePreparationInput {
+            snapshot: None,
+            session: &session,
+            source: source_plan_for_batch(get_record_batch(None, false)),
+            mode: SaveMode::Overwrite,
+            schema_mode: None,
+            safe_cast: false,
+            partition_columns: vec![],
+            predicate: Some(col("id").eq(lit("A")).into()),
+            target_file_size: None,
+            write_batch_size: None,
+            writer_properties: None,
+            configuration: &configuration,
+        })
+        .unwrap();
+
+        let overwrite_plan = plan_overwrite_rewrite(
+            None,
+            &table.log_store(),
+            &session,
+            SaveMode::Overwrite,
+            &prepared,
+            Uuid::new_v4(),
+        )
+        .await
+        .unwrap();
+
+        assert!(overwrite_plan.actions.is_empty());
+        assert!(!overwrite_plan.contains_cdc);
+        assert_eq!(
+            overwrite_plan.sink_plan.schema().as_arrow(),
+            prepared.insert_plan.schema().as_arrow()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_plan_overwrite_rewrite_passthrough_for_append_mode() {
+        let table = DeltaTable::new_in_memory()
+            .write(vec![get_record_batch(None, false)])
+            .await
+            .unwrap();
+
+        let session = create_session().state();
+        let configuration = HashMap::new();
+        let prepared = prepare_write(WritePreparationInput {
+            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            session: &session,
+            source: source_plan_for_batch(get_record_batch(None, false)),
+            mode: SaveMode::Append,
+            schema_mode: None,
+            safe_cast: false,
+            partition_columns: vec![],
+            predicate: Some(col("id").eq(lit("A")).into()),
+            target_file_size: None,
+            write_batch_size: None,
+            writer_properties: None,
+            configuration: &configuration,
+        })
+        .unwrap();
+
+        let overwrite_plan = plan_overwrite_rewrite(
+            Some(table.snapshot().unwrap().snapshot()),
+            &table.log_store(),
+            &session,
+            SaveMode::Append,
+            &prepared,
+            Uuid::new_v4(),
+        )
+        .await
+        .unwrap();
+
+        assert!(overwrite_plan.actions.is_empty());
+        assert!(!overwrite_plan.contains_cdc);
+        assert_eq!(
+            overwrite_plan.sink_plan.schema().as_arrow(),
+            prepared.insert_plan.schema().as_arrow()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_plan_overwrite_rewrite_no_match_preserves_insert_plan() {
+        let table = DeltaTable::new_in_memory()
+            .write(vec![get_record_batch(None, false)])
+            .await
+            .unwrap();
+
+        let batch = RecordBatch::try_new(
+            get_arrow_schema(&None),
+            vec![
+                Arc::new(StringArray::from(vec![Some("Z")])),
+                Arc::new(Int32Array::from(vec![Some(999)])),
+                Arc::new(StringArray::from(vec![Some("2026-04-16")])),
+            ],
+        )
+        .unwrap();
+
+        let session = create_session().state();
+        let configuration = HashMap::new();
+        let prepared = prepare_write(WritePreparationInput {
+            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            session: &session,
+            source: source_plan_for_batch(batch),
+            mode: SaveMode::Overwrite,
+            schema_mode: None,
+            safe_cast: false,
+            partition_columns: vec![],
+            predicate: Some(col("id").eq(lit("missing")).into()),
+            target_file_size: None,
+            write_batch_size: None,
+            writer_properties: None,
+            configuration: &configuration,
+        })
+        .unwrap();
+
+        let overwrite_plan = plan_overwrite_rewrite(
+            Some(table.snapshot().unwrap().snapshot()),
+            &table.log_store(),
+            &session,
+            SaveMode::Overwrite,
+            &prepared,
+            Uuid::new_v4(),
+        )
+        .await
+        .unwrap();
+
+        assert!(overwrite_plan.actions.is_empty());
+        assert!(!overwrite_plan.contains_cdc);
+        assert_eq!(
+            overwrite_plan.sink_plan.schema().as_arrow(),
+            prepared.insert_plan.schema().as_arrow()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_plan_overwrite_rewrite_full_overwrite_collects_remove_actions() {
+        let table = DeltaTable::new_in_memory()
+            .write(vec![get_record_batch(None, false)])
+            .await
+            .unwrap();
+
+        let batch = RecordBatch::try_new(
+            get_arrow_schema(&None),
+            vec![
+                Arc::new(StringArray::from(vec![Some("Z")])),
+                Arc::new(Int32Array::from(vec![Some(999)])),
+                Arc::new(StringArray::from(vec![Some("2026-04-16")])),
+            ],
+        )
+        .unwrap();
+
+        let session = create_session().state();
+        let configuration = HashMap::new();
+        let prepared = prepare_write(WritePreparationInput {
+            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            session: &session,
+            source: source_plan_for_batch(batch),
+            mode: SaveMode::Overwrite,
+            schema_mode: None,
+            safe_cast: false,
+            partition_columns: vec![],
+            predicate: None,
+            target_file_size: None,
+            write_batch_size: None,
+            writer_properties: None,
+            configuration: &configuration,
+        })
+        .unwrap();
+
+        let overwrite_plan = plan_overwrite_rewrite(
+            Some(table.snapshot().unwrap().snapshot()),
+            &table.log_store(),
+            &session,
+            SaveMode::Overwrite,
+            &prepared,
+            Uuid::new_v4(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!overwrite_plan.contains_cdc);
+        assert!(
+            overwrite_plan
+                .actions
+                .iter()
+                .any(|action| matches!(action, Action::Remove(_)))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_plan_overwrite_rewrite_marks_cdc_for_predicate_rewrite() {
+        let table =
+            setup_table_with_configuration(TableProperty::EnableChangeDataFeed, Some("true"))
+                .await
+                .write(vec![get_record_batch(None, false)])
+                .await
+                .unwrap();
+
+        let batch = RecordBatch::try_new(
+            get_arrow_schema(&None),
+            vec![
+                Arc::new(StringArray::from(vec![Some("3")])),
+                Arc::new(Int32Array::from(vec![Some(3)])),
+                Arc::new(StringArray::from(vec![Some("updated")])),
+            ],
+        )
+        .unwrap();
+
+        let session = create_session().state();
+        let configuration = HashMap::new();
+        let prepared = prepare_write(WritePreparationInput {
+            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            session: &session,
+            source: source_plan_for_batch(batch),
+            mode: SaveMode::Overwrite,
+            schema_mode: None,
+            safe_cast: false,
+            partition_columns: vec![],
+            predicate: Some(col("value").eq(lit(3)).into()),
+            target_file_size: None,
+            write_batch_size: None,
+            writer_properties: None,
+            configuration: &configuration,
+        })
+        .unwrap();
+
+        let overwrite_plan = plan_overwrite_rewrite(
+            Some(table.snapshot().unwrap().snapshot()),
+            &table.log_store(),
+            &session,
+            SaveMode::Overwrite,
+            &prepared,
+            Uuid::new_v4(),
+        )
+        .await
+        .unwrap();
+
+        assert!(overwrite_plan.contains_cdc);
+        assert!(
+            overwrite_plan
+                .sink_plan
+                .schema()
+                .iter()
+                .any(|(_, field)| field.name() == CDC_COLUMN_NAME)
+        );
+    }
+}

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -1,8 +1,8 @@
-//! Write planning is split into two stages:
-//! - `prepare_write` normalizes incoming rows into table-shaped insert data and resolves exact
-//!   validations against that prepared schema.
-//! - `plan_overwrite_rewrite` adjusts the sink plan for overwrite flows and returns any
-//!   overwrite-side actions the caller must commit before add actions.
+//! Write planning has two stages.
+//! `prepare_write` normalizes incoming rows into table shaped insert data and resolves exact
+//! validations against that prepared schema.
+//! `plan_overwrite_rewrite` adjusts the sink plan for overwrite flows and returns any
+//! overwrite side actions the caller must commit before add actions.
 
 use std::collections::HashMap;
 use std::num::NonZeroU64;
@@ -12,7 +12,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use arrow_schema::Schema;
 use datafusion::catalog::Session;
 use datafusion::common::{Column, ScalarValue};
-use datafusion::logical_expr::utils::conjunction;
 use datafusion::logical_expr::{
     Expr, Extension, LogicalPlan, LogicalPlanBuilder, UNNAMED_TABLE, cast, lit, try_cast,
 };
@@ -31,7 +30,6 @@ use super::metrics::SOURCE_COUNT_ID;
 use super::schema_evolution::try_cast_schema;
 use crate::delta_datafusion::DataFusionMixins;
 use crate::delta_datafusion::Expression;
-use crate::delta_datafusion::expr::fmt_expr_to_sql;
 use crate::delta_datafusion::logical::MetricObserver;
 use crate::errors::DeltaResult;
 use crate::kernel::schema::cast::{merge_arrow_schema, normalize_for_delta};
@@ -45,76 +43,69 @@ use crate::operations::{get_num_idx_cols_and_stats_columns, get_target_file_size
 use crate::protocol::SaveMode;
 
 /// Schema and protocol actions required before the sink executes the write.
-#[derive(Clone, Default)]
-pub(crate) struct SchemaDelta {
+#[derive(Default)]
+pub(super) struct SchemaDelta {
     metadata: Option<Action>,
     protocol: Option<Action>,
 }
 
 impl SchemaDelta {
     #[cfg(test)]
-    pub(crate) fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.metadata.is_none() && self.protocol.is_none()
     }
 
-    pub(crate) fn actions(&self) -> Vec<Action> {
+    pub(super) fn into_actions(self) -> Vec<Action> {
         let mut actions = Vec::with_capacity(2);
-        if let Some(metadata) = &self.metadata {
-            actions.push(metadata.clone());
+        if let Some(metadata) = self.metadata {
+            actions.push(metadata);
         }
-        if let Some(protocol) = &self.protocol {
-            actions.push(protocol.clone());
+        if let Some(protocol) = self.protocol {
+            actions.push(protocol);
         }
         actions
     }
 }
 
-/// Sink-only knobs that must survive planning unchanged.
-#[derive(Clone)]
-pub(crate) struct WriteExecOptions {
-    pub partition_columns: Vec<String>,
-    pub target_file_size: Option<NonZeroU64>,
-    pub write_batch_size: Option<usize>,
-    pub writer_properties: Option<WriterProperties>,
-    pub writer_stats_config: WriterStatsConfig,
+/// Sink specific knobs that must survive planning unchanged.
+pub(super) struct WriteExecOptions {
+    pub(super) partition_columns: Vec<String>,
+    pub(super) target_file_size: Option<NonZeroU64>,
+    pub(super) write_batch_size: Option<usize>,
+    pub(super) writer_properties: Option<WriterProperties>,
+    pub(super) writer_stats_config: WriterStatsConfig,
 }
 
-/// Prepared insert input plus the exact validations the sink must enforce.
-pub(crate) struct PreparedWrite {
-    pub insert_plan: LogicalPlan,
-    pub schema_delta: SchemaDelta,
-    pub exact_validations: Vec<Expr>,
-    pub predicate_sql: Option<String>,
-    pub exec_options: WriteExecOptions,
+/// Prepared insert input plus the exact validation the sink must enforce.
+pub(super) struct PreparedWrite {
+    insert_plan: LogicalPlan,
+    mode: SaveMode,
+    pub(super) schema_delta: SchemaDelta,
+    pub(super) exact_validation: Option<Expr>,
+    pub(super) exec_options: WriteExecOptions,
 }
 
-impl PreparedWrite {
-    pub(crate) fn exact_validation_predicate(&self) -> Option<Expr> {
-        conjunction(self.exact_validations.clone())
-    }
-}
-
-/// Inputs required to normalize source rows into table-shaped insert data.
-pub(crate) struct WritePreparationInput<'a> {
-    pub snapshot: Option<&'a EagerSnapshot>,
-    pub session: &'a dyn Session,
-    pub source: LogicalPlan,
-    pub mode: SaveMode,
-    pub schema_mode: Option<SchemaMode>,
-    pub safe_cast: bool,
-    pub partition_columns: Vec<String>,
-    pub predicate: Option<Expression>,
-    pub target_file_size: Option<Option<NonZeroU64>>,
-    pub write_batch_size: Option<usize>,
-    pub writer_properties: Option<WriterProperties>,
-    pub configuration: &'a HashMap<String, Option<String>>,
+/// Inputs required to normalize source rows into table shaped insert data.
+pub(super) struct WritePreparationInput<'a> {
+    pub(super) snapshot: Option<&'a EagerSnapshot>,
+    pub(super) session: &'a dyn Session,
+    pub(super) source: LogicalPlan,
+    pub(super) mode: SaveMode,
+    pub(super) schema_mode: Option<SchemaMode>,
+    pub(super) safe_cast: bool,
+    pub(super) partition_columns: Vec<String>,
+    pub(super) predicate: Option<Expression>,
+    pub(super) target_file_size: Option<Option<NonZeroU64>>,
+    pub(super) write_batch_size: Option<usize>,
+    pub(super) writer_properties: Option<WriterProperties>,
+    pub(super) configuration: &'a HashMap<String, Option<String>>,
 }
 
 /// Planner output for overwrite flows before the sink materializes new files.
-pub(crate) struct OverwritePlan {
-    pub sink_plan: LogicalPlan,
-    pub actions: Vec<Action>,
-    pub contains_cdc: bool,
+pub(super) struct OverwritePlan {
+    pub(super) sink_plan: LogicalPlan,
+    pub(super) actions: Vec<Action>,
+    pub(super) contains_cdc: bool,
 }
 
 impl OverwritePlan {
@@ -126,7 +117,7 @@ impl OverwritePlan {
         }
     }
 
-    pub(crate) fn num_removed_files(&self) -> usize {
+    pub(super) fn num_removed_files(&self) -> usize {
         self.actions
             .iter()
             .filter(|action| matches!(action, Action::Remove(_)))
@@ -134,7 +125,7 @@ impl OverwritePlan {
     }
 }
 
-pub(crate) fn prepare_write(input: WritePreparationInput<'_>) -> DeltaResult<PreparedWrite> {
+pub(super) fn prepare_write(input: WritePreparationInput<'_>) -> DeltaResult<PreparedWrite> {
     let WritePreparationInput {
         snapshot,
         session,
@@ -267,14 +258,13 @@ pub(crate) fn prepare_write(input: WritePreparationInput<'_>) -> DeltaResult<Pre
         new_schema.as_deref(),
     )?;
 
-    let exact_validations = resolve_exact_validations(session, &insert_plan, predicate)?;
-    let predicate_sql = exact_validations.first().map(fmt_expr_to_sql).transpose()?;
+    let exact_validation = resolve_exact_validation(session, &insert_plan, predicate)?;
 
     Ok(PreparedWrite {
         insert_plan,
+        mode,
         schema_delta,
-        exact_validations,
-        predicate_sql,
+        exact_validation,
         exec_options: build_exec_options(
             snapshot,
             partition_columns,
@@ -286,7 +276,7 @@ pub(crate) fn prepare_write(input: WritePreparationInput<'_>) -> DeltaResult<Pre
     })
 }
 
-pub(crate) async fn plan_overwrite_rewrite(
+pub(super) async fn plan_overwrite_rewrite(
     snapshot: Option<&EagerSnapshot>,
     log_store: &LogStoreRef,
     session: &dyn Session,
@@ -300,7 +290,12 @@ pub(crate) async fn plan_overwrite_rewrite(
         ));
     };
 
-    if !matches!(mode, SaveMode::Overwrite) {
+    debug_assert_eq!(
+        mode, prepared_write.mode,
+        "plan_overwrite_rewrite mode must match prepared write mode"
+    );
+
+    if !matches!(prepared_write.mode, SaveMode::Overwrite) {
         return Ok(OverwritePlan::passthrough(
             prepared_write.insert_plan.clone(),
         ));
@@ -310,7 +305,7 @@ pub(crate) async fn plan_overwrite_rewrite(
     let mut actions = Vec::new();
     let mut contains_cdc = false;
 
-    match prepared_write.exact_validation_predicate() {
+    match prepared_write.exact_validation.clone() {
         Some(predicate) => {
             let deletion_timestamp = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -389,11 +384,11 @@ fn build_exec_options(
     }
 }
 
-fn resolve_exact_validations(
+fn resolve_exact_validation(
     session: &dyn Session,
     insert_plan: &LogicalPlan,
     predicate: Option<Expression>,
-) -> DeltaResult<Vec<Expr>> {
+) -> DeltaResult<Option<Expr>> {
     let df_schema = insert_plan
         .schema()
         .as_ref()
@@ -401,9 +396,7 @@ fn resolve_exact_validations(
         .replace_qualifier(UNNAMED_TABLE);
     Ok(predicate
         .map(|predicate| predicate.resolve(session, Arc::new(df_schema)))
-        .transpose()?
-        .into_iter()
-        .collect())
+        .transpose()?)
 }
 
 fn schema_delta_for_prepared_source(
@@ -448,7 +441,7 @@ fn schema_delta_for_prepared_source(
         .apply_column_metadata_to_protocol(&schema_struct)?
         .move_table_properties_into_features(&configuration);
 
-    let mut metadata = new_metadata(&schema_struct, partition_columns, configuration.clone())?;
+    let mut metadata = new_metadata(&schema_struct, partition_columns, configuration)?;
     let existing_metadata_id = snapshot.metadata().id().to_string();
     if !existing_metadata_id.is_empty() {
         metadata = metadata.with_table_id(existing_metadata_id)?;
@@ -472,7 +465,6 @@ mod tests {
     use datafusion::datasource::{MemTable, provider_as_source};
     use datafusion::logical_expr::{LogicalPlanBuilder, UNNAMED_TABLE};
     use datafusion::prelude::{col, lit};
-    use delta_kernel::table_properties::DataSkippingNumIndexedCols;
     use uuid::Uuid;
 
     use crate::DeltaTable;
@@ -494,21 +486,6 @@ mod tests {
         .unwrap()
         .build()
         .unwrap()
-    }
-
-    fn remove_action(path: &str) -> Action {
-        Action::Remove(crate::kernel::Remove {
-            path: path.to_string(),
-            data_change: true,
-            deletion_timestamp: Some(1),
-            extended_file_metadata: Some(true),
-            partition_values: Some(HashMap::new()),
-            size: Some(1),
-            tags: None,
-            deletion_vector: None,
-            base_row_id: None,
-            default_row_commit_version: None,
-        })
     }
 
     #[tokio::test]
@@ -556,7 +533,7 @@ mod tests {
         assert!(
             prepared
                 .schema_delta
-                .actions()
+                .into_actions()
                 .iter()
                 .any(|action| matches!(action, Action::Metadata(_)))
         );
@@ -596,61 +573,7 @@ mod tests {
         .unwrap();
 
         assert!(prepared.schema_delta.is_empty());
-    }
-
-    #[test]
-    fn test_exact_validation_predicate_returns_none_without_predicate() {
-        let prepared = PreparedWrite {
-            insert_plan: source_plan_for_batch(get_record_batch(None, false)),
-            schema_delta: SchemaDelta::default(),
-            exact_validations: Vec::new(),
-            predicate_sql: None,
-            exec_options: WriteExecOptions {
-                partition_columns: vec![],
-                target_file_size: None,
-                write_batch_size: None,
-                writer_properties: None,
-                writer_stats_config: WriterStatsConfig {
-                    num_indexed_cols: DataSkippingNumIndexedCols::NumColumns(32),
-                    stats_columns: None,
-                },
-            },
-        };
-
-        assert!(prepared.exact_validation_predicate().is_none());
-    }
-
-    #[tokio::test]
-    async fn test_schema_delta_actions_preserve_metadata_then_protocol_order() {
-        let table = DeltaTable::new_in_memory()
-            .write(vec![get_record_batch(None, false)])
-            .await
-            .unwrap();
-        let snapshot = table.snapshot().unwrap().snapshot();
-
-        let schema_delta = SchemaDelta {
-            metadata: Some(Action::Metadata(snapshot.metadata().clone())),
-            protocol: Some(Action::Protocol(snapshot.protocol().clone())),
-        };
-
-        let actions = schema_delta.actions();
-        assert!(matches!(actions.first(), Some(Action::Metadata(_))));
-        assert!(matches!(actions.get(1), Some(Action::Protocol(_))));
-    }
-
-    #[test]
-    fn test_overwrite_plan_num_removed_files_counts_only_remove_actions() {
-        let overwrite_plan = OverwritePlan {
-            sink_plan: source_plan_for_batch(get_record_batch(None, false)),
-            actions: vec![
-                remove_action("part-000.parquet"),
-                Action::Protocol(Default::default()),
-                remove_action("part-001.parquet"),
-            ],
-            contains_cdc: false,
-        };
-
-        assert_eq!(overwrite_plan.num_removed_files(), 2);
+        assert!(prepared.exact_validation.is_none());
     }
 
     #[tokio::test]
@@ -735,6 +658,43 @@ mod tests {
             overwrite_plan.sink_plan.schema().as_arrow(),
             prepared.insert_plan.schema().as_arrow()
         );
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "plan_overwrite_rewrite mode must match prepared write mode")]
+    async fn test_plan_overwrite_rewrite_panics_on_mode_mismatch() {
+        let table = DeltaTable::new_in_memory()
+            .write(vec![get_record_batch(None, false)])
+            .await
+            .unwrap();
+
+        let session = create_session().state();
+        let configuration = HashMap::new();
+        let prepared = prepare_write(WritePreparationInput {
+            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            session: &session,
+            source: source_plan_for_batch(get_record_batch(None, false)),
+            mode: SaveMode::Append,
+            schema_mode: None,
+            safe_cast: false,
+            partition_columns: vec![],
+            predicate: None,
+            target_file_size: None,
+            write_batch_size: None,
+            writer_properties: None,
+            configuration: &configuration,
+        })
+        .unwrap();
+
+        let _ = plan_overwrite_rewrite(
+            Some(table.snapshot().unwrap().snapshot()),
+            &table.log_store(),
+            &session,
+            SaveMode::Overwrite,
+            &prepared,
+            Uuid::new_v4(),
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/core/tests/command_optimize.rs
+++ b/crates/core/tests/command_optimize.rs
@@ -251,6 +251,72 @@ async fn latest_commit_actions(table: &DeltaTable) -> Result<Vec<Action>, Box<dy
     Ok(get_actions(version, &commit_bytes)?)
 }
 
+struct DvSmallAppendedTable {
+    _tmp_dir: TempDir,
+    table: DeltaTable,
+    expected_values: Vec<i32>,
+}
+
+async fn setup_dv_small_with_appended_values() -> Result<DvSmallAppendedTable, Box<dyn Error>> {
+    let tmp_dir = tempfile::tempdir()?;
+    let table_dir = tmp_dir.path().join("table-with-dv-small");
+    fs_extra::dir::copy(
+        TestTables::WithDvSmall.as_path(),
+        tmp_dir.path(),
+        &Default::default(),
+    )?;
+    let table_url = url::Url::from_directory_path(table_dir.canonicalize()?).unwrap();
+
+    let mut table = open_table(table_url).await?;
+    assert_eq!(
+        sorted_int_values(&table).await?,
+        vec![1, 2, 3, 4, 5, 6, 7, 8]
+    );
+
+    let mut writer = RecordBatchWriter::for_table(&table)?;
+    write(&mut writer, &mut table, single_int_batch(vec![10, 11])?).await?;
+
+    let expected_values = vec![1, 2, 3, 4, 5, 6, 7, 8, 10, 11];
+    assert_eq!(sorted_int_values(&table).await?, expected_values);
+
+    Ok(DvSmallAppendedTable {
+        _tmp_dir: tmp_dir,
+        table,
+        expected_values,
+    })
+}
+
+async fn assert_optimize_preserves_live_rows_with_deletion_vectors(
+    optimize_type: OptimizeType,
+) -> Result<(), Box<dyn Error>> {
+    let DvSmallAppendedTable {
+        _tmp_dir,
+        table,
+        expected_values,
+    } = setup_dv_small_with_appended_values().await?;
+
+    let (optimized, metrics) = match optimize_type {
+        OptimizeType::Compact => {
+            table
+                .optimize()
+                .with_target_size(NonZeroU64::new(1_000_000).unwrap())
+                .await?
+        }
+        OptimizeType::ZOrder(columns) => {
+            table
+                .optimize()
+                .with_type(OptimizeType::ZOrder(columns))
+                .await?
+        }
+    };
+
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 2);
+    assert_eq!(sorted_int_values(&optimized).await?, expected_values);
+
+    Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum TrackedLogStoreCall {
     Object(Option<Uuid>),
@@ -669,52 +735,17 @@ async fn test_optimize_selected_file_scans_register_operation_scoped_log_store()
 #[tokio::test]
 async fn test_optimize_compaction_preserves_live_rows_with_deletion_vectors()
 -> Result<(), Box<dyn Error>> {
-    let temp_dir = tempfile::tempdir()?;
-    let table_dir = temp_dir.path().join("table-with-dv-small");
-    fs_extra::dir::copy(
-        TestTables::WithDvSmall.as_path(),
-        temp_dir.path(),
-        &Default::default(),
-    )?;
-    let table_url = url::Url::from_directory_path(table_dir.canonicalize()?).unwrap();
-
-    let mut dt = open_table(table_url).await?;
-    let initial_values = sorted_int_values(&dt).await?;
-    assert_eq!(initial_values, vec![1, 2, 3, 4, 5, 6, 7, 8]);
-
-    let mut writer = RecordBatchWriter::for_table(&dt)?;
-    write(&mut writer, &mut dt, single_int_batch(vec![10, 11])?).await?;
-
-    let expected_values = vec![1, 2, 3, 4, 5, 6, 7, 8, 10, 11];
-    assert_eq!(sorted_int_values(&dt).await?, expected_values);
-
-    let (dt, metrics) = dt
-        .optimize()
-        .with_target_size(NonZeroU64::new(1_000_000).unwrap())
-        .await?;
-
-    assert_eq!(metrics.num_files_added, 1);
-    assert_eq!(metrics.num_files_removed, 2);
-    assert_eq!(sorted_int_values(&dt).await?, expected_values);
-
-    Ok(())
+    assert_optimize_preserves_live_rows_with_deletion_vectors(OptimizeType::Compact).await
 }
 
 #[tokio::test]
 async fn test_optimize_compaction_tombstones_preserve_deletion_vector_metadata()
 -> Result<(), Box<dyn Error>> {
-    let temp_dir = tempfile::tempdir()?;
-    let table_dir = temp_dir.path().join("table-with-dv-small");
-    fs_extra::dir::copy(
-        TestTables::WithDvSmall.as_path(),
-        temp_dir.path(),
-        &Default::default(),
-    )?;
-    let table_url = url::Url::from_directory_path(table_dir.canonicalize()?).unwrap();
-
-    let mut dt = open_table(table_url).await?;
-    let mut writer = RecordBatchWriter::for_table(&dt)?;
-    write(&mut writer, &mut dt, single_int_batch(vec![10, 11])?).await?;
+    let DvSmallAppendedTable {
+        _tmp_dir,
+        table: dt,
+        expected_values: _expected_values,
+    } = setup_dv_small_with_appended_values().await?;
 
     let source_files = dt
         .get_active_add_actions_by_partitions(&[])
@@ -775,30 +806,10 @@ async fn test_optimize_compaction_tombstones_preserve_deletion_vector_metadata()
 #[tokio::test]
 async fn test_optimize_zorder_preserves_live_rows_with_deletion_vectors()
 -> Result<(), Box<dyn Error>> {
-    let temp_dir = tempfile::tempdir()?;
-    let table_dir = temp_dir.path().join("table-with-dv-small");
-    fs_extra::dir::copy(
-        TestTables::WithDvSmall.as_path(),
-        temp_dir.path(),
-        &Default::default(),
-    )?;
-    let table_url = url::Url::from_directory_path(table_dir.canonicalize()?).unwrap();
-
-    let mut dt = open_table(table_url).await?;
-    let mut writer = RecordBatchWriter::for_table(&dt)?;
-    write(&mut writer, &mut dt, single_int_batch(vec![10, 11])?).await?;
-
-    let expected_values = vec![1, 2, 3, 4, 5, 6, 7, 8, 10, 11];
-    let (dt, metrics) = dt
-        .optimize()
-        .with_type(OptimizeType::ZOrder(vec!["value".to_string()]))
-        .await?;
-
-    assert_eq!(metrics.num_files_added, 1);
-    assert_eq!(metrics.num_files_removed, 2);
-    assert_eq!(sorted_int_values(&dt).await?, expected_values);
-
-    Ok(())
+    assert_optimize_preserves_live_rows_with_deletion_vectors(OptimizeType::ZOrder(vec![
+        "value".to_string(),
+    ]))
+    .await
 }
 
 #[tokio::test]

--- a/crates/core/tests/command_optimize.rs
+++ b/crates/core/tests/command_optimize.rs
@@ -1,23 +1,30 @@
 use std::num::NonZeroU64;
 use std::time::Duration;
-use std::{error::Error, sync::Arc};
+use std::{
+    error::Error,
+    sync::{Arc, Mutex},
+};
 
 use arrow_array::{Int32Array, RecordBatch, StringArray};
 use arrow_schema::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
 use arrow_select::concat::concat_batches;
+use bytes::Bytes;
 use datafusion::prelude::SessionContext;
 use deltalake_core::delta_datafusion::DeltaSessionContext;
 use deltalake_core::ensure_table_uri;
 use deltalake_core::errors::DeltaTableError;
-use deltalake_core::kernel::transaction::{CommitBuilder, CommitProperties};
+use deltalake_core::kernel::transaction::{CommitBuilder, CommitProperties, TransactionError};
 use deltalake_core::kernel::{Action, DataType, PrimitiveType, StructField};
-use deltalake_core::logstore::ObjectStoreRef;
+use deltalake_core::logstore::{
+    CommitOrBytes, LogStore, LogStoreConfig, LogStoreRef, ObjectStoreRef, get_actions,
+};
 use deltalake_core::operations::optimize::{
     MetricDetails, Metrics, OptimizeType, PlannerStrategy, create_merge_plan,
 };
 use deltalake_core::protocol::DeltaOperation;
+use deltalake_core::test_utils::TestTables;
 use deltalake_core::writer::{DeltaWriter, RecordBatchWriter};
-use deltalake_core::{DeltaTable, PartitionFilter, Path};
+use deltalake_core::{DeltaTable, PartitionFilter, Path, open_table};
 use futures::TryStreamExt;
 use object_store::ObjectStoreExt as _;
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
@@ -188,6 +195,139 @@ fn ordered_range_batch(
             Arc::new(StringArray::from(partitions)),
         ],
     )?)
+}
+
+fn single_int_batch(values: Vec<i32>) -> Result<RecordBatch, Box<dyn Error>> {
+    Ok(RecordBatch::try_new(
+        Arc::new(ArrowSchema::new(vec![Field::new(
+            "value",
+            ArrowDataType::Int32,
+            true,
+        )])),
+        vec![Arc::new(Int32Array::from(values))],
+    )?)
+}
+
+async fn sorted_int_values(table: &DeltaTable) -> Result<Vec<i32>, Box<dyn Error>> {
+    let ctx: SessionContext = DeltaSessionContext::default().into();
+    table.update_datafusion_session(&ctx.state())?;
+    ctx.register_table("delta_table", table.table_provider().await?)?;
+
+    let batches = ctx
+        .sql("SELECT value FROM delta_table ORDER BY value")
+        .await?
+        .collect()
+        .await?;
+
+    let mut values = Vec::new();
+    for batch in batches {
+        let array = batch
+            .column_by_name("value")
+            .ok_or_else(|| std::io::Error::other("missing value column"))?
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .ok_or_else(|| std::io::Error::other("value column is not Int32"))?;
+        values.extend(
+            array
+                .iter()
+                .map(|value| value.expect("unexpected null value")),
+        );
+    }
+
+    Ok(values)
+}
+
+async fn latest_commit_actions(table: &DeltaTable) -> Result<Vec<Action>, Box<dyn Error>> {
+    let version = table
+        .version()
+        .ok_or_else(|| std::io::Error::other("table has no committed version"))?;
+    let commit_bytes = table
+        .log_store()
+        .read_commit_entry(version)
+        .await?
+        .ok_or_else(|| {
+            std::io::Error::other(format!("missing commit entry for version {version}"))
+        })?;
+    Ok(get_actions(version, &commit_bytes)?)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TrackedLogStoreCall {
+    Object(Option<Uuid>),
+    Root(Option<Uuid>),
+}
+
+#[derive(Debug)]
+struct OperationTrackingLogStore {
+    inner: LogStoreRef,
+    calls: Arc<Mutex<Vec<TrackedLogStoreCall>>>,
+}
+
+#[async_trait::async_trait]
+impl LogStore for OperationTrackingLogStore {
+    fn name(&self) -> String {
+        self.inner.name()
+    }
+
+    async fn refresh(&self) -> deltalake_core::errors::DeltaResult<()> {
+        self.inner.refresh().await
+    }
+
+    async fn read_commit_entry(
+        &self,
+        version: deltalake_core::kernel::Version,
+    ) -> deltalake_core::errors::DeltaResult<Option<Bytes>> {
+        self.inner.read_commit_entry(version).await
+    }
+
+    async fn write_commit_entry(
+        &self,
+        version: deltalake_core::kernel::Version,
+        commit_or_bytes: CommitOrBytes,
+        operation_id: Uuid,
+    ) -> Result<(), TransactionError> {
+        self.inner
+            .write_commit_entry(version, commit_or_bytes, operation_id)
+            .await
+    }
+
+    async fn abort_commit_entry(
+        &self,
+        version: deltalake_core::kernel::Version,
+        commit_or_bytes: CommitOrBytes,
+        operation_id: Uuid,
+    ) -> Result<(), TransactionError> {
+        self.inner
+            .abort_commit_entry(version, commit_or_bytes, operation_id)
+            .await
+    }
+
+    async fn get_latest_version(
+        &self,
+        start_version: deltalake_core::kernel::Version,
+    ) -> deltalake_core::errors::DeltaResult<deltalake_core::kernel::Version> {
+        self.inner.get_latest_version(start_version).await
+    }
+
+    fn object_store(&self, operation_id: Option<Uuid>) -> Arc<dyn object_store::ObjectStore> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(TrackedLogStoreCall::Object(operation_id));
+        self.inner.object_store(operation_id)
+    }
+
+    fn root_object_store(&self, operation_id: Option<Uuid>) -> Arc<dyn object_store::ObjectStore> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(TrackedLogStoreCall::Root(operation_id));
+        self.inner.root_object_store(operation_id)
+    }
+
+    fn config(&self) -> &LogStoreConfig {
+        self.inner.config()
+    }
 }
 
 async fn active_file_ranges(table: &DeltaTable) -> Result<Vec<(i32, i32, i64)>, Box<dyn Error>> {
@@ -451,6 +591,212 @@ async fn test_optimize_with_partitions() -> Result<(), Box<dyn Error>> {
             "2022-05-22".to_string()
         ))
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_optimize_selected_file_scans_register_operation_scoped_log_store()
+-> Result<(), Box<dyn Error>> {
+    let table = DeltaTable::new_in_memory()
+        .write(vec![tuples_to_batch(
+            vec![(1, 2), (1, 3), (1, 4)],
+            "2022-05-22",
+        )?])
+        .with_save_mode(deltalake_core::protocol::SaveMode::Append)
+        .await?;
+    let table = table
+        .write(vec![tuples_to_batch(
+            vec![(2, 2), (2, 3), (2, 4)],
+            "2022-05-23",
+        )?])
+        .with_save_mode(deltalake_core::protocol::SaveMode::Append)
+        .await?;
+
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let tracked_log_store: LogStoreRef = Arc::new(OperationTrackingLogStore {
+        inner: table.log_store(),
+        calls: calls.clone(),
+    });
+    let mut tracked_table = DeltaTable::new(tracked_log_store, Default::default());
+    tracked_table.load().await?;
+    let df_context: SessionContext = DeltaSessionContext::default().into();
+    let plan = create_merge_plan(
+        &tracked_table.log_store(),
+        OptimizeType::Compact,
+        tracked_table.snapshot()?.snapshot(),
+        &[],
+        Some(NonZeroU64::new(1_000_000).unwrap()),
+        WriterProperties::builder().build(),
+        df_context.state(),
+    )
+    .await?;
+
+    calls.lock().unwrap().clear();
+    let operation_id = Uuid::new_v4();
+    let metrics = plan
+        .execute(
+            tracked_table.log_store(),
+            tracked_table.snapshot()?.snapshot(),
+            1,
+            None,
+            CommitProperties::default(),
+            operation_id,
+            None,
+        )
+        .await?;
+
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 2);
+
+    let calls = calls.lock().unwrap().clone();
+    assert!(
+        calls
+            .iter()
+            .any(|call| matches!(call, TrackedLogStoreCall::Root(Some(id)) if *id == operation_id)),
+        "expected optimize selected-file scans to register an operation-scoped root object store, got {calls:?}",
+    );
+    assert!(
+        calls.iter().any(
+            |call| matches!(call, TrackedLogStoreCall::Object(Some(id)) if *id == operation_id)
+        ),
+        "expected optimize execution to use an operation-scoped object store, got {calls:?}",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_optimize_compaction_preserves_live_rows_with_deletion_vectors()
+-> Result<(), Box<dyn Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let table_dir = temp_dir.path().join("table-with-dv-small");
+    fs_extra::dir::copy(
+        TestTables::WithDvSmall.as_path(),
+        temp_dir.path(),
+        &Default::default(),
+    )?;
+    let table_url = url::Url::from_directory_path(table_dir.canonicalize()?).unwrap();
+
+    let mut dt = open_table(table_url).await?;
+    let initial_values = sorted_int_values(&dt).await?;
+    assert_eq!(initial_values, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
+    write(&mut writer, &mut dt, single_int_batch(vec![10, 11])?).await?;
+
+    let expected_values = vec![1, 2, 3, 4, 5, 6, 7, 8, 10, 11];
+    assert_eq!(sorted_int_values(&dt).await?, expected_values);
+
+    let (dt, metrics) = dt
+        .optimize()
+        .with_target_size(NonZeroU64::new(1_000_000).unwrap())
+        .await?;
+
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 2);
+    assert_eq!(sorted_int_values(&dt).await?, expected_values);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_optimize_compaction_tombstones_preserve_deletion_vector_metadata()
+-> Result<(), Box<dyn Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let table_dir = temp_dir.path().join("table-with-dv-small");
+    fs_extra::dir::copy(
+        TestTables::WithDvSmall.as_path(),
+        temp_dir.path(),
+        &Default::default(),
+    )?;
+    let table_url = url::Url::from_directory_path(table_dir.canonicalize()?).unwrap();
+
+    let mut dt = open_table(table_url).await?;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
+    write(&mut writer, &mut dt, single_int_batch(vec![10, 11])?).await?;
+
+    let source_files = dt
+        .get_active_add_actions_by_partitions(&[])
+        .try_collect::<Vec<_>>()
+        .await?;
+    assert_eq!(source_files.len(), 2);
+    let dv_source = source_files
+        .iter()
+        .find(|file| file.deletion_vector_descriptor().is_some())
+        .ok_or_else(|| std::io::Error::other("expected a DV-backed source add"))?;
+
+    let (optimized, metrics) = dt
+        .optimize()
+        .with_target_size(NonZeroU64::new(1_000_000).unwrap())
+        .await?;
+    assert_eq!(metrics.num_files_removed, 2);
+
+    let actions = latest_commit_actions(&optimized).await?;
+    let removes = actions
+        .iter()
+        .filter_map(|action| match action {
+            Action::Remove(remove) => Some(remove),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(removes.len(), 2);
+    assert!(
+        removes
+            .iter()
+            .all(|remove| remove.extended_file_metadata == Some(true)),
+        "{removes:?}"
+    );
+    assert!(
+        removes
+            .iter()
+            .all(|remove| remove.partition_values.is_some() && remove.size.is_some()),
+        "{removes:?}"
+    );
+
+    let dv_remove = removes
+        .iter()
+        .find(|remove| remove.path == dv_source.path().to_string())
+        .ok_or_else(|| std::io::Error::other("expected tombstone for the DV-backed source add"))?;
+    assert_eq!(
+        dv_remove.deletion_vector,
+        dv_source.deletion_vector_descriptor()
+    );
+    assert_eq!(
+        dv_remove.partition_values.as_ref(),
+        Some(&std::collections::HashMap::new())
+    );
+    assert_eq!(dv_remove.size, Some(dv_source.size()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_optimize_zorder_preserves_live_rows_with_deletion_vectors()
+-> Result<(), Box<dyn Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let table_dir = temp_dir.path().join("table-with-dv-small");
+    fs_extra::dir::copy(
+        TestTables::WithDvSmall.as_path(),
+        temp_dir.path(),
+        &Default::default(),
+    )?;
+    let table_url = url::Url::from_directory_path(table_dir.canonicalize()?).unwrap();
+
+    let mut dt = open_table(table_url).await?;
+    let mut writer = RecordBatchWriter::for_table(&dt)?;
+    write(&mut writer, &mut dt, single_int_batch(vec![10, 11])?).await?;
+
+    let expected_values = vec![1, 2, 3, 4, 5, 6, 7, 8, 10, 11];
+    let (dt, metrics) = dt
+        .optimize()
+        .with_type(OptimizeType::ZOrder(vec!["value".to_string()]))
+        .await?;
+
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 2);
+    assert_eq!(sorted_int_values(&dt).await?, expected_values);
 
     Ok(())
 }


### PR DESCRIPTION
Stacked on #4383  Will rebase once that merges

Only unique commit: 
- 1f89215ad98176b514bf2a3043cff96e31466683
- 3fe469e8816fb1f5453b5bf2abd4e5b75af7db49
- f49dd4dfe44c1dd28122dbe2ce18a25bb049e801

Moves `overwrite` / `replaceWhere` onto `scan_files_where_matches()`. Write no longer depends on `find_files()` -> `Add list` -> `DeltaTableProvider::with_files()`

Replaces `prepare_predicate_actions` / `execute_non_empty_expr` with typed rewrite planning in write/plan.rs. Matched files stay typed until commit assembly instead of lowering to raw actions during planning

Rescue rewrites built from the matched file scan and unioned with validated inserts. Partition only rewrites skip the rescue scan. CDC handling stays within the rewrite/sink boundary. Insert only validation threaded through via an internal write marker column dropped before final output

`replaceWhere` validation is now explicit across all outcomes with no matched files, partition only, and full rescue rewrites