### PR TITLE
feat: support writes to name-mapped column mapping tables

### DIFF
--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -242,3 +242,14 @@ impl DeltaTableError {
         Self::Generic(msg.to_string())
     }
 }
+
+pub(crate) fn unsupported_column_mapping_write(
+    feature: impl AsRef<str>,
+    reason: impl AsRef<str>,
+) -> DeltaTableError {
+    DeltaTableError::Generic(format!(
+        "Unsupported column mapping write for {}: {}",
+        feature.as_ref(),
+        reason.as_ref()
+    ))
+}

--- a/crates/core/src/kernel/transaction/protocol.rs
+++ b/crates/core/src/kernel/transaction/protocol.rs
@@ -237,7 +237,7 @@ pub static INSTANCE: LazyLock<ProtocolChecker> = LazyLock::new(|| {
     let mut reader_features = HashSet::new();
     reader_features.insert(TableFeature::TimestampWithoutTimezone);
     reader_features.insert(TableFeature::DeletionVectors);
-    // reader_features.insert(TableFeature::ColumnMapping);
+    reader_features.insert(TableFeature::ColumnMapping);
 
     let mut writer_features = HashSet::new();
     writer_features.insert(TableFeature::AppendOnly);
@@ -250,7 +250,7 @@ pub static INSTANCE: LazyLock<ProtocolChecker> = LazyLock::new(|| {
         writer_features.insert(TableFeature::GeneratedColumns);
     }
     writer_features.insert(TableFeature::DeletionVectors);
-    // writer_features.insert(TableFeature::ColumnMapping);
+    writer_features.insert(TableFeature::ColumnMapping);
     // writer_features.insert(TableFeature::IdentityColumns);
 
     ProtocolChecker::new(reader_features, writer_features)

--- a/crates/core/src/operations/add_column.rs
+++ b/crates/core/src/operations/add_column.rs
@@ -3,10 +3,12 @@
 use std::sync::Arc;
 
 use delta_kernel::schema::StructType;
+use delta_kernel::table_features::ColumnMappingMode;
 use futures::future::BoxFuture;
 use itertools::Itertools;
 
 use super::{CustomExecuteHandler, Operation};
+use crate::errors::unsupported_column_mapping_write;
 use crate::kernel::schema::merge_delta_struct;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{
@@ -100,6 +102,13 @@ impl std::future::IntoFuture for AddColumnBuilder {
                 ));
             }
 
+            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+                return Err(unsupported_column_mapping_write(
+                    "ADD COLUMN",
+                    "adding column mapping metadata outside write schema merge is not supported yet",
+                ));
+            }
+
             let table_schema = snapshot.schema();
             let new_table_schema = merge_delta_struct(table_schema.as_ref(), fields_right)?;
 
@@ -136,5 +145,45 @@ impl std::future::IntoFuture for AddColumnBuilder {
                 commit.snapshot(),
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kernel::{DataType, PrimitiveType, StructField};
+
+    #[tokio::test]
+    async fn test_add_column_rejects_column_mapping_table() -> crate::DeltaResult<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let fixture_source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../test/tests/data/table_with_column_mapping");
+        fs_extra::dir::copy(&fixture_source, temp_dir.path(), &Default::default())
+            .map_err(crate::DeltaTableError::generic)?;
+        let table_url = url::Url::from_directory_path(
+            temp_dir
+                .path()
+                .join("table_with_column_mapping")
+                .canonicalize()?,
+        )
+        .unwrap();
+        let table = crate::open_table(table_url).await?;
+
+        let err = table
+            .add_columns()
+            .with_fields([StructField::new(
+                "new_column",
+                DataType::Primitive(PrimitiveType::String),
+                true,
+            )])
+            .await
+            .expect_err("ADD COLUMN should be rejected for column-mapped tables");
+
+        assert!(
+            err.to_string()
+                .contains("Unsupported column mapping write for ADD COLUMN:"),
+            "unexpected error: {err}"
+        );
+
+        Ok(())
     }
 }

--- a/crates/core/src/operations/add_feature.rs
+++ b/crates/core/src/operations/add_feature.rs
@@ -8,7 +8,6 @@ use itertools::Itertools;
 
 use super::{CustomExecuteHandler, Operation};
 use crate::DeltaTable;
-use crate::errors::unsupported_column_mapping_write;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{EagerSnapshot, ProtocolExt as _, TableFeatures, resolve_snapshot};
 use crate::logstore::LogStoreRef;
@@ -103,13 +102,6 @@ impl std::future::IntoFuture for AddTableFeatureBuilder {
             };
             let operation_id = this.get_operation_id();
             this.pre_execute(operation_id).await?;
-
-            if name.contains(&TableFeatures::ColumnMapping) {
-                return Err(unsupported_column_mapping_write(
-                    "ADD FEATURE columnMapping",
-                    "enabling column mapping requires schema metadata migration and is not supported yet",
-                ));
-            }
 
             let (reader_features, writer_features): (
                 Vec<Option<TableFeature>>,
@@ -234,21 +226,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn add_column_mapping_feature_is_rejected() -> DeltaResult<()> {
+    async fn add_column_mapping_feature() -> DeltaResult<()> {
         let batch = get_record_batch(None, false);
         let table = create_bare_table().write(vec![batch]).await.unwrap();
-        let err = table
+        let result = table
             .add_feature()
             .with_feature(TableFeatures::ColumnMapping)
             .with_allow_protocol_versions_increase(true)
             .await
-            .expect_err("columnMapping feature should not be enabled directly");
+            .unwrap();
 
+        let current_protocol = result.snapshot().unwrap().protocol().clone();
         assert!(
-            err.to_string()
-                .contains("Unsupported column mapping write for ADD FEATURE columnMapping:"),
-            "unexpected error: {err}"
+            &current_protocol
+                .writer_features()
+                .unwrap_or_default()
+                .contains(&TableFeature::ColumnMapping)
         );
+        assert!(
+            &current_protocol
+                .reader_features()
+                .unwrap_or_default()
+                .contains(&TableFeature::ColumnMapping)
+        );
+
         Ok(())
     }
 }

--- a/crates/core/src/operations/add_feature.rs
+++ b/crates/core/src/operations/add_feature.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 
 use super::{CustomExecuteHandler, Operation};
 use crate::DeltaTable;
+use crate::errors::unsupported_column_mapping_write;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{EagerSnapshot, ProtocolExt as _, TableFeatures, resolve_snapshot};
 use crate::logstore::LogStoreRef;
@@ -102,6 +103,13 @@ impl std::future::IntoFuture for AddTableFeatureBuilder {
             };
             let operation_id = this.get_operation_id();
             this.pre_execute(operation_id).await?;
+
+            if name.contains(&TableFeatures::ColumnMapping) {
+                return Err(unsupported_column_mapping_write(
+                    "ADD FEATURE columnMapping",
+                    "enabling column mapping requires schema metadata migration and is not supported yet",
+                ));
+            }
 
             let (reader_features, writer_features): (
                 Vec<Option<TableFeature>>,
@@ -222,6 +230,25 @@ mod tests {
             .await;
 
         assert!(result.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn add_column_mapping_feature_is_rejected() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let table = create_bare_table().write(vec![batch]).await.unwrap();
+        let err = table
+            .add_feature()
+            .with_feature(TableFeatures::ColumnMapping)
+            .with_allow_protocol_versions_increase(true)
+            .await
+            .expect_err("columnMapping feature should not be enabled directly");
+
+        assert!(
+            err.to_string()
+                .contains("Unsupported column mapping write for ADD FEATURE columnMapping:"),
+            "unexpected error: {err}"
+        );
         Ok(())
     }
 }

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -86,6 +86,7 @@ use crate::delta_datafusion::{
     resolve_session_state, update_datafusion_session,
 };
 use crate::delta_datafusion::{Expression, into_expr, maybe_into_expr};
+use crate::errors::unsupported_column_mapping_write;
 use crate::kernel::schema::cast::{merge_arrow_field, merge_arrow_schema};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
 use crate::kernel::{Action, EagerSnapshot, StructTypeExt, new_metadata, resolve_snapshot};
@@ -848,8 +849,9 @@ async fn execute(
     if merge_schema
         && snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None
     {
-        return Err(DeltaTableError::Generic(
-            "Merge schema evolution for column-mapped tables is not supported yet".to_string(),
+        return Err(unsupported_column_mapping_write(
+            "merge schema evolution",
+            "schema evolution during MERGE is not implemented for column-mapped tables yet",
         ));
     }
 
@@ -1568,6 +1570,7 @@ async fn execute(
         None,
         should_cdc, // if true, write execution plan splits batches in [normal, cdc] data before writing
         None,
+        false,
     )
     .await?;
     if let Some(schema_metadata) = schema_action {

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -64,6 +64,7 @@ use datafusion::{
 
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow as _, TryIntoKernel as _};
 use delta_kernel::schema::{ColumnMetadataKey, StructType};
+use delta_kernel::table_features::ColumnMappingMode;
 use filter::try_construct_early_filter;
 use futures::future::BoxFuture;
 use parquet::file::properties::WriterProperties;
@@ -843,6 +844,13 @@ async fn execute(
 
     if should_cdc {
         debug!("Executing a merge and I should write CDC!");
+    }
+    if merge_schema
+        && snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None
+    {
+        return Err(DeltaTableError::Generic(
+            "Merge schema evolution for column-mapped tables is not supported yet".to_string(),
+        ));
     }
 
     info!(cdc_enabled = should_cdc, "merge execution details");

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1548,6 +1548,7 @@ async fn execute(
 
     let (mut actions, write_plan_metrics) = write_execution_plan_v2(
         Some(&snapshot),
+        None,
         &state,
         write,
         table_partition_cols.to_vec(),

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -686,6 +686,7 @@ impl MergePlan {
         let writer_config = PartitionWriterConfig::try_new(
             task_parameters.file_schema.clone(),
             partition_values.clone(),
+            None,
             Some(task_parameters.writer_properties.clone()),
             // Since we know the total size of the bin, we can set the target file size to None.
             if ignore_target_size {

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -32,6 +32,7 @@ use datafusion::catalog::Session;
 use datafusion::execution::context::{SessionContext, SessionState};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::Scalar;
+use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
@@ -416,6 +417,11 @@ impl<'a> std::future::IntoFuture for OptimizeBuilder<'a> {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
             PROTOCOL.can_write_to(&snapshot)?;
+            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+                return Err(DeltaTableError::Generic(
+                    "OPTIMIZE on column-mapped tables is not supported yet".to_string(),
+                ));
+            }
 
             let operation_id = this.get_operation_id();
             this.pre_execute(operation_id).await?;
@@ -1385,6 +1391,34 @@ async fn build_zorder_plan(
 mod compact_planner_tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn test_optimize_rejects_column_mapping_table() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let fixture_source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../test/tests/data/table_with_column_mapping");
+        fs_extra::dir::copy(&fixture_source, temp_dir.path(), &Default::default())?;
+        let table_url = url::Url::from_directory_path(
+            temp_dir
+                .path()
+                .join("table_with_column_mapping")
+                .canonicalize()?,
+        )
+        .unwrap();
+        let table = crate::open_table(table_url).await?;
+
+        let err = table
+            .optimize()
+            .await
+            .expect_err("optimize should reject column-mapped tables");
+
+        assert!(
+            err.to_string()
+                .contains("OPTIMIZE on column-mapped tables is not supported yet")
+        );
+        Ok(())
+    }
 
     fn candidate(stable_ordinal: usize, size_bytes: u64) -> OrderedFileCandidate {
         OrderedFileCandidate {

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -53,7 +53,7 @@ use crate::delta_datafusion::{
     DataFusionMixins, DeltaScanConfig, DeltaScanNext, SessionFallbackPolicy, SessionResolveContext,
     create_session_state_with_spill_config, resolve_session_state, update_datafusion_session,
 };
-use crate::errors::{DeltaResult, DeltaTableError};
+use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, DEFAULT_RETRIES, PROTOCOL};
 use crate::kernel::{Action, Add, DataType, PartitionsExt, Remove, StructType, Version};
 use crate::kernel::{EagerSnapshot, resolve_snapshot};
@@ -418,8 +418,9 @@ impl<'a> std::future::IntoFuture for OptimizeBuilder<'a> {
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
             PROTOCOL.can_write_to(&snapshot)?;
             if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
-                return Err(DeltaTableError::Generic(
-                    "OPTIMIZE on column-mapped tables is not supported yet".to_string(),
+                return Err(unsupported_column_mapping_write(
+                    "OPTIMIZE",
+                    "rewritten optimized files do not preserve column mapping semantics yet",
                 ));
             }
 
@@ -1415,7 +1416,8 @@ mod compact_planner_tests {
 
         assert!(
             err.to_string()
-                .contains("OPTIMIZE on column-mapped tables is not supported yet")
+                .contains("Unsupported column mapping write for OPTIMIZE:"),
+            "unexpected error: {err}"
         );
         Ok(())
     }

--- a/crates/core/src/operations/set_tbl_properties.rs
+++ b/crates/core/src/operations/set_tbl_properties.rs
@@ -8,6 +8,8 @@ use futures::future::BoxFuture;
 use super::{CustomExecuteHandler, Operation};
 use crate::DeltaResult;
 use crate::DeltaTable;
+use crate::TableProperty;
+use crate::errors::unsupported_column_mapping_write;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{Action, EagerSnapshot, MetadataExt as _, ProtocolExt as _, resolve_snapshot};
 use crate::logstore::LogStoreRef;
@@ -95,6 +97,13 @@ impl std::future::IntoFuture for SetTablePropertiesBuilder {
             let current_protocol = snapshot.protocol();
             let properties = this.properties;
 
+            if properties.contains_key(TableProperty::ColumnMappingMode.as_ref()) {
+                return Err(unsupported_column_mapping_write(
+                    "SET TBLPROPERTIES delta.columnMapping.mode",
+                    "enabling or changing column mapping through set_tbl_properties is not supported yet",
+                ));
+            }
+
             let new_protocol = current_protocol
                 .clone()
                 .apply_properties_to_protocol(&properties, this.raise_if_not_exists)?;
@@ -134,6 +143,7 @@ impl std::future::IntoFuture for SetTablePropertiesBuilder {
 
 #[cfg(test)]
 pub mod tests {
+    use crate::TableProperty;
     use crate::writer::test_utils::create_initialized_table;
     use std::collections::HashMap;
     use tempfile::tempdir;
@@ -147,6 +157,32 @@ pub mod tests {
             ("delta.minWriterVersion".to_string(), "7".to_string()),
         ]);
         ops.set_tbl_properties().with_properties(props).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn test_set_tbl_properties_rejects_column_mapping_mode() -> crate::DeltaResult<()> {
+        let temp_loc = tempdir()?;
+        let ops = create_initialized_table(temp_loc.path().to_str().unwrap(), &[]).await;
+        let props = HashMap::from([(
+            TableProperty::ColumnMappingMode.as_ref().to_string(),
+            "name".to_string(),
+        )]);
+
+        let err = ops
+            .set_tbl_properties()
+            .with_raise_if_not_exists(false)
+            .with_properties(props)
+            .await
+            .expect_err("setting delta.columnMapping.mode should be rejected");
+
+        assert!(
+            err.to_string().contains(
+                "Unsupported column mapping write for SET TBLPROPERTIES delta.columnMapping.mode:"
+            ),
+            "unexpected error: {err}"
+        );
 
         Ok(())
     }

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -273,6 +273,7 @@ pub(crate) struct WriteExecutionPlanMetrics {
 struct WriteSinkConfig {
     partition_columns: Vec<String>,
     object_store: ObjectStoreRef,
+    table_config: Option<TableConfiguration>,
     target_file_size: Option<NonZeroU64>,
     write_batch_size: Option<usize>,
     writer_properties: Option<WriterProperties>,
@@ -415,6 +416,7 @@ pub(crate) async fn write_execution_plan_v2(
     let sink_config = WriteSinkConfig {
         partition_columns,
         object_store,
+        table_config: snapshot.map(|snapshot| snapshot.table_configuration().clone()),
         target_file_size,
         write_batch_size,
         writer_properties,
@@ -471,6 +473,7 @@ pub(crate) async fn write_exec_plan(
     let sink_config = WriteSinkConfig {
         partition_columns: table_config.metadata().partition_columns().to_vec(),
         object_store,
+        table_config: Some(table_config.clone()),
         target_file_size,
         write_batch_size: None,
         writer_properties: Some(writer_properties),
@@ -660,6 +663,7 @@ async fn write_data_plan(
     let WriteSinkConfig {
         partition_columns,
         object_store,
+        table_config,
         target_file_size,
         write_batch_size,
         writer_properties,
@@ -674,6 +678,10 @@ async fn write_data_plan(
         writer_stats_config.num_indexed_cols,
         writer_stats_config.stats_columns.clone(),
     );
+    let config = match table_config.as_ref() {
+        Some(table_config) => config.with_table_configuration(table_config)?,
+        None => config,
+    };
 
     // For unpartitioned writes, centralize writer behavior through write_streams.
     if partition_columns.is_empty() {
@@ -755,6 +763,7 @@ async fn write_cdc_plan(
     let WriteSinkConfig {
         partition_columns,
         object_store,
+        table_config,
         target_file_size,
         write_batch_size,
         writer_properties,
@@ -787,6 +796,10 @@ async fn write_cdc_plan(
         writer_stats_config.num_indexed_cols,
         writer_stats_config.stats_columns.clone(),
     );
+    let normal_config = match table_config.as_ref() {
+        Some(table_config) => normal_config.with_table_configuration(table_config)?,
+        None => normal_config,
+    };
 
     let cdf_config = WriterConfig::new(
         cdf_schema.clone(),

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -31,7 +31,7 @@ use crate::DeltaTableError;
 use crate::delta_datafusion::{
     DataValidationExec, generated_columns_to_exprs, validation_predicates,
 };
-use crate::errors::DeltaResult;
+use crate::errors::{DeltaResult, unsupported_column_mapping_write};
 use crate::kernel::{Action, Add, AddCDCFile, EagerSnapshot, StructType, StructTypeExt};
 use crate::logstore::{LogStore, ObjectStoreRef};
 use crate::operations::cdc::CDC_COLUMN_NAME;
@@ -276,6 +276,7 @@ struct WriteSinkConfig {
     object_store: ObjectStoreRef,
     table_config: Option<TableConfiguration>,
     effective_schema: Option<StructType>,
+    preserve_column_mapping_hive_style_partitions: bool,
     target_file_size: Option<NonZeroU64>,
     write_batch_size: Option<usize>,
     writer_properties: Option<WriterProperties>,
@@ -362,6 +363,7 @@ pub(crate) async fn write_execution_plan(
         None,
         false,
         None,
+        false,
     )
     .await?;
     Ok(actions)
@@ -382,6 +384,7 @@ pub(crate) async fn write_execution_plan_v2(
     predicate: Option<Expr>,
     contains_cdc: bool,
     insert_marker_column: Option<String>,
+    preserve_column_mapping_hive_style_partitions: bool,
 ) -> DeltaResult<(Vec<Action>, WriteExecutionPlanMetrics)> {
     // We always take the plan Schema since the data may contain Large/View arrow types,
     // the schema and batches were prior constructed with this in mind.
@@ -417,9 +420,9 @@ pub(crate) async fn write_execution_plan_v2(
             snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None
         })
     {
-        return Err(DeltaTableError::Generic(
-            "Writing change data feed files for column-mapped tables is not supported yet"
-                .to_string(),
+        return Err(unsupported_column_mapping_write(
+            "change data feed",
+            "CDC file writes do not rewrite physical names for column-mapped tables yet",
         ));
     }
 
@@ -433,6 +436,7 @@ pub(crate) async fn write_execution_plan_v2(
         object_store,
         table_config: snapshot.map(|snapshot| snapshot.table_configuration().clone()),
         effective_schema,
+        preserve_column_mapping_hive_style_partitions,
         target_file_size,
         write_batch_size,
         writer_properties,
@@ -491,6 +495,7 @@ pub(crate) async fn write_exec_plan(
         object_store,
         table_config: Some(table_config.clone()),
         effective_schema: None,
+        preserve_column_mapping_hive_style_partitions: false,
         target_file_size,
         write_batch_size: None,
         writer_properties: Some(writer_properties),
@@ -682,6 +687,7 @@ async fn write_data_plan(
         object_store,
         table_config,
         effective_schema,
+        preserve_column_mapping_hive_style_partitions,
         target_file_size,
         write_batch_size,
         writer_properties,
@@ -697,9 +703,11 @@ async fn write_data_plan(
         writer_stats_config.stats_columns.clone(),
     );
     let config = match table_config.as_ref() {
-        Some(table_config) => {
-            config.with_table_configuration(table_config, effective_schema.as_ref())?
-        }
+        Some(table_config) => config
+            .with_preserve_column_mapping_hive_style_partitions(
+                preserve_column_mapping_hive_style_partitions,
+            )
+            .with_table_configuration(table_config, effective_schema.as_ref())?,
         None => config,
     };
 
@@ -785,6 +793,7 @@ async fn write_cdc_plan(
         object_store,
         table_config,
         effective_schema,
+        preserve_column_mapping_hive_style_partitions,
         target_file_size,
         write_batch_size,
         writer_properties,
@@ -818,9 +827,11 @@ async fn write_cdc_plan(
         writer_stats_config.stats_columns.clone(),
     );
     let normal_config = match table_config.as_ref() {
-        Some(table_config) => {
-            normal_config.with_table_configuration(table_config, effective_schema.as_ref())?
-        }
+        Some(table_config) => normal_config
+            .with_preserve_column_mapping_hive_style_partitions(
+                preserve_column_mapping_hive_style_partitions,
+            )
+            .with_table_configuration(table_config, effective_schema.as_ref())?,
         None => normal_config,
     };
 

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -17,6 +17,7 @@ use datafusion::physical_plan::{
 };
 use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
 use delta_kernel::table_configuration::TableConfiguration;
+use delta_kernel::table_features::ColumnMappingMode;
 use futures::{StreamExt as _, TryStreamExt as _};
 use object_store::prefix::PrefixStore;
 use parquet::file::properties::WriterProperties;
@@ -409,6 +410,17 @@ pub(crate) async fn write_execution_plan_v2(
             pred = when(col(CDC_COLUMN_NAME).eq(lit("insert")), pred).otherwise(lit(true))?;
         }
         validations.push(pred);
+    }
+
+    if contains_cdc
+        && snapshot.is_some_and(|snapshot| {
+            snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None
+        })
+    {
+        return Err(DeltaTableError::Generic(
+            "Writing change data feed files for column-mapped tables is not supported yet"
+                .to_string(),
+        ));
     }
 
     let mut plan = DataValidationExec::try_new_with_predicates(session, plan, validations)?;

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -274,6 +274,7 @@ struct WriteSinkConfig {
     partition_columns: Vec<String>,
     object_store: ObjectStoreRef,
     table_config: Option<TableConfiguration>,
+    effective_schema: Option<StructType>,
     target_file_size: Option<NonZeroU64>,
     write_batch_size: Option<usize>,
     writer_properties: Option<WriterProperties>,
@@ -348,6 +349,7 @@ pub(crate) async fn write_execution_plan(
 ) -> DeltaResult<Vec<Action>> {
     let (actions, _) = write_execution_plan_v2(
         snapshot,
+        None,
         session,
         plan,
         partition_columns,
@@ -367,6 +369,7 @@ pub(crate) async fn write_execution_plan(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn write_execution_plan_v2(
     snapshot: Option<&EagerSnapshot>,
+    effective_schema: Option<StructType>,
     session: &dyn Session,
     plan: Arc<dyn ExecutionPlan>,
     partition_columns: Vec<String>,
@@ -417,6 +420,7 @@ pub(crate) async fn write_execution_plan_v2(
         partition_columns,
         object_store,
         table_config: snapshot.map(|snapshot| snapshot.table_configuration().clone()),
+        effective_schema,
         target_file_size,
         write_batch_size,
         writer_properties,
@@ -474,6 +478,7 @@ pub(crate) async fn write_exec_plan(
         partition_columns: table_config.metadata().partition_columns().to_vec(),
         object_store,
         table_config: Some(table_config.clone()),
+        effective_schema: None,
         target_file_size,
         write_batch_size: None,
         writer_properties: Some(writer_properties),
@@ -664,6 +669,7 @@ async fn write_data_plan(
         partition_columns,
         object_store,
         table_config,
+        effective_schema,
         target_file_size,
         write_batch_size,
         writer_properties,
@@ -679,7 +685,9 @@ async fn write_data_plan(
         writer_stats_config.stats_columns.clone(),
     );
     let config = match table_config.as_ref() {
-        Some(table_config) => config.with_table_configuration(table_config)?,
+        Some(table_config) => {
+            config.with_table_configuration(table_config, effective_schema.as_ref())?
+        }
         None => config,
     };
 
@@ -764,6 +772,7 @@ async fn write_cdc_plan(
         partition_columns,
         object_store,
         table_config,
+        effective_schema,
         target_file_size,
         write_batch_size,
         writer_properties,
@@ -797,7 +806,9 @@ async fn write_cdc_plan(
         writer_stats_config.stats_columns.clone(),
     );
     let normal_config = match table_config.as_ref() {
-        Some(table_config) => normal_config.with_table_configuration(table_config)?,
+        Some(table_config) => {
+            normal_config.with_table_configuration(table_config, effective_schema.as_ref())?
+        }
         None => normal_config,
     };
 

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -729,6 +729,24 @@ mod tests {
             .collect())
     }
 
+    async fn latest_add_actions(table: &DeltaTable) -> TestResult<Vec<crate::kernel::Add>> {
+        let version = table
+            .version()
+            .expect("expected committed version for latest add actions");
+        let snapshot_bytes = table
+            .log_store
+            .read_commit_entry(version)
+            .await?
+            .expect("failed to get snapshot bytes");
+        Ok(get_actions(version, &snapshot_bytes)?
+            .into_iter()
+            .filter_map(|action| match action {
+                Action::Add(add) => Some(add),
+                _ => None,
+            })
+            .collect())
+    }
+
     fn assert_common_write_metrics(write_metrics: WriteMetrics) {
         // assert!(write_metrics.execution_time_ms > 0);
         assert!(write_metrics.num_added_files > 0);
@@ -2053,6 +2071,56 @@ mod tests {
         let remove = &remove_actions[0];
         assert_eq!(remove.path, source_path);
         assert_eq!(remove.deletion_vector, source_deletion_vector);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_append_column_mapping_name_table_writes_physical_names() -> TestResult {
+        let fixture_source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../test/tests/data/table_with_column_mapping");
+        let (_temp_dir, table) =
+            open_copied_table_fixture(&fixture_source, "table_with_column_mapping").await?;
+
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                Field::new("Company Very Short", DataType::Utf8, true),
+                Field::new("Super Name", DataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec![Some("DRS")])) as _,
+                Arc::new(StringArray::from(vec![Some("Delta RS")])) as _,
+            ],
+        )?;
+
+        let table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let add_actions = latest_add_actions(&table).await?;
+        assert_eq!(add_actions.len(), 1);
+        let add = &add_actions[0];
+        let physical_partition = "col-173b4db9-b5ad-427f-9e75-516aae37fbbb";
+        let physical_data = "col-3877fd94-0973-4941-ac6b-646849a1ff65";
+
+        assert_eq!(
+            add.partition_values.get(physical_partition),
+            Some(&Some("DRS".to_string()))
+        );
+        assert!(!add.path.starts_with("Company Very Short="));
+        assert_eq!(add.path.split('/').next().map(str::len), Some(2));
+
+        let stats: Value = serde_json::from_str(add.stats.as_ref().unwrap())?;
+        assert_eq!(stats["minValues"][physical_data], json!("Delta RS"));
+        assert!(stats["minValues"]["Super Name"].is_null());
+
+        let rows = query_single_i64_row(
+            &table,
+            r#"SELECT COUNT(*) FROM test WHERE "Company Very Short" = 'DRS' AND "Super Name" = 'Delta RS'"#,
+        )
+        .await?;
+        assert_eq!(rows, vec![1]);
 
         Ok(())
     }

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -651,6 +651,8 @@ mod tests {
     use delta_kernel::schema::{ColumnMetadataKey, MetadataValue};
     use futures::TryStreamExt;
     use itertools::Itertools;
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
     use serde_json::{Value, json};
 
     async fn get_write_metrics(table: &DeltaTable) -> WriteMetrics {
@@ -799,6 +801,123 @@ mod tests {
             MetadataValue::String(physical_name.to_string()),
         );
         field
+    }
+
+    fn column_mapping_protocol() -> TestResult<Protocol> {
+        Ok(serde_json::from_value(json!({
+            "minReaderVersion": 2,
+            "minWriterVersion": 5
+        }))?)
+    }
+
+    fn logical_partition_column_mapping_configuration(
+        enable_cdf: bool,
+    ) -> Vec<(String, Option<String>)> {
+        let mut configuration = vec![
+            (
+                TableProperty::ColumnMappingMode.as_ref().to_string(),
+                Some("name".to_string()),
+            ),
+            (
+                "delta.columnMapping.maxColumnId".to_string(),
+                Some("3".to_string()),
+            ),
+        ];
+        if enable_cdf {
+            configuration.push((
+                TableProperty::EnableChangeDataFeed.as_ref().to_string(),
+                Some("true".to_string()),
+            ));
+        }
+        configuration
+    }
+
+    async fn create_logical_partition_column_mapping_table(
+        enable_cdf: bool,
+    ) -> TestResult<DeltaTable> {
+        Ok(DeltaTable::new_in_memory()
+            .create()
+            .with_columns([
+                column_mapping_field("id", PrimitiveType::Long, 1, "id", false),
+                column_mapping_field(
+                    "partition_column",
+                    PrimitiveType::String,
+                    2,
+                    "partition_column",
+                    false,
+                ),
+                column_mapping_field(
+                    "data_column",
+                    PrimitiveType::String,
+                    3,
+                    "col-data_column",
+                    true,
+                ),
+            ])
+            .with_partition_columns(["partition_column"])
+            .with_actions([Action::Protocol(column_mapping_protocol()?)])
+            .with_raise_if_key_not_exists(false)
+            .with_configuration(logical_partition_column_mapping_configuration(enable_cdf))
+            .await?)
+    }
+
+    fn logical_partition_column_mapping_batch(
+        rows: &[(i64, &str, &str)],
+    ) -> TestResult<RecordBatch> {
+        Ok(RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("partition_column", DataType::Utf8, false),
+                Field::new("data_column", DataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|(id, _, _)| *id).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(StringArray::from(
+                    rows.iter()
+                        .map(|(_, partition, _)| Some(*partition))
+                        .collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(StringArray::from(
+                    rows.iter()
+                        .map(|(_, _, value)| Some(*value))
+                        .collect::<Vec<_>>(),
+                )) as _,
+            ],
+        )?)
+    }
+
+    fn assert_parquet_columns(
+        table_root: &std::path::Path,
+        add: &crate::kernel::Add,
+        present: &[&str],
+        absent: &[&str],
+    ) -> TestResult {
+        let file = std::fs::File::open(table_root.join(&add.path))?;
+        let reader = SerializedFileReader::new(file)?;
+        let columns = reader
+            .metadata()
+            .file_metadata()
+            .schema_descr()
+            .columns()
+            .iter()
+            .map(|column| column.path().string())
+            .collect::<Vec<_>>();
+
+        for expected in present {
+            assert!(
+                columns.iter().any(|column| column == expected),
+                "expected Parquet column {expected}, got {columns:?}"
+            );
+        }
+        for unexpected in absent {
+            assert!(
+                columns.iter().all(|column| column != unexpected),
+                "did not expect Parquet column {unexpected}, got {columns:?}"
+            );
+        }
+        Ok(())
     }
 
     fn assert_common_write_metrics(write_metrics: WriteMetrics) {
@@ -2132,7 +2251,7 @@ mod tests {
     #[tokio::test]
     async fn test_append_column_mapping_name_table_writes_physical_names() -> TestResult {
         let fixture_source = column_mapping_fixture_path();
-        let (_temp_dir, table) =
+        let (temp_dir, table) =
             open_copied_table_fixture(&fixture_source, "table_with_column_mapping").await?;
 
         let batch = RecordBatch::try_new(
@@ -2156,6 +2275,7 @@ mod tests {
         let add = &add_actions[0];
         let physical_partition = "col-173b4db9-b5ad-427f-9e75-516aae37fbbb";
         let physical_data = "col-3877fd94-0973-4941-ac6b-646849a1ff65";
+        let table_root = temp_dir.path().join("table_with_column_mapping");
 
         assert_eq!(
             add.partition_values.get(physical_partition),
@@ -2163,6 +2283,12 @@ mod tests {
         );
         assert!(!add.path.starts_with("Company Very Short="));
         assert_eq!(add.path.split('/').next().map(str::len), Some(2));
+        assert_parquet_columns(
+            &table_root,
+            add,
+            &[physical_data],
+            &["Super Name", physical_partition, "Company Very Short"],
+        )?;
 
         let stats: Value = serde_json::from_str(add.stats.as_ref().unwrap())?;
         assert_eq!(stats["minValues"][physical_data], json!("Delta RS"));
@@ -2181,56 +2307,9 @@ mod tests {
     #[tokio::test]
     async fn test_append_column_mapping_name_table_preserves_hive_partition_path_when_partition_physical_names_are_logical()
     -> TestResult {
-        let protocol: Protocol = serde_json::from_value(json!({
-            "minReaderVersion": 2,
-            "minWriterVersion": 5
-        }))?;
-        let table = DeltaTable::new_in_memory()
-            .create()
-            .with_columns([
-                column_mapping_field("id", PrimitiveType::Long, 1, "id", false),
-                column_mapping_field(
-                    "partition_column",
-                    PrimitiveType::String,
-                    2,
-                    "partition_column",
-                    false,
-                ),
-                column_mapping_field(
-                    "data_column",
-                    PrimitiveType::String,
-                    3,
-                    "col-data_column",
-                    true,
-                ),
-            ])
-            .with_partition_columns(["partition_column"])
-            .with_actions([Action::Protocol(protocol)])
-            .with_raise_if_key_not_exists(false)
-            .with_configuration([
-                (
-                    TableProperty::ColumnMappingMode.as_ref().to_string(),
-                    Some("name".to_string()),
-                ),
-                (
-                    "delta.columnMapping.maxColumnId".to_string(),
-                    Some("3".to_string()),
-                ),
-            ])
-            .await?;
-
-        let batch = RecordBatch::try_new(
-            Arc::new(ArrowSchema::new(vec![
-                Field::new("id", DataType::Int64, false),
-                Field::new("partition_column", DataType::Utf8, false),
-                Field::new("data_column", DataType::Utf8, true),
-            ])),
-            vec![
-                Arc::new(Int64Array::from(vec![1])) as _,
-                Arc::new(StringArray::from(vec![Some("partition-value")])) as _,
-                Arc::new(StringArray::from(vec![Some("data-value")])) as _,
-            ],
-        )?;
+        let table = create_logical_partition_column_mapping_table(false).await?;
+        let batch =
+            logical_partition_column_mapping_batch(&[(1, "partition-value", "data-value")])?;
 
         let table = table
             .write(vec![batch])
@@ -2261,10 +2340,160 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_overwrite_column_mapping_name_table_preserves_hive_partition_path_when_partition_physical_names_are_logical()
+    -> TestResult {
+        let table = create_logical_partition_column_mapping_table(false).await?;
+        let table = table
+            .write(vec![logical_partition_column_mapping_batch(&[
+                (1, "partition-a", "old"),
+                (2, "partition-b", "keep"),
+            ])?])
+            .await?;
+
+        let table = table
+            .write(vec![logical_partition_column_mapping_batch(&[(
+                3,
+                "partition-a",
+                "new",
+            )])?])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_replace_where("partition_column = 'partition-a'")
+            .await?;
+
+        let add_actions = latest_add_actions(&table).await?;
+        assert_eq!(add_actions.len(), 1);
+        let add = &add_actions[0];
+        assert_eq!(
+            add.partition_values.get("partition_column"),
+            Some(&Some("partition-a".to_string()))
+        );
+        assert!(add.path.starts_with("partition_column=partition-a/"));
+        let stats: Value = serde_json::from_str(add.stats.as_ref().unwrap())?;
+        assert_eq!(stats["minValues"]["col-data_column"], json!("new"));
+        assert!(stats["minValues"]["data_column"].is_null());
+
+        let remove_actions = latest_remove_actions(&table).await?;
+        assert_eq!(remove_actions.len(), 1);
+        assert!(
+            remove_actions[0]
+                .path
+                .starts_with("partition_column=partition-a/")
+        );
+
+        let replacement_rows = query_single_i64_row(
+            &table,
+            "SELECT COUNT(*) FROM test WHERE partition_column = 'partition-a' AND data_column = 'new'",
+        )
+        .await?;
+        assert_eq!(replacement_rows, vec![1]);
+        let preserved_rows = query_single_i64_row(
+            &table,
+            "SELECT COUNT(*) FROM test WHERE partition_column = 'partition-b' AND data_column = 'keep'",
+        )
+        .await?;
+        assert_eq!(preserved_rows, vec![1]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_merge_column_mapping_name_table_writes_physical_names() -> TestResult {
+        let table = create_logical_partition_column_mapping_table(false).await?;
+        let table = table
+            .write(vec![logical_partition_column_mapping_batch(&[(
+                1,
+                "partition-a",
+                "old",
+            )])?])
+            .await?;
+
+        let source =
+            SessionContext::new().read_batch(logical_partition_column_mapping_batch(&[
+                (1, "partition-a", "updated"),
+                (2, "partition-b", "inserted"),
+            ])?)?;
+
+        let (table, metrics) = table
+            .merge(source, col("target.id").eq(col("source.id")))
+            .with_source_alias("source")
+            .with_target_alias("target")
+            .when_matched_update(|update| update.update("data_column", col("source.data_column")))
+            .unwrap()
+            .when_not_matched_insert(|insert| {
+                insert
+                    .set("id", col("source.id"))
+                    .set("partition_column", col("source.partition_column"))
+                    .set("data_column", col("source.data_column"))
+            })
+            .unwrap()
+            .await?;
+
+        assert_eq!(metrics.num_target_rows_updated, 1);
+        assert_eq!(metrics.num_target_rows_inserted, 1);
+
+        let add_actions = latest_add_actions(&table).await?;
+        assert!(!add_actions.is_empty());
+        for add in &add_actions {
+            assert!(add.partition_values.contains_key("partition_column"));
+            assert!(add.path.starts_with("partition_column="));
+            let stats: Value = serde_json::from_str(add.stats.as_ref().unwrap())?;
+            assert!(!stats["minValues"]["col-data_column"].is_null());
+            assert!(stats["minValues"]["data_column"].is_null());
+        }
+
+        let updated_rows = query_single_i64_row(
+            &table,
+            "SELECT COUNT(*) FROM test WHERE id = 1 AND partition_column = 'partition-a' AND data_column = 'updated'",
+        )
+        .await?;
+        assert_eq!(updated_rows, vec![1]);
+        let inserted_rows = query_single_i64_row(
+            &table,
+            "SELECT COUNT(*) FROM test WHERE id = 2 AND partition_column = 'partition-b' AND data_column = 'inserted'",
+        )
+        .await?;
+        assert_eq!(inserted_rows, vec![1]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_merge_schema_column_mapping_name_table_is_rejected() -> TestResult {
+        let table = create_logical_partition_column_mapping_table(false).await?;
+        let table = table
+            .write(vec![logical_partition_column_mapping_batch(&[(
+                1,
+                "partition-a",
+                "old",
+            )])?])
+            .await?;
+        let source = SessionContext::new().read_batch(logical_partition_column_mapping_batch(
+            &[(1, "partition-a", "updated")],
+        )?)?;
+
+        let err = table
+            .merge(source, col("target.id").eq(col("source.id")))
+            .with_source_alias("source")
+            .with_target_alias("target")
+            .with_merge_schema(true)
+            .when_matched_update(|update| update.update("data_column", col("source.data_column")))
+            .unwrap()
+            .await
+            .expect_err("merge schema evolution should be rejected for column-mapped tables");
+
+        assert!(
+            err.to_string()
+                .contains("Merge schema evolution for column-mapped tables is not supported yet")
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_append_column_mapping_name_table_schema_merge_assigns_physical_names()
     -> TestResult {
         let fixture_source = column_mapping_fixture_path();
-        let (_temp_dir, table) =
+        let (temp_dir, table) =
             open_copied_table_fixture(&fixture_source, "table_with_column_mapping").await?;
 
         let batch = RecordBatch::try_new(
@@ -2309,6 +2538,13 @@ mod tests {
 
         let add_actions = latest_add_actions(&table).await?;
         assert_eq!(add_actions.len(), 1);
+        let table_root = temp_dir.path().join("table_with_column_mapping");
+        assert_parquet_columns(
+            &table_root,
+            &add_actions[0],
+            &[physical_extra.as_str()],
+            &["Extra Name"],
+        )?;
         let stats: Value = serde_json::from_str(add_actions[0].stats.as_ref().unwrap())?;
         assert_eq!(stats["minValues"][physical_extra.as_str()], json!("extra"));
         assert!(stats["minValues"]["Extra Name"].is_null());
@@ -2502,6 +2738,35 @@ mod tests {
             .expect_err("column-mapped table creation through WriteBuilder should fail");
 
         assert!(err.to_string().contains("Creating column-mapped tables"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_column_mapping_name_cdc_write_is_rejected() -> TestResult {
+        let table = create_logical_partition_column_mapping_table(true).await?;
+        let table = table
+            .write(vec![logical_partition_column_mapping_batch(&[(
+                1,
+                "partition-a",
+                "old",
+            )])?])
+            .await?;
+
+        let err = table
+            .write(vec![logical_partition_column_mapping_batch(&[(
+                2,
+                "partition-a",
+                "new",
+            )])?])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_replace_where("data_column = 'old'")
+            .await
+            .expect_err("CDC writes should be rejected for column-mapped tables");
+
+        assert!(err.to_string().contains(
+            "Writing change data feed files for column-mapped tables is not supported yet"
+        ));
+
         Ok(())
     }
 

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -406,6 +406,18 @@ impl WriteBuilder {
                 }
             }
             None => {
+                if matches!(
+                    self.configuration
+                        .get("delta.columnMapping.mode")
+                        .and_then(|value| value.as_deref()),
+                    Some("name" | "id")
+                ) {
+                    return Err(DeltaTableError::Generic(
+                        "Creating column-mapped tables through WriteBuilder is not supported yet"
+                            .to_string(),
+                    ));
+                }
+
                 let mut builder = CreateBuilder::new()
                     .with_log_store(self.log_store.clone())
                     .with_columns(schema.fields().cloned())
@@ -514,6 +526,7 @@ impl std::future::IntoFuture for WriteBuilder {
                     exec_options,
                     ..
                 } = prepared_write;
+                let effective_schema = schema_delta.effective_schema.clone();
                 actions.extend(schema_delta.into_actions());
 
                 metrics.num_removed_files = overwrite_plan.num_removed_files();
@@ -533,6 +546,7 @@ impl std::future::IntoFuture for WriteBuilder {
                 // Here we need to validate if the new data conforms to a predicate if one is provided
                 let (add_actions, _) = write_execution_plan_v2(
                     this.snapshot.as_ref(),
+                    effective_schema,
                     &session,
                     source_plan.clone(),
                     partition_columns.clone(),
@@ -633,7 +647,7 @@ mod tests {
     use datafusion::prelude::*;
     use datafusion::{assert_batches_eq, assert_batches_sorted_eq};
     use delta_kernel::engine::arrow_conversion::TryIntoArrow;
-    use delta_kernel::schema::MetadataValue;
+    use delta_kernel::schema::{ColumnMetadataKey, MetadataValue};
     use futures::TryStreamExt;
     use itertools::Itertools;
     use serde_json::{Value, json};
@@ -745,6 +759,24 @@ mod tests {
                 _ => None,
             })
             .collect())
+    }
+
+    fn column_mapping_fixture_path() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../test/tests/data/table_with_column_mapping")
+    }
+
+    fn column_mapping_physical_name(field: &crate::kernel::StructField) -> TestResult<String> {
+        match field
+            .metadata()
+            .get(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref())
+        {
+            Some(MetadataValue::String(name)) => Ok(name.clone()),
+            other => Err(std::io::Error::other(format!(
+                "expected column mapping physical name, got {other:?}"
+            ))
+            .into()),
+        }
     }
 
     fn assert_common_write_metrics(write_metrics: WriteMetrics) {
@@ -2077,8 +2109,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_column_mapping_name_table_writes_physical_names() -> TestResult {
-        let fixture_source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../test/tests/data/table_with_column_mapping");
+        let fixture_source = column_mapping_fixture_path();
         let (_temp_dir, table) =
             open_copied_table_fixture(&fixture_source, "table_with_column_mapping").await?;
 
@@ -2122,6 +2153,251 @@ mod tests {
         .await?;
         assert_eq!(rows, vec![1]);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_append_column_mapping_name_table_schema_merge_assigns_physical_names()
+    -> TestResult {
+        let fixture_source = column_mapping_fixture_path();
+        let (_temp_dir, table) =
+            open_copied_table_fixture(&fixture_source, "table_with_column_mapping").await?;
+
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                Field::new("Company Very Short", DataType::Utf8, true),
+                Field::new("Super Name", DataType::Utf8, true),
+                Field::new("Extra Name", DataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec![Some("DRS")])) as _,
+                Arc::new(StringArray::from(vec![Some("Delta RS")])) as _,
+                Arc::new(StringArray::from(vec![Some("extra")])) as _,
+            ],
+        )?;
+
+        let table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .with_schema_mode(SchemaMode::Merge)
+            .await?;
+
+        let schema = table.snapshot()?.schema();
+        let extra = schema
+            .field("Extra Name")
+            .expect("expected merged field in table schema");
+        assert!(matches!(
+            extra
+                .metadata()
+                .get(ColumnMetadataKey::ColumnMappingId.as_ref()),
+            Some(MetadataValue::Number(_))
+        ));
+        let physical_extra = column_mapping_physical_name(extra)?;
+
+        let max_column_id = table
+            .snapshot()?
+            .metadata()
+            .configuration()
+            .get("delta.columnMapping.maxColumnId")
+            .expect("expected max column id")
+            .parse::<i64>()?;
+        assert!(max_column_id >= 3);
+
+        let add_actions = latest_add_actions(&table).await?;
+        assert_eq!(add_actions.len(), 1);
+        let stats: Value = serde_json::from_str(add_actions[0].stats.as_ref().unwrap())?;
+        assert_eq!(stats["minValues"][physical_extra.as_str()], json!("extra"));
+        assert!(stats["minValues"]["Extra Name"].is_null());
+
+        let rows = query_single_i64_row(
+            &table,
+            r#"SELECT COUNT(*) FROM test WHERE "Company Very Short" = 'DRS' AND "Extra Name" = 'extra'"#,
+        )
+        .await?;
+        assert_eq!(rows, vec![1]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_replace_where_column_mapping_name_table_writes_physical_names() -> TestResult {
+        let fixture_source = column_mapping_fixture_path();
+        let (_temp_dir, table) =
+            open_copied_table_fixture(&fixture_source, "table_with_column_mapping").await?;
+
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                Field::new("Company Very Short", DataType::Utf8, true),
+                Field::new("Super Name", DataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec![Some("BME")])) as _,
+                Arc::new(StringArray::from(vec![Some("Replacement")])) as _,
+            ],
+        )?;
+
+        let table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_replace_where(r#""Company Very Short" = 'BME'"#)
+            .await?;
+
+        let physical_partition = "col-173b4db9-b5ad-427f-9e75-516aae37fbbb";
+        let physical_data = "col-3877fd94-0973-4941-ac6b-646849a1ff65";
+        let add_actions = latest_add_actions(&table).await?;
+        assert_eq!(add_actions.len(), 1);
+        let add = &add_actions[0];
+        assert_eq!(
+            add.partition_values.get(physical_partition),
+            Some(&Some("BME".to_string()))
+        );
+        assert_eq!(add.path.split('/').next().map(str::len), Some(2));
+        let stats: Value = serde_json::from_str(add.stats.as_ref().unwrap())?;
+        assert_eq!(stats["minValues"][physical_data], json!("Replacement"));
+        assert!(stats["minValues"]["Super Name"].is_null());
+
+        let rows = query_single_i64_row(
+            &table,
+            r#"SELECT COUNT(*) FROM test WHERE "Company Very Short" = 'BME' AND "Super Name" = 'Replacement'"#,
+        )
+        .await?;
+        assert_eq!(rows, vec![1]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_column_mapping_name_data_skipping_stats_columns_are_physical() -> TestResult {
+        let fixture_source = column_mapping_fixture_path();
+        let (_temp_dir, table) =
+            open_copied_table_fixture(&fixture_source, "table_with_column_mapping").await?;
+
+        let table = table
+            .set_tbl_properties()
+            .with_raise_if_not_exists(false)
+            .with_properties(HashMap::from([(
+                TableProperty::DataSkippingStatsColumns.as_ref().to_string(),
+                "Super Name".to_string(),
+            )]))
+            .await?;
+
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                Field::new("Company Very Short", DataType::Utf8, true),
+                Field::new("Super Name", DataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec![Some("DRS")])) as _,
+                Arc::new(StringArray::from(vec![Some("Stats Only")])) as _,
+            ],
+        )?;
+
+        let table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let physical_data = "col-3877fd94-0973-4941-ac6b-646849a1ff65";
+        let add_actions = latest_add_actions(&table).await?;
+        assert_eq!(add_actions.len(), 1);
+        let stats: Value = serde_json::from_str(add_actions[0].stats.as_ref().unwrap())?;
+        assert_eq!(stats["minValues"][physical_data], json!("Stats Only"));
+        assert!(stats["minValues"]["Super Name"].is_null());
+        assert!(stats["minValues"]["col-173b4db9-b5ad-427f-9e75-516aae37fbbb"].is_null());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_update_column_mapping_name_table_writes_physical_names() -> TestResult {
+        let fixture_source = column_mapping_fixture_path();
+        let (_temp_dir, table) =
+            open_copied_table_fixture(&fixture_source, "table_with_column_mapping").await?;
+
+        let (table, _metrics) = table
+            .update()
+            .with_predicate(r#""Company Very Short" = 'BME'"#)
+            .with_update("Super Name", lit("Updated Lamb"))
+            .await?;
+
+        let physical_partition = "col-173b4db9-b5ad-427f-9e75-516aae37fbbb";
+        let physical_data = "col-3877fd94-0973-4941-ac6b-646849a1ff65";
+        let add_actions = latest_add_actions(&table).await?;
+        assert_eq!(add_actions.len(), 1);
+        let add = &add_actions[0];
+        assert_eq!(
+            add.partition_values.get(physical_partition),
+            Some(&Some("BME".to_string()))
+        );
+        let stats: Value = serde_json::from_str(add.stats.as_ref().unwrap())?;
+        assert_eq!(stats["minValues"][physical_data], json!("Updated Lamb"));
+        assert!(stats["minValues"]["Super Name"].is_null());
+
+        let rows = query_single_i64_row(
+            &table,
+            r#"SELECT COUNT(*) FROM test WHERE "Company Very Short" = 'BME' AND "Super Name" = 'Updated Lamb'"#,
+        )
+        .await?;
+        assert_eq!(rows, vec![1]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_delete_column_mapping_name_table_rewrite_writes_physical_names() -> TestResult {
+        let fixture_source = column_mapping_fixture_path();
+        let (_temp_dir, table) =
+            open_copied_table_fixture(&fixture_source, "table_with_column_mapping").await?;
+
+        let (table, _metrics) = table
+            .delete()
+            .with_predicate(r#""Super Name" = 'Anthony Johnson'"#)
+            .await?;
+
+        let physical_partition = "col-173b4db9-b5ad-427f-9e75-516aae37fbbb";
+        let physical_data = "col-3877fd94-0973-4941-ac6b-646849a1ff65";
+        let add_actions = latest_add_actions(&table).await?;
+        assert_eq!(add_actions.len(), 1);
+        let add = &add_actions[0];
+        assert_eq!(
+            add.partition_values.get(physical_partition),
+            Some(&Some("BMS".to_string()))
+        );
+        let stats: Value = serde_json::from_str(add.stats.as_ref().unwrap())?;
+        assert!(!stats["minValues"][physical_data].is_null());
+        assert!(stats["minValues"]["Super Name"].is_null());
+
+        let rows = query_single_i64_row(
+            &table,
+            r#"SELECT COUNT(*) FROM test WHERE "Super Name" = 'Anthony Johnson'"#,
+        )
+        .await?;
+        assert_eq!(rows, vec![0]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_write_create_column_mapping_table_is_rejected() -> TestResult {
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "value",
+                DataType::Utf8,
+                true,
+            )])),
+            vec![Arc::new(StringArray::from(vec![Some("a")])) as _],
+        )?;
+
+        let err = DeltaTable::new_in_memory()
+            .write(vec![batch])
+            .with_configuration(HashMap::from([(
+                TableProperty::ColumnMappingMode.as_ref().to_string(),
+                Some("name".to_string()),
+            )]))
+            .await
+            .expect_err("column-mapped table creation through WriteBuilder should fail");
+
+        assert!(err.to_string().contains("Creating column-mapped tables"));
         Ok(())
     }
 

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -630,6 +630,7 @@ mod tests {
     use crate::TableProperty;
     use crate::ensure_table_uri;
     use crate::kernel::CommitInfo;
+    use crate::kernel::{DataType as DeltaDataType, PrimitiveType, Protocol, StructField};
     use crate::logstore::get_actions;
     use crate::operations::collect_sendable_stream;
     use crate::protocol::SaveMode;
@@ -777,6 +778,27 @@ mod tests {
             ))
             .into()),
         }
+    }
+
+    fn column_mapping_field(
+        name: &str,
+        primitive_type: PrimitiveType,
+        id: i64,
+        physical_name: &str,
+        nullable: bool,
+    ) -> StructField {
+        let mut field = StructField::new(name, DeltaDataType::Primitive(primitive_type), nullable);
+        field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(id),
+        );
+        field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingPhysicalName
+                .as_ref()
+                .to_string(),
+            MetadataValue::String(physical_name.to_string()),
+        );
+        field
     }
 
     fn assert_common_write_metrics(write_metrics: WriteMetrics) {
@@ -2149,6 +2171,88 @@ mod tests {
         let rows = query_single_i64_row(
             &table,
             r#"SELECT COUNT(*) FROM test WHERE "Company Very Short" = 'DRS' AND "Super Name" = 'Delta RS'"#,
+        )
+        .await?;
+        assert_eq!(rows, vec![1]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_append_column_mapping_name_table_preserves_hive_partition_path_when_partition_physical_names_are_logical()
+    -> TestResult {
+        let protocol: Protocol = serde_json::from_value(json!({
+            "minReaderVersion": 2,
+            "minWriterVersion": 5
+        }))?;
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([
+                column_mapping_field("id", PrimitiveType::Long, 1, "id", false),
+                column_mapping_field(
+                    "partition_column",
+                    PrimitiveType::String,
+                    2,
+                    "partition_column",
+                    false,
+                ),
+                column_mapping_field(
+                    "data_column",
+                    PrimitiveType::String,
+                    3,
+                    "col-data_column",
+                    true,
+                ),
+            ])
+            .with_partition_columns(["partition_column"])
+            .with_actions([Action::Protocol(protocol)])
+            .with_raise_if_key_not_exists(false)
+            .with_configuration([
+                (
+                    TableProperty::ColumnMappingMode.as_ref().to_string(),
+                    Some("name".to_string()),
+                ),
+                (
+                    "delta.columnMapping.maxColumnId".to_string(),
+                    Some("3".to_string()),
+                ),
+            ])
+            .await?;
+
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("partition_column", DataType::Utf8, false),
+                Field::new("data_column", DataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(Int64Array::from(vec![1])) as _,
+                Arc::new(StringArray::from(vec![Some("partition-value")])) as _,
+                Arc::new(StringArray::from(vec![Some("data-value")])) as _,
+            ],
+        )?;
+
+        let table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let add_actions = latest_add_actions(&table).await?;
+        assert_eq!(add_actions.len(), 1);
+        let add = &add_actions[0];
+        assert_eq!(
+            add.partition_values.get("partition_column"),
+            Some(&Some("partition-value".to_string()))
+        );
+        assert!(add.path.starts_with("partition_column=partition-value/"));
+
+        let stats: Value = serde_json::from_str(add.stats.as_ref().unwrap())?;
+        assert_eq!(stats["minValues"]["col-data_column"], json!("data-value"));
+        assert!(stats["minValues"]["data_column"].is_null());
+
+        let rows = query_single_i64_row(
+            &table,
+            "SELECT COUNT(*) FROM test WHERE partition_column = 'partition-value' AND data_column = 'data-value'",
         )
         .await?;
         assert_eq!(rows, vec![1]);

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -54,7 +54,7 @@ use crate::delta_datafusion::{
     DeltaSessionExt, SessionFallbackPolicy, SessionResolveContext, create_session,
     resolve_session_state, update_datafusion_session,
 };
-use crate::errors::{DeltaResult, DeltaTableError};
+use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::schema::cast::normalize_for_delta;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL, TableReference};
 use crate::kernel::{Action, EagerSnapshot, StructType};
@@ -145,6 +145,8 @@ pub struct WriteBuilder {
     safe_cast: bool,
     /// Parquet writer properties
     writer_properties: Option<WriterProperties>,
+    /// Preserve Hive-style partition directories for column-mapped tables.
+    preserve_column_mapping_hive_style_partitions: bool,
     /// Additional information to add to the commit
     commit_properties: CommitProperties,
     /// Name of the table, only used when table doesn't exist yet
@@ -197,6 +199,7 @@ impl WriteBuilder {
             safe_cast: false,
             schema_mode: None,
             writer_properties: None,
+            preserve_column_mapping_hive_style_partitions: false,
             commit_properties: CommitProperties::default(),
             name: None,
             description: None,
@@ -289,6 +292,16 @@ impl WriteBuilder {
     /// Specify the writer properties to use when writing a parquet file
     pub fn with_writer_properties(mut self, writer_properties: WriterProperties) -> Self {
         self.writer_properties = Some(writer_properties);
+        self
+    }
+
+    /// Preserve Hive-style partition directories for column-mapped tables.
+    ///
+    /// The default column-mapped write layout uses randomized file prefixes, which matches Spark
+    /// and Databricks. This option keeps `partition=value/...` paths for integrations that
+    /// explicitly depend on that layout.
+    pub fn with_preserve_column_mapping_hive_style_partitions(mut self, preserve: bool) -> Self {
+        self.preserve_column_mapping_hive_style_partitions = preserve;
         self
     }
 
@@ -412,9 +425,9 @@ impl WriteBuilder {
                         .and_then(|value| value.as_deref()),
                     Some("name" | "id")
                 ) {
-                    return Err(DeltaTableError::Generic(
-                        "Creating column-mapped tables through WriteBuilder is not supported yet"
-                            .to_string(),
+                    return Err(unsupported_column_mapping_write(
+                        "WriteBuilder table creation",
+                        "creating column-mapped tables through WriteBuilder is not supported yet",
                     ));
                 }
 
@@ -558,6 +571,7 @@ impl std::future::IntoFuture for WriteBuilder {
                     exact_validation,
                     contains_cdc,
                     insert_marker_column,
+                    this.preserve_column_mapping_hive_style_partitions,
                 )
                 .await?;
 
@@ -780,6 +794,14 @@ mod tests {
             ))
             .into()),
         }
+    }
+
+    fn assert_unsupported_column_mapping_write(err: &DeltaTableError, feature: &str) {
+        assert!(
+            err.to_string()
+                .contains(&format!("Unsupported column mapping write for {feature}:")),
+            "unexpected error: {err}"
+        );
     }
 
     fn column_mapping_field(
@@ -2305,7 +2327,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_append_column_mapping_name_table_preserves_hive_partition_path_when_partition_physical_names_are_logical()
+    async fn test_append_column_mapping_name_table_uses_random_prefix_by_default_when_partition_physical_names_are_logical()
     -> TestResult {
         let table = create_logical_partition_column_mapping_table(false).await?;
         let batch =
@@ -2323,7 +2345,8 @@ mod tests {
             add.partition_values.get("partition_column"),
             Some(&Some("partition-value".to_string()))
         );
-        assert!(add.path.starts_with("partition_column=partition-value/"));
+        assert!(!add.path.starts_with("partition_column=partition-value/"));
+        assert_eq!(add.path.split('/').next().map(str::len), Some(2));
 
         let stats: Value = serde_json::from_str(add.stats.as_ref().unwrap())?;
         assert_eq!(stats["minValues"]["col-data_column"], json!("data-value"));
@@ -2340,7 +2363,101 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_overwrite_column_mapping_name_table_preserves_hive_partition_path_when_partition_physical_names_are_logical()
+    async fn test_append_column_mapping_name_table_can_preserve_hive_partition_paths() -> TestResult
+    {
+        let table = create_logical_partition_column_mapping_table(false).await?;
+        let batch =
+            logical_partition_column_mapping_batch(&[(1, "partition-value", "data-value")])?;
+
+        let table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .with_preserve_column_mapping_hive_style_partitions(true)
+            .await?;
+
+        let add_actions = latest_add_actions(&table).await?;
+        assert_eq!(add_actions.len(), 1);
+        let add = &add_actions[0];
+        assert_eq!(
+            add.partition_values.get("partition_column"),
+            Some(&Some("partition-value".to_string()))
+        );
+        assert!(add.path.starts_with("partition_column=partition-value/"));
+
+        let rows = query_single_i64_row(
+            &table,
+            "SELECT COUNT(*) FROM test WHERE partition_column = 'partition-value' AND data_column = 'data-value'",
+        )
+        .await?;
+        assert_eq!(rows, vec![1]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_column_mapping_name_table_uses_configured_random_prefix_length() -> TestResult {
+        let table = create_logical_partition_column_mapping_table(false).await?;
+        let table = table
+            .set_tbl_properties()
+            .with_raise_if_not_exists(false)
+            .with_properties(HashMap::from([(
+                TableProperty::RandomPrefixLength.as_ref().to_string(),
+                "3".to_string(),
+            )]))
+            .await?;
+
+        let table = table
+            .write(vec![logical_partition_column_mapping_batch(&[(
+                1,
+                "partition-value",
+                "data-value",
+            )])?])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let add_actions = latest_add_actions(&table).await?;
+        assert_eq!(add_actions.len(), 1);
+        assert_eq!(add_actions[0].path.split('/').next().map(str::len), Some(3));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_column_mapping_name_table_rejects_invalid_random_prefix_length() -> TestResult {
+        for invalid_length in ["0", "33"] {
+            let table = create_logical_partition_column_mapping_table(false).await?;
+            let table = table
+                .set_tbl_properties()
+                .with_raise_if_not_exists(false)
+                .with_properties(HashMap::from([(
+                    TableProperty::RandomPrefixLength.as_ref().to_string(),
+                    invalid_length.to_string(),
+                )]))
+                .await?;
+
+            let err = table
+                .write(vec![logical_partition_column_mapping_batch(&[(
+                    1,
+                    "partition-value",
+                    "data-value",
+                )])?])
+                .with_save_mode(SaveMode::Append)
+                .await
+                .expect_err("invalid delta.randomPrefixLength should be rejected");
+
+            assert!(
+                err.to_string().contains(&format!(
+                    "invalid delta.randomPrefixLength value `{invalid_length}`"
+                )),
+                "unexpected error for {invalid_length}: {err}"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_column_mapping_name_table_uses_random_prefix_by_default_when_partition_physical_names_are_logical()
     -> TestResult {
         let table = create_logical_partition_column_mapping_table(false).await?;
         let table = table
@@ -2367,7 +2484,8 @@ mod tests {
             add.partition_values.get("partition_column"),
             Some(&Some("partition-a".to_string()))
         );
-        assert!(add.path.starts_with("partition_column=partition-a/"));
+        assert!(!add.path.starts_with("partition_column=partition-a/"));
+        assert_eq!(add.path.split('/').next().map(str::len), Some(2));
         let stats: Value = serde_json::from_str(add.stats.as_ref().unwrap())?;
         assert_eq!(stats["minValues"]["col-data_column"], json!("new"));
         assert!(stats["minValues"]["data_column"].is_null());
@@ -2375,7 +2493,7 @@ mod tests {
         let remove_actions = latest_remove_actions(&table).await?;
         assert_eq!(remove_actions.len(), 1);
         assert!(
-            remove_actions[0]
+            !remove_actions[0]
                 .path
                 .starts_with("partition_column=partition-a/")
         );
@@ -2435,7 +2553,8 @@ mod tests {
         assert!(!add_actions.is_empty());
         for add in &add_actions {
             assert!(add.partition_values.contains_key("partition_column"));
-            assert!(add.path.starts_with("partition_column="));
+            assert!(!add.path.starts_with("partition_column="));
+            assert_eq!(add.path.split('/').next().map(str::len), Some(2));
             let stats: Value = serde_json::from_str(add.stats.as_ref().unwrap())?;
             assert!(!stats["minValues"]["col-data_column"].is_null());
             assert!(stats["minValues"]["data_column"].is_null());
@@ -2481,10 +2600,7 @@ mod tests {
             .await
             .expect_err("merge schema evolution should be rejected for column-mapped tables");
 
-        assert!(
-            err.to_string()
-                .contains("Merge schema evolution for column-mapped tables is not supported yet")
-        );
+        assert_unsupported_column_mapping_write(&err, "merge schema evolution");
 
         Ok(())
     }
@@ -2499,7 +2615,10 @@ mod tests {
         let batch = RecordBatch::try_new(
             Arc::new(ArrowSchema::new(vec![
                 Field::new("Company Very Short", DataType::Utf8, true),
-                Field::new("Super Name", DataType::Utf8, true),
+                Field::new("Super Name", DataType::Utf8, true).with_metadata(HashMap::from([(
+                    "delta.userMetadata".to_string(),
+                    "preserve-new-metadata".to_string(),
+                )])),
                 Field::new("Extra Name", DataType::Utf8, true),
             ])),
             vec![
@@ -2526,6 +2645,23 @@ mod tests {
             Some(MetadataValue::Number(_))
         ));
         let physical_extra = column_mapping_physical_name(extra)?;
+        let super_name = schema
+            .field("Super Name")
+            .expect("expected existing mapped field");
+        assert_eq!(
+            super_name
+                .metadata()
+                .get(ColumnMetadataKey::ColumnMappingId.as_ref()),
+            Some(&MetadataValue::Number(2))
+        );
+        assert_eq!(
+            column_mapping_physical_name(super_name)?,
+            "col-3877fd94-0973-4941-ac6b-646849a1ff65"
+        );
+        assert_eq!(
+            super_name.metadata().get("delta.userMetadata"),
+            Some(&MetadataValue::String("preserve-new-metadata".to_string()))
+        );
 
         let max_column_id = table
             .snapshot()?
@@ -2534,7 +2670,7 @@ mod tests {
             .get("delta.columnMapping.maxColumnId")
             .expect("expected max column id")
             .parse::<i64>()?;
-        assert!(max_column_id >= 3);
+        assert_eq!(max_column_id, 3);
 
         let add_actions = latest_add_actions(&table).await?;
         assert_eq!(add_actions.len(), 1);
@@ -2556,6 +2692,45 @@ mod tests {
         .await?;
         assert_eq!(rows, vec![1]);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_append_column_mapping_name_table_schema_merge_rejects_malformed_max_column_id()
+    -> TestResult {
+        let fixture_source = column_mapping_fixture_path();
+        let (_temp_dir, table) =
+            open_copied_table_fixture(&fixture_source, "table_with_column_mapping").await?;
+        let table = table
+            .set_tbl_properties()
+            .with_raise_if_not_exists(false)
+            .with_properties(HashMap::from([(
+                "delta.columnMapping.maxColumnId".to_string(),
+                "not-a-number".to_string(),
+            )]))
+            .await?;
+
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                Field::new("Company Very Short", DataType::Utf8, true),
+                Field::new("Super Name", DataType::Utf8, true),
+                Field::new("Extra Name", DataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec![Some("DRS")])) as _,
+                Arc::new(StringArray::from(vec![Some("Delta RS")])) as _,
+                Arc::new(StringArray::from(vec![Some("extra")])) as _,
+            ],
+        )?;
+
+        let err = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .with_schema_mode(SchemaMode::Merge)
+            .await
+            .expect_err("malformed maxColumnId should be rejected");
+
+        assert!(matches!(err, DeltaTableError::MetadataError(_)));
         Ok(())
     }
 
@@ -2737,7 +2912,85 @@ mod tests {
             .await
             .expect_err("column-mapped table creation through WriteBuilder should fail");
 
-        assert!(err.to_string().contains("Creating column-mapped tables"));
+        assert_unsupported_column_mapping_write(&err, "WriteBuilder table creation");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_column_mapping_id_write_is_rejected() -> TestResult {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([
+                column_mapping_field("id", PrimitiveType::String, 1, "id", true),
+                column_mapping_field("value", PrimitiveType::Integer, 2, "value", true),
+                column_mapping_field("modified", PrimitiveType::String, 3, "modified", true),
+            ])
+            .with_actions([Action::Protocol(column_mapping_protocol()?)])
+            .with_raise_if_key_not_exists(false)
+            .with_configuration([(TableProperty::ColumnMappingMode.as_ref(), Some("id"))])
+            .await?;
+
+        let err = table
+            .write(vec![get_record_batch(None, false)])
+            .await
+            .expect_err("id-mode column mapping writes should fail");
+
+        assert_unsupported_column_mapping_write(&err, "columnMapping.mode = id");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_column_mapping_name_nested_write_is_rejected() -> TestResult {
+        let mut nested_count =
+            StructField::new("count", DeltaDataType::Primitive(PrimitiveType::Long), true);
+        nested_count.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(5),
+        );
+        nested_count.metadata.insert(
+            ColumnMetadataKey::ColumnMappingPhysicalName
+                .as_ref()
+                .to_string(),
+            MetadataValue::String("count".to_string()),
+        );
+        let mut nested = StructField::new(
+            "nested",
+            DeltaDataType::Struct(Box::new(StructType::try_new([nested_count])?)),
+            true,
+        );
+        nested.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(4),
+        );
+        nested.metadata.insert(
+            ColumnMetadataKey::ColumnMappingPhysicalName
+                .as_ref()
+                .to_string(),
+            MetadataValue::String("nested".to_string()),
+        );
+
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([
+                column_mapping_field("id", PrimitiveType::String, 1, "id", true),
+                column_mapping_field("value", PrimitiveType::Integer, 2, "value", true),
+                column_mapping_field("modified", PrimitiveType::String, 3, "modified", true),
+                nested,
+            ])
+            .with_actions([Action::Protocol(column_mapping_protocol()?)])
+            .with_raise_if_key_not_exists(false)
+            .with_configuration([
+                (TableProperty::ColumnMappingMode.as_ref(), Some("name")),
+                ("delta.columnMapping.maxColumnId", Some("4")),
+            ])
+            .await?;
+
+        let err = table
+            .write(vec![get_record_batch_with_nested_struct()])
+            .await
+            .expect_err("nested column-mapped writes should fail");
+
+        assert_unsupported_column_mapping_write(&err, "nested columns");
         Ok(())
     }
 
@@ -2763,9 +3016,7 @@ mod tests {
             .await
             .expect_err("CDC writes should be rejected for column-mapped tables");
 
-        assert!(err.to_string().contains(
-            "Writing change data feed files for column-mapped tables is not supported yet"
-        ));
+        assert_unsupported_column_mapping_write(&err, "change data feed");
 
         Ok(())
     }

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -17,6 +17,8 @@ use datafusion::logical_expr::{
 };
 use datafusion::prelude::col;
 use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
+use delta_kernel::schema::{ColumnMetadataKey, MetadataValue};
+use delta_kernel::table_features::ColumnMappingMode;
 use futures::TryStreamExt as _;
 use itertools::Itertools as _;
 use parquet::file::properties::WriterProperties;
@@ -34,8 +36,9 @@ use crate::delta_datafusion::{
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::schema::cast::{merge_arrow_schema, normalize_for_delta};
 use crate::kernel::{
-    Action, Add, DeletionVectorDescriptor, EagerSnapshot, MetadataExt as _, ProtocolExt as _,
-    Remove, StructType, StructTypeExt, new_metadata,
+    Action, Add, ArrayType, DataType as DeltaDataType, DeletionVectorDescriptor, EagerSnapshot,
+    MapType, MetadataExt as _, ProtocolExt as _, Remove, StructField, StructType, StructTypeExt,
+    new_metadata,
 };
 use crate::logstore::LogStoreRef;
 use crate::operations::cdc::{CDC_COLUMN_NAME, should_write_cdc};
@@ -47,6 +50,7 @@ use crate::protocol::SaveMode;
 pub(super) struct SchemaDelta {
     metadata: Option<Action>,
     protocol: Option<Action>,
+    pub(super) effective_schema: Option<StructType>,
 }
 
 impl SchemaDelta {
@@ -734,7 +738,7 @@ fn schema_delta_for_prepared_source(
         return Ok(SchemaDelta::default());
     }
 
-    let schema_struct: StructType = match (schema_mode, schema_drift, new_schema) {
+    let mut schema_struct: StructType = match (schema_mode, schema_drift, new_schema) {
         (Some(SchemaMode::Merge), true, Some(schema)) => schema.try_into_kernel()?,
         _ => insert_plan.schema().as_arrow().try_into_kernel()?,
     };
@@ -744,7 +748,22 @@ fn schema_delta_for_prepared_source(
     }
 
     let current_protocol = snapshot.protocol();
-    let configuration = snapshot.metadata().configuration().clone();
+    let mut configuration = snapshot.metadata().configuration().clone();
+    if snapshot.table_configuration().column_mapping_mode() == ColumnMappingMode::Name {
+        let mut max_column_id = configuration
+            .get("delta.columnMapping.maxColumnId")
+            .and_then(|value| value.parse::<i64>().ok())
+            .unwrap_or_else(|| max_column_mapping_id(snapshot.schema().as_ref()));
+        schema_struct = assign_column_mapping_to_new_fields(
+            snapshot.schema().as_ref(),
+            &schema_struct,
+            &mut max_column_id,
+        )?;
+        configuration.insert(
+            "delta.columnMapping.maxColumnId".to_string(),
+            max_column_id.to_string(),
+        );
+    }
     let new_protocol = current_protocol
         .clone()
         .apply_column_metadata_to_protocol(&schema_struct)?
@@ -759,7 +778,174 @@ fn schema_delta_for_prepared_source(
     Ok(SchemaDelta {
         metadata: Some(metadata.into()),
         protocol: (current_protocol != &new_protocol).then_some(new_protocol.into()),
+        effective_schema: Some(schema_struct),
     })
+}
+
+fn max_column_mapping_id(schema: &StructType) -> i64 {
+    schema
+        .fields()
+        .map(max_column_mapping_id_for_field)
+        .max()
+        .unwrap_or_default()
+}
+
+fn max_column_mapping_id_for_field(field: &StructField) -> i64 {
+    let field_id = match field
+        .metadata()
+        .get(ColumnMetadataKey::ColumnMappingId.as_ref())
+    {
+        Some(MetadataValue::Number(id)) => *id,
+        _ => 0,
+    };
+
+    field_id.max(max_column_mapping_id_for_data_type(field.data_type()))
+}
+
+fn max_column_mapping_id_for_data_type(data_type: &DeltaDataType) -> i64 {
+    match data_type {
+        DeltaDataType::Struct(inner) => max_column_mapping_id(inner),
+        DeltaDataType::Array(inner) => max_column_mapping_id_for_data_type(inner.element_type()),
+        DeltaDataType::Map(inner) => max_column_mapping_id_for_data_type(inner.key_type())
+            .max(max_column_mapping_id_for_data_type(inner.value_type())),
+        _ => 0,
+    }
+}
+
+fn assign_column_mapping_to_new_fields(
+    previous: &StructType,
+    next: &StructType,
+    max_column_id: &mut i64,
+) -> DeltaResult<StructType> {
+    let fields = next
+        .fields()
+        .map(|field| match previous.field(field.name()) {
+            Some(previous_field) => {
+                assign_column_mapping_to_existing_field(previous_field, field, max_column_id)
+            }
+            None => assign_column_mapping_to_field(field, max_column_id),
+        })
+        .collect::<DeltaResult<Vec<_>>>()?;
+
+    Ok(StructType::try_new(fields)?)
+}
+
+fn assign_column_mapping_to_existing_field(
+    previous: &StructField,
+    next: &StructField,
+    max_column_id: &mut i64,
+) -> DeltaResult<StructField> {
+    let mut field = next.clone();
+    field.metadata = previous.metadata().clone();
+    field.data_type = assign_column_mapping_to_existing_data_type(
+        previous.data_type(),
+        next.data_type(),
+        max_column_id,
+    )?;
+    Ok(field)
+}
+
+fn assign_column_mapping_to_existing_data_type(
+    previous: &DeltaDataType,
+    next: &DeltaDataType,
+    max_column_id: &mut i64,
+) -> DeltaResult<DeltaDataType> {
+    match (previous, next) {
+        (DeltaDataType::Struct(previous_inner), DeltaDataType::Struct(next_inner)) => {
+            Ok(DeltaDataType::Struct(Box::new(
+                assign_column_mapping_to_new_fields(previous_inner, next_inner, max_column_id)?,
+            )))
+        }
+        (DeltaDataType::Array(previous_inner), DeltaDataType::Array(next_inner)) => {
+            Ok(DeltaDataType::Array(Box::new(ArrayType::new(
+                assign_column_mapping_to_existing_data_type(
+                    previous_inner.element_type(),
+                    next_inner.element_type(),
+                    max_column_id,
+                )?,
+                next_inner.contains_null(),
+            ))))
+        }
+        (DeltaDataType::Map(previous_inner), DeltaDataType::Map(next_inner)) => {
+            Ok(DeltaDataType::Map(Box::new(MapType::new(
+                assign_column_mapping_to_existing_data_type(
+                    previous_inner.key_type(),
+                    next_inner.key_type(),
+                    max_column_id,
+                )?,
+                assign_column_mapping_to_existing_data_type(
+                    previous_inner.value_type(),
+                    next_inner.value_type(),
+                    max_column_id,
+                )?,
+                next_inner.value_contains_null(),
+            ))))
+        }
+        _ => Ok(next.clone()),
+    }
+}
+
+fn assign_column_mapping_to_field(
+    field: &StructField,
+    max_column_id: &mut i64,
+) -> DeltaResult<StructField> {
+    let mut field = field.clone();
+    if !field
+        .metadata()
+        .contains_key(ColumnMetadataKey::ColumnMappingId.as_ref())
+    {
+        *max_column_id += 1;
+        field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(*max_column_id),
+        );
+    }
+    if !field
+        .metadata()
+        .contains_key(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref())
+    {
+        field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingPhysicalName
+                .as_ref()
+                .to_string(),
+            MetadataValue::String(format!("col-{}", Uuid::new_v4())),
+        );
+    }
+    field.data_type = assign_column_mapping_to_data_type(field.data_type(), max_column_id)?;
+    Ok(field)
+}
+
+fn assign_column_mapping_to_data_type(
+    data_type: &DeltaDataType,
+    max_column_id: &mut i64,
+) -> DeltaResult<DeltaDataType> {
+    match data_type {
+        DeltaDataType::Struct(inner) => Ok(DeltaDataType::Struct(Box::new(
+            assign_column_mapping_to_struct(inner, max_column_id)?,
+        ))),
+        DeltaDataType::Array(inner) => Ok(DeltaDataType::Array(Box::new(ArrayType::new(
+            assign_column_mapping_to_data_type(inner.element_type(), max_column_id)?,
+            inner.contains_null(),
+        )))),
+        DeltaDataType::Map(inner) => Ok(DeltaDataType::Map(Box::new(MapType::new(
+            assign_column_mapping_to_data_type(inner.key_type(), max_column_id)?,
+            assign_column_mapping_to_data_type(inner.value_type(), max_column_id)?,
+            inner.value_contains_null(),
+        )))),
+        _ => Ok(data_type.clone()),
+    }
+}
+
+fn assign_column_mapping_to_struct(
+    schema: &StructType,
+    max_column_id: &mut i64,
+) -> DeltaResult<StructType> {
+    let fields = schema
+        .fields()
+        .map(|field| assign_column_mapping_to_field(field, max_column_id))
+        .collect::<DeltaResult<Vec<_>>>()?;
+
+    Ok(StructType::try_new(fields)?)
 }
 
 #[cfg(test)]

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -29,11 +29,12 @@ use super::configs::WriterStatsConfig;
 use super::generated_columns::{gc_is_enabled, with_generated_columns};
 use super::metrics::SOURCE_COUNT_ID;
 use super::schema_evolution::try_cast_schema;
+use super::writer::contains_nested_type;
 use crate::delta_datafusion::logical::{LogicalPlanBuilderExt as _, MetricObserver};
 use crate::delta_datafusion::{
     DataFusionMixins, Expression, analyze_predicate_for_find_files, scan_files_where_matches,
 };
-use crate::errors::{DeltaResult, DeltaTableError};
+use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::schema::cast::{merge_arrow_schema, normalize_for_delta};
 use crate::kernel::{
     Action, Add, ArrayType, DataType as DeltaDataType, DeletionVectorDescriptor, EagerSnapshot,
@@ -750,10 +751,25 @@ fn schema_delta_for_prepared_source(
     let current_protocol = snapshot.protocol();
     let mut configuration = snapshot.metadata().configuration().clone();
     if snapshot.table_configuration().column_mapping_mode() == ColumnMappingMode::Name {
-        let mut max_column_id = configuration
-            .get("delta.columnMapping.maxColumnId")
-            .and_then(|value| value.parse::<i64>().ok())
-            .unwrap_or_else(|| max_column_mapping_id(snapshot.schema().as_ref()));
+        if schema_struct
+            .fields()
+            .any(|field| contains_nested_type(field.data_type()))
+        {
+            return Err(unsupported_column_mapping_write(
+                "nested columns",
+                "schema evolution for nested column-mapped fields is not implemented yet",
+            ));
+        }
+        let mut max_column_id = match configuration.get("delta.columnMapping.maxColumnId") {
+            Some(value) => value.parse::<i64>().map_err(|err| {
+                DeltaTableError::MetadataError(format!(
+                    "invalid delta.columnMapping.maxColumnId value `{value}`: {err}"
+                ))
+            })?,
+            None => max_column_mapping_id(snapshot.schema().as_ref()),
+        };
+        // Concurrent schema-merge writers may choose the same candidate IDs. The Delta conflict
+        // checker rejects the stale metadata commit, and the losing writer must retry.
         schema_struct = assign_column_mapping_to_new_fields(
             snapshot.schema().as_ref(),
             &schema_struct,
@@ -836,13 +852,24 @@ fn assign_column_mapping_to_existing_field(
     max_column_id: &mut i64,
 ) -> DeltaResult<StructField> {
     let mut field = next.clone();
-    field.metadata = previous.metadata().clone();
+    preserve_column_mapping_metadata(previous, &mut field);
     field.data_type = assign_column_mapping_to_existing_data_type(
         previous.data_type(),
         next.data_type(),
         max_column_id,
     )?;
     Ok(field)
+}
+
+fn preserve_column_mapping_metadata(previous: &StructField, next: &mut StructField) {
+    for key in [
+        ColumnMetadataKey::ColumnMappingId.as_ref(),
+        ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+    ] {
+        if let Some(value) = previous.metadata().get(key) {
+            next.metadata.insert(key.to_string(), value.clone());
+        }
+    }
 }
 
 fn assign_column_mapping_to_existing_data_type(

--- a/crates/core/src/operations/write/writer.rs
+++ b/crates/core/src/operations/write/writer.rs
@@ -5,9 +5,12 @@ use std::num::NonZeroU64;
 use std::sync::{Arc, OnceLock};
 
 use arrow_array::RecordBatch;
-use arrow_schema::{ArrowError, SchemaRef as ArrowSchemaRef};
+use arrow_schema::{
+    ArrowError, Field as ArrowField, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
+};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::Scalar;
+use delta_kernel::schema::{ColumnMetadataKey, DataType as KernelDataType, MetadataValue};
 use delta_kernel::table_configuration::TableConfiguration;
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
@@ -23,7 +26,8 @@ use tokio::task::JoinSet;
 use tracing::*;
 
 use crate::errors::{DeltaResult, DeltaTableError};
-use crate::kernel::{Add, PartitionsExt};
+use crate::kernel::schema::cast::cast_record_batch;
+use crate::kernel::{Add, PartitionsExt, StructField, StructType};
 use crate::logstore::ObjectStoreRef;
 use crate::parquet_utils::default_writer_properties;
 use crate::writer::record_batch::{PartitionResult, divide_by_partition_values};
@@ -187,19 +191,38 @@ impl WriterConfig {
     pub fn with_table_configuration(
         mut self,
         table_config: &TableConfiguration,
+        effective_schema: Option<&StructType>,
     ) -> DeltaResult<Self> {
-        if table_config.column_mapping_mode() == ColumnMappingMode::None {
-            return Ok(self);
+        match table_config.column_mapping_mode() {
+            ColumnMappingMode::None => return Ok(self),
+            ColumnMappingMode::Id => {
+                return Err(DeltaTableError::Generic(
+                    "Writing to columnMapping.mode = id tables is not supported yet".to_string(),
+                ));
+            }
+            ColumnMappingMode::Name => {}
         }
 
-        let logical_schema = table_config.logical_schema();
-        let physical_schema = table_config.physical_schema();
+        let table_logical_schema = table_config.logical_schema();
+        let logical_schema = effective_schema.unwrap_or_else(|| table_logical_schema.as_ref());
+
+        if logical_schema
+            .fields()
+            .any(|field| contains_nested_type(field.data_type()))
+        {
+            return Err(DeltaTableError::Generic(
+                "Writing nested columns to columnMapping.mode = name tables is not supported yet"
+                    .to_string(),
+            ));
+        }
+
         let partition_columns = table_config.metadata().partition_columns();
+        let logical_arrow_schema: ArrowSchema = logical_schema.try_into_arrow()?;
+        self.table_schema = Arc::new(logical_arrow_schema);
 
         let physical_columns = logical_schema
             .fields()
-            .zip(physical_schema.fields())
-            .map(|(logical, physical)| (logical.name().clone(), physical.name().clone()))
+            .map(|field| (field.name().clone(), physical_name_for_field(field)))
             .collect::<HashMap<_, _>>();
 
         self.physical_partition_columns = physical_columns
@@ -210,8 +233,7 @@ impl WriterConfig {
                     .then(|| (logical.clone(), physical.clone()))
             })
             .collect();
-        let physical_arrow_schema: arrow_schema::Schema =
-            physical_schema.as_ref().try_into_arrow()?;
+        let physical_arrow_schema = physical_arrow_schema(logical_schema)?;
         let physical_partition_columns = self
             .physical_partition_columns
             .values()
@@ -278,12 +300,23 @@ impl WriterConfig {
             return Ok(record_batch);
         }
 
-        if record_batch.num_columns() != file_schema.fields().len() {
+        let logical_file_schema = self.logical_file_schema();
+        if record_batch.num_columns() != logical_file_schema.fields().len() {
             return Err(WriteError::SchemaMismatch {
                 schema: record_batch.schema(),
                 expected_schema: file_schema,
             }
             .into());
+        }
+
+        let record_batch = if record_batch.schema() == logical_file_schema {
+            record_batch
+        } else {
+            cast_record_batch(&record_batch, logical_file_schema, false, false)?
+        };
+
+        if record_batch.schema() == file_schema {
+            return Ok(record_batch);
         }
 
         Ok(RecordBatch::try_new(
@@ -295,6 +328,45 @@ impl WriterConfig {
 
 fn random_prefix() -> String {
     uuid::Uuid::new_v4().simple().to_string()[..2].to_string()
+}
+
+fn contains_nested_type(data_type: &KernelDataType) -> bool {
+    match data_type {
+        KernelDataType::Struct(_) => true,
+        KernelDataType::Array(inner) => contains_nested_type(inner.element_type()),
+        KernelDataType::Map(inner) => {
+            contains_nested_type(inner.key_type()) || contains_nested_type(inner.value_type())
+        }
+        _ => false,
+    }
+}
+
+fn physical_arrow_schema(logical_schema: &StructType) -> DeltaResult<ArrowSchema> {
+    let logical_arrow_schema: ArrowSchema = logical_schema.try_into_arrow()?;
+    let fields = logical_schema
+        .fields()
+        .zip(logical_arrow_schema.fields().iter())
+        .map(|(delta_field, arrow_field)| {
+            ArrowField::new(
+                physical_name_for_field(delta_field),
+                arrow_field.data_type().clone(),
+                arrow_field.is_nullable(),
+            )
+            .with_metadata(arrow_field.metadata().clone())
+        })
+        .collect::<Vec<_>>();
+
+    Ok(ArrowSchema::new(fields))
+}
+
+fn physical_name_for_field(field: &StructField) -> String {
+    match field
+        .metadata()
+        .get(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref())
+    {
+        Some(MetadataValue::String(name)) => name.clone(),
+        _ => field.name().clone(),
+    }
 }
 
 /// A parquet writer implementation tailored to the needs of writing data to a delta table.
@@ -385,7 +457,13 @@ impl DeltaWriter {
     /// The `close` method has to be invoked to write all data still buffered
     /// and get the list of all written files.
     pub async fn write(&mut self, batch: &RecordBatch) -> DeltaResult<()> {
-        for result in self.divide_by_partition_values(batch)? {
+        let batch = if batch.schema() == self.config.table_schema {
+            batch.clone()
+        } else {
+            cast_record_batch(batch, self.config.table_schema.clone(), false, false)?
+        };
+
+        for result in self.divide_by_partition_values(&batch)? {
             self.write_partition(result.record_batch, &result.partition_values)
                 .await?;
         }

--- a/crates/core/src/operations/write/writer.rs
+++ b/crates/core/src/operations/write/writer.rs
@@ -250,7 +250,13 @@ impl WriterConfig {
                 }
             }
         }
-        self.use_random_prefixes = true;
+        // Tables that enabled column mapping after they were already partitioned can keep
+        // partition physical names equal to their logical names. Preserve that layout so new
+        // writes land next to existing Hive-style partition directories.
+        self.use_random_prefixes = self
+            .physical_partition_columns
+            .iter()
+            .any(|(logical, physical)| logical != physical);
 
         Ok(self)
     }

--- a/crates/core/src/operations/write/writer.rs
+++ b/crates/core/src/operations/write/writer.rs
@@ -2,11 +2,14 @@
 
 use std::collections::HashMap;
 use std::num::NonZeroU64;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use arrow_array::RecordBatch;
 use arrow_schema::{ArrowError, SchemaRef as ArrowSchemaRef};
+use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::Scalar;
+use delta_kernel::table_configuration::TableConfiguration;
+use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use futures::{StreamExt, TryStreamExt};
 use indexmap::IndexMap;
@@ -129,8 +132,14 @@ impl From<WriteError> for DeltaTableError {
 pub struct WriterConfig {
     /// Schema of the delta table
     table_schema: ArrowSchemaRef,
+    /// Physical schema written to parquet files, if it differs from the table schema.
+    physical_file_schema: Option<ArrowSchemaRef>,
     /// Column names for columns the table is partitioned by
     partition_columns: Vec<String>,
+    /// Mapping from logical partition column names to their physical names.
+    physical_partition_columns: HashMap<String, String>,
+    /// Use randomized file prefixes instead of Hive-style partition directories.
+    use_random_prefixes: bool,
     /// Properties passed to underlying parquet writer
     writer_properties: WriterProperties,
     /// Size above which we will write a buffered parquet file to disk.
@@ -162,7 +171,10 @@ impl WriterConfig {
 
         Self {
             table_schema,
+            physical_file_schema: None,
             partition_columns,
+            physical_partition_columns: HashMap::new(),
+            use_random_prefixes: false,
             writer_properties,
             target_file_size,
             write_batch_size,
@@ -171,10 +183,118 @@ impl WriterConfig {
         }
     }
 
-    /// Schema of files written to disk
-    pub fn file_schema(&self) -> ArrowSchemaRef {
+    /// Apply table-level write metadata such as column mapping.
+    pub fn with_table_configuration(
+        mut self,
+        table_config: &TableConfiguration,
+    ) -> DeltaResult<Self> {
+        if table_config.column_mapping_mode() == ColumnMappingMode::None {
+            return Ok(self);
+        }
+
+        let logical_schema = table_config.logical_schema();
+        let physical_schema = table_config.physical_schema();
+        let partition_columns = table_config.metadata().partition_columns();
+
+        let physical_columns = logical_schema
+            .fields()
+            .zip(physical_schema.fields())
+            .map(|(logical, physical)| (logical.name().clone(), physical.name().clone()))
+            .collect::<HashMap<_, _>>();
+
+        self.physical_partition_columns = physical_columns
+            .iter()
+            .filter_map(|(logical, physical)| {
+                partition_columns
+                    .contains(logical)
+                    .then(|| (logical.clone(), physical.clone()))
+            })
+            .collect();
+        let physical_arrow_schema: arrow_schema::Schema =
+            physical_schema.as_ref().try_into_arrow()?;
+        let physical_partition_columns = self
+            .physical_partition_columns
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        self.physical_file_schema = Some(arrow_schema_without_partitions(
+            &Arc::new(physical_arrow_schema),
+            &physical_partition_columns,
+        ));
+        if let Some(stats_columns) = self.stats_columns.as_mut() {
+            for column in stats_columns {
+                if let Some(physical_name) = physical_columns.get(column) {
+                    *column = physical_name.clone();
+                }
+            }
+        }
+        self.use_random_prefixes = true;
+
+        Ok(self)
+    }
+
+    /// Logical schema of files before column mapping is applied.
+    fn logical_file_schema(&self) -> ArrowSchemaRef {
         arrow_schema_without_partitions(&self.table_schema, &self.partition_columns)
     }
+
+    /// Schema of files written to disk
+    pub fn file_schema(&self) -> ArrowSchemaRef {
+        self.physical_file_schema
+            .clone()
+            .unwrap_or_else(|| self.logical_file_schema())
+    }
+
+    fn physical_partition_values(
+        &self,
+        partition_values: &IndexMap<String, Scalar>,
+    ) -> IndexMap<String, Scalar> {
+        partition_values
+            .iter()
+            .map(|(logical_name, value)| {
+                (
+                    self.physical_partition_columns
+                        .get(logical_name)
+                        .cloned()
+                        .unwrap_or_else(|| logical_name.clone()),
+                    value.clone(),
+                )
+            })
+            .collect()
+    }
+
+    fn partition_prefix(&self, partition_values: &IndexMap<String, Scalar>) -> DeltaResult<Path> {
+        if self.use_random_prefixes {
+            Path::parse(random_prefix())
+        } else {
+            Path::parse(partition_values.hive_partition_path())
+        }
+        .map_err(Into::into)
+    }
+
+    fn materialize_file_batch(&self, record_batch: RecordBatch) -> DeltaResult<RecordBatch> {
+        let file_schema = self.file_schema();
+        if record_batch.schema() == file_schema {
+            return Ok(record_batch);
+        }
+
+        if record_batch.num_columns() != file_schema.fields().len() {
+            return Err(WriteError::SchemaMismatch {
+                schema: record_batch.schema(),
+                expected_schema: file_schema,
+            }
+            .into());
+        }
+
+        Ok(RecordBatch::try_new(
+            file_schema,
+            record_batch.columns().to_vec(),
+        )?)
+    }
+}
+
+fn random_prefix() -> String {
+    uuid::Uuid::new_v4().simple().to_string()[..2].to_string()
 }
 
 /// A parquet writer implementation tailored to the needs of writing data to a delta table.
@@ -208,7 +328,7 @@ impl DeltaWriter {
         values: &RecordBatch,
     ) -> DeltaResult<Vec<PartitionResult>> {
         Ok(divide_by_partition_values(
-            self.config.file_schema(),
+            self.config.logical_file_schema(),
             self.config.partition_columns.clone(),
             values,
         )
@@ -227,6 +347,9 @@ impl DeltaWriter {
 
         let record_batch =
             record_batch_without_partitions(&record_batch, &self.config.partition_columns)?;
+        let record_batch = self.config.materialize_file_batch(record_batch)?;
+        let partition_values = self.config.physical_partition_values(partition_values);
+        let prefix = self.config.partition_prefix(&partition_values)?;
 
         match self.partition_writers.get_mut(&partition_key) {
             Some(writer) => {
@@ -236,6 +359,7 @@ impl DeltaWriter {
                 let config = PartitionWriterConfig::try_new(
                     self.config.file_schema(),
                     partition_values.clone(),
+                    Some(prefix),
                     Some(self.config.writer_properties.clone()),
                     self.config.target_file_size,
                     Some(self.config.write_batch_size),
@@ -315,13 +439,16 @@ impl PartitionWriterConfig {
     pub fn try_new(
         file_schema: ArrowSchemaRef,
         partition_values: IndexMap<String, Scalar>,
+        prefix: Option<Path>,
         writer_properties: Option<WriterProperties>,
         target_file_size: Option<NonZeroU64>,
         write_batch_size: Option<usize>,
         max_concurrency_tasks: Option<usize>,
     ) -> DeltaResult<Self> {
-        let part_path = partition_values.hive_partition_path();
-        let prefix = Path::parse(part_path)?;
+        let prefix = match prefix {
+            Some(prefix) => prefix,
+            None => Path::parse(partition_values.hive_partition_path())?,
+        };
         let writer_properties =
             writer_properties.unwrap_or_else(|| default_writer_properties(Compression::SNAPPY));
         let write_batch_size = write_batch_size.unwrap_or(DEFAULT_WRITE_BATCH_SIZE);
@@ -577,6 +704,7 @@ mod tests {
         let config = PartitionWriterConfig::try_new(
             batch.schema(),
             IndexMap::new(),
+            None,
             writer_properties,
             target_file_size,
             write_batch_size,
@@ -633,7 +761,7 @@ mod tests {
             true,
         )]));
         let config =
-            PartitionWriterConfig::try_new(schema, IndexMap::new(), None, None, None, None)
+            PartitionWriterConfig::try_new(schema, IndexMap::new(), None, None, None, None, None)
                 .unwrap();
 
         assert_default_created_by(&config.writer_properties);

--- a/crates/core/src/operations/write/writer.rs
+++ b/crates/core/src/operations/write/writer.rs
@@ -25,11 +25,12 @@ use parquet::file::properties::WriterProperties;
 use tokio::task::JoinSet;
 use tracing::*;
 
-use crate::errors::{DeltaResult, DeltaTableError};
+use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::schema::cast::cast_record_batch;
 use crate::kernel::{Add, PartitionsExt, StructField, StructType};
 use crate::logstore::ObjectStoreRef;
 use crate::parquet_utils::default_writer_properties;
+use crate::table::config::TableProperty;
 use crate::writer::record_batch::{PartitionResult, divide_by_partition_values};
 use crate::writer::stats::create_add;
 use crate::writer::utils::{
@@ -142,8 +143,14 @@ pub struct WriterConfig {
     partition_columns: Vec<String>,
     /// Mapping from logical partition column names to their physical names.
     physical_partition_columns: HashMap<String, String>,
+    /// Whether table metadata has column mapping enabled.
+    column_mapping_enabled: bool,
     /// Use randomized file prefixes instead of Hive-style partition directories.
     use_random_prefixes: bool,
+    /// Length of randomized file prefixes.
+    random_prefix_length: usize,
+    /// Preserve Hive-style partition directories for column-mapped tables.
+    preserve_column_mapping_hive_style_partitions: bool,
     /// Properties passed to underlying parquet writer
     writer_properties: WriterProperties,
     /// Size above which we will write a buffered parquet file to disk.
@@ -178,13 +185,26 @@ impl WriterConfig {
             physical_file_schema: None,
             partition_columns,
             physical_partition_columns: HashMap::new(),
+            column_mapping_enabled: false,
             use_random_prefixes: false,
+            random_prefix_length: 2,
+            preserve_column_mapping_hive_style_partitions: false,
             writer_properties,
             target_file_size,
             write_batch_size,
             num_indexed_cols,
             stats_columns,
         }
+    }
+
+    /// Preserve Hive-style partition directories for column-mapped tables.
+    ///
+    /// By default, column-mapped writes use randomized file prefixes, which matches Spark and
+    /// Databricks behavior. This opt-in keeps paths like `part=value/...` for integrations that
+    /// intentionally rely on that layout while still writing physical names to Parquet and the log.
+    pub fn with_preserve_column_mapping_hive_style_partitions(mut self, preserve: bool) -> Self {
+        self.preserve_column_mapping_hive_style_partitions = preserve;
+        self
     }
 
     /// Apply table-level write metadata such as column mapping.
@@ -196,12 +216,14 @@ impl WriterConfig {
         match table_config.column_mapping_mode() {
             ColumnMappingMode::None => return Ok(self),
             ColumnMappingMode::Id => {
-                return Err(DeltaTableError::Generic(
-                    "Writing to columnMapping.mode = id tables is not supported yet".to_string(),
+                return Err(unsupported_column_mapping_write(
+                    "columnMapping.mode = id",
+                    "Parquet field IDs are not handled end to end yet",
                 ));
             }
             ColumnMappingMode::Name => {}
         }
+        self.column_mapping_enabled = true;
 
         let table_logical_schema = table_config.logical_schema();
         let logical_schema = effective_schema.unwrap_or_else(|| table_logical_schema.as_ref());
@@ -210,9 +232,9 @@ impl WriterConfig {
             .fields()
             .any(|field| contains_nested_type(field.data_type()))
         {
-            return Err(DeltaTableError::Generic(
-                "Writing nested columns to columnMapping.mode = name tables is not supported yet"
-                    .to_string(),
+            return Err(unsupported_column_mapping_write(
+                "nested columns",
+                "recursive physical name rewrites are not implemented yet",
             ));
         }
 
@@ -244,19 +266,35 @@ impl WriterConfig {
             &physical_partition_columns,
         ));
         if let Some(stats_columns) = self.stats_columns.as_mut() {
+            // This shallow rewrite is safe while nested column-mapped writes are rejected above.
             for column in stats_columns {
                 if let Some(physical_name) = physical_columns.get(column) {
                     *column = physical_name.clone();
                 }
             }
         }
-        // Tables that enabled column mapping after they were already partitioned can keep
-        // partition physical names equal to their logical names. Preserve that layout so new
-        // writes land next to existing Hive-style partition directories.
-        self.use_random_prefixes = self
-            .physical_partition_columns
-            .iter()
-            .any(|(logical, physical)| logical != physical);
+        self.random_prefix_length = table_config
+            .metadata()
+            .configuration()
+            .get(TableProperty::RandomPrefixLength.as_ref())
+            .map(|value| {
+                let length = value.parse::<usize>().map_err(|err| {
+                    DeltaTableError::MetadataError(format!(
+                        "invalid delta.randomPrefixLength value `{value}`: {err}"
+                    ))
+                })?;
+                if !(1..=32).contains(&length) {
+                    return Err(DeltaTableError::MetadataError(format!(
+                        "invalid delta.randomPrefixLength value `{value}`: expected a value between 1 and 32"
+                    )));
+                }
+                Ok(length)
+            })
+            .transpose()?
+            .unwrap_or(2);
+        // Spark and Databricks write randomized prefixes for partitioned column-mapped tables.
+        // Keep Hive-style paths only when the caller explicitly opts into that layout.
+        self.use_random_prefixes = !self.preserve_column_mapping_hive_style_partitions;
 
         Ok(self)
     }
@@ -276,24 +314,30 @@ impl WriterConfig {
     fn physical_partition_values(
         &self,
         partition_values: &IndexMap<String, Scalar>,
-    ) -> IndexMap<String, Scalar> {
+    ) -> DeltaResult<IndexMap<String, Scalar>> {
         partition_values
             .iter()
             .map(|(logical_name, value)| {
-                (
-                    self.physical_partition_columns
-                        .get(logical_name)
-                        .cloned()
-                        .unwrap_or_else(|| logical_name.clone()),
-                    value.clone(),
-                )
+                let physical_name = self.physical_partition_columns.get(logical_name).cloned();
+                let physical_name = match (self.column_mapping_enabled, physical_name) {
+                    (_, Some(name)) => name,
+                    (false, None) => logical_name.clone(),
+                    (true, None) => {
+                        return Err(DeltaTableError::SchemaMismatch {
+                            msg: format!(
+                                "Missing physical partition column mapping for `{logical_name}`"
+                            ),
+                        });
+                    }
+                };
+                Ok((physical_name, value.clone()))
             })
             .collect()
     }
 
     fn partition_prefix(&self, partition_values: &IndexMap<String, Scalar>) -> DeltaResult<Path> {
         if self.use_random_prefixes {
-            Path::parse(random_prefix())
+            Path::parse(random_prefix(self.random_prefix_length))
         } else {
             Path::parse(partition_values.hive_partition_path())
         }
@@ -310,7 +354,7 @@ impl WriterConfig {
         if record_batch.num_columns() != logical_file_schema.fields().len() {
             return Err(WriteError::SchemaMismatch {
                 schema: record_batch.schema(),
-                expected_schema: file_schema,
+                expected_schema: logical_file_schema,
             }
             .into());
         }
@@ -332,11 +376,16 @@ impl WriterConfig {
     }
 }
 
-fn random_prefix() -> String {
-    uuid::Uuid::new_v4().simple().to_string()[..2].to_string()
+fn random_prefix(length: usize) -> String {
+    uuid::Uuid::new_v4()
+        .simple()
+        .to_string()
+        .chars()
+        .take(length)
+        .collect()
 }
 
-fn contains_nested_type(data_type: &KernelDataType) -> bool {
+pub(crate) fn contains_nested_type(data_type: &KernelDataType) -> bool {
     match data_type {
         KernelDataType::Struct(_) => true,
         KernelDataType::Array(inner) => contains_nested_type(inner.element_type()),
@@ -353,6 +402,8 @@ fn physical_arrow_schema(logical_schema: &StructType) -> DeltaResult<ArrowSchema
         .fields()
         .zip(logical_arrow_schema.fields().iter())
         .map(|(delta_field, arrow_field)| {
+            // Preserve Arrow field metadata in the Parquet footer. Column mapping IDs remain
+            // available there as metadata, while name-mode readers resolve by physical name.
             ArrowField::new(
                 physical_name_for_field(delta_field),
                 arrow_field.data_type().clone(),
@@ -426,7 +477,7 @@ impl DeltaWriter {
         let record_batch =
             record_batch_without_partitions(&record_batch, &self.config.partition_columns)?;
         let record_batch = self.config.materialize_file_batch(record_batch)?;
-        let partition_values = self.config.physical_partition_values(partition_values);
+        let partition_values = self.config.physical_partition_values(partition_values)?;
         let prefix = self.config.partition_prefix(&partition_values)?;
 
         match self.partition_writers.get_mut(&partition_key) {
@@ -802,6 +853,34 @@ mod tests {
             None,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn column_mapping_partition_values_require_complete_physical_mapping() {
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "partition_column",
+            DataType::Utf8,
+            false,
+        )]));
+        let mut config = WriterConfig::new(
+            schema,
+            vec!["partition_column".to_string()],
+            None,
+            None,
+            None,
+            DataSkippingNumIndexedCols::NumColumns(DEFAULT_NUM_INDEX_COLS),
+            None,
+        );
+        config.column_mapping_enabled = true;
+
+        let err = config
+            .physical_partition_values(&IndexMap::from([(
+                "partition_column".to_string(),
+                Scalar::String("partition-value".to_string()),
+            )]))
+            .expect_err("column mapping should require physical partition mapping");
+
+        assert!(matches!(err, DeltaTableError::SchemaMismatch { .. }));
     }
 
     fn assert_default_created_by(writer_properties: &WriterProperties) {


### PR DESCRIPTION
  ## what changed

  Refs #930.

  This PR adds support for writing to existing Delta tables that use
  `delta.columnMapping.mode = name`.

  The write path now resolves logical columns to their column mapping physical
  names before writing Parquet files. Partition values and data skipping stats are
  also written with physical keys, while table scans and DataFusion queries keep
  using logical column names.

  `SchemaMode::Merge` is supported for top-level fields on existing name-mapped
  tables. Existing column mapping metadata is preserved, and newly added
  top-level fields receive column mapping IDs and generated physical names.

  ## supported behavior

  - appends to existing name-mapped tables;
  - top-level schema evolution with `SchemaMode::Merge`;
  - logical-name reads and DataFusion filters after writes;
  - physical Parquet field names for mapped data columns;
  - physical partition values and physical data skipping stats;
  - `replaceWhere`, partitioned overwrite, update, delete, and non-evolving
    merge rewrites;
  - randomized partition prefixes by default for partitioned column-mapped
    writes;
  - explicit opt-in for Hive-style partition path preservation with
    `with_preserve_column_mapping_hive_style_partitions(true)`;
  - `ADD FEATURE columnMapping` continues to work as a protocol-only feature
    addition. It does not activate column mapping unless table metadata also sets
    `delta.columnMapping.mode`.

  ## guardrails

  The following paths are intentionally rejected instead of being partially
  enabled:

  - `columnMapping.mode = id`;
  - nested column-mapped writes;
  - creating column-mapped tables through `WriteBuilder`;
  - `ADD COLUMN` on column-mapped tables outside write schema merge;
  - enabling or changing column mapping through
    `SET TBLPROPERTIES delta.columnMapping.mode`;
  - CDC writes on column-mapped tables;
  - `OPTIMIZE` rewrites on column-mapped tables;
  - `MERGE` with schema evolution on column-mapped tables.

  These paths return a consistent unsupported column mapping write error without
  adding a new public `DeltaTableError` variant.

  ## validation

  Passed locally:

  ```bash
  cargo check -p deltalake-core --features datafusion
  cargo test -p deltalake-core --features datafusion --lib column_mapping -- --nocapture
  cargo test -p deltalake-core --features datafusion --lib add_feature -- --nocapture
  cargo test -p deltalake-core --features datafusion --lib test_add_column_rejects_column_mapping_table -- --nocapture
  cargo test -p deltalake-core --features datafusion --lib test_set_tbl_properties_rejects_column_mapping_mode -- --nocapture
  cargo test -p deltalake-core --features datafusion --lib test_column_mapping_name_table_rejects_invalid_random_prefix_length -- --nocapture
  cargo fmt --check
```
  Python validation after rebuilding the local binding with CPython 3.10:
```bash
  uv run --no-sync pytest tests/test_alter.py -q -k "add_feature_variations or add_features" --maxfail=1
  uv run --no-sync pytest tests/test_lakefs.py -q -m "lakefs and integration" -k add_features --maxfail=1
```
  Results:
```
  tests/test_alter.py: 17 passed
  tests/test_lakefs.py::test_add_features: 1 passed
```
  I also ran the standalone lab against the local checkout. It covers regular
  partitioned tables, freshly name-mapped partitioned tables, evolved name-mapped
  tables with Hive-style partition path preservation enabled, and report-style
  filtered reads.

  Latest lab result:
```
  regular: rows=3000
  column_mapping: rows=3000
  evolved_column_mapping: rows=6000
  validation passed
```
  Lab repository: [https://github.com/fksegundo/delta-column-mapping-lab](https://github.com/fksegundo/delta-column-mapping-lab)

  ## current limitations

  This PR is limited to top-level columnMapping.mode = name writes. Nested
  physical-name rewrites, columnMapping.mode = id, CDC output files,
  OPTIMIZE, and schema-evolving MERGE remain follow-up work.

  ## disclosure

  I used Codex for code navigation, patch drafting, and test scaffolding. I
  reviewed the changes and validated them with the Rust tests, Python tests, and
  standalone lab run listed above.
