### PR TITLE
fix: listing catalogs from Unity

### DIFF
--- a/crates/catalog-unity/src/models.rs
+++ b/crates/catalog-unity/src/models.rs
@@ -147,6 +147,9 @@ pub enum CatalogType {
     ManagedCatalog,
     DeltasharingCatalog,
     SystemCatalog,
+    InternalCatalog,
+    ForeignCatalog,
+    ManagedOnlineCatalog,
 }
 
 /// A catalog within a metastore

--- a/crates/catalog-unity/src/models.rs
+++ b/crates/catalog-unity/src/models.rs
@@ -192,6 +192,7 @@ pub struct ProvisioningInfo {
 }
 
 #[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ProvisioningState {
     #[default]
     Provisioning,
@@ -199,6 +200,7 @@ pub enum ProvisioningState {
     Failed,
     Deleting,
     Updating,
+    Degraded,
 }
 
 #[derive(Deserialize, Default, Debug)]


### PR DESCRIPTION
# Description
- Adds more types of catalogs.
- Adds a new type of ProvisioningState.
- Uses macro for formatting the ProvisioningState.

This should align with the Databricks API.

## Side notes (out of scope)
There are potentially more work that could be done to align the data model with the Databricks API.
For instance, `securable_type` is an enum, but treated as string in data model.

Some of the CatalogTypes are not really queriable (Foreign for instance). But this problem is not really introduced by this change.

# Related Issue(s)
- closes #4360 

# Documentation

- [Databricks API](https://docs.databricks.com/api/azure/workspace/catalogs/list)
- [Unity Catalog OSS](https://docs.unitycatalog.io/swagger-docs/#/Catalogs/)
