### PR TITLE
fix: support Spark TRUNC in generated columns

### DIFF
--- a/crates/core/src/delta_datafusion/data_validation.rs
+++ b/crates/core/src/delta_datafusion/data_validation.rs
@@ -45,7 +45,9 @@ use itertools::Itertools as _;
 use pin_project_lite::pin_project;
 
 use crate::delta_datafusion::engine::{to_datafusion_expr, to_delta_expression};
-use crate::delta_datafusion::expr::parse_predicate_expression;
+use crate::delta_datafusion::expr::{
+    parse_generated_column_expression, parse_predicate_expression,
+};
 use crate::delta_datafusion::table_provider::simplify_expr;
 use crate::table::config::TablePropertiesExt as _;
 use crate::table::{Constraint, GeneratedColumn};
@@ -333,7 +335,7 @@ pub(crate) fn generated_columns_to_exprs<'a>(
     generated_columns
         .into_iter()
         .map(|gen_col| {
-            let expr = parse_predicate_expression(df_schema, &gen_col.generation_expr, session)?;
+            let expr = parse_generated_column_expression(df_schema, gen_col, session)?;
             let col_expr = col(&gen_col.name);
             let validation_expr = binary_expr(col_expr, Operator::IsNotDistinctFrom, expr);
             Ok::<_, DataFusionError>(validation_expr)

--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -22,6 +22,7 @@
 //! Utility functions for Datafusion's Expressions
 use std::fmt::{self, Display, Error, Formatter, Write};
 use std::marker::PhantomData;
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use arrow_array::{Array, GenericListArray};
@@ -41,15 +42,23 @@ use datafusion::logical_expr::{
 };
 // Needed for MakeParquetArray
 use datafusion::functions::core::planner::CoreFunctionPlanner;
-use datafusion::logical_expr::{ColumnarValue, Documentation, ScalarUDF, ScalarUDFImpl, Signature};
+use datafusion::logical_expr::{
+    ColumnarValue, Documentation, ExprSchemable, ScalarUDF, ScalarUDFImpl, Signature,
+};
 use datafusion::sql::planner::{ContextProvider, SqlToRel};
 use datafusion::sql::sqlparser::ast::escape_quoted_string;
+use datafusion::sql::sqlparser::ast::{
+    Expr as SqlExpr, Function, FunctionArg, FunctionArgExpr, FunctionArgumentList,
+    FunctionArguments, Ident, ObjectName, ObjectNamePart, Value, VisitMut, VisitorMut,
+};
 use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
 use datafusion::sql::sqlparser::tokenizer::Tokenizer;
+use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use tracing::log::*;
 
 use crate::delta_datafusion::session::DeltaParserOptions;
+use crate::table::GeneratedColumn;
 use crate::{DeltaResult, DeltaTableError};
 
 /// This struct is like Datafusion's MakeArray but ensures that `element` is used rather than `item
@@ -204,7 +213,7 @@ impl<'a> DeltaContextProvider<'a> {
             crate::delta_datafusion::SessionFallbackPolicy::DeriveFromTrait,
             || SessionStateBuilder::new().with_default_features().build(),
             crate::delta_datafusion::SessionResolveContext {
-                operation: "parse_predicate_expression",
+                operation: "parse_sql_expression",
                 table_uri: None,
                 cdc: false,
             },
@@ -270,6 +279,10 @@ pub fn parse_predicate_expression(
     expr: impl AsRef<str>,
     session: &dyn Session,
 ) -> DeltaResult<Expr> {
+    sql_expr_to_df_expr(session, schema, parse_sql_expr(expr)?)
+}
+
+fn parse_sql_expr(expr: impl AsRef<str>) -> DeltaResult<SqlExpr> {
     let dialect = &GenericDialect {};
     let mut tokenizer = Tokenizer::new(dialect, expr.as_ref());
     let tokens = tokenizer
@@ -277,18 +290,156 @@ pub fn parse_predicate_expression(
         .map_err(|err| DeltaTableError::GenericError {
             source: Box::new(err),
         })?;
-    let sql = Parser::new(dialect)
+    Parser::new(dialect)
         .with_tokens(tokens)
         .parse_expr()
         .map_err(|err| DeltaTableError::GenericError {
             source: Box::new(err),
-        })?;
+        })
+}
 
+fn sql_expr_to_df_expr(
+    session: &dyn Session,
+    schema: &DFSchema,
+    sql: SqlExpr,
+) -> DeltaResult<Expr> {
     let context_provider = DeltaContextProvider::try_new(session)?;
     let sql_to_rel =
         SqlToRel::new_with_options(&context_provider, DeltaParserOptions::default().into());
 
     Ok(sql_to_rel.sql_to_expr(sql, schema, &mut Default::default())?)
+}
+
+const SUPPORTED_SPARK_TRUNC_UNITS: &[(&str, &str)] = &[
+    ("YEAR", "year"),
+    ("YYYY", "year"),
+    ("YY", "year"),
+    ("QUARTER", "quarter"),
+    ("MONTH", "month"),
+    ("MON", "month"),
+    ("MM", "month"),
+    ("WEEK", "week"),
+];
+
+struct SparkGeneratedColumnExprRewrite;
+
+impl SparkGeneratedColumnExprRewrite {
+    fn normalize_trunc_unit(unit: &str) -> DeltaResult<&'static str> {
+        match SUPPORTED_SPARK_TRUNC_UNITS
+            .iter()
+            .find(|(alias, _)| alias.eq_ignore_ascii_case(unit))
+        {
+            Some((_, normalized)) => Ok(*normalized),
+            None => {
+                let supported_units = SUPPORTED_SPARK_TRUNC_UNITS
+                    .iter()
+                    .map(|(alias, _)| *alias)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Err(DeltaTableError::generic(format!(
+                    "Unsupported Spark generated column TRUNC unit '{unit}'. Supported units: {supported_units}"
+                )))
+            }
+        }
+    }
+
+    fn is_trunc(function: &Function) -> bool {
+        // Generated column metadata uses builtin Spark names directly.
+        // Qualified calls are left unchanged.
+        function.name.0.len() == 1
+            && function.name.0[0]
+                .as_ident()
+                .is_some_and(|ident| ident.value.eq_ignore_ascii_case("trunc"))
+    }
+
+    fn truncate_args(function: &Function) -> Option<(&SqlExpr, &str)> {
+        let FunctionArguments::List(FunctionArgumentList { args, .. }) = &function.args else {
+            return None;
+        };
+        if args.len() != 2 {
+            return None;
+        }
+
+        let FunctionArg::Unnamed(FunctionArgExpr::Expr(expr)) = &args[0] else {
+            return None;
+        };
+        let FunctionArg::Unnamed(FunctionArgExpr::Expr(SqlExpr::Value(value))) = &args[1] else {
+            return None;
+        };
+
+        match &value.value {
+            Value::SingleQuotedString(unit) | Value::TripleSingleQuotedString(unit) => {
+                Some((expr, unit.as_str()))
+            }
+            _ => None,
+        }
+    }
+
+    fn rewrite_date_trunc(expr: &SqlExpr, unit: &str) -> DeltaResult<SqlExpr> {
+        let normalized = Self::normalize_trunc_unit(unit)?;
+        Ok(SqlExpr::Function(Function {
+            name: ObjectName(vec![ObjectNamePart::Identifier(Ident::new("date_trunc"))]),
+            uses_odbc_syntax: false,
+            parameters: FunctionArguments::None,
+            args: FunctionArguments::List(FunctionArgumentList {
+                duplicate_treatment: None,
+                args: vec![
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(SqlExpr::Value(
+                        Value::SingleQuotedString(normalized.to_string()).into(),
+                    ))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(expr.clone())),
+                ],
+                clauses: vec![],
+            }),
+            filter: None,
+            null_treatment: None,
+            over: None,
+            within_group: vec![],
+        }))
+    }
+}
+
+impl VisitorMut for SparkGeneratedColumnExprRewrite {
+    type Break = DeltaTableError;
+
+    fn post_visit_expr(&mut self, expr: &mut SqlExpr) -> ControlFlow<Self::Break> {
+        let SqlExpr::Function(function) = expr else {
+            return ControlFlow::Continue(());
+        };
+        if !Self::is_trunc(function) {
+            return ControlFlow::Continue(());
+        }
+        let Some((arg_expr, unit)) = Self::truncate_args(function) else {
+            return ControlFlow::Continue(());
+        };
+
+        match Self::rewrite_date_trunc(arg_expr, unit) {
+            Ok(rewritten) => {
+                *expr = rewritten;
+                ControlFlow::Continue(())
+            }
+            Err(err) => ControlFlow::Break(err),
+        }
+    }
+}
+
+/// Delta metadata expressions use Spark SQL.
+/// Generated columns need a small rewrite before DataFusion plans them.
+pub(crate) fn parse_generated_column_expression(
+    schema: &DFSchema,
+    generated_col: &GeneratedColumn,
+    session: &dyn Session,
+) -> DeltaResult<Expr> {
+    let mut sql = parse_sql_expr(generated_col.get_generation_expression())?;
+    match sql.visit(&mut SparkGeneratedColumnExprRewrite) {
+        ControlFlow::Continue(()) => {}
+        ControlFlow::Break(err) => return Err(err),
+    }
+
+    let expr = sql_expr_to_df_expr(session, schema, sql)?;
+    let expected = (&generated_col.data_type).try_into_arrow()?;
+
+    Ok(expr.cast_to(&expected, schema)?)
 }
 
 struct SqlFormat<'a> {
@@ -585,7 +736,7 @@ impl fmt::Display for ScalarValueFormat<'_> {
 
 #[cfg(test)]
 mod test {
-    use arrow_schema::DataType as ArrowDataType;
+    use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
     use datafusion::common::{Column, DFSchema, ScalarValue, ToDFSchema};
     use datafusion::execution::SessionStateBuilder;
     use datafusion::execution::runtime_env::RuntimeEnvBuilder;
@@ -603,9 +754,11 @@ mod test {
     use crate::delta_datafusion::planner::DeltaPlanner;
     use crate::delta_datafusion::{DataFusionMixins, DeltaSessionContext};
     use crate::kernel::{ArrayType, DataType, PrimitiveType, StructField, StructType};
+    use crate::table::GeneratedColumn;
     use crate::test_utils::datafusion::{WrapperSession, make_test_scalar_udf};
 
     use super::fmt_expr_to_sql;
+    use super::parse_generated_column_expression;
     use super::parse_predicate_expression;
 
     const TEST_UDF_NAME: &str = "delta_rs_parse_expr_test_udf";
@@ -755,6 +908,131 @@ mod test {
         assert!(
             expr.is_ok(),
             "Expected UDF to be available during parsing but got: {expr:?}"
+        );
+    }
+
+    #[test]
+    fn parse_generated_column_expression_rewrites_quoted_spark_trunc() {
+        let session = SessionContext::new();
+        let schema = DFSchema::try_from(ArrowSchema::new(vec![ArrowField::new(
+            "event_date",
+            ArrowDataType::Date32,
+            false,
+        )]))
+        .unwrap();
+
+        let generated_col = GeneratedColumn::new(
+            "event_year",
+            "\"TRUNC\"(event_date, 'YEAR')",
+            &DataType::DATE,
+        );
+
+        let expr =
+            parse_generated_column_expression(&schema, &generated_col, &session.state()).unwrap();
+        assert_eq!(
+            fmt_expr_to_sql(&expr).unwrap(),
+            "arrow_cast(date_trunc('year', event_date), 'Date32')"
+        );
+    }
+
+    #[test]
+    fn parse_generated_column_expression_normalizes_supported_spark_trunc_aliases() {
+        let session = SessionContext::new();
+        let schema = DFSchema::try_from(ArrowSchema::new(vec![ArrowField::new(
+            "event_date",
+            ArrowDataType::Date32,
+            false,
+        )]))
+        .unwrap();
+
+        for (unit, normalized) in [
+            ("YEAR", "year"),
+            ("YYYY", "year"),
+            ("YY", "year"),
+            ("year", "year"),
+            ("QUARTER", "quarter"),
+            ("MONTH", "month"),
+            ("MON", "month"),
+            ("MM", "month"),
+            ("mOn", "month"),
+            ("WEEK", "week"),
+        ] {
+            let generated_col = GeneratedColumn::new(
+                "event_period",
+                &format!("TRUNC(event_date, '{unit}')"),
+                &DataType::DATE,
+            );
+
+            let expr = parse_generated_column_expression(&schema, &generated_col, &session.state())
+                .unwrap();
+            assert_eq!(
+                fmt_expr_to_sql(&expr).unwrap(),
+                format!("arrow_cast(date_trunc('{normalized}', event_date), 'Date32')"),
+                "unit {unit} normalized unexpectedly",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_generated_column_expression_preserves_numeric_trunc() {
+        let session = SessionContext::new();
+        let schema = DFSchema::try_from(ArrowSchema::new(vec![ArrowField::new(
+            "amount",
+            ArrowDataType::Float64,
+            false,
+        )]))
+        .unwrap();
+
+        let generated_col =
+            GeneratedColumn::new("amount_trunc", "TRUNC(amount, 2)", &DataType::DOUBLE);
+
+        let expr =
+            parse_generated_column_expression(&schema, &generated_col, &session.state()).unwrap();
+        assert_eq!(fmt_expr_to_sql(&expr).unwrap(), "trunc(amount, 2)");
+    }
+
+    #[test]
+    fn parse_generated_column_expression_rejects_unsupported_spark_trunc_unit() {
+        let session = SessionContext::new();
+        let schema = DFSchema::try_from(ArrowSchema::new(vec![ArrowField::new(
+            "event_date",
+            ArrowDataType::Date32,
+            false,
+        )]))
+        .unwrap();
+
+        let generated_col =
+            GeneratedColumn::new("event_year", "TRUNC(event_date, 'DAY')", &DataType::DATE);
+
+        let err = parse_generated_column_expression(&schema, &generated_col, &session.state())
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Unsupported Spark generated column TRUNC unit 'DAY'")
+        );
+    }
+
+    #[test]
+    fn parse_generated_column_expression_rewrites_nested_spark_trunc() {
+        let session = SessionContext::new();
+        let schema = DFSchema::try_from(ArrowSchema::new(vec![ArrowField::new(
+            "event_date",
+            ArrowDataType::Date32,
+            false,
+        )]))
+        .unwrap();
+
+        let generated_col = GeneratedColumn::new(
+            "event_month_or_date",
+            "coalesce(TRUNC(event_date, 'MONTH'), event_date)",
+            &DataType::DATE,
+        );
+
+        let expr =
+            parse_generated_column_expression(&schema, &generated_col, &session.state()).unwrap();
+        assert_eq!(
+            fmt_expr_to_sql(&expr).unwrap(),
+            "arrow_cast(coalesce(date_trunc('month', event_date), event_date), 'Date32')"
         );
     }
 

--- a/crates/core/src/operations/write/generated_columns.rs
+++ b/crates/core/src/operations/write/generated_columns.rs
@@ -2,15 +2,15 @@ use arrow_schema::Schema;
 use datafusion::catalog::Session;
 use datafusion::common::{Result, ScalarValue};
 use datafusion::logical_expr::{ExprSchemable, LogicalPlan, LogicalPlanBuilder, col, when};
+use datafusion::prelude::DataFrame;
 use datafusion::prelude::{cast, lit};
-use datafusion::{execution::SessionState, prelude::DataFrame};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::table_features::TableFeature;
 use tracing::debug;
 
 use crate::{
     DeltaResult,
-    delta_datafusion::expr::parse_predicate_expression,
+    delta_datafusion::expr::parse_generated_column_expression,
     kernel::{DataCheck, EagerSnapshot},
     table::GeneratedColumn,
 };
@@ -23,11 +23,11 @@ pub fn gc_is_enabled(snapshot: &EagerSnapshot) -> bool {
         .is_feature_enabled(&TableFeature::GeneratedColumns)
 }
 
-/// Returns `true` when the error indicates that a column referenced in the
-/// generation expression could not be found in the current plan schema.
-/// This happens during `SchemaMode::Merge` when the input batch omits
-/// nullable columns that schema evolution will add later.  All other errors
-/// (e.g. SQL syntax errors, type mismatches) should still be surfaced.
+/// Returns `true` when the error indicates that a referenced column is
+/// missing from the current plan schema.
+/// This occurs during `SchemaMode::Merge` when the input batch omits
+/// nullable columns added later by schema evolution. Other errors, such as
+/// SQL syntax errors or type mismatches, are still returned.
 fn is_column_resolution_error(err: &crate::DeltaTableError) -> bool {
     let msg = err.to_string();
     // DataFusion emits "No field named ..." for unresolved column references
@@ -45,8 +45,8 @@ pub fn with_generated_columns(
         return Ok(plan);
     }
 
-    // Preserve the full input projection: missing non-generated columns are handled later by
-    // schema evolution logic when `SchemaMode::Merge` is used.
+    // Preserve the full input projection.
+    // Missing base columns are handled later by schema evolution in `SchemaMode::Merge`.
     let mut projection: Vec<_> = plan
         .schema()
         .fields()
@@ -62,28 +62,18 @@ pub fn with_generated_columns(
 
         debug!("Adding missing generated column {}.", name);
         // Try to resolve the generation expression against the current plan schema.
-        // When SchemaMode::Merge is used, the input batch may omit nullable columns
-        // that the expression references. In that case, parse_predicate_expression
-        // will fail because the column doesn't exist yet (schema evolution hasn't
-        // run). We fall back to a typed NULL placeholder so the pipeline can
-        // continue; schema evolution will later add the missing base columns as NULL,
-        // and DataValidationExec will see NULL IS NOT DISTINCT FROM NULL = true.
-        let expr = match parse_predicate_expression(
-            plan.schema(),
-            &generated_col.generation_expr,
-            session,
-        ) {
-            Ok(resolved) => {
-                let mut e = resolved.alias(name);
-                if let Ok(field) = table_schema.field_with_name(name) {
-                    e = e.cast_to(field.data_type(), plan.schema())?;
-                }
-                e
-            }
+        // In `SchemaMode::Merge`, the input batch may omit nullable columns
+        // referenced by the expression. In that case,
+        // parse_generated_column_expression fails because the column is not present yet.
+        // A typed NULL placeholder keeps the pipeline moving. Schema evolution adds
+        // the missing base columns as NULL later, and DataValidationExec evaluates
+        // NULL IS NOT DISTINCT FROM NULL as true.
+        let expr = match parse_generated_column_expression(plan.schema(), generated_col, session) {
+            Ok(resolved) => resolved.alias(name),
             Err(ref err) if is_column_resolution_error(err) => {
                 debug!(
                     "Could not resolve generation expression for column {} ({}), \
-                     inserting NULL placeholder (will be resolved after schema evolution).",
+                     inserting NULL placeholder; schema evolution resolves it later.",
                     name, err
                 );
                 // Use the target data type from the table schema if available,
@@ -134,7 +124,7 @@ pub fn add_generated_columns(
     mut df: DataFrame,
     generated_cols: &Vec<GeneratedColumn>,
     generated_cols_missing_in_source: &[String],
-    state: &SessionState,
+    session: &dyn Session,
 ) -> DeltaResult<DataFrame> {
     debug!("Generating columns in dataframe");
     for generated_col in generated_cols {
@@ -144,10 +134,8 @@ pub fn add_generated_columns(
             continue;
         }
 
-        let generation_expr = state.create_logical_expr(
-            generated_col.get_generation_expression(),
-            df.clone().schema(),
-        )?;
+        let generation_expr =
+            parse_generated_column_expression(df.schema(), generated_col, session)?;
         let col_name = generated_col.get_name();
 
         df = df.clone().with_column(
@@ -163,7 +151,7 @@ pub fn add_generated_columns(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::Int32Array;
+    use arrow::array::{Date32Array, Int32Array};
     use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField};
     use arrow_array::RecordBatch;
     use datafusion::assert_batches_eq;
@@ -189,6 +177,30 @@ mod tests {
 
         let batch =
             RecordBatch::try_new(schema, vec![Arc::new(id_array), Arc::new(value_array)]).unwrap();
+
+        let source = provider_as_source(Arc::new(
+            MemTable::try_new(batch.schema(), vec![vec![batch]]).unwrap(),
+        ));
+        LogicalPlanBuilder::scan("test", source, None)
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
+    fn create_date_test_plan() -> LogicalPlan {
+        let schema = Arc::new(Schema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, false),
+            ArrowField::new("event_date", ArrowDataType::Date32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(Date32Array::from(vec![18428, 18859])),
+            ],
+        )
+        .unwrap();
 
         let source = provider_as_source(Arc::new(
             MemTable::try_new(batch.schema(), vec![vec![batch]]).unwrap(),
@@ -250,6 +262,54 @@ mod tests {
                 .schema()
                 .field_with_unqualified_name("computed")
                 .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_add_missing_generated_date_column_with_spark_trunc() {
+        let session = create_test_session();
+        let plan = create_date_test_plan();
+        let ctx = SessionContext::new();
+
+        let table_schema = Schema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, false),
+            ArrowField::new("event_date", ArrowDataType::Date32, false),
+            ArrowField::new("event_year", ArrowDataType::Date32, false),
+        ]);
+
+        let generated_cols = vec![GeneratedColumn::new(
+            "event_year",
+            "TRUNC(event_date, 'YEAR')",
+            &KernelDataType::DATE,
+        )];
+
+        let result = with_generated_columns(&session, plan, &table_schema, &generated_cols);
+        assert!(result.is_ok(), "unexpected planning error: {result:?}");
+        let result_plan = result.unwrap();
+        assert!(
+            result_plan
+                .schema()
+                .field_with_unqualified_name("event_year")
+                .is_ok()
+        );
+
+        let actual = ctx
+            .execute_logical_plan(result_plan)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_batches_eq!(
+            &[
+                "+----+------------+------------+",
+                "| id | event_date | event_year |",
+                "+----+------------+------------+",
+                "| 1  | 2020-06-15 | 2020-01-01 |",
+                "| 2  | 2021-08-20 | 2021-01-01 |",
+                "+----+------------+------------+",
+            ],
+            &actual
         );
     }
 

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -17,7 +17,7 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::TableProvider;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::context::SessionContext;
-use datafusion::logical_expr::Expr;
+use datafusion::logical_expr::{Expr, col};
 use datafusion::physical_plan::metrics::Label;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanVisitor, visit_execution_plan};
 use datafusion::prelude::SessionConfig;
@@ -1567,6 +1567,64 @@ async fn create_table_with_schema(table_uri: &str, table_schema: &StructType) ->
         .unwrap()
 }
 
+fn schema_with_generated_trunc_year_column() -> StructType {
+    StructType::try_new(vec![
+        StructField::new(
+            "id".to_string(),
+            DataType::Primitive(PrimitiveType::Integer),
+            false,
+        ),
+        StructField::new(
+            "event_date".to_string(),
+            DataType::Primitive(PrimitiveType::Date),
+            false,
+        ),
+        StructField::new(
+            "event_year".to_string(),
+            DataType::Primitive(PrimitiveType::Date),
+            false,
+        )
+        .with_metadata(vec![(
+            ColumnMetadataKey::GenerationExpression.as_ref().to_string(),
+            MetadataValue::String("TRUNC(event_date, 'YEAR')".to_string()),
+        )]),
+    ])
+    .unwrap()
+}
+
+fn event_date_record_batch(ids: Vec<i32>, event_dates: Vec<i32>) -> RecordBatch {
+    RecordBatch::try_from_iter_with_nullable(vec![
+        ("id", Arc::new(Int32Array::from(ids)) as ArrayRef, false),
+        (
+            "event_date",
+            Arc::new(Date32Array::from(event_dates)) as ArrayRef,
+            false,
+        ),
+    ])
+    .unwrap()
+}
+
+fn event_date_with_year_record_batch(
+    ids: Vec<i32>,
+    event_dates: Vec<i32>,
+    event_years: Vec<i32>,
+) -> RecordBatch {
+    RecordBatch::try_from_iter_with_nullable(vec![
+        ("id", Arc::new(Int32Array::from(ids)) as ArrayRef, false),
+        (
+            "event_date",
+            Arc::new(Date32Array::from(event_dates)) as ArrayRef,
+            false,
+        ),
+        (
+            "event_year",
+            Arc::new(Date32Array::from(event_years)) as ArrayRef,
+            false,
+        ),
+    ])
+    .unwrap()
+}
+
 #[tokio::test]
 async fn test_schema_merge_append_missing_nullable_column_with_generated_columns() {
     let ctx = SessionContext::new();
@@ -1632,6 +1690,113 @@ async fn test_schema_merge_append_missing_nullable_column_with_generated_columns
             "| 3  | 30    | 33       |      |",
             "| 4  | 40    | 44       |      |",
             "+----+-------+----------+------+",
+        ],
+        &batches
+    );
+}
+
+#[tokio::test]
+async fn test_generated_column_spark_trunc_append_generates_date() {
+    let ctx = SessionContext::new();
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let table_uri = tmp_dir.path().to_str().unwrap();
+
+    let table =
+        create_table_with_schema(table_uri, &schema_with_generated_trunc_year_column()).await;
+    let table = table
+        .write(vec![event_date_record_batch(
+            vec![1, 2],
+            vec![18428, 18859],
+        )])
+        .await
+        .unwrap();
+
+    let batches = ctx
+        .read_table(table.table_provider().await.unwrap())
+        .unwrap()
+        .select_exprs(&["id", "event_date", "event_year"])
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        &[
+            "+----+------------+------------+",
+            "| id | event_date | event_year |",
+            "+----+------------+------------+",
+            "| 1  | 2020-06-15 | 2020-01-01 |",
+            "| 2  | 2021-08-20 | 2021-01-01 |",
+            "+----+------------+------------+",
+        ],
+        &batches
+    );
+}
+
+#[tokio::test]
+async fn test_generated_column_spark_trunc_validation_rejects_invalid_values() {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let table_uri = tmp_dir.path().to_str().unwrap();
+
+    let table =
+        create_table_with_schema(table_uri, &schema_with_generated_trunc_year_column()).await;
+    let result = table
+        .write(vec![event_date_with_year_record_batch(
+            vec![1],
+            vec![18428],
+            vec![18428],
+        )])
+        .await;
+
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("failed validation check"),
+        "expected generated column validation failure, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_generated_column_spark_trunc_merge_generates_missing_values() {
+    let ctx = SessionContext::new();
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let table_uri = tmp_dir.path().to_str().unwrap();
+
+    let table =
+        create_table_with_schema(table_uri, &schema_with_generated_trunc_year_column()).await;
+    let source = ctx
+        .read_batch(event_date_record_batch(vec![1, 2], vec![18428, 18859]))
+        .unwrap();
+
+    let (table, _) = table
+        .merge(source, col("target.id").eq(col("source.id")))
+        .with_source_alias("source")
+        .with_target_alias("target")
+        .when_not_matched_insert(|insert| {
+            insert
+                .set("id", col("source.id"))
+                .set("event_date", col("source.event_date"))
+        })
+        .unwrap()
+        .await
+        .unwrap();
+
+    let batches = ctx
+        .read_table(table.table_provider().await.unwrap())
+        .unwrap()
+        .select_exprs(&["id", "event_date", "event_year"])
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+
+    assert_batches_sorted_eq!(
+        &[
+            "+----+------------+------------+",
+            "| id | event_date | event_year |",
+            "+----+------------+------------+",
+            "| 1  | 2020-06-15 | 2020-01-01 |",
+            "| 2  | 2021-08-20 | 2021-01-01 |",
+            "+----+------------+------------+",
         ],
         &batches
     );

--- a/python/tests/test_generated_columns.py
+++ b/python/tests/test_generated_columns.py
@@ -179,6 +179,7 @@ def test_write_to_table_generating_data(table_with_gc: DeltaTable):
     assert result.schema == expected_data.schema
 
 
+@pytest.mark.pyarrow
 def test_write_to_table_generating_data_with_spark_trunc_gc(tmp_path):
     import pyarrow as pa
 
@@ -206,6 +207,7 @@ def test_write_to_table_generating_data_with_spark_trunc_gc(tmp_path):
     }
 
 
+@pytest.mark.pyarrow
 def test_write_with_invalid_spark_trunc_gc_to_table(tmp_path):
     import pyarrow as pa
 
@@ -300,6 +302,7 @@ def test_merge_with_gc(table_with_gc: DeltaTable, data_without_gc):
     assert result == expected_data
 
 
+@pytest.mark.pyarrow
 def test_merge_with_spark_trunc_gc(tmp_path):
     import pyarrow as pa
 

--- a/python/tests/test_generated_columns.py
+++ b/python/tests/test_generated_columns.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import TYPE_CHECKING
 
 import pytest
@@ -12,6 +13,21 @@ from deltalake.schema import PrimitiveType
 
 if TYPE_CHECKING:
     import pyarrow as pa
+
+
+def spark_trunc_gc_schema() -> DeltaSchema:
+    return DeltaSchema(
+        [
+            Field(name="id", type=PrimitiveType("integer"), nullable=False),
+            Field(name="event_date", type=PrimitiveType("date"), nullable=False),
+            Field(
+                name="event_year",
+                type=PrimitiveType("date"),
+                nullable=False,
+                metadata={"delta.generationExpression": "TRUNC(event_date, 'YEAR')"},
+            ),
+        ]
+    )
 
 
 @pytest.fixture
@@ -163,6 +179,55 @@ def test_write_to_table_generating_data(table_with_gc: DeltaTable):
     assert result.schema == expected_data.schema
 
 
+def test_write_to_table_generating_data_with_spark_trunc_gc(tmp_path):
+    import pyarrow as pa
+
+    dt = DeltaTable.create(tmp_path, schema=spark_trunc_gc_schema())
+
+    write_deltalake(
+        dt,
+        mode="append",
+        data=pa.table(
+            {
+                "id": pa.array([1, 2], pa.int32()),
+                "event_date": pa.array(
+                    [datetime.date(2020, 6, 15), datetime.date(2021, 8, 20)],
+                    pa.date32(),
+                ),
+            }
+        ),
+    )
+
+    result = DeltaTable(tmp_path).to_pyarrow_table().sort_by([("id", "ascending")])
+    assert result.to_pydict() == {
+        "id": [1, 2],
+        "event_date": [datetime.date(2020, 6, 15), datetime.date(2021, 8, 20)],
+        "event_year": [datetime.date(2020, 1, 1), datetime.date(2021, 1, 1)],
+    }
+
+
+def test_write_with_invalid_spark_trunc_gc_to_table(tmp_path):
+    import pyarrow as pa
+
+    dt = DeltaTable.create(tmp_path, schema=spark_trunc_gc_schema())
+
+    with pytest.raises(
+        DeltaError,
+        match="failed validation check",
+    ):
+        write_deltalake(
+            dt,
+            mode="append",
+            data=pa.table(
+                {
+                    "id": pa.array([1], pa.int32()),
+                    "event_date": pa.array([datetime.date(2020, 6, 15)], pa.date32()),
+                    "event_year": pa.array([datetime.date(2020, 6, 15)], pa.date32()),
+                }
+            ),
+        )
+
+
 def test_raise_when_gc_passed_during_schema_evolution(
     tmp_path, data_without_gc, valid_gc_data
 ):
@@ -233,6 +298,36 @@ def test_merge_with_gc(table_with_gc: DeltaTable, data_without_gc):
     )
 
     assert result == expected_data
+
+
+def test_merge_with_spark_trunc_gc(tmp_path):
+    import pyarrow as pa
+
+    dt = DeltaTable.create(tmp_path, schema=spark_trunc_gc_schema())
+    source = pa.table(
+        {
+            "id": pa.array([1, 2], pa.int32()),
+            "event_date": pa.array(
+                [datetime.date(2020, 6, 15), datetime.date(2021, 8, 20)],
+                pa.date32(),
+            ),
+        }
+    )
+
+    (
+        dt.merge(source, predicate="s.id = t.id", source_alias="s", target_alias="t")
+        .when_not_matched_insert(
+            updates={"id": "s.id", "event_date": "s.event_date"},
+        )
+        .execute()
+    )
+
+    result = DeltaTable(tmp_path).to_pyarrow_table().sort_by([("id", "ascending")])
+    assert result.to_pydict() == {
+        "id": [1, 2],
+        "event_date": [datetime.date(2020, 6, 15), datetime.date(2021, 8, 20)],
+        "event_year": [datetime.date(2020, 1, 1), datetime.date(2021, 1, 1)],
+    }
 
 
 def test_merge_with_g_during_schema_evolution(


### PR DESCRIPTION
Closes #4386.

Generated column expressions come from delta metadata in spark sql form. Spark's `TRUNC(event_date, 'YEAR')` is date truncation, but datafusion's trunc is numeric causing generated column planning failure for these expressions.

The fix here is to add a generated column specific parsing path that rewrites spark date TRUNC to datafusion's `date_trunc()` before planning and then cast the result to the generated column type.

Scope is intentionally limited to generated column expressions and global sql parsing behavior is unchanged. Applied to append/write projection, generated column validation, and merge.