### PR TITLE
fix: preserve mixed case columns in replaceWhere writes

### DIFF
--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -1940,6 +1940,68 @@ mod tests {
         Ok(())
     }
 
+    fn mixed_case_replace_where_batches() -> TestResult<(Arc<ArrowSchema>, RecordBatch, RecordBatch)>
+    {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("utcDate", DataType::Utf8, true),
+            Field::new("homeTeam", DataType::Utf8, true),
+            Field::new("score", DataType::Utf8, true),
+        ]));
+        let base_batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec![
+                    Some("2008-08-16T15:00:00Z"),
+                    Some("2009-05-16T15:00:00Z"),
+                ])),
+                Arc::new(StringArray::from(vec![Some("Everton"), Some("Everton")])),
+                Arc::new(StringArray::from(vec![Some("0-1"), Some("3-1")])),
+            ],
+        )?;
+        let replacement_batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec![Some("2010-01-01T15:00:00Z")])),
+                Arc::new(StringArray::from(vec![Some("Everton")])),
+                Arc::new(StringArray::from(vec![Some("0-1")])),
+            ],
+        )?;
+
+        Ok((schema, base_batch, replacement_batch))
+    }
+
+    #[tokio::test]
+    async fn test_replace_where_preserves_mixed_case_columns_when_rescuing_rows() -> TestResult {
+        let (_, base_batch, replacement_batch) = mixed_case_replace_where_batches()?;
+
+        let table = DeltaTable::new_in_memory()
+            .write(vec![base_batch])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let table = table
+            .write(vec![replacement_batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_schema_mode(SchemaMode::Overwrite)
+            .with_replace_where(col("score").eq(lit("0-1")))
+            .await?;
+
+        let actual = get_data_sorted(&table, r#""utcDate","homeTeam",score"#).await;
+        assert_batches_sorted_eq!(
+            &[
+                "+----------------------+----------+-------+",
+                "| utcDate              | homeTeam | score |",
+                "+----------------------+----------+-------+",
+                "| 2009-05-16T15:00:00Z | Everton  | 3-1   |",
+                "| 2010-01-01T15:00:00Z | Everton  | 0-1   |",
+                "+----------------------+----------+-------+",
+            ],
+            &actual
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_replace_where_preserves_live_rows_with_deletion_vectors() -> TestResult {
         let (_temp_dir, table) = open_copied_table_fixture(
@@ -2512,6 +2574,64 @@ mod tests {
             .filter(|action| matches!(action, &&Action::Cdc(_)))
             .collect_vec();
         assert!(!cdc_actions.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_write_cdc_with_replace_where_preserves_mixed_case_columns() -> TestResult {
+        let (schema, base_batch, replacement_batch) = mixed_case_replace_where_batches()?;
+        let delta_schema: StructType = Arc::clone(&schema).try_into_kernel()?;
+        let table: DeltaTable = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(delta_schema.fields().cloned())
+            .with_configuration_property(TableProperty::EnableChangeDataFeed, Some("true"))
+            .await?;
+        assert_eq!(table.version(), Some(0));
+
+        let table = table.write(vec![base_batch]).await?;
+        assert_eq!(table.version(), Some(1));
+
+        let table = table
+            .write(vec![replacement_batch])
+            .with_save_mode(crate::protocol::SaveMode::Overwrite)
+            .with_replace_where("score='0-1'")
+            .await?;
+        assert_eq!(table.version(), Some(2));
+
+        let ctx = SessionContext::new();
+        let cdf_scan = table
+            .clone()
+            .scan_cdf()
+            .with_starting_version(0)
+            .build(&ctx.state(), None)
+            .await
+            .expect("Failed to load CDF");
+        let mut batches = collect(cdf_scan, ctx.state().task_ctx())
+            .await
+            .expect("Failed to collect CDF batches");
+
+        let commit_timestamp_index = batches
+            .first()
+            .expect("expected CDF batches")
+            .schema()
+            .index_of("_commit_timestamp")
+            .expect("expected CDF commit timestamp column");
+        let _: Vec<_> = batches
+            .iter_mut()
+            .map(|batch| batch.remove_column(commit_timestamp_index))
+            .collect();
+
+        assert_batches_sorted_eq! {[
+            "+----------------------+----------+-------+--------------+-----------------+",
+            "| utcDate              | homeTeam | score | _change_type | _commit_version |",
+            "+----------------------+----------+-------+--------------+-----------------+",
+            "| 2008-08-16T15:00:00Z | Everton  | 0-1   | delete       | 2               |",
+            "| 2008-08-16T15:00:00Z | Everton  | 0-1   | insert       | 1               |",
+            "| 2009-05-16T15:00:00Z | Everton  | 3-1   | insert       | 1               |",
+            "| 2010-01-01T15:00:00Z | Everton  | 0-1   | insert       | 2               |",
+            "+----------------------+----------+-------+--------------+-----------------+",
+        ], &batches }
+
         Ok(())
     }
 

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -643,12 +643,20 @@ fn align_plan_to_schema(plan: LogicalPlan, target_plan: &LogicalPlan) -> DeltaRe
         .iter()
         .map(|target_field| {
             let name = target_field.name();
-            let expr = match source_schema.field_with_unqualified_name(name) {
-                Ok(source_field) if source_field.data_type() != target_field.data_type() => {
-                    cast(col(name), target_field.data_type().clone()).alias(name)
+            let expr = match source_schema.qualified_field_with_unqualified_name(name) {
+                Ok((qualifier, source_field)) => {
+                    // Use a direct column reference here. DataFusion col(name) treats the value
+                    // as SQL text and folds unquoted names to lowercase.
+                    let source_col =
+                        Expr::Column(Column::new(qualifier.cloned(), source_field.name().clone()));
+                    if source_field.data_type() != target_field.data_type() {
+                        cast(source_col, target_field.data_type().clone()).alias(name)
+                    } else {
+                        source_col.alias(name)
+                    }
                 }
-                Ok(_) => col(name).alias(name),
                 Err(_) => {
+                    // Keep alignment behavior for missing or ambiguous fields.
                     cast(lit(ScalarValue::Null), target_field.data_type().clone()).alias(name)
                 }
             };

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1262,6 +1262,52 @@ def test_replace_where_overwrite(
 
 
 @pytest.mark.pyarrow
+def test_replace_where_overwrite_preserves_mixed_case_columns(tmp_path: pathlib.Path):
+    """Regression test for issue 4404."""
+    import pyarrow as pa
+
+    initial = pa.table(
+        {
+            "utcDate": ["2008-08-16T15:00:00Z", "2009-05-16T15:00:00Z"],
+            "homeTeam": ["Everton", "Everton"],
+            "score": ["0-1", "3-1"],
+        }
+    )
+    write_deltalake(
+        tmp_path,
+        initial,
+        mode="overwrite",
+        schema_mode="overwrite",
+    )
+
+    update = pa.table(
+        {
+            "utcDate": ["2010-01-01T15:00:00Z"],
+            "homeTeam": ["Everton"],
+            "score": ["0-1"],
+        }
+    )
+    write_deltalake(
+        tmp_path,
+        update,
+        mode="overwrite",
+        schema_mode="overwrite",
+        predicate="score = '0-1'",
+    )
+
+    expected = pa.table(
+        {
+            "utcDate": ["2009-05-16T15:00:00Z", "2010-01-01T15:00:00Z"],
+            "homeTeam": ["Everton", "Everton"],
+            "score": ["3-1", "0-1"],
+        }
+    )
+    actual = DeltaTable(tmp_path).to_pyarrow_table().sort_by("utcDate")
+    assert actual.schema.names == ["utcDate", "homeTeam", "score"]
+    assert actual == expected
+
+
+@pytest.mark.pyarrow
 @pytest.mark.parametrize(
     "func",
     [


### PR DESCRIPTION
Closes #4404

`replaceWhere` with `schema_mode`="overwrite" on mixed case column tables was lowercasing field names. The write planner used `col(name)` for rescued/CDF row alignment, which datafusion treats as sql text (silly me... can't believe I missed this orginally) and folds to lowercase therefore turning `utcDate` into `utcdate`.

The fix is to resolve the source field first and build the column expression from the resolved schema field directly.