### PR TITLE
fix: exclude partition columns from add stats schema

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
@@ -30,6 +30,7 @@ use delta_kernel::{
         state::{DvInfo, ScanFile},
     },
     schema::{DataType, Schema, StructField},
+    table_configuration::TableConfiguration,
 };
 use futures::Stream;
 use itertools::Itertools;
@@ -41,7 +42,8 @@ use crate::{
     delta_datafusion::{DeltaScanConfig, engine::to_datafusion_scalar},
     kernel::{
         LogicalFileView, ReceiverStreamBuilder, Scan, StructDataExt,
-        arrow::engine_ext::stats_schema, parse_stats_column_with_schema,
+        arrow::engine_ext::{stats_inputs, stats_schema},
+        parse_stats_column_with_schema,
     },
 };
 
@@ -73,10 +75,10 @@ fn extract_predicate_columns(scan: &KernelScan) -> Option<HashSet<String>> {
 /// Create a stats schema containing only columns needed for predicate evaluation
 ///
 /// Returns:
-/// - If no predicate: Schema with just `numRecords`
-/// - If predicate exists: Schema with `numRecords` + stats for referenced columns only
+/// No predicate returns a schema with just `numRecords`.
+/// A predicate returns `numRecords` plus stats for referenced columns.
 fn create_minimal_stats_schema(
-    scan: &KernelScan,
+    table_configuration: &TableConfiguration,
     predicate_columns: Option<&HashSet<String>>,
 ) -> DeltaResult<Arc<Schema>> {
     let minimal_schema = || {
@@ -87,31 +89,31 @@ fn create_minimal_stats_schema(
 
     match predicate_columns {
         None => {
-            // No predicate - only need numRecords for file statistics
+            // No predicate. Only numRecords is needed for file statistics.
             minimal_schema()
         }
         Some(cols) if cols.is_empty() => {
-            // Empty predicate columns - minimal schema
+            // Empty predicate columns use the minimal schema.
             minimal_schema()
         }
         Some(cols) => {
-            // Filter physical schema to only referenced columns
-            let physical_schema = scan.physical_schema();
-            let filtered_fields: Vec<_> = physical_schema
+            let (stats_source_schema, table_properties) = stats_inputs(table_configuration)?;
+
+            let filtered_fields: Vec<_> = stats_source_schema
                 .fields()
                 .filter(|field| cols.contains(field.name()))
                 .cloned()
                 .collect();
 
             if filtered_fields.is_empty() {
-                // Predicate references only partition columns - minimal schema
+                // Predicates that only reference partition columns use the minimal schema.
                 minimal_schema()
             } else {
                 // Create stats schema for filtered fields
                 let filtered_schema = Schema::try_new(filtered_fields)?;
                 Ok(Arc::new(stats_schema(
                     &filtered_schema,
-                    scan.snapshot().table_properties(),
+                    table_properties.as_ref(),
                 )))
             }
         }
@@ -234,7 +236,7 @@ where
 
                 // Create minimal stats schema based on predicate columns
                 let stats_schema = match create_minimal_stats_schema(
-                    this.kernel_scan.as_ref(),
+                    this.kernel_scan.snapshot().table_configuration(),
                     predicate_columns.as_ref(),
                 ) {
                     Ok(schema) => schema,
@@ -569,12 +571,14 @@ fn visit_scan_file(ctx: &mut ScanContext, scan_file: ScanFile) {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
+    use crate::test_utils::{build_test_table_configuration, column_mapping_test_field};
     use delta_kernel::scan::state::{DvInfo, ScanFile};
+    use delta_kernel::schema::{DataType, StructField, StructType};
     use url::Url;
 
-    use super::{ScanContext, visit_scan_file};
+    use super::{ScanContext, create_minimal_stats_schema, visit_scan_file};
 
     fn scan_file(path: impl Into<String>) -> ScanFile {
         ScanFile {
@@ -586,6 +590,77 @@ mod tests {
             transform: None,
             partition_values: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn test_minimal_stats_schema_uses_stats_source_for_partitioned_tables() {
+        for configuration in [
+            HashMap::from([(
+                "delta.dataSkippingNumIndexedCols".to_string(),
+                "1".to_string(),
+            )]),
+            HashMap::from([(
+                "delta.dataSkippingStatsColumns".to_string(),
+                "p,a".to_string(),
+            )]),
+        ] {
+            let table_configuration = build_test_table_configuration(
+                StructType::try_new([
+                    StructField::nullable("p", DataType::INTEGER),
+                    StructField::nullable("a", DataType::INTEGER),
+                    StructField::nullable("b", DataType::INTEGER),
+                ])
+                .unwrap(),
+                vec!["p".to_string()],
+                configuration,
+            );
+            let predicate_columns = HashSet::from(["p".to_string(), "a".to_string()]);
+
+            let stats_schema =
+                create_minimal_stats_schema(&table_configuration, Some(&predicate_columns))
+                    .unwrap();
+
+            let min_values = match stats_schema.field("minValues").unwrap().data_type() {
+                DataType::Struct(fields) => fields,
+                other => panic!("expected minValues struct, got {other:?}"),
+            };
+            assert!(min_values.field("a").is_some());
+            assert!(min_values.field("p").is_none());
+            assert!(min_values.field("b").is_none());
+        }
+    }
+
+    #[test]
+    fn test_minimal_stats_schema_translates_stats_columns_for_column_mapping() {
+        let table_configuration = build_test_table_configuration(
+            StructType::try_new([
+                column_mapping_test_field("p", "col_p", 1),
+                column_mapping_test_field("a", "col_a", 2),
+                column_mapping_test_field("b", "col_b", 3),
+            ])
+            .unwrap(),
+            vec!["p".to_string()],
+            HashMap::from([
+                ("delta.columnMapping.mode".to_string(), "name".to_string()),
+                (
+                    "delta.dataSkippingStatsColumns".to_string(),
+                    "a".to_string(),
+                ),
+            ]),
+        );
+        let predicate_columns = HashSet::from(["col_p".to_string(), "col_a".to_string()]);
+
+        let stats_schema =
+            create_minimal_stats_schema(&table_configuration, Some(&predicate_columns)).unwrap();
+
+        let min_values = match stats_schema.field("minValues").unwrap().data_type() {
+            DataType::Struct(fields) => fields,
+            other => panic!("expected minValues struct, got {other:?}"),
+        };
+        assert!(min_values.field("col_a").is_some());
+        assert!(min_values.field("a").is_none());
+        assert!(min_values.field("col_p").is_none());
+        assert!(min_values.field("col_b").is_none());
     }
 
     #[test]

--- a/crates/core/src/kernel/arrow/engine_ext.rs
+++ b/crates/core/src/kernel/arrow/engine_ext.rs
@@ -18,6 +18,7 @@ use delta_kernel::schema::{
 };
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_configuration::TableConfiguration;
+use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::table_properties::{DataSkippingNumIndexedCols, TableProperties};
 use delta_kernel::transforms::SchemaTransform;
 use delta_kernel::{DeltaResult, ExpressionEvaluator};
@@ -69,9 +70,10 @@ pub(crate) trait SnapshotExt {
 
 impl SnapshotExt for TableConfiguration {
     fn stats_schema(&self) -> DeltaResult<SchemaRef> {
+        let (source_schema, table_properties) = stats_inputs(self)?;
         Ok(Arc::new(stats_schema(
-            self.physical_schema().as_ref(),
-            self.table_properties(),
+            &source_schema,
+            table_properties.as_ref(),
         )))
     }
 
@@ -113,14 +115,107 @@ fn partitions_schema(
     )?))
 }
 
-/// Generates the expected schema for file statistics.
+/// Returns the schema and table properties used to parse `Add.stats`.
 ///
-/// The base stats schema is dependent on the current table configuration and derived via:
-/// - only fields present in data files are included (use physical names, no partition columns)
-/// - if `dataSkippingStatsColumns` is set, include only those columns.
-///   Column names may refer to struct fields in which case all child fields are included.
-/// - otherwise the first `dataSkippingNumIndexedCols` (default 32) leaf fields are included.
-/// - all fields are made nullable.
+/// Partition columns are excluded from the returned schema; see [`stats_source_schema`].
+pub(crate) fn stats_inputs(
+    table_configuration: &TableConfiguration,
+) -> DeltaResult<(StructType, Cow<'_, TableProperties>)> {
+    let source_schema = stats_source_schema(
+        table_configuration.logical_schema().as_ref(),
+        table_configuration.metadata().partition_columns(),
+        table_configuration.column_mapping_mode(),
+    )?;
+    let table_properties = stats_table_properties(
+        table_configuration.logical_schema().as_ref(),
+        table_configuration.table_properties(),
+        table_configuration.column_mapping_mode(),
+    );
+    Ok((source_schema, table_properties))
+}
+
+/// Returns the schema of columns that may legally appear inside `Add.stats`.
+///
+/// Partition columns are excluded intentionally: their stats belong in
+/// `Add.partitionValues`, not `Add.stats`, even when table features materialize them in
+/// parquet files. When column mapping is disabled, fields retain their logical names.
+/// When column mapping is enabled (`Name` or `Id`), fields use their physical names.
+fn stats_source_schema(
+    logical_schema: &StructType,
+    partition_columns: &[String],
+    column_mapping_mode: ColumnMappingMode,
+) -> DeltaResult<StructType> {
+    let fields = logical_schema
+        .fields()
+        .filter(|field| !partition_columns.contains(field.name()))
+        .map(|field| field.make_physical(column_mapping_mode))
+        .collect::<DeltaResult<Vec<_>>>()?;
+    StructType::try_new(fields)
+}
+
+/// Translates `dataSkippingStatsColumns` from logical to physical names.
+///
+/// Columns that cannot be resolved against `logical_schema` are dropped.
+fn stats_table_properties<'a>(
+    logical_schema: &StructType,
+    table_properties: &'a TableProperties,
+    column_mapping_mode: ColumnMappingMode,
+) -> Cow<'a, TableProperties> {
+    if column_mapping_mode == ColumnMappingMode::None
+        || table_properties.data_skipping_stats_columns.is_none()
+    {
+        return Cow::Borrowed(table_properties);
+    }
+
+    let mut table_properties = table_properties.clone();
+    table_properties.data_skipping_stats_columns =
+        table_properties.data_skipping_stats_columns.map(|columns| {
+            columns
+                .iter()
+                .filter_map(|column| {
+                    physical_column_name(logical_schema, column, column_mapping_mode)
+                })
+                .collect()
+        });
+    Cow::Owned(table_properties)
+}
+
+/// Returns a physical column path, or `None` if the logical path cannot be resolved.
+fn physical_column_name(
+    logical_schema: &StructType,
+    column: &ColumnName,
+    column_mapping_mode: ColumnMappingMode,
+) -> Option<ColumnName> {
+    let mut path = column.path().iter().peekable();
+    let mut physical_path = Vec::with_capacity(column.path().len());
+    let mut current_struct = logical_schema;
+
+    while let Some(field_name) = path.next() {
+        let field = current_struct.field(field_name)?;
+        physical_path.push(field.physical_name(column_mapping_mode).to_string());
+
+        if path.peek().is_some() {
+            let DataType::Struct(inner) = field.data_type() else {
+                return None;
+            };
+            current_struct = inner;
+        }
+    }
+
+    Some(ColumnName::new(physical_path))
+}
+
+/// Generates the expected schema for parsing `Add.stats`.
+///
+/// The input schema must already represent only columns that may legally appear
+/// in `Add.stats`: use physical names when column mapping is enabled, and
+/// exclude partition columns even if data files materialize them.
+///
+/// The base stats schema follows the current table configuration.
+/// With `dataSkippingStatsColumns`, include only those columns. Column names may
+/// refer to struct fields, which includes all child fields.
+/// Without that setting, include the first `dataSkippingNumIndexedCols` leaf
+/// fields, defaulting to 32. All fields are made nullable.
 ///
 /// For the `nullCount` schema, we consider the whole base schema and convert all leaf fields
 /// to data type LONG. Maps, arrays, and variant are considered leaf fields in this case.
@@ -138,17 +233,15 @@ fn partitions_schema(
 /// }
 /// ```
 pub(crate) fn stats_schema(
-    physical_file_schema: &Schema,
+    stats_source_schema: &Schema,
     table_properties: &TableProperties,
 ) -> Schema {
     let mut fields = Vec::with_capacity(4);
     fields.push(StructField::nullable("numRecords", DataType::LONG));
 
-    // generate the base stats schema:
-    // - make all fields nullable
-    // - include fields according to table properties (num_indexed_cols, stats_coliumns, ...)
+    // Build the base stats schema by making fields nullable and applying table properties.
     let mut base_transform = BaseStatsTransform::new(table_properties);
-    if let Some(base_schema) = base_transform.transform_struct(physical_file_schema) {
+    if let Some(base_schema) = base_transform.transform_struct(stats_source_schema) {
         let base_schema = base_schema.into_owned();
 
         // convert all leaf fields to data type LONG for null count
@@ -424,9 +517,15 @@ impl StructDataExt for StructData {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use super::*;
+
+    use crate::test_utils::{
+        build_test_table_configuration, column_mapping_test_field,
+        column_mapping_test_field_with_type,
+    };
 
     use delta_kernel::EvaluationHandler;
     use delta_kernel::arrow::array::Int32Array;
@@ -601,6 +700,191 @@ mod tests {
         .unwrap();
 
         assert_eq!(&expected, &stats_schema);
+    }
+
+    #[test]
+    fn test_stats_source_schema_excludes_partition_columns() {
+        let logical_schema = StructType::try_new([
+            StructField::nullable("p", DataType::INTEGER),
+            StructField::nullable("a", DataType::INTEGER),
+        ])
+        .unwrap();
+
+        let stats_schema =
+            stats_source_schema(&logical_schema, &["p".to_string()], ColumnMappingMode::None)
+                .unwrap();
+
+        assert!(stats_schema.field("a").is_some());
+        assert!(stats_schema.field("p").is_none());
+    }
+
+    #[test]
+    fn test_stats_source_schema_applies_column_mapping_physical_names() {
+        let logical_schema = StructType::try_new([
+            column_mapping_test_field("p", "col_p", 1),
+            column_mapping_test_field("a", "col_a", 2),
+        ])
+        .unwrap();
+
+        for column_mapping_mode in [ColumnMappingMode::Name, ColumnMappingMode::Id] {
+            let stats_schema =
+                stats_source_schema(&logical_schema, &["p".to_string()], column_mapping_mode)
+                    .unwrap();
+
+            assert!(stats_schema.field("col_a").is_some());
+            assert!(stats_schema.field("a").is_none());
+            assert!(stats_schema.field("col_p").is_none());
+            assert!(stats_schema.field("p").is_none());
+        }
+    }
+
+    #[test]
+    fn test_table_configuration_stats_schema_translates_stats_columns_to_physical_names() {
+        // Use table property strings to exercise TableConfiguration parsing.
+        for column_mapping_mode in ["name", "id"] {
+            let logical_schema = StructType::try_new([
+                column_mapping_test_field("p", "col_p", 1),
+                column_mapping_test_field("a", "col_a", 2),
+                column_mapping_test_field("b", "col_b", 3),
+            ])
+            .unwrap();
+            let table_configuration = build_test_table_configuration(
+                logical_schema,
+                vec!["p".to_string()],
+                HashMap::from([
+                    (
+                        "delta.columnMapping.mode".to_string(),
+                        column_mapping_mode.to_string(),
+                    ),
+                    (
+                        "delta.dataSkippingStatsColumns".to_string(),
+                        "a".to_string(),
+                    ),
+                ]),
+            );
+
+            let stats_schema = table_configuration.stats_schema().unwrap();
+
+            let min_values = match stats_schema.field("minValues").unwrap().data_type() {
+                DataType::Struct(fields) => fields,
+                other => panic!("expected minValues struct, got {other:?}"),
+            };
+            assert!(min_values.field("col_a").is_some());
+            assert!(min_values.field("a").is_none());
+            assert!(min_values.field("col_p").is_none());
+            assert!(min_values.field("col_b").is_none());
+        }
+    }
+
+    #[test]
+    fn test_table_configuration_stats_schema_translates_nested_stats_columns_to_physical_names() {
+        // Use table property strings to exercise TableConfiguration parsing.
+        for column_mapping_mode in ["name", "id"] {
+            let nested_schema = StructType::try_new([
+                column_mapping_test_field("a", "col_a", 3),
+                column_mapping_test_field("b", "col_b", 4),
+            ])
+            .unwrap();
+            let logical_schema = StructType::try_new([
+                column_mapping_test_field("p", "col_p", 1),
+                column_mapping_test_field_with_type(
+                    "s",
+                    "col_s",
+                    2,
+                    DataType::Struct(Box::new(nested_schema)),
+                ),
+            ])
+            .unwrap();
+            let table_configuration = build_test_table_configuration(
+                logical_schema,
+                vec!["p".to_string()],
+                HashMap::from([
+                    (
+                        "delta.columnMapping.mode".to_string(),
+                        column_mapping_mode.to_string(),
+                    ),
+                    (
+                        "delta.dataSkippingStatsColumns".to_string(),
+                        "s.a".to_string(),
+                    ),
+                ]),
+            );
+
+            let stats_schema = table_configuration.stats_schema().unwrap();
+
+            let min_values = match stats_schema.field("minValues").unwrap().data_type() {
+                DataType::Struct(fields) => fields,
+                other => panic!("expected minValues struct, got {other:?}"),
+            };
+            let nested_min_values = match min_values.field("col_s").unwrap().data_type() {
+                DataType::Struct(fields) => fields,
+                other => panic!("expected nested minValues struct, got {other:?}"),
+            };
+            assert!(nested_min_values.field("col_a").is_some());
+            assert!(nested_min_values.field("a").is_none());
+            assert!(nested_min_values.field("col_b").is_none());
+            assert!(min_values.field("s").is_none());
+            assert!(min_values.field("col_p").is_none());
+        }
+    }
+
+    #[test]
+    fn test_table_configuration_stats_schema_drops_stats_columns_with_non_struct_intermediate() {
+        // Use table property strings to exercise TableConfiguration parsing.
+        for column_mapping_mode in ["name", "id"] {
+            let logical_schema = StructType::try_new([
+                column_mapping_test_field("p", "col_p", 1),
+                column_mapping_test_field("a", "col_a", 2),
+            ])
+            .unwrap();
+            let table_configuration = build_test_table_configuration(
+                logical_schema,
+                vec!["p".to_string()],
+                HashMap::from([
+                    (
+                        "delta.columnMapping.mode".to_string(),
+                        column_mapping_mode.to_string(),
+                    ),
+                    (
+                        "delta.dataSkippingStatsColumns".to_string(),
+                        "a.b".to_string(),
+                    ),
+                ]),
+            );
+
+            let stats_schema = table_configuration.stats_schema().unwrap();
+
+            assert!(stats_schema.field("nullCount").is_none());
+            assert!(stats_schema.field("minValues").is_none());
+            assert!(stats_schema.field("maxValues").is_none());
+        }
+    }
+
+    #[test]
+    fn test_table_configuration_stats_schema_num_indexed_cols_ignores_partition_columns() {
+        let logical_schema = StructType::try_new([
+            StructField::nullable("p", DataType::INTEGER),
+            StructField::nullable("a", DataType::INTEGER),
+        ])
+        .unwrap();
+        let table_configuration = build_test_table_configuration(
+            logical_schema,
+            vec!["p".to_string()],
+            HashMap::from([(
+                "delta.dataSkippingNumIndexedCols".to_string(),
+                "1".to_string(),
+            )]),
+        );
+
+        let stats_schema = table_configuration.stats_schema().unwrap();
+
+        let min_values = match stats_schema.field("minValues").unwrap().data_type() {
+            DataType::Struct(fields) => fields,
+            other => panic!("expected minValues struct, got {other:?}"),
+        };
+        assert!(min_values.field("a").is_some());
+        assert!(min_values.field("p").is_none());
+        assert_eq!(1, min_values.fields().count());
     }
 
     #[test]

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -784,16 +784,10 @@ mod tests {
                     Arc::new(array::Int64Array::from(vec![None, None])),
                 ),
                 (
-                    "null_count.k",
-                    Arc::new(array::Int64Array::from(vec![None, None])),
-                ),
-                (
                     "null_count.v",
                     Arc::new(array::Int64Array::from(vec![None, None])),
                 ),
-                ("min.k", Arc::new(array::StringArray::new_null(2))),
                 ("min.v", Arc::new(array::Int64Array::from(vec![None, None]))),
-                ("max.k", Arc::new(array::StringArray::new_null(2))),
                 ("max.v", Arc::new(array::Int64Array::from(vec![None, None]))),
                 (
                     "partition.k",

--- a/crates/core/src/test_utils/mod.rs
+++ b/crates/core/src/test_utils/mod.rs
@@ -7,6 +7,12 @@ pub(crate) mod object_store;
 
 use std::{collections::HashMap, path::PathBuf, process::Command};
 
+#[cfg(test)]
+use delta_kernel::{
+    actions::{Metadata, Protocol},
+    schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType},
+    table_configuration::TableConfiguration,
+};
 use url::Url;
 
 pub use self::factories::*;
@@ -29,6 +35,59 @@ pub(crate) fn open_fs_path(path: &str) -> DeltaTable {
     let url =
         url::Url::from_directory_path(std::path::Path::new(path).canonicalize().unwrap()).unwrap();
     DeltaTableBuilder::from_url(url).unwrap().build().unwrap()
+}
+
+#[cfg(test)]
+pub(crate) fn build_test_table_configuration(
+    schema: StructType,
+    partition_columns: Vec<String>,
+    configuration: HashMap<String, String>,
+) -> TableConfiguration {
+    let metadata = Metadata::try_new(
+        None,
+        None,
+        std::sync::Arc::new(schema),
+        partition_columns,
+        0,
+        configuration,
+    )
+    .unwrap();
+    let protocol: Protocol = serde_json::from_value(serde_json::json!({
+        "minReaderVersion": 2,
+        "minWriterVersion": 5,
+    }))
+    .unwrap();
+    TableConfiguration::try_new(
+        metadata,
+        protocol,
+        Url::parse("file:///tmp/table").unwrap(),
+        0,
+    )
+    .unwrap()
+}
+
+#[cfg(test)]
+pub(crate) fn column_mapping_test_field_with_type(
+    name: &str,
+    physical_name: &str,
+    id: i64,
+    data_type: DataType,
+) -> StructField {
+    StructField::nullable(name, data_type).with_metadata([
+        (
+            ColumnMetadataKey::ColumnMappingId.as_ref(),
+            MetadataValue::Number(id),
+        ),
+        (
+            ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+            MetadataValue::String(physical_name.to_string()),
+        ),
+    ])
+}
+
+#[cfg(test)]
+pub(crate) fn column_mapping_test_field(name: &str, physical_name: &str, id: i64) -> StructField {
+    column_mapping_test_field_with_type(name, physical_name, id, DataType::INTEGER)
 }
 
 /// Internal test helper function to return the raw paths from every file view in the snapshot.

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1885,6 +1885,54 @@ def test_write_stats_column_idx(tmp_path: pathlib.Path):
     _check_stats(dt)
 
 
+@pytest.mark.parametrize(
+    "configuration",
+    [
+        pytest.param(
+            {"delta.dataSkippingNumIndexedCols": "1"},
+            id="num_indexed_cols",
+        ),
+        pytest.param(
+            {"delta.dataSkippingStatsColumns": "p,a"},
+            id="stats_columns",
+        ),
+    ],
+)
+def test_get_add_actions_excludes_partition_columns_from_stats_schema(
+    tmp_path: pathlib.Path,
+    configuration: dict[str, str],
+):
+    data = Table(
+        {
+            "p": Array(
+                [10, 10, 20, 20],
+                ArrowField("p", type=DataType.int64(), nullable=False),
+            ),
+            "a": Array(
+                [1, 2, 3, 4],
+                ArrowField("a", type=DataType.int64(), nullable=False),
+            ),
+        }
+    )
+
+    write_deltalake(
+        tmp_path,
+        data,
+        mode="append",
+        partition_by=["p"],
+        configuration=configuration,
+    )
+
+    actions = DeltaTable(tmp_path).get_add_actions(flatten=True)
+    paths = actions["path"].to_pylist()
+    order = sorted(range(len(paths)), key=paths.__getitem__)
+
+    assert [actions.column("min.a")[idx].as_py() for idx in order] == [1, 3]
+    assert [actions.column("max.a")[idx].as_py() for idx in order] == [2, 4]
+
+    assert "min.p" not in actions.column_names
+
+
 def test_write_stats_columns_stats_provided(tmp_path: pathlib.Path):
     def _check_stats(dt: DeltaTable):
         add_actions_table = dt.get_add_actions(flatten=True)


### PR DESCRIPTION
Fixes #4398

`buoyant_kernel` changed parsed stats schema to use `physical_schema()`, which includes partition columns on partitioned tables. However, writers don't store partition column stats in `Add.stats`, those values live in `Add.partitionValues`. This broke stats parsing for partitioned tables in python-v1.5.1.

The fix here is to restore the invariant that partition columns are excluded from the stats schema. Share the corrected derivation between the legacy add actions path and the datafusion next replay path. Preserve the existing stats schema naming behavior while excluding partition columns.

This pr is scoped to the shared read path and does not change `dataset_partitions` pruning in `python/src/lib.rs`. This is related but separate.

As always you know I bring the tests, I've included rust and python regression for partitioned tables with `dataSkippingNumIndexedCols` and `dataSkippingStatsColumns`