### PR TITLE
chore: update datafusion to 53.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,11 @@ object_store = { version = "0.13.2" }
 parquet = { version = "58" }
 
 # datafusion 53
-datafusion = { version = "53.0.0" }
-datafusion-datasource = { version = "53.0.0" }
-datafusion-physical-expr-adapter = { version = "53.0.0" }
-datafusion-ffi = { version = "53.0.0" }
-datafusion-proto = { version = "53.0.0" }
+datafusion = { version = "53.1.0" }
+datafusion-datasource = { version = "53.1.0" }
+datafusion-physical-expr-adapter = { version = "53.1.0" }
+datafusion-ffi = { version = "53.1.0" }
+datafusion-proto = { version = "53.1.0" }
 
 # serde
 serde = { version = "1.0.194", features = ["derive"] }


### PR DESCRIPTION
# Description

DataFusion release a minor update for patching some bugs last week. This PR bumps the DataFusion version used in delta-rs to 53.1.0. There should be no breaking changes that require a change on our side.

# Related Issue(s)

No issue as I think this is a minor PR.

# Documentation

https://github.com/apache/datafusion/issues/21079