### PR TITLE
chore: cap the upper range of the buoyant_kernel for this release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/delta-io/delta.rs"
 
 [workspace.dependencies]
 #delta_kernel = { package = "buoyant_kernel", path = "../delta-kernel-rs/kernel", features = [
-delta_kernel = { package = "buoyant_kernel", version = "0.21.103", features = [
+delta_kernel = { package = "buoyant_kernel", version = "0.21.103, <0.21.200", features = [
     "arrow-58",
     "internal-api",
 ] }


### PR DESCRIPTION
By putting a cap in the top end of the version range the buoant_kernel version range can be more tolerant of internal API incompatibilities between versions without breaking builds of delta-rs in the field.

If for example an API added in kernel 0.21.100 which is only used by 0.32.1 is modified, then the subsequent versions of buoyant_kernel can jump up to the 0.21.200 version range and allow the next delta-rs release to switch to 0.21.200-300.

This sort of juggling is a little bit necessary in order to keep the major.minor of buoyant_kernel in line with delta_kernel while allowing more incremental releases
