### PR TITLE
refactor: selective stats materialization policy

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
@@ -29,8 +29,6 @@ use delta_kernel::{
         Scan as KernelScan, ScanMetadata,
         state::{DvInfo, ScanFile},
     },
-    schema::{DataType, Schema, StructField},
-    table_configuration::TableConfiguration,
 };
 use futures::Stream;
 use itertools::Itertools;
@@ -41,8 +39,7 @@ use crate::{
     DeltaResult, DeltaTableError,
     delta_datafusion::{DeltaScanConfig, engine::to_datafusion_scalar},
     kernel::{
-        LogicalFileView, ReceiverStreamBuilder, Scan, StructDataExt,
-        arrow::engine_ext::{stats_inputs, stats_schema},
+        LogicalFileView, ReceiverStreamBuilder, Scan, StatsProjection, StructDataExt,
         parse_stats_column_with_schema,
     },
 };
@@ -55,68 +52,6 @@ pub(crate) struct ReplayStats {
 impl ReplayStats {
     fn new() -> Self {
         Self { num_scanned: 0 }
-    }
-}
-
-/// Extracts column names referenced in the scan's physical predicate.
-///
-/// Returns a set of column names that are actually used in predicates, which helps
-/// optimize statistics parsing to only process relevant columns.
-fn extract_predicate_columns(scan: &KernelScan) -> Option<HashSet<String>> {
-    scan.physical_predicate().map(|predicate| {
-        predicate
-            .references()
-            .into_iter()
-            .map(|col_name| col_name.to_string().trim_matches('`').to_string())
-            .collect()
-    })
-}
-
-/// Create a stats schema containing only columns needed for predicate evaluation
-///
-/// Returns:
-/// No predicate returns a schema with just `numRecords`.
-/// A predicate returns `numRecords` plus stats for referenced columns.
-fn create_minimal_stats_schema(
-    table_configuration: &TableConfiguration,
-    predicate_columns: Option<&HashSet<String>>,
-) -> DeltaResult<Arc<Schema>> {
-    let minimal_schema = || {
-        Schema::try_new(vec![StructField::nullable("numRecords", DataType::LONG)])
-            .map(Arc::new)
-            .map_err(Into::into)
-    };
-
-    match predicate_columns {
-        None => {
-            // No predicate. Only numRecords is needed for file statistics.
-            minimal_schema()
-        }
-        Some(cols) if cols.is_empty() => {
-            // Empty predicate columns use the minimal schema.
-            minimal_schema()
-        }
-        Some(cols) => {
-            let (stats_source_schema, table_properties) = stats_inputs(table_configuration)?;
-
-            let filtered_fields: Vec<_> = stats_source_schema
-                .fields()
-                .filter(|field| cols.contains(field.name()))
-                .cloned()
-                .collect();
-
-            if filtered_fields.is_empty() {
-                // Predicates that only reference partition columns use the minimal schema.
-                minimal_schema()
-            } else {
-                // Create stats schema for filtered fields
-                let filtered_schema = Schema::try_new(filtered_fields)?;
-                Ok(Arc::new(stats_schema(
-                    &filtered_schema,
-                    table_properties.as_ref(),
-                )))
-            }
-        }
     }
 }
 
@@ -184,7 +119,11 @@ where
             .physical_schema()
             .as_ref()
             .try_into_arrow()
-            .unwrap();
+            .map_err(DeltaTableError::from);
+        let physical_arrow = match physical_arrow {
+            Ok(schema) => schema,
+            Err(err) => return Poll::Ready(Some(Err(err))),
+        };
         match this.stream.poll_next(cx) {
             Poll::Ready(Some(Ok(scan_data))) => {
                 let scan_data = if let Some(selection) = this.file_selection {
@@ -231,30 +170,25 @@ where
                 let scan_files =
                     filter_record_batch(&batch, &BooleanArray::from(selection_vector))?;
 
-                // Extract columns referenced in predicate (if any)
-                let predicate_columns = extract_predicate_columns(this.kernel_scan.as_ref());
-
-                // Create minimal stats schema based on predicate columns
-                let stats_schema = match create_minimal_stats_schema(
-                    this.kernel_scan.snapshot().table_configuration(),
-                    predicate_columns.as_ref(),
-                ) {
+                let stats_projection = match StatsProjection::for_scan(this.kernel_scan.as_ref()) {
+                    Ok(projection) => projection,
+                    Err(err) => return Poll::Ready(Some(Err(err))),
+                };
+                let snapshot = this.kernel_scan.snapshot();
+                let stats_schema = match stats_projection.stats_schema(snapshot) {
                     Ok(schema) => schema,
                     Err(err) => return Poll::Ready(Some(Err(err))),
                 };
 
                 // Parse statistics (will skip parsing for unreferenced columns)
-                let parsed_stats = parse_stats_column_with_schema(
-                    this.kernel_scan.snapshot().as_ref(),
-                    &scan_files,
-                    stats_schema,
-                )?;
+                let parsed_stats =
+                    parse_stats_column_with_schema(snapshot.as_ref(), &scan_files, stats_schema)?;
 
                 let mut file_statistics = extract_file_statistics(
                     this.kernel_scan,
                     this.scan_config,
                     parsed_stats,
-                    predicate_columns.as_ref(),
+                    &stats_projection,
                 );
 
                 Poll::Ready(Some(Ok(ctx
@@ -281,27 +215,22 @@ where
 
 /// Extracts DataFusion statistics from parsed file metadata.
 ///
-/// Converts Delta Kernel's file statistics into DataFusion's [`Statistics`] format,
-/// which is used for query optimization and predicate pushdown. This function implements
-/// an important optimization: it only extracts statistics for columns that appear in
-/// predicates, avoiding expensive parsing for unused columns.
+/// Convert Delta Kernel file statistics into DataFusion [`Statistics`].
 ///
-/// # Arguments
+/// Only statistics for predicate columns are extracted.
 ///
-/// * `scan` - The kernel scan containing schema and predicate information
-/// * `parsed_stats` - RecordBatch containing parsed statistics for all files
-/// * `predicate_columns` - Optional set of columns referenced in predicates
+/// The scan provides schema and predicate information. `parsed_stats` contains parsed
+/// statistics for all files. `stats_projection` names the stats fields materialized
+/// for this scan.
 ///
 /// # Returns
 ///
-/// A map from file URL to tuple of:
-/// - [`Statistics`]: DataFusion statistics for query optimization
-/// - [`StructData`]: Partition values to be materialized in the output
+/// A map from file URL to DataFusion statistics and optional partition values.
 fn extract_file_statistics(
     scan: &KernelScan,
     scan_config: &DeltaScanConfig,
     parsed_stats: RecordBatch,
-    predicate_columns: Option<&HashSet<String>>,
+    stats_projection: &StatsProjection,
 ) -> HashMap<Url, (Statistics, Option<StructData>)> {
     (0..parsed_stats.num_rows())
         .map(move |idx| LogicalFileView::new(parsed_stats.clone(), idx))
@@ -320,10 +249,8 @@ fn extract_file_statistics(
                 .physical_schema()
                 .fields()
                 .map(|f| {
-                    // Check if we should extract stats for this column
-                    let should_extract_stats = predicate_columns
-                        .map(|cols| cols.contains(f.name()))
-                        .unwrap_or(false); // No predicate = no stats needed for pruning
+                    let should_extract_stats =
+                        stats_projection.emits_top_level_column_stats(f.name());
 
                     if !should_extract_stats {
                         // Return unknown statistics for non-predicate columns
@@ -571,14 +498,12 @@ fn visit_scan_file(ctx: &mut ScanContext, scan_file: ScanFile) {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
 
-    use crate::test_utils::{build_test_table_configuration, column_mapping_test_field};
     use delta_kernel::scan::state::{DvInfo, ScanFile};
-    use delta_kernel::schema::{DataType, StructField, StructType};
     use url::Url;
 
-    use super::{ScanContext, create_minimal_stats_schema, visit_scan_file};
+    use super::{ScanContext, visit_scan_file};
 
     fn scan_file(path: impl Into<String>) -> ScanFile {
         ScanFile {
@@ -590,77 +515,6 @@ mod tests {
             transform: None,
             partition_values: HashMap::new(),
         }
-    }
-
-    #[test]
-    fn test_minimal_stats_schema_uses_stats_source_for_partitioned_tables() {
-        for configuration in [
-            HashMap::from([(
-                "delta.dataSkippingNumIndexedCols".to_string(),
-                "1".to_string(),
-            )]),
-            HashMap::from([(
-                "delta.dataSkippingStatsColumns".to_string(),
-                "p,a".to_string(),
-            )]),
-        ] {
-            let table_configuration = build_test_table_configuration(
-                StructType::try_new([
-                    StructField::nullable("p", DataType::INTEGER),
-                    StructField::nullable("a", DataType::INTEGER),
-                    StructField::nullable("b", DataType::INTEGER),
-                ])
-                .unwrap(),
-                vec!["p".to_string()],
-                configuration,
-            );
-            let predicate_columns = HashSet::from(["p".to_string(), "a".to_string()]);
-
-            let stats_schema =
-                create_minimal_stats_schema(&table_configuration, Some(&predicate_columns))
-                    .unwrap();
-
-            let min_values = match stats_schema.field("minValues").unwrap().data_type() {
-                DataType::Struct(fields) => fields,
-                other => panic!("expected minValues struct, got {other:?}"),
-            };
-            assert!(min_values.field("a").is_some());
-            assert!(min_values.field("p").is_none());
-            assert!(min_values.field("b").is_none());
-        }
-    }
-
-    #[test]
-    fn test_minimal_stats_schema_translates_stats_columns_for_column_mapping() {
-        let table_configuration = build_test_table_configuration(
-            StructType::try_new([
-                column_mapping_test_field("p", "col_p", 1),
-                column_mapping_test_field("a", "col_a", 2),
-                column_mapping_test_field("b", "col_b", 3),
-            ])
-            .unwrap(),
-            vec!["p".to_string()],
-            HashMap::from([
-                ("delta.columnMapping.mode".to_string(), "name".to_string()),
-                (
-                    "delta.dataSkippingStatsColumns".to_string(),
-                    "a".to_string(),
-                ),
-            ]),
-        );
-        let predicate_columns = HashSet::from(["col_p".to_string(), "col_a".to_string()]);
-
-        let stats_schema =
-            create_minimal_stats_schema(&table_configuration, Some(&predicate_columns)).unwrap();
-
-        let min_values = match stats_schema.field("minValues").unwrap().data_type() {
-            DataType::Struct(fields) => fields,
-            other => panic!("expected minValues struct, got {other:?}"),
-        };
-        assert!(min_values.field("col_a").is_some());
-        assert!(min_values.field("a").is_none());
-        assert!(min_values.field("col_p").is_none());
-        assert!(min_values.field("col_b").is_none());
     }
 
     #[test]

--- a/crates/core/src/kernel/snapshot/iterators.rs
+++ b/crates/core/src/kernel/snapshot/iterators.rs
@@ -16,7 +16,7 @@ use object_store::ObjectMeta;
 use object_store::path::Path;
 use percent_encoding::percent_decode_str;
 
-#[cfg(any(test, feature = "datafusion"))]
+#[cfg(feature = "datafusion")]
 pub(crate) use self::scan_row::parse_stats_column_with_schema;
 pub use self::tombstones::TombstoneView;
 use crate::kernel::scalars::ScalarExt;

--- a/crates/core/src/kernel/snapshot/iterators/scan_row.rs
+++ b/crates/core/src/kernel/snapshot/iterators/scan_row.rs
@@ -43,19 +43,16 @@ pin_project! {
 }
 
 impl<S> ScanRowOutStream<S> {
-    pub fn try_new(
+    pub fn try_new_with_materialization(
         snapshot: Arc<KernelSnapshot>,
         stream: S,
-        skip_stats: bool,
+        stats_materialization: FileStatsMaterialization,
     ) -> DeltaResult<Self> {
-        let stats_schema = snapshot.stats_schema()?;
+        let stats_schema = stats_materialization
+            .stats_projection()
+            .stats_schema(snapshot.as_ref())?;
         let partitions_schema = snapshot.partitions_schema()?;
         let column_mapping_mode = snapshot.table_configuration().column_mapping_mode();
-        let stats_materialization = if skip_stats {
-            FileStatsMaterialization::without_stats()
-        } else {
-            FileStatsMaterialization::compatibility(StatsProjection::full())
-        };
         Ok(Self {
             stats_schema,
             partitions_schema,

--- a/crates/core/src/kernel/snapshot/iterators/scan_row.rs
+++ b/crates/core/src/kernel/snapshot/iterators/scan_row.rs
@@ -4,7 +4,9 @@ use std::sync::{Arc, LazyLock};
 use std::task::{Context, Poll};
 
 use arrow::array::{Array as _, *};
-use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Fields};
+use arrow_schema::{
+    DataType as ArrowDataType, Field as ArrowField, Fields, SchemaRef as ArrowSchemaRef,
+};
 use arrow_schema::{Field, Schema};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_conversion::TryIntoKernel;
@@ -25,14 +27,18 @@ use crate::kernel::ARROW_HANDLER;
 use crate::kernel::StructType;
 use crate::kernel::arrow::engine_ext::SnapshotExt;
 use crate::kernel::arrow::extract::{self as ex};
+#[cfg(any(test, feature = "datafusion"))]
+use crate::kernel::snapshot::stats_projection::StatsProjection;
 use crate::kernel::snapshot::stats_projection::{
-    FileStatsMaterialization, StatsProjection, StatsSourcePolicy,
+    FIELD_PARTITION_VALUES_PARSED, FIELD_STATS, FIELD_STATS_PARSED, FileStatsMaterialization,
+    StatsSourcePolicy,
 };
 use crate::{DeltaResult, DeltaTableError};
 
 pin_project! {
     pub(crate) struct ScanRowOutStream<S> {
         stats_schema: KernelSchemaRef,
+        stats_arrow_schema: ArrowSchemaRef,
         partitions_schema: Option<KernelSchemaRef>,
         column_mapping_mode: ColumnMappingMode,
         stats_materialization: FileStatsMaterialization,
@@ -51,10 +57,12 @@ impl<S> ScanRowOutStream<S> {
         let stats_schema = stats_materialization
             .stats_projection()
             .stats_schema(snapshot.as_ref())?;
+        let stats_arrow_schema = Arc::new(stats_schema.as_ref().try_into_arrow()?);
         let partitions_schema = snapshot.partitions_schema()?;
         let column_mapping_mode = snapshot.table_configuration().column_mapping_mode();
         Ok(Self {
             stats_schema,
+            stats_arrow_schema,
             partitions_schema,
             column_mapping_mode,
             stats_materialization,
@@ -76,6 +84,7 @@ where
                 let result = parse_stats_column_impl(
                     &batch,
                     this.stats_schema.clone(),
+                    Some(this.stats_arrow_schema.fields()),
                     this.partitions_schema.as_ref(),
                     *this.column_mapping_mode,
                     this.stats_materialization,
@@ -126,6 +135,7 @@ pub(crate) fn parse_stats_column_with_schema(
     parse_stats_column_impl(
         batch,
         stats_schema,
+        None,
         partitions_schema.as_ref(),
         column_mapping_mode,
         &FileStatsMaterialization::compatibility(StatsProjection::full()),
@@ -135,28 +145,40 @@ pub(crate) fn parse_stats_column_with_schema(
 fn parse_stats_column_impl(
     batch: &RecordBatch,
     stats_schema: KernelSchemaRef,
+    stats_arrow_fields: Option<&Fields>,
     partitions_schema: Option<&KernelSchemaRef>,
     column_mapping_mode: ColumnMappingMode,
     stats_materialization: &FileStatsMaterialization,
 ) -> DeltaResult<RecordBatch> {
+    let stats_arrow_schema: Schema;
+    let stats_arrow_fields = if let Some(stats_arrow_fields) = stats_arrow_fields {
+        stats_arrow_fields
+    } else {
+        stats_arrow_schema = stats_schema.as_ref().try_into_arrow()?;
+        stats_arrow_schema.fields()
+    };
     let mut columns = Vec::with_capacity(batch.num_columns() + 2);
     let mut fields = Vec::with_capacity(batch.num_columns() + 2);
 
     for (field, column) in batch.schema().fields().iter().zip(batch.columns()) {
-        if field.name() == "stats_parsed" {
+        if field.name() == FIELD_STATS_PARSED {
             continue;
         }
-        if field.name() == "stats" && !stats_materialization.preserves_raw_stats() {
+        if field.name() == FIELD_STATS && !stats_materialization.preserves_raw_stats() {
             continue;
         }
         fields.push(field.clone());
         columns.push(column.clone());
     }
 
-    if let Some(stats_array) = materialize_stats_array(batch, stats_schema, stats_materialization)?
-    {
+    if let Some(stats_array) = materialize_stats_array(
+        batch,
+        stats_schema,
+        stats_arrow_fields,
+        stats_materialization,
+    )? {
         fields.push(Arc::new(Field::new(
-            "stats_parsed",
+            FIELD_STATS_PARSED,
             stats_array.data_type().to_owned(),
             true,
         )));
@@ -171,7 +193,7 @@ fn parse_stats_column_impl(
             column_mapping_mode,
         )?;
         fields.push(Arc::new(Field::new(
-            "partitionValues_parsed",
+            FIELD_PARTITION_VALUES_PARSED,
             partition_array.data_type().to_owned(),
             false,
         )));
@@ -187,14 +209,14 @@ fn parse_stats_column_impl(
 fn materialize_stats_array(
     batch: &RecordBatch,
     stats_schema: KernelSchemaRef,
+    stats_arrow_fields: &Fields,
     stats_materialization: &FileStatsMaterialization,
 ) -> DeltaResult<Option<Arc<StructArray>>> {
     match stats_materialization.stats_source_policy() {
         StatsSourcePolicy::None => Ok(None),
-        StatsSourcePolicy::JsonOnly => parse_raw_stats_array(batch, stats_schema).map(Some),
         StatsSourcePolicy::ParsedWithJsonFallback => {
-            let requested_schema: arrow_schema::Schema = stats_schema.as_ref().try_into_arrow()?;
-            if let Some((idx, _)) = batch.schema_ref().column_with_name("stats_parsed") {
+            let mut projection_error = None;
+            if let Some((idx, _)) = batch.schema_ref().column_with_name(FIELD_STATS_PARSED) {
                 let parsed = batch
                     .column(idx)
                     .as_any()
@@ -202,14 +224,20 @@ fn materialize_stats_array(
                     .ok_or_else(|| DeltaTableError::SchemaMismatch {
                         msg: "stats_parsed column is not a struct".to_string(),
                     })?;
-                match project_struct_array(parsed, requested_schema.fields()) {
+                match project_struct_array(parsed, stats_arrow_fields) {
                     Ok(projected) => return Ok(Some(Arc::new(projected))),
                     Err(err) => {
                         debug!(
                             "existing stats_parsed did not satisfy requested stats schema; falling back to raw stats: {err}"
                         );
+                        projection_error = Some(err);
                     }
                 }
+            }
+            if batch.schema_ref().column_with_name(FIELD_STATS).is_none()
+                && let Some(err) = projection_error
+            {
+                return Err(err);
             }
             parse_raw_stats_array(batch, stats_schema).map(Some)
         }
@@ -220,7 +248,7 @@ fn parse_raw_stats_array(
     batch: &RecordBatch,
     stats_schema: KernelSchemaRef,
 ) -> DeltaResult<Arc<StructArray>> {
-    let Some((stats_idx, _)) = batch.schema_ref().column_with_name("stats") else {
+    let Some((stats_idx, _)) = batch.schema_ref().column_with_name(FIELD_STATS) else {
         return Err(DeltaTableError::SchemaMismatch {
             msg: "stats column not found".to_string(),
         });
@@ -251,7 +279,15 @@ fn project_struct_array(
             .iter()
             .position(|field| field.name() == requested_field.name())
             .ok_or_else(|| DeltaTableError::SchemaMismatch {
-                msg: format!("stats_parsed field {} not found", requested_field.name()),
+                msg: format!(
+                    "stats_parsed field {} not found; existing fields: [{}]",
+                    requested_field.name(),
+                    existing_fields
+                        .iter()
+                        .map(|field| field.name().as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
             })?;
         let existing_column = array.column(existing_idx);
         let column: ArrayRef = match (requested_field.data_type(), existing_column.data_type()) {
@@ -267,7 +303,17 @@ fn project_struct_array(
                     })?;
                 Arc::new(project_struct_array(child, requested_child_fields)?)
             }
-            _ => existing_column.clone(),
+            (requested, existing) if requested == existing => existing_column.clone(),
+            (requested, existing) => {
+                return Err(DeltaTableError::SchemaMismatch {
+                    msg: format!(
+                        "stats_parsed field {} has type {:?} but requested {:?}",
+                        requested_field.name(),
+                        existing,
+                        requested
+                    ),
+                });
+            }
         };
         columns.push(column);
     }
@@ -337,131 +383,27 @@ pub(crate) fn parse_partitions(
             })
             .collect::<Result<_, _>>()?;
 
-        partition_schema.fields().for_each(|f| {
+        for f in partition_schema.fields() {
             let value = data
                 .get(f.physical_name(column_mapping_mode))
                 .cloned()
                 .unwrap_or(Scalar::Null(f.data_type().clone()));
             values
                 .get_mut(f.physical_name(column_mapping_mode))
-                .unwrap()
+                .ok_or_else(|| missing_partition_values_error(f, column_mapping_mode))?
                 .push(value);
-        });
+        }
     }
 
     let columns = partition_schema
         .fields()
         .map(|f| {
-            let values = values.get(f.physical_name(column_mapping_mode)).unwrap();
+            let values = values
+                .get(f.physical_name(column_mapping_mode))
+                .ok_or_else(|| missing_partition_values_error(f, column_mapping_mode))?;
             match f.data_type() {
                 DataType::Primitive(p) => {
-                    // Safety: we created the Scalars above using the parsing function of the same PrimitiveType
-                    // should this fail, it's a bug in our code, and we should panic
-                    let arr = match p {
-                        PrimitiveType::String => {
-                            Arc::new(StringArray::from_iter(values.iter().map(|v| match v {
-                                Scalar::String(s) => Some(s.clone()),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))) as ArrayRef
-                        }
-                        PrimitiveType::Long => {
-                            Arc::new(Int64Array::from_iter(values.iter().map(|v| match v {
-                                Scalar::Long(i) => Some(*i),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))) as ArrayRef
-                        }
-                        PrimitiveType::Integer => {
-                            Arc::new(Int32Array::from_iter(values.iter().map(|v| match v {
-                                Scalar::Integer(i) => Some(*i),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))) as ArrayRef
-                        }
-                        PrimitiveType::Short => {
-                            Arc::new(Int16Array::from_iter(values.iter().map(|v| match v {
-                                Scalar::Short(i) => Some(*i),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))) as ArrayRef
-                        }
-                        PrimitiveType::Byte => {
-                            Arc::new(Int8Array::from_iter(values.iter().map(|v| match v {
-                                Scalar::Byte(i) => Some(*i),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))) as ArrayRef
-                        }
-                        PrimitiveType::Float => {
-                            Arc::new(Float32Array::from_iter(values.iter().map(|v| match v {
-                                Scalar::Float(f) => Some(*f),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))) as ArrayRef
-                        }
-                        PrimitiveType::Double => {
-                            Arc::new(Float64Array::from_iter(values.iter().map(|v| match v {
-                                Scalar::Double(f) => Some(*f),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))) as ArrayRef
-                        }
-                        PrimitiveType::Boolean => {
-                            Arc::new(BooleanArray::from_iter(values.iter().map(|v| match v {
-                                Scalar::Boolean(b) => Some(*b),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))) as ArrayRef
-                        }
-                        PrimitiveType::Binary => {
-                            Arc::new(BinaryArray::from_iter(values.iter().map(|v| match v {
-                                Scalar::Binary(b) => Some(b.clone()),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))) as ArrayRef
-                        }
-                        PrimitiveType::Date => {
-                            Arc::new(Date32Array::from_iter(values.iter().map(|v| match v {
-                                Scalar::Date(d) => Some(*d),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))) as ArrayRef
-                        }
-                        PrimitiveType::Timestamp => Arc::new(
-                            TimestampMicrosecondArray::from_iter(values.iter().map(|v| match v {
-                                Scalar::Timestamp(t) => Some(*t),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))
-                            .with_timezone("UTC"),
-                        ) as ArrayRef,
-                        #[cfg(feature = "nanosecond-timestamps")]
-                        PrimitiveType::TimestampNanos => Arc::new(
-                            TimestampNanosecondArray::from_iter(values.iter().map(|v| match v {
-                                Scalar::TimestampNanos(t) => Some(*t),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))
-                            .with_timezone("UTC"),
-                        ) as ArrayRef,
-                        PrimitiveType::TimestampNtz => Arc::new(
-                            TimestampMicrosecondArray::from_iter(values.iter().map(|v| match v {
-                                Scalar::TimestampNtz(t) => Some(*t),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            })),
-                        ) as ArrayRef,
-                        PrimitiveType::Decimal(decimal) => Arc::new(
-                            Decimal128Array::from_iter(values.iter().map(|v| match v {
-                                Scalar::Decimal(decimal) => Some(decimal.bits()),
-                                Scalar::Null(_) => None,
-                                _ => panic!("unexpected scalar type"),
-                            }))
-                            .with_precision_and_scale(decimal.precision(), decimal.scale() as i8)?,
-                        ) as ArrayRef,
-                    };
-                    Ok(arr)
+                    primitive_partition_values_to_array(f.name(), p, f.data_type(), values)
                 }
                 _ => Err(DeltaTableError::generic(
                     "complex partitioning values are not supported",
@@ -481,6 +423,221 @@ pub(crate) fn parse_partitions(
         None,
         num_rows,
     )?)
+}
+
+fn missing_partition_values_error(
+    field: &delta_kernel::schema::StructField,
+    column_mapping_mode: ColumnMappingMode,
+) -> DeltaTableError {
+    DeltaTableError::SchemaMismatch {
+        msg: format!(
+            "Partition field {} with physical name {} was not initialized.",
+            field.name(),
+            field.physical_name(column_mapping_mode)
+        ),
+    }
+}
+
+fn primitive_partition_values_to_array(
+    field_name: &str,
+    primitive_type: &PrimitiveType,
+    expected_data_type: &DataType,
+    values: &[Scalar],
+) -> DeltaResult<ArrayRef> {
+    Ok(match primitive_type {
+        PrimitiveType::String => Arc::new(StringArray::from_iter(typed_partition_values(
+            field_name,
+            expected_data_type,
+            values,
+            |value| match value {
+                Scalar::String(value) => Some(value.clone()),
+                _ => None,
+            },
+        )?)) as ArrayRef,
+        PrimitiveType::Long => Arc::new(Int64Array::from_iter(typed_partition_values(
+            field_name,
+            expected_data_type,
+            values,
+            |value| match value {
+                Scalar::Long(value) => Some(*value),
+                _ => None,
+            },
+        )?)) as ArrayRef,
+        PrimitiveType::Integer => Arc::new(Int32Array::from_iter(typed_partition_values(
+            field_name,
+            expected_data_type,
+            values,
+            |value| match value {
+                Scalar::Integer(value) => Some(*value),
+                _ => None,
+            },
+        )?)) as ArrayRef,
+        PrimitiveType::Short => Arc::new(Int16Array::from_iter(typed_partition_values(
+            field_name,
+            expected_data_type,
+            values,
+            |value| match value {
+                Scalar::Short(value) => Some(*value),
+                _ => None,
+            },
+        )?)) as ArrayRef,
+        PrimitiveType::Byte => Arc::new(Int8Array::from_iter(typed_partition_values(
+            field_name,
+            expected_data_type,
+            values,
+            |value| match value {
+                Scalar::Byte(value) => Some(*value),
+                _ => None,
+            },
+        )?)) as ArrayRef,
+        PrimitiveType::Float => Arc::new(Float32Array::from_iter(typed_partition_values(
+            field_name,
+            expected_data_type,
+            values,
+            |value| match value {
+                Scalar::Float(value) => Some(*value),
+                _ => None,
+            },
+        )?)) as ArrayRef,
+        PrimitiveType::Double => Arc::new(Float64Array::from_iter(typed_partition_values(
+            field_name,
+            expected_data_type,
+            values,
+            |value| match value {
+                Scalar::Double(value) => Some(*value),
+                _ => None,
+            },
+        )?)) as ArrayRef,
+        PrimitiveType::Boolean => Arc::new(BooleanArray::from_iter(typed_partition_values(
+            field_name,
+            expected_data_type,
+            values,
+            |value| match value {
+                Scalar::Boolean(value) => Some(*value),
+                _ => None,
+            },
+        )?)) as ArrayRef,
+        PrimitiveType::Binary => Arc::new(BinaryArray::from_iter(typed_partition_values(
+            field_name,
+            expected_data_type,
+            values,
+            |value| match value {
+                Scalar::Binary(value) => Some(value.clone()),
+                _ => None,
+            },
+        )?)) as ArrayRef,
+        PrimitiveType::Date => Arc::new(Date32Array::from_iter(typed_partition_values(
+            field_name,
+            expected_data_type,
+            values,
+            |value| match value {
+                Scalar::Date(value) => Some(*value),
+                _ => None,
+            },
+        )?)) as ArrayRef,
+        PrimitiveType::Timestamp => Arc::new(
+            TimestampMicrosecondArray::from_iter(typed_partition_values(
+                field_name,
+                expected_data_type,
+                values,
+                |value| match value {
+                    Scalar::Timestamp(value) => Some(*value),
+                    _ => None,
+                },
+            )?)
+            .with_timezone("UTC"),
+        ) as ArrayRef,
+        #[cfg(feature = "nanosecond-timestamps")]
+        PrimitiveType::TimestampNanos => Arc::new(
+            TimestampNanosecondArray::from_iter(typed_partition_values(
+                field_name,
+                expected_data_type,
+                values,
+                |value| match value {
+                    Scalar::TimestampNanos(value) => Some(*value),
+                    _ => None,
+                },
+            )?)
+            .with_timezone("UTC"),
+        ) as ArrayRef,
+        PrimitiveType::TimestampNtz => Arc::new(TimestampMicrosecondArray::from_iter(
+            typed_partition_values(
+                field_name,
+                expected_data_type,
+                values,
+                |value| match value {
+                    Scalar::TimestampNtz(value) => Some(*value),
+                    _ => None,
+                },
+            )?,
+        )) as ArrayRef,
+        PrimitiveType::Decimal(decimal) => Arc::new(
+            Decimal128Array::from_iter(typed_partition_values(
+                field_name,
+                expected_data_type,
+                values,
+                |value| match value {
+                    Scalar::Decimal(value) => Some(value.bits()),
+                    _ => None,
+                },
+            )?)
+            .with_precision_and_scale(decimal.precision(), decimal.scale() as i8)?,
+        ) as ArrayRef,
+    })
+}
+
+fn typed_partition_values<T>(
+    field_name: &str,
+    expected_data_type: &DataType,
+    values: &[Scalar],
+    extract: impl Fn(&Scalar) -> Option<T>,
+) -> DeltaResult<Vec<Option<T>>> {
+    values
+        .iter()
+        .map(|value| match value {
+            Scalar::Null(_) => Ok(None),
+            value => extract(value)
+                .map(Some)
+                .ok_or_else(|| partition_scalar_type_error(field_name, expected_data_type, value)),
+        })
+        .collect()
+}
+
+fn partition_scalar_type_error(
+    field_name: &str,
+    expected_data_type: &DataType,
+    actual: &Scalar,
+) -> DeltaTableError {
+    DeltaTableError::SchemaMismatch {
+        msg: format!(
+            "Partition field {field_name} expected {expected_data_type:?} but found {}.",
+            scalar_type_name(actual)
+        ),
+    }
+}
+
+fn scalar_type_name(value: &Scalar) -> &'static str {
+    match value {
+        Scalar::Null(_) => "Null",
+        Scalar::Boolean(_) => "Boolean",
+        Scalar::Byte(_) => "Byte",
+        Scalar::Short(_) => "Short",
+        Scalar::Integer(_) => "Integer",
+        Scalar::Long(_) => "Long",
+        Scalar::Float(_) => "Float",
+        Scalar::Double(_) => "Double",
+        Scalar::String(_) => "String",
+        Scalar::Binary(_) => "Binary",
+        Scalar::Date(_) => "Date",
+        Scalar::Timestamp(_) => "Timestamp",
+        #[cfg(feature = "nanosecond-timestamps")]
+        Scalar::TimestampNanos(_) => "TimestampNanos",
+        Scalar::TimestampNtz(_) => "TimestampNtz",
+        Scalar::Decimal(_) => "Decimal",
+        Scalar::Struct(_) => "Struct",
+        Scalar::Array(_) => "Array",
+        Scalar::Map(_) => "Map",
+    }
 }
 
 fn collect_map(val: &StructArray) -> Option<impl Iterator<Item = (String, Option<String>)> + '_> {
@@ -611,6 +768,13 @@ mod tests {
         )])
     }
 
+    fn mismatched_num_records_stats_parsed() -> StructArray {
+        StructArray::from(vec![(
+            Arc::new(Field::new("numRecords", ArrowDataType::Int32, true)),
+            Arc::new(Int32Array::from(vec![Some(11)])) as ArrayRef,
+        )])
+    }
+
     fn value_stats_parsed() -> StructArray {
         let min_values = StructArray::from(vec![(
             Arc::new(Field::new("value", ArrowDataType::Int32, true)),
@@ -664,6 +828,26 @@ mod tests {
             panic!("stats_parsed should be a struct");
         };
         fields.iter().map(|field| field.name().clone()).collect()
+    }
+
+    #[test]
+    fn primitive_partition_values_to_array_returns_schema_mismatch_for_wrong_scalar() {
+        let err = primitive_partition_values_to_array(
+            "part",
+            &PrimitiveType::Integer,
+            &DataType::INTEGER,
+            &[Scalar::String("not an integer".to_string())],
+        )
+        .expect_err("wrong scalar type should return an error");
+
+        assert!(
+            matches!(err, DeltaTableError::SchemaMismatch { .. }),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.to_string().contains("Partition field part expected"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -816,6 +1000,7 @@ mod tests {
             &batch,
             stats_schema,
             None,
+            None,
             ColumnMappingMode::None,
             &FileStatsMaterialization::compatibility(StatsProjection::full()),
         )?;
@@ -839,8 +1024,9 @@ mod tests {
             &batch,
             num_records_stats_schema(),
             None,
+            None,
             ColumnMappingMode::None,
-            &FileStatsMaterialization::query(StatsProjection::num_records_only()),
+            &FileStatsMaterialization::query(StatsProjection::NumRecordsOnly),
         )?;
 
         assert!(projected.schema().column_with_name("stats").is_none());
@@ -857,12 +1043,88 @@ mod tests {
             &batch,
             num_records_stats_schema(),
             None,
+            None,
             ColumnMappingMode::None,
-            &FileStatsMaterialization::query(StatsProjection::num_records_only()),
+            &FileStatsMaterialization::query(StatsProjection::NumRecordsOnly),
         )?;
 
         assert!(projected.schema().column_with_name("stats").is_none());
         assert_eq!(stats_parsed_field_names(&projected), vec!["numRecords"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_stats_column_impl_rejects_existing_stats_parsed_type_mismatch() -> DeltaResult<()> {
+        let batch = scan_row_batch_with_stats(r#"{"numRecords":11}"#);
+        let batch = append_stats_parsed(
+            &without_raw_stats(&batch),
+            mismatched_num_records_stats_parsed(),
+        );
+
+        let err = parse_stats_column_impl(
+            &batch,
+            num_records_stats_schema(),
+            None,
+            None,
+            ColumnMappingMode::None,
+            &FileStatsMaterialization::query(StatsProjection::NumRecordsOnly),
+        )
+        .expect_err("mismatched stats_parsed field type should fail projection");
+
+        assert!(
+            err.to_string()
+                .contains("stats_parsed field numRecords has type Int32 but requested Int64"),
+            "unexpected error: {err}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_stats_column_impl_falls_back_to_raw_stats_when_existing_parsed_is_partial()
+    -> DeltaResult<()> {
+        let raw_stats = r#"{"maxValues":{"value":9},"numRecords":11,"nullCount":{"value":0},"minValues":{"value":1}}"#;
+        let batch = scan_row_batch_with_stats(raw_stats);
+        let batch = append_stats_parsed(&batch, num_records_stats_parsed(11));
+
+        let projected = parse_stats_column_impl(
+            &batch,
+            value_stats_schema(),
+            None,
+            None,
+            ColumnMappingMode::None,
+            &FileStatsMaterialization::compatibility(StatsProjection::full()),
+        )?;
+
+        assert_eq!(
+            stats_parsed_field_names(&projected),
+            vec!["numRecords", "minValues", "maxValues", "nullCount"]
+        );
+        assert_eq!(raw_stats_string(projected, 0), Some(raw_stats.to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_stats_column_impl_accepts_raw_stats_without_min_max_values() -> DeltaResult<()> {
+        let raw_stats = r#"{"numRecords":11}"#;
+        let batch = scan_row_batch_with_stats(raw_stats);
+
+        let projected = parse_stats_column_impl(
+            &batch,
+            value_stats_schema(),
+            None,
+            None,
+            ColumnMappingMode::None,
+            &FileStatsMaterialization::compatibility(StatsProjection::full()),
+        )?;
+
+        assert_eq!(
+            stats_parsed_field_names(&projected),
+            vec!["numRecords", "minValues", "maxValues", "nullCount"]
+        );
+        assert_eq!(raw_stats_string(projected, 0), Some(raw_stats.to_string()));
 
         Ok(())
     }
@@ -875,6 +1137,7 @@ mod tests {
         let projected = parse_stats_column_impl(
             &batch,
             value_stats_schema(),
+            None,
             None,
             ColumnMappingMode::None,
             &FileStatsMaterialization::compatibility(StatsProjection::full()),
@@ -896,6 +1159,7 @@ mod tests {
         let err = parse_stats_column_impl(
             &batch,
             stats_schema,
+            None,
             None,
             ColumnMappingMode::None,
             &FileStatsMaterialization::compatibility(StatsProjection::full()),

--- a/crates/core/src/kernel/snapshot/iterators/scan_row.rs
+++ b/crates/core/src/kernel/snapshot/iterators/scan_row.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, LazyLock};
 use std::task::{Context, Poll};
 
 use arrow::array::{Array as _, *};
-use arrow_schema::{Field as ArrowField, Fields};
+use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Fields};
 use arrow_schema::{Field, Schema};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_conversion::TryIntoKernel;
@@ -25,6 +25,9 @@ use crate::kernel::ARROW_HANDLER;
 use crate::kernel::StructType;
 use crate::kernel::arrow::engine_ext::SnapshotExt;
 use crate::kernel::arrow::extract::{self as ex};
+use crate::kernel::snapshot::stats_projection::{
+    FileStatsMaterialization, StatsProjection, StatsSourcePolicy,
+};
 use crate::{DeltaResult, DeltaTableError};
 
 pin_project! {
@@ -32,7 +35,7 @@ pin_project! {
         stats_schema: KernelSchemaRef,
         partitions_schema: Option<KernelSchemaRef>,
         column_mapping_mode: ColumnMappingMode,
-        skip_stats: bool,
+        stats_materialization: FileStatsMaterialization,
 
         #[pin]
         stream: S,
@@ -48,11 +51,16 @@ impl<S> ScanRowOutStream<S> {
         let stats_schema = snapshot.stats_schema()?;
         let partitions_schema = snapshot.partitions_schema()?;
         let column_mapping_mode = snapshot.table_configuration().column_mapping_mode();
+        let stats_materialization = if skip_stats {
+            FileStatsMaterialization::without_stats()
+        } else {
+            FileStatsMaterialization::compatibility(StatsProjection::full())
+        };
         Ok(Self {
             stats_schema,
             partitions_schema,
             column_mapping_mode,
-            skip_stats,
+            stats_materialization,
             stream,
         })
     }
@@ -73,7 +81,7 @@ where
                     this.stats_schema.clone(),
                     this.partitions_schema.as_ref(),
                     *this.column_mapping_mode,
-                    *this.skip_stats,
+                    this.stats_materialization,
                 );
                 Poll::Ready(Some(result))
             }
@@ -123,7 +131,7 @@ pub(crate) fn parse_stats_column_with_schema(
         stats_schema,
         partitions_schema.as_ref(),
         column_mapping_mode,
-        false,
+        &FileStatsMaterialization::compatibility(StatsProjection::full()),
     )
 }
 
@@ -132,41 +140,31 @@ fn parse_stats_column_impl(
     stats_schema: KernelSchemaRef,
     partitions_schema: Option<&KernelSchemaRef>,
     column_mapping_mode: ColumnMappingMode,
-    skip_stats: bool,
+    stats_materialization: &FileStatsMaterialization,
 ) -> DeltaResult<RecordBatch> {
-    let Some((stats_idx, _)) = batch.schema_ref().column_with_name("stats") else {
-        return Err(DeltaTableError::SchemaMismatch {
-            msg: "stats column not found".to_string(),
-        });
-    };
+    let mut columns = Vec::with_capacity(batch.num_columns() + 2);
+    let mut fields = Vec::with_capacity(batch.num_columns() + 2);
 
-    let mut columns = batch.columns().to_vec();
-    let mut fields = batch.schema().fields().to_vec();
+    for (field, column) in batch.schema().fields().iter().zip(batch.columns()) {
+        if field.name() == "stats_parsed" {
+            continue;
+        }
+        if field.name() == "stats" && !stats_materialization.preserves_raw_stats() {
+            continue;
+        }
+        fields.push(field.clone());
+        columns.push(column.clone());
+    }
 
-    let stats_array: Arc<StructArray> = if skip_stats {
-        // `parse_json` on a null `stats` column still runs the full JSON
-        // machinery and produces `{}` structs, not nulls: cancels the
-        // skip_stats win. Build the fully-null `StructArray` directly instead.
-        let arrow_struct: arrow_schema::Schema = stats_schema.as_ref().try_into_arrow()?;
-        Arc::new(StructArray::new_null(
-            arrow_struct.fields().clone(),
-            batch.num_rows(),
-        ))
-    } else {
-        let stats_batch = batch.project(&[stats_idx])?;
-        let stats_data = Box::new(ArrowEngineData::new(stats_batch));
-
-        let parsed = parse_json(stats_data, stats_schema)?;
-        let parsed: RecordBatch = ArrowEngineData::try_from_engine_data(parsed)?.into();
-
-        Arc::new(parsed.into())
-    };
-    fields.push(Arc::new(Field::new(
-        "stats_parsed",
-        stats_array.data_type().to_owned(),
-        true,
-    )));
-    columns.push(stats_array);
+    if let Some(stats_array) = materialize_stats_array(batch, stats_schema, stats_materialization)?
+    {
+        fields.push(Arc::new(Field::new(
+            "stats_parsed",
+            stats_array.data_type().to_owned(),
+            true,
+        )));
+        columns.push(stats_array);
+    }
 
     if let Some(partition_schema) = partitions_schema {
         let partition_array = parse_partitions(
@@ -186,6 +184,102 @@ fn parse_stats_column_impl(
     Ok(RecordBatch::try_new(
         Arc::new(Schema::new(fields)),
         columns,
+    )?)
+}
+
+fn materialize_stats_array(
+    batch: &RecordBatch,
+    stats_schema: KernelSchemaRef,
+    stats_materialization: &FileStatsMaterialization,
+) -> DeltaResult<Option<Arc<StructArray>>> {
+    match stats_materialization.stats_source_policy() {
+        StatsSourcePolicy::None => Ok(None),
+        StatsSourcePolicy::JsonOnly => parse_raw_stats_array(batch, stats_schema).map(Some),
+        StatsSourcePolicy::ParsedWithJsonFallback => {
+            let requested_schema: arrow_schema::Schema = stats_schema.as_ref().try_into_arrow()?;
+            if let Some((idx, _)) = batch.schema_ref().column_with_name("stats_parsed") {
+                let parsed = batch
+                    .column(idx)
+                    .as_any()
+                    .downcast_ref::<StructArray>()
+                    .ok_or_else(|| DeltaTableError::SchemaMismatch {
+                        msg: "stats_parsed column is not a struct".to_string(),
+                    })?;
+                match project_struct_array(parsed, requested_schema.fields()) {
+                    Ok(projected) => return Ok(Some(Arc::new(projected))),
+                    Err(err) => {
+                        debug!(
+                            "existing stats_parsed did not satisfy requested stats schema; falling back to raw stats: {err}"
+                        );
+                    }
+                }
+            }
+            parse_raw_stats_array(batch, stats_schema).map(Some)
+        }
+    }
+}
+
+fn parse_raw_stats_array(
+    batch: &RecordBatch,
+    stats_schema: KernelSchemaRef,
+) -> DeltaResult<Arc<StructArray>> {
+    let Some((stats_idx, _)) = batch.schema_ref().column_with_name("stats") else {
+        return Err(DeltaTableError::SchemaMismatch {
+            msg: "stats column not found".to_string(),
+        });
+    };
+
+    let stats_batch = batch.project(&[stats_idx])?;
+    let stats_data = Box::new(ArrowEngineData::new(stats_batch));
+
+    let parsed = parse_json(stats_data, stats_schema)?;
+    let parsed: RecordBatch = ArrowEngineData::try_from_engine_data(parsed)?.into();
+
+    Ok(Arc::new(parsed.into()))
+}
+
+fn project_struct_array(
+    array: &StructArray,
+    requested_fields: &Fields,
+) -> DeltaResult<StructArray> {
+    let ArrowDataType::Struct(existing_fields) = array.data_type() else {
+        return Err(DeltaTableError::SchemaMismatch {
+            msg: "expected struct array for stats_parsed".to_string(),
+        });
+    };
+
+    let mut columns = Vec::with_capacity(requested_fields.len());
+    for requested_field in requested_fields {
+        let existing_idx = existing_fields
+            .iter()
+            .position(|field| field.name() == requested_field.name())
+            .ok_or_else(|| DeltaTableError::SchemaMismatch {
+                msg: format!("stats_parsed field {} not found", requested_field.name()),
+            })?;
+        let existing_column = array.column(existing_idx);
+        let column: ArrayRef = match (requested_field.data_type(), existing_column.data_type()) {
+            (ArrowDataType::Struct(requested_child_fields), ArrowDataType::Struct(_)) => {
+                let child = existing_column
+                    .as_any()
+                    .downcast_ref::<StructArray>()
+                    .ok_or_else(|| DeltaTableError::SchemaMismatch {
+                        msg: format!(
+                            "stats_parsed field {} is not a struct",
+                            requested_field.name()
+                        ),
+                    })?;
+                Arc::new(project_struct_array(child, requested_child_fields)?)
+            }
+            _ => existing_column.clone(),
+        };
+        columns.push(column);
+    }
+
+    Ok(StructArray::try_new_with_length(
+        requested_fields.clone(),
+        columns,
+        array.nulls().cloned(),
+        array.len(),
     )?)
 }
 
@@ -427,6 +521,7 @@ mod tests {
 
     use crate::kernel::arrow::engine_ext::{ExpressionEvaluatorExt, SnapshotExt};
     use crate::kernel::snapshot::Snapshot;
+    use crate::kernel::snapshot::stats_projection::{FileStatsMaterialization, StatsProjection};
     use crate::test_utils::TestTables;
 
     fn scan_row_batch_with_stats(raw_stats: &str) -> RecordBatch {
@@ -451,6 +546,127 @@ mod tests {
             .column_by_name("stats")
             .and_then(|col| col.as_string_opt::<i32>())
             .and_then(|col| col.is_valid(row).then(|| col.value(row).to_string()))
+    }
+
+    fn num_records_stats_schema() -> SchemaRef {
+        Arc::new(
+            StructType::try_new([StructField::nullable("numRecords", DataType::LONG)]).unwrap(),
+        )
+    }
+
+    fn value_stats_schema() -> SchemaRef {
+        Arc::new(
+            StructType::try_new([
+                StructField::nullable("numRecords", DataType::LONG),
+                StructField::nullable(
+                    "minValues",
+                    StructType::try_new([StructField::nullable("value", DataType::INTEGER)])
+                        .unwrap(),
+                ),
+                StructField::nullable(
+                    "maxValues",
+                    StructType::try_new([StructField::nullable("value", DataType::INTEGER)])
+                        .unwrap(),
+                ),
+                StructField::nullable(
+                    "nullCount",
+                    StructType::try_new([StructField::nullable("value", DataType::LONG)]).unwrap(),
+                ),
+            ])
+            .unwrap(),
+        )
+    }
+
+    fn append_stats_parsed(batch: &RecordBatch, stats_parsed: StructArray) -> RecordBatch {
+        let mut fields = batch.schema().fields().to_vec();
+        let mut columns = batch.columns().to_vec();
+        fields.push(Arc::new(Field::new(
+            "stats_parsed",
+            stats_parsed.data_type().clone(),
+            true,
+        )));
+        columns.push(Arc::new(stats_parsed));
+        RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), columns).unwrap()
+    }
+
+    fn without_raw_stats(batch: &RecordBatch) -> RecordBatch {
+        let stats_idx = batch.schema().index_of("stats").unwrap();
+        let fields = batch
+            .schema()
+            .fields()
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, field)| (idx != stats_idx).then_some(field.clone()))
+            .collect::<Vec<_>>();
+        let columns = batch
+            .columns()
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, column)| (idx != stats_idx).then_some(column.clone()))
+            .collect::<Vec<_>>();
+        RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), columns).unwrap()
+    }
+
+    fn num_records_stats_parsed(num_records: i64) -> StructArray {
+        StructArray::from(vec![(
+            Arc::new(Field::new("numRecords", ArrowDataType::Int64, true)),
+            Arc::new(Int64Array::from(vec![Some(num_records)])) as ArrayRef,
+        )])
+    }
+
+    fn value_stats_parsed() -> StructArray {
+        let min_values = StructArray::from(vec![(
+            Arc::new(Field::new("value", ArrowDataType::Int32, true)),
+            Arc::new(Int32Array::from(vec![Some(1)])) as ArrayRef,
+        )]);
+        let max_values = StructArray::from(vec![(
+            Arc::new(Field::new("value", ArrowDataType::Int32, true)),
+            Arc::new(Int32Array::from(vec![Some(9)])) as ArrayRef,
+        )]);
+        let null_count = StructArray::from(vec![(
+            Arc::new(Field::new("value", ArrowDataType::Int64, true)),
+            Arc::new(Int64Array::from(vec![Some(0)])) as ArrayRef,
+        )]);
+
+        StructArray::from(vec![
+            (
+                Arc::new(Field::new("numRecords", ArrowDataType::Int64, true)),
+                Arc::new(Int64Array::from(vec![Some(11)])) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new(
+                    "minValues",
+                    min_values.data_type().clone(),
+                    true,
+                )),
+                Arc::new(min_values) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new(
+                    "maxValues",
+                    max_values.data_type().clone(),
+                    true,
+                )),
+                Arc::new(max_values) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new(
+                    "nullCount",
+                    null_count.data_type().clone(),
+                    true,
+                )),
+                Arc::new(null_count) as ArrayRef,
+            ),
+        ])
+    }
+
+    fn stats_parsed_field_names(batch: &RecordBatch) -> Vec<String> {
+        let schema = batch.schema();
+        let field = schema.field_with_name("stats_parsed").unwrap();
+        let ArrowDataType::Struct(fields) = field.data_type() else {
+            panic!("stats_parsed should be a struct");
+        };
+        fields.iter().map(|field| field.name().clone()).collect()
     }
 
     #[test]
@@ -599,8 +815,13 @@ mod tests {
             DataType::LONG,
         )])?);
 
-        let projected =
-            parse_stats_column_impl(&batch, stats_schema, None, ColumnMappingMode::None, false)?;
+        let projected = parse_stats_column_impl(
+            &batch,
+            stats_schema,
+            None,
+            ColumnMappingMode::None,
+            &FileStatsMaterialization::compatibility(StatsProjection::full()),
+        )?;
 
         assert!(projected.schema().column_with_name("stats").is_some());
         assert!(
@@ -614,6 +835,60 @@ mod tests {
     }
 
     #[test]
+    fn parse_stats_column_impl_reuses_existing_stats_parsed_without_raw_json() -> DeltaResult<()> {
+        let batch = scan_row_batch_with_stats(r#"{"numRecords":11"#);
+        let batch = append_stats_parsed(&without_raw_stats(&batch), num_records_stats_parsed(11));
+        let projected = parse_stats_column_impl(
+            &batch,
+            num_records_stats_schema(),
+            None,
+            ColumnMappingMode::None,
+            &FileStatsMaterialization::query(StatsProjection::num_records_only()),
+        )?;
+
+        assert!(projected.schema().column_with_name("stats").is_none());
+        assert_eq!(stats_parsed_field_names(&projected), vec!["numRecords"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_stats_column_impl_projects_wide_stats_parsed_to_requested_fields() -> DeltaResult<()> {
+        let batch = scan_row_batch_with_stats(r#"{"numRecords":11"#);
+        let batch = append_stats_parsed(&batch, value_stats_parsed());
+        let projected = parse_stats_column_impl(
+            &batch,
+            num_records_stats_schema(),
+            None,
+            ColumnMappingMode::None,
+            &FileStatsMaterialization::query(StatsProjection::num_records_only()),
+        )?;
+
+        assert!(projected.schema().column_with_name("stats").is_none());
+        assert_eq!(stats_parsed_field_names(&projected), vec!["numRecords"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_stats_column_impl_keeps_raw_stats_when_raw_policy_preserves() -> DeltaResult<()> {
+        let raw_stats = r#"{"maxValues":{"value":9},"numRecords":11,"nullCount":{"value":0},"minValues":{"value":1}}"#;
+        let batch = scan_row_batch_with_stats(raw_stats);
+        let batch = append_stats_parsed(&batch, value_stats_parsed());
+        let projected = parse_stats_column_impl(
+            &batch,
+            value_stats_schema(),
+            None,
+            ColumnMappingMode::None,
+            &FileStatsMaterialization::compatibility(StatsProjection::full()),
+        )?;
+
+        assert_eq!(raw_stats_string(projected, 0), Some(raw_stats.to_string()));
+
+        Ok(())
+    }
+
+    #[test]
     fn parse_stats_column_impl_errors_on_malformed_stats_json() -> DeltaResult<()> {
         let batch = scan_row_batch_with_stats(r#"{"numRecords":11"#);
         let stats_schema = Arc::new(StructType::try_new([StructField::nullable(
@@ -621,9 +896,14 @@ mod tests {
             DataType::LONG,
         )])?);
 
-        let err =
-            parse_stats_column_impl(&batch, stats_schema, None, ColumnMappingMode::None, false)
-                .expect_err("malformed stats JSON should fail parsing");
+        let err = parse_stats_column_impl(
+            &batch,
+            stats_schema,
+            None,
+            ColumnMappingMode::None,
+            &FileStatsMaterialization::compatibility(StatsProjection::full()),
+        )
+        .expect_err("malformed stats JSON should fail parsing");
 
         assert!(
             err.to_string().contains("json") || err.to_string().contains("JSON"),

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -348,12 +348,15 @@ impl Snapshot {
         log_store: &dyn LogStore,
         predicate: Option<PredicateRef>,
     ) -> SendableRBStream {
-        // Avoid the `stats_parsed -> JSON -> stats_parsed` roundtrip that
-        // `scan_metadata_from` forces on a no-predicate cache replay.
+        // Use cached parsed batches when no predicate is present. This avoids
+        // replaying stats through JSON.
         if predicate.is_none()
             && let Some(cached) = self.cached_parsed_batches()
         {
             return cached;
+        }
+        if predicate.is_some() && self.config.skip_stats {
+            return self.files_with_engine(log_store.engine(None), predicate);
         }
 
         match self
@@ -396,7 +399,7 @@ impl Snapshot {
         engine: Arc<dyn Engine>,
         predicate: Option<PredicateRef>,
     ) -> SendableRBStream {
-        self.files_with_engine_materialized(engine, predicate, false)
+        self.files_with_engine_materialized(engine, predicate, FileStatsMode::PreserveRaw)
     }
 
     fn files_with_engine_preserving_raw(
@@ -404,18 +407,18 @@ impl Snapshot {
         engine: Arc<dyn Engine>,
         predicate: Option<PredicateRef>,
     ) -> SendableRBStream {
-        self.files_with_engine_materialized(engine, predicate, true)
+        self.files_with_engine_materialized(engine, predicate, FileStatsMode::FullPreserveRaw)
     }
 
     fn files_with_engine_materialized(
         &self,
         engine: Arc<dyn Engine>,
         predicate: Option<PredicateRef>,
-        preserve_raw_stats: bool,
+        stats_mode: FileStatsMode,
     ) -> SendableRBStream {
         self.warn_if_skip_stats_with_predicate(&predicate);
-        let skip_stats = predicate.is_none() && self.config.skip_stats;
-        let scan = match self.scan_for_files(predicate, skip_stats, preserve_raw_stats) {
+        let skip_stats = self.config.skip_stats;
+        let scan = match self.scan_for_files(predicate, skip_stats, stats_mode) {
             Ok(scan) => scan,
             Err(err) => return Box::pin(once(ready(Err(err)))),
         };
@@ -439,24 +442,35 @@ impl Snapshot {
         &self,
         predicate: Option<PredicateRef>,
         skip_stats: bool,
-        preserve_raw_stats: bool,
+        stats_mode: FileStatsMode,
     ) -> DeltaResult<Scan> {
-        let scan = self
-            .scan_builder()
-            .with_predicate(predicate.clone())
-            .with_skip_stats(skip_stats)
-            .build()?;
-        if preserve_raw_stats && !skip_stats {
-            let stats_materialization = FileStatsMaterialization::compatibility(
-                scan.stats_materialization().stats_projection().clone(),
-            );
-            self.scan_builder()
-                .with_predicate(predicate)
-                .with_stats_materialization(stats_materialization)
-                .build()
-        } else {
-            Ok(scan)
+        let stats_materialization =
+            self.file_stats_materialization(predicate.as_ref(), skip_stats, stats_mode)?;
+
+        self.scan_builder()
+            .with_predicate(predicate)
+            .with_stats_materialization(stats_materialization)
+            .build()
+    }
+
+    fn file_stats_materialization(
+        &self,
+        predicate: Option<&PredicateRef>,
+        skip_stats: bool,
+        stats_mode: FileStatsMode,
+    ) -> DeltaResult<FileStatsMaterialization> {
+        if skip_stats {
+            return Ok(FileStatsMaterialization::without_stats());
         }
+
+        let stats_projection = match stats_mode {
+            FileStatsMode::PreserveRaw => {
+                StatsProjection::for_scan_inputs(self.inner.as_ref(), None, predicate)?
+            }
+            FileStatsMode::FullPreserveRaw => StatsProjection::full(),
+        };
+
+        Ok(FileStatsMaterialization::compatibility(stats_projection))
     }
 
     fn warn_if_skip_stats_with_predicate(&self, predicate: &Option<PredicateRef>) {
@@ -484,7 +498,7 @@ impl Snapshot {
             existing_version,
             existing_data,
             existing_predicate,
-            false,
+            FileStatsMode::PreserveRaw,
         )
     }
 
@@ -502,7 +516,7 @@ impl Snapshot {
             existing_version,
             existing_data,
             existing_predicate,
-            true,
+            FileStatsMode::FullPreserveRaw,
         )
     }
 
@@ -513,11 +527,11 @@ impl Snapshot {
         existing_version: Version,
         existing_data: Box<T>,
         existing_predicate: Option<PredicateRef>,
-        preserve_raw_stats: bool,
+        stats_mode: FileStatsMode,
     ) -> SendableRBStream {
         self.warn_if_skip_stats_with_predicate(&predicate);
-        let skip_stats = predicate.is_none() && self.config.skip_stats;
-        let scan = match self.scan_for_files(predicate, skip_stats, preserve_raw_stats) {
+        let skip_stats = self.config.skip_stats;
+        let scan = match self.scan_for_files(predicate, skip_stats, stats_mode) {
             Ok(scan) => scan,
             Err(err) => return Box::pin(once(ready(Err(err)))),
         };
@@ -643,8 +657,9 @@ impl Snapshot {
             .try_collect::<Vec<_>>()
             .await?
         {
-            // safety: object store path are always valid urls paths.
-            let dummy_path = dummy_url.join(meta.location.as_ref()).unwrap();
+            let dummy_path = dummy_url
+                .join(meta.location.as_ref())
+                .map_err(|err| DeltaTableError::InvalidTableLocation(err.to_string()))?;
             if let Some(parsed_path) = ParsedLogPath::try_from(dummy_path)?
                 && matches!(parsed_path.file_type, LogPathFileType::Commit)
             {
@@ -790,7 +805,16 @@ impl Snapshot {
     }
 }
 
-/// A snapshot of a Delta table that has been eagerly loaded into memory.
+/// Stats materialization mode for file replay APIs that preserve compatibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FileStatsMode {
+    /// Use raw JSON stats and the requested parsed stats shape.
+    PreserveRaw,
+    /// Use raw JSON stats and the full parsed stats schema.
+    FullPreserveRaw,
+}
+
+/// Scope for materialized file replay data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ::serde::Serialize, ::serde::Deserialize)]
 pub(crate) enum MaterializedFilesScope {
     FullTable,
@@ -884,7 +908,7 @@ pub struct EagerSnapshot {
 
 /// Read `_last_checkpoint` and return the hinted version when present.
 ///
-/// Missing, empty, or invalid hint files return `Ok(None)` so callers can fall back to listing.
+/// Missing, empty, or invalid hint files return `Ok(None)`. Callers can fall back to listing.
 async fn read_last_checkpoint_version(
     engine: Arc<dyn Engine>,
     log_root: Url,
@@ -1052,14 +1076,27 @@ impl EagerSnapshot {
         self.snapshot.table_configuration()
     }
 
+    /// Try to get a [`LogDataHandler`] for the snapshot to inspect the currently loaded state of
+    /// the log.
+    pub fn try_log_data(&self) -> DeltaResult<LogDataHandler<'_>> {
+        match self.snapshot.try_log_data() {
+            Ok(log_data) => Ok(log_data),
+            Err(DeltaTableError::NotInitializedWithFiles(_)) => Ok(LogDataHandler::new(
+                &[],
+                self.snapshot.table_configuration(),
+            )),
+            Err(err) => Err(err),
+        }
+    }
+
     /// Get a [`LogDataHandler`] for the snapshot to inspect the currently loaded state of the log.
     pub fn log_data(&self) -> LogDataHandler<'_> {
-        match self.snapshot.try_log_data() {
+        match self.try_log_data() {
             Ok(log_data) => log_data,
-            Err(DeltaTableError::NotInitializedWithFiles(_)) => {
+            Err(err) => {
+                tracing::error!("unexpected error loading EagerSnapshot log data: {err}");
                 LogDataHandler::new(&[], self.snapshot.table_configuration())
             }
-            Err(err) => panic!("unexpected error loading EagerSnapshot log data: {err}"),
         }
     }
 
@@ -1144,9 +1181,8 @@ pub(crate) fn partitions_schema(
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::Int64Array;
     use arrow_ipc::writer::FileWriter;
-    use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+    use arrow_schema::DataType as ArrowDataType;
     use delta_kernel::expressions::Scalar;
     use futures::TryStreamExt;
     use itertools::Itertools;
@@ -1258,21 +1294,39 @@ mod tests {
         Ok(version)
     }
 
+    async fn append_test_add_with_stats(
+        table: &mut DeltaTable,
+        path: &str,
+        stats: &str,
+    ) -> DeltaResult<Version> {
+        let mut add = make_test_add(path, &[], 0);
+        add.size = 1;
+        add.stats = Some(stats.to_string());
+
+        let version = CommitBuilder::default()
+            .with_actions(vec![Action::Add(add)])
+            .build(
+                table
+                    .state
+                    .as_ref()
+                    .map(|state| state as &dyn TableReference),
+                table.log_store(),
+                DeltaOperation::Write {
+                    mode: SaveMode::Append,
+                    partition_by: None,
+                    predicate: None,
+                },
+            )
+            .await?
+            .version();
+        table.update_state().await?;
+        Ok(version)
+    }
+
     async fn selective_stats_table() -> DeltaResult<(TempDir, DeltaTable)> {
         let table_dir = tempfile::tempdir().unwrap();
-        let schema = Arc::new(ArrowSchema::new(vec![
-            ArrowField::new("value", ArrowDataType::Int64, true),
-            ArrowField::new("other", ArrowDataType::Int64, true),
-        ]));
-        let batch = RecordBatch::try_new(
-            schema,
-            vec![
-                Arc::new(Int64Array::from(vec![1, 2, 3])),
-                Arc::new(Int64Array::from(vec![10, 20, 30])),
-            ],
-        )?;
         let table_url = url::Url::from_directory_path(table_dir.path()).unwrap();
-        let table = DeltaTable::try_from_url(table_url)
+        let mut table = DeltaTable::try_from_url(table_url)
             .await?
             .create()
             .with_columns([
@@ -1280,33 +1334,10 @@ mod tests {
                 StructField::new("other", DataType::Primitive(PrimitiveType::Long), true),
             ])
             .with_configuration_property(TableProperty::DataSkippingNumIndexedCols, Some("2"))
-            .await?
-            .write(vec![batch])
-            .with_save_mode(SaveMode::Append)
             .await?;
 
         let custom_stats = r#"{"numRecords":3,"minValues":{"value":1,"other":10},"maxValues":{"value":3,"other":30},"nullCount":{"value":0,"other":0}}"#;
-        let log_dir = table_dir.path().join("_delta_log");
-        for entry in std::fs::read_dir(&log_dir)? {
-            let path = entry?.path();
-            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
-                continue;
-            }
-
-            let content = std::fs::read_to_string(&path)?;
-            let mut rewritten = Vec::new();
-            for line in content.lines() {
-                let mut value: serde_json::Value = serde_json::from_str(line)?;
-                if let Some(add) = value.get_mut("add").and_then(|v| v.as_object_mut()) {
-                    add.insert(
-                        "stats".to_string(),
-                        serde_json::Value::String(custom_stats.to_string()),
-                    );
-                }
-                rewritten.push(serde_json::to_string(&value)?);
-            }
-            std::fs::write(&path, rewritten.join("\n") + "\n")?;
-        }
+        append_test_add_with_stats(&mut table, "part-00000.snappy.parquet", custom_stats).await?;
 
         Ok((table_dir, table))
     }
@@ -1456,15 +1487,15 @@ mod tests {
             .try_collect::<Vec<_>>()
             .await?;
         let expected = [
-            "+---------------------------------------------------------------------+------+------------------+----------------+---------------------------------------------------------------------------------------------+----------------+",
-            "| path                                                                | size | modificationTime | deletionVector | fileConstantValues                                                                          | stats_parsed   |",
-            "+---------------------------------------------------------------------+------+------------------+----------------+---------------------------------------------------------------------------------------------+----------------+",
-            "| part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet | 262  | 1587968626000    |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
-            "| part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet | 262  | 1587968602000    |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
-            "| part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet | 429  | 1587968602000    |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
-            "| part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet | 429  | 1587968602000    |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
-            "| part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet | 429  | 1587968602000    |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
-            "+---------------------------------------------------------------------+------+------------------+----------------+---------------------------------------------------------------------------------------------+----------------+",
+            "+---------------------------------------------------------------------+------+------------------+-------+----------------+---------------------------------------------------------------------------------------------+----------------+",
+            "| path                                                                | size | modificationTime | stats | deletionVector | fileConstantValues                                                                          | stats_parsed   |",
+            "+---------------------------------------------------------------------+------+------------------+-------+----------------+---------------------------------------------------------------------------------------------+----------------+",
+            "| part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet | 262  | 1587968626000    |       |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
+            "| part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet | 262  | 1587968602000    |       |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
+            "| part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet | 429  | 1587968602000    |       |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
+            "| part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet | 429  | 1587968602000    |       |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
+            "| part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet | 429  | 1587968602000    |       |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
+            "+---------------------------------------------------------------------+------+------------------+-------+----------------+---------------------------------------------------------------------------------------------+----------------+",
         ];
         assert_batches_sorted_eq!(expected, &batches);
 
@@ -1505,6 +1536,19 @@ mod tests {
         let snapshot = EagerSnapshot::try_new(&log_store, config, None).await?;
 
         assert_eq!(snapshot.log_data().num_files(), 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_eager_snapshot_try_log_data_is_non_panicking_without_files() -> TestResult {
+        let log_store = TestTables::Simple.table_builder()?.build_storage()?;
+        let mut config = DeltaTableConfig::default();
+        config.require_files = false;
+
+        let snapshot = EagerSnapshot::try_new(&log_store, config, None).await?;
+
+        assert_eq!(snapshot.try_log_data()?.num_files(), 0);
 
         Ok(())
     }
@@ -1686,7 +1730,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_skip_stats_bypassed_when_predicate_present() -> TestResult {
+    async fn test_skip_stats_with_predicate_keeps_stats_omitted() -> TestResult {
         use delta_kernel::expressions::Scalar;
 
         let base = TestTables::Checkpoints.table_builder()?.build_storage()?;
@@ -1698,30 +1742,58 @@ mod tests {
         let predicate: PredicateRef =
             Arc::new(Expression::column(["value"]).gt(Scalar::String("".to_string())));
 
-        let has_stats: Vec<bool> = snapshot
+        let stats: Vec<Option<String>> = snapshot
             .file_views(base.as_ref(), Some(predicate))
-            .map_ok(|view| view.stats().is_some())
+            .map_ok(|view| view.stats())
             .try_collect()
             .await?;
 
-        assert!(!has_stats.is_empty());
-        assert!(has_stats.iter().any(|b| *b));
+        assert!(!stats.is_empty());
+        assert!(stats.iter().all(|stats| stats.is_none()));
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn snapshot_no_predicate_scan_omits_raw_stats_but_keeps_num_records() -> TestResult {
+    async fn test_eager_skip_stats_with_predicate_keeps_stats_omitted() -> TestResult {
         let base = TestTables::Checkpoints.table_builder()?.build_storage()?;
-        let snapshot = Snapshot::try_new(base.as_ref(), Default::default(), Some(12)).await?;
 
-        let batches: Vec<_> = snapshot.files(base.as_ref(), None).try_collect().await?;
+        let mut skip_cfg = DeltaTableConfig::default();
+        skip_cfg.skip_stats = true;
+        let snapshot = EagerSnapshot::try_new(base.as_ref(), skip_cfg, Some(12)).await?;
+
+        let predicate: PredicateRef =
+            Arc::new(Expression::column(["value"]).gt(Scalar::String("".to_string())));
+
+        let stats: Vec<Option<String>> = snapshot
+            .file_views(base.as_ref(), Some(predicate))
+            .map_ok(|view| view.stats())
+            .try_collect()
+            .await?;
+
+        assert!(!stats.is_empty());
+        assert!(stats.iter().all(|stats| stats.is_none()));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_no_predicate_scan_preserves_raw_stats_but_keeps_narrow_parsed_stats()
+    -> TestResult {
+        let (_table_dir, table) = selective_stats_table().await?;
+        let log_store = table.log_store();
+        let snapshot = Snapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
+
+        let batches: Vec<_> = snapshot
+            .files(log_store.as_ref(), None)
+            .try_collect()
+            .await?;
 
         assert!(!batches.is_empty());
         assert!(
             batches
                 .iter()
-                .all(|batch| batch.column_by_name("stats").is_none())
+                .all(|batch| batch.column_by_name("stats").is_some())
         );
         assert!(
             batches
@@ -1733,13 +1805,46 @@ mod tests {
                 .iter()
                 .all(|batch| stats_parsed_field_names(batch) == vec!["numRecords"])
         );
-        assert!(batches.iter().any(|batch| {
-            (0..batch.num_rows()).any(|idx| {
-                LogicalFileView::new(batch.clone(), idx)
-                    .num_records()
-                    .is_some()
-            })
-        }));
+
+        let file = LogicalFileView::new(batches[0].clone(), 0);
+        assert_eq!(file.num_records(), Some(3));
+
+        let add = file.to_add();
+        let stats = add
+            .stats
+            .expect("raw stats should be preserved for Add compatibility");
+        let stats: serde_json::Value = serde_json::from_str(&stats)?;
+        assert_eq!(stats["minValues"]["value"], json!(1));
+        assert_eq!(stats["maxValues"]["other"], json!(30));
+        assert_eq!(stats["nullCount"]["value"], json!(0));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn eager_snapshot_materialized_files_keep_full_parsed_stats() -> TestResult {
+        let (_table_dir, table) = selective_stats_table().await?;
+        let eager =
+            EagerSnapshot::try_new(table.log_store().as_ref(), Default::default(), None).await?;
+
+        let log_data = eager.log_data();
+        let files = log_data.iter().collect::<Vec<_>>();
+        assert_eq!(files.len(), 1);
+
+        let file = &files[0];
+        assert_eq!(file.num_records(), Some(3));
+        assert!(
+            file.min_values().is_some(),
+            "materialized compatibility data must retain parsed min stats"
+        );
+        assert!(
+            file.max_values().is_some(),
+            "materialized compatibility data must retain parsed max stats"
+        );
+        assert!(
+            file.null_counts().is_some(),
+            "materialized compatibility data must retain parsed null-count stats"
+        );
 
         Ok(())
     }
@@ -1757,7 +1862,7 @@ mod tests {
             .await?;
 
         assert_eq!(batches.len(), 1);
-        assert!(batches[0].column_by_name("stats").is_none());
+        assert!(batches[0].column_by_name("stats").is_some());
         assert_eq!(field_count(&batches[0], "stats_parsed"), 1);
         assert_eq!(
             stats_parsed_field_names(&batches[0]),
@@ -1775,6 +1880,13 @@ mod tests {
             nested_stats_field_names(&batches[0], "nullCount"),
             vec!["value"]
         );
+
+        let add = LogicalFileView::new(batches[0].clone(), 0).to_add();
+        let stats = add
+            .stats
+            .expect("raw stats should be preserved for Add compatibility");
+        let stats: serde_json::Value = serde_json::from_str(&stats)?;
+        assert_eq!(stats["minValues"]["other"], json!(10));
 
         Ok(())
     }
@@ -1979,6 +2091,32 @@ mod tests {
         assert!(
             replay_ops.iter().all(|op| !op.is_log_replay_read()),
             "expected predicate file_views() to reuse materialized state, got {replay_ops:?}",
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_eager_file_views_reuses_materialized_files_with_data_predicate() -> TestResult {
+        let (_table_dir, table) = selective_stats_table().await?;
+        let (log_store, mut operations) = recording_log_store(table.log_store());
+
+        let eager = EagerSnapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
+        drain_recorded_ops(&mut operations).await;
+
+        let predicate: PredicateRef = Arc::new(Expression::column(["value"]).eq(Scalar::Long(1)));
+        let files: Vec<_> = eager
+            .file_views(log_store.as_ref(), Some(predicate))
+            .try_collect()
+            .await?;
+        let replay_ops = drain_recorded_ops(&mut operations).await;
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].num_records(), Some(3));
+        assert!(files[0].min_values().is_some());
+        assert!(
+            replay_ops.iter().all(|op| !op.is_log_replay_read()),
+            "expected data-predicate file_views() to reuse materialized state, got {replay_ops:?}",
         );
 
         Ok(())

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -49,7 +49,7 @@ use crate::logstore::{LogStore, LogStoreExt};
 use crate::{DeltaResult, DeltaTableConfig, DeltaTableError, PartitionFilter, to_kernel_predicate};
 
 pub use self::log_data::*;
-pub(crate) use self::stats_projection::StatsProjection;
+pub(crate) use self::stats_projection::{FileStatsMaterialization, StatsProjection};
 pub use iterators::*;
 pub use scan::*;
 pub use stream::*;
@@ -396,25 +396,66 @@ impl Snapshot {
         engine: Arc<dyn Engine>,
         predicate: Option<PredicateRef>,
     ) -> SendableRBStream {
+        self.files_with_engine_materialized(engine, predicate, false)
+    }
+
+    fn files_with_engine_preserving_raw(
+        &self,
+        engine: Arc<dyn Engine>,
+        predicate: Option<PredicateRef>,
+    ) -> SendableRBStream {
+        self.files_with_engine_materialized(engine, predicate, true)
+    }
+
+    fn files_with_engine_materialized(
+        &self,
+        engine: Arc<dyn Engine>,
+        predicate: Option<PredicateRef>,
+        preserve_raw_stats: bool,
+    ) -> SendableRBStream {
         self.warn_if_skip_stats_with_predicate(&predicate);
         let skip_stats = predicate.is_none() && self.config.skip_stats;
-        let scan = match self
-            .scan_builder()
-            .with_predicate(predicate)
-            .with_skip_stats(skip_stats)
-            .build()
-        {
+        let scan = match self.scan_for_files(predicate, skip_stats, preserve_raw_stats) {
             Ok(scan) => scan,
             Err(err) => return Box::pin(once(ready(Err(err)))),
         };
+        let stats_materialization = scan.stats_materialization().clone();
 
         let stream = scan
             .scan_metadata(engine)
             .map(|d| Ok(rb_from_scan_meta(d?)?));
 
-        match ScanRowOutStream::try_new(self.inner.clone(), stream, skip_stats) {
+        match ScanRowOutStream::try_new_with_materialization(
+            self.inner.clone(),
+            stream,
+            stats_materialization,
+        ) {
             Ok(s) => s.boxed(),
             Err(err) => Box::pin(once(ready(Err(err)))),
+        }
+    }
+
+    fn scan_for_files(
+        &self,
+        predicate: Option<PredicateRef>,
+        skip_stats: bool,
+        preserve_raw_stats: bool,
+    ) -> DeltaResult<Scan> {
+        let scan = self
+            .scan_builder()
+            .with_predicate(predicate.clone())
+            .with_skip_stats(skip_stats)
+            .build()?;
+        if preserve_raw_stats && !skip_stats {
+            let stats_materialization = FileStatsMaterialization::compatibility(
+                scan.stats_materialization().stats_projection().clone(),
+            );
+            self.scan_builder()
+                .with_predicate(predicate)
+                .with_stats_materialization(stats_materialization)
+                .build()
+        } else {
+            Ok(scan)
         }
     }
 
@@ -437,23 +478,60 @@ impl Snapshot {
         existing_data: Box<T>,
         existing_predicate: Option<PredicateRef>,
     ) -> SendableRBStream {
+        self.files_from_materialized(
+            engine,
+            predicate,
+            existing_version,
+            existing_data,
+            existing_predicate,
+            false,
+        )
+    }
+
+    fn files_from_preserving_raw<T: Iterator<Item = RecordBatch> + Send + 'static>(
+        &self,
+        engine: Arc<dyn Engine>,
+        predicate: Option<PredicateRef>,
+        existing_version: Version,
+        existing_data: Box<T>,
+        existing_predicate: Option<PredicateRef>,
+    ) -> SendableRBStream {
+        self.files_from_materialized(
+            engine,
+            predicate,
+            existing_version,
+            existing_data,
+            existing_predicate,
+            true,
+        )
+    }
+
+    fn files_from_materialized<T: Iterator<Item = RecordBatch> + Send + 'static>(
+        &self,
+        engine: Arc<dyn Engine>,
+        predicate: Option<PredicateRef>,
+        existing_version: Version,
+        existing_data: Box<T>,
+        existing_predicate: Option<PredicateRef>,
+        preserve_raw_stats: bool,
+    ) -> SendableRBStream {
         self.warn_if_skip_stats_with_predicate(&predicate);
         let skip_stats = predicate.is_none() && self.config.skip_stats;
-        let scan = match self
-            .scan_builder()
-            .with_predicate(predicate)
-            .with_skip_stats(skip_stats)
-            .build()
-        {
+        let scan = match self.scan_for_files(predicate, skip_stats, preserve_raw_stats) {
             Ok(scan) => scan,
             Err(err) => return Box::pin(once(ready(Err(err)))),
         };
+        let stats_materialization = scan.stats_materialization().clone();
 
         let stream = scan
             .scan_metadata_from(engine, existing_version, existing_data, existing_predicate)
             .map(|d| Ok(rb_from_scan_meta(d?)?));
 
-        match ScanRowOutStream::try_new(self.inner.clone(), stream, skip_stats) {
+        match ScanRowOutStream::try_new_with_materialization(
+            self.inner.clone(),
+            stream,
+            stats_materialization,
+        ) {
             Ok(s) => s.boxed(),
             Err(err) => Box::pin(once(ready(Err(err)))),
         }
@@ -508,7 +586,7 @@ impl Snapshot {
             Some(materialized_seed) => {
                 let (existing_version, existing_data, existing_predicate) =
                     materialized_seed.into_parts();
-                self.files_from(
+                self.files_from_preserving_raw(
                     engine,
                     None,
                     existing_version,
@@ -518,7 +596,11 @@ impl Snapshot {
                 .try_collect()
                 .await?
             }
-            None => self.files_with_engine(engine, None).try_collect().await?,
+            None => {
+                self.files_with_engine_preserving_raw(engine, None)
+                    .try_collect()
+                    .await?
+            }
         };
         let materialized_files = Arc::new(MaterializedFiles::full(self.version(), batches));
         Ok(Arc::new(
@@ -1062,7 +1144,10 @@ pub(crate) fn partitions_schema(
 mod tests {
     use std::sync::Arc;
 
+    use arrow::array::Int64Array;
     use arrow_ipc::writer::FileWriter;
+    use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+    use delta_kernel::expressions::Scalar;
     use futures::TryStreamExt;
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
@@ -1073,7 +1158,7 @@ mod tests {
     // use super::replay::tests::test_log_replay;
     use super::*;
     use crate::{
-        DeltaTable, DeltaTableConfig, checkpoints,
+        DeltaTable, DeltaTableConfig, TableProperty, checkpoints,
         kernel::transaction::CommitData,
         kernel::transaction::{CommitBuilder, TableReference},
         kernel::{Action, DataType, PrimitiveType, StructField, StructType},
@@ -1171,6 +1256,96 @@ mod tests {
             .version();
         table.update_state().await?;
         Ok(version)
+    }
+
+    async fn selective_stats_table() -> DeltaResult<(TempDir, DeltaTable)> {
+        let table_dir = tempfile::tempdir().unwrap();
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("value", ArrowDataType::Int64, true),
+            ArrowField::new("other", ArrowDataType::Int64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(Int64Array::from(vec![10, 20, 30])),
+            ],
+        )?;
+        let table_url = url::Url::from_directory_path(table_dir.path()).unwrap();
+        let table = DeltaTable::try_from_url(table_url)
+            .await?
+            .create()
+            .with_columns([
+                StructField::new("value", DataType::Primitive(PrimitiveType::Long), true),
+                StructField::new("other", DataType::Primitive(PrimitiveType::Long), true),
+            ])
+            .with_configuration_property(TableProperty::DataSkippingNumIndexedCols, Some("2"))
+            .await?
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let custom_stats = r#"{"numRecords":3,"minValues":{"value":1,"other":10},"maxValues":{"value":3,"other":30},"nullCount":{"value":0,"other":0}}"#;
+        let log_dir = table_dir.path().join("_delta_log");
+        for entry in std::fs::read_dir(&log_dir)? {
+            let path = entry?.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+
+            let content = std::fs::read_to_string(&path)?;
+            let mut rewritten = Vec::new();
+            for line in content.lines() {
+                let mut value: serde_json::Value = serde_json::from_str(line)?;
+                if let Some(add) = value.get_mut("add").and_then(|v| v.as_object_mut()) {
+                    add.insert(
+                        "stats".to_string(),
+                        serde_json::Value::String(custom_stats.to_string()),
+                    );
+                }
+                rewritten.push(serde_json::to_string(&value)?);
+            }
+            std::fs::write(&path, rewritten.join("\n") + "\n")?;
+        }
+
+        Ok((table_dir, table))
+    }
+
+    fn field_count(batch: &RecordBatch, name: &str) -> usize {
+        batch
+            .schema()
+            .fields()
+            .iter()
+            .filter(|field| field.name() == name)
+            .count()
+    }
+
+    fn stats_parsed_field_names(batch: &RecordBatch) -> Vec<String> {
+        let schema = batch.schema();
+        let stats_field = schema
+            .field_with_name("stats_parsed")
+            .expect("stats_parsed field should exist");
+        let ArrowDataType::Struct(fields) = stats_field.data_type() else {
+            panic!("stats_parsed should be a struct");
+        };
+        fields.iter().map(|field| field.name().clone()).collect()
+    }
+
+    fn nested_stats_field_names(batch: &RecordBatch, field_name: &str) -> Vec<String> {
+        let schema = batch.schema();
+        let stats_field = schema
+            .field_with_name("stats_parsed")
+            .expect("stats_parsed field should exist");
+        let ArrowDataType::Struct(stats_fields) = stats_field.data_type() else {
+            panic!("stats_parsed should be a struct");
+        };
+        let (_, field) = stats_fields
+            .find(field_name)
+            .unwrap_or_else(|| panic!("{field_name} should exist"));
+        let ArrowDataType::Struct(fields) = field.data_type() else {
+            panic!("{field_name} should be a struct");
+        };
+        fields.iter().map(|field| field.name().clone()).collect()
     }
 
     async fn eager_file_paths(
@@ -1281,15 +1456,15 @@ mod tests {
             .try_collect::<Vec<_>>()
             .await?;
         let expected = [
-            "+---------------------------------------------------------------------+------+------------------+-------+----------------+---------------------------------------------------------------------------------------------+-------------------------------------------------------+",
-            "| path                                                                | size | modificationTime | stats | deletionVector | fileConstantValues                                                                          | stats_parsed                                          |",
-            "+---------------------------------------------------------------------+------+------------------+-------+----------------+---------------------------------------------------------------------------------------------+-------------------------------------------------------+",
-            "| part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet | 262  | 1587968626000    |       |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: , nullCount: , minValues: , maxValues: } |",
-            "| part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet | 262  | 1587968602000    |       |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: , nullCount: , minValues: , maxValues: } |",
-            "| part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet | 429  | 1587968602000    |       |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: , nullCount: , minValues: , maxValues: } |",
-            "| part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet | 429  | 1587968602000    |       |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: , nullCount: , minValues: , maxValues: } |",
-            "| part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet | 429  | 1587968602000    |       |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: , nullCount: , minValues: , maxValues: } |",
-            "+---------------------------------------------------------------------+------+------------------+-------+----------------+---------------------------------------------------------------------------------------------+-------------------------------------------------------+",
+            "+---------------------------------------------------------------------+------+------------------+----------------+---------------------------------------------------------------------------------------------+----------------+",
+            "| path                                                                | size | modificationTime | deletionVector | fileConstantValues                                                                          | stats_parsed   |",
+            "+---------------------------------------------------------------------+------+------------------+----------------+---------------------------------------------------------------------------------------------+----------------+",
+            "| part-00000-2befed33-c358-4768-a43c-3eda0d2a499d-c000.snappy.parquet | 262  | 1587968626000    |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
+            "| part-00000-c1777d7d-89d9-4790-b38a-6ee7e24456b1-c000.snappy.parquet | 262  | 1587968602000    |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
+            "| part-00001-7891c33d-cedc-47c3-88a6-abcfb049d3b4-c000.snappy.parquet | 429  | 1587968602000    |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
+            "| part-00004-315835fe-fb44-4562-98f6-5e6cfa3ae45d-c000.snappy.parquet | 429  | 1587968602000    |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
+            "| part-00007-3a0e4727-de0d-41b6-81ef-5223cf40f025-c000.snappy.parquet | 429  | 1587968602000    |                | {partitionValues: {}, baseRowId: , defaultRowCommitVersion: , tags: , clusteringProvider: } | {numRecords: } |",
+            "+---------------------------------------------------------------------+------+------------------+----------------+---------------------------------------------------------------------------------------------+----------------+",
         ];
         assert_batches_sorted_eq!(expected, &batches);
 
@@ -1531,6 +1706,75 @@ mod tests {
 
         assert!(!has_stats.is_empty());
         assert!(has_stats.iter().any(|b| *b));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_no_predicate_scan_omits_raw_stats_but_keeps_num_records() -> TestResult {
+        let base = TestTables::Checkpoints.table_builder()?.build_storage()?;
+        let snapshot = Snapshot::try_new(base.as_ref(), Default::default(), Some(12)).await?;
+
+        let batches: Vec<_> = snapshot.files(base.as_ref(), None).try_collect().await?;
+
+        assert!(!batches.is_empty());
+        assert!(
+            batches
+                .iter()
+                .all(|batch| batch.column_by_name("stats").is_none())
+        );
+        assert!(
+            batches
+                .iter()
+                .all(|batch| field_count(batch, "stats_parsed") == 1)
+        );
+        assert!(
+            batches
+                .iter()
+                .all(|batch| stats_parsed_field_names(batch) == vec!["numRecords"])
+        );
+        assert!(batches.iter().any(|batch| {
+            (0..batch.num_rows()).any(|idx| {
+                LogicalFileView::new(batch.clone(), idx)
+                    .num_records()
+                    .is_some()
+            })
+        }));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_predicate_scan_projects_only_required_stats_fields() -> TestResult {
+        let (_table_dir, table) = selective_stats_table().await?;
+        let snapshot =
+            Snapshot::try_new(table.log_store().as_ref(), Default::default(), None).await?;
+        let predicate: PredicateRef = Arc::new(Expression::column(["value"]).eq(Scalar::Long(1)));
+
+        let batches: Vec<_> = snapshot
+            .files(table.log_store().as_ref(), Some(predicate))
+            .try_collect()
+            .await?;
+
+        assert_eq!(batches.len(), 1);
+        assert!(batches[0].column_by_name("stats").is_none());
+        assert_eq!(field_count(&batches[0], "stats_parsed"), 1);
+        assert_eq!(
+            stats_parsed_field_names(&batches[0]),
+            vec!["numRecords", "nullCount", "minValues", "maxValues"]
+        );
+        assert_eq!(
+            nested_stats_field_names(&batches[0], "minValues"),
+            vec!["value"]
+        );
+        assert_eq!(
+            nested_stats_field_names(&batches[0], "maxValues"),
+            vec!["value"]
+        );
+        assert_eq!(
+            nested_stats_field_names(&batches[0], "nullCount"),
+            vec!["value"]
+        );
 
         Ok(())
     }

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -49,7 +49,9 @@ use crate::logstore::{LogStore, LogStoreExt};
 use crate::{DeltaResult, DeltaTableConfig, DeltaTableError, PartitionFilter, to_kernel_predicate};
 
 pub use self::log_data::*;
-pub(crate) use self::stats_projection::{FileStatsMaterialization, StatsProjection};
+pub(crate) use self::stats_projection::{
+    FIELD_STATS_PARSED, FileStatsMaterialization, StatsProjection,
+};
 pub use iterators::*;
 pub use scan::*;
 pub use stream::*;

--- a/crates/core/src/kernel/snapshot/scan.rs
+++ b/crates/core/src/kernel/snapshot/scan.rs
@@ -14,6 +14,7 @@ use url::Url;
 
 #[cfg(feature = "datafusion")]
 use super::MaterializedFiles;
+use super::stats_projection::{FileStatsMaterialization, StatsProjection, StatsSourcePolicy};
 use crate::DeltaResult;
 use crate::kernel::{ReceiverStreamBuilder, scan_row_in_eval};
 
@@ -22,14 +23,20 @@ pub type SendableScanMetadataStream = Pin<Box<dyn Stream<Item = DeltaResult<Scan
 /// Builder to scan a snapshot of a table.
 #[derive(Debug)]
 pub struct ScanBuilder {
-    inner: KernelScanBuilder,
+    snapshot: Arc<KernelSnapshot>,
+    schema: Option<SchemaRef>,
+    predicate: Option<PredicateRef>,
+    stats_materialization: Option<FileStatsMaterialization>,
 }
 
 impl ScanBuilder {
     /// Create a new [`ScanBuilder`] instance.
     pub fn new(snapshot: impl Into<Arc<KernelSnapshot>>) -> Self {
         Self {
-            inner: KernelScanBuilder::new(snapshot.into()),
+            snapshot: snapshot.into(),
+            schema: None,
+            predicate: None,
+            stats_materialization: None,
         }
     }
 
@@ -41,7 +48,7 @@ impl ScanBuilder {
     /// [`Schema`]: crate::schema::Schema
     /// [`Snapshot`]: crate::snapshot::Snapshot
     pub fn with_schema(mut self, schema: SchemaRef) -> Self {
-        self.inner = self.inner.with_schema(schema);
+        self.schema = Some(schema);
         self
     }
 
@@ -50,7 +57,9 @@ impl ScanBuilder {
     ///
     /// [`Snapshot`]: crate::Snapshot
     pub fn with_schema_opt(mut self, schema_opt: Option<SchemaRef>) -> Self {
-        self.inner = self.inner.with_schema_opt(schema_opt);
+        if let Some(schema) = schema_opt {
+            self.schema = Some(schema);
+        }
         self
     }
 
@@ -61,7 +70,7 @@ impl ScanBuilder {
     /// NOTE: The filtering is best-effort and can produce false positives (rows that should should
     /// have been filtered out but were kept).
     pub fn with_predicate(mut self, predicate: impl Into<Option<PredicateRef>>) -> Self {
-        self.inner = self.inner.with_predicate(predicate);
+        self.predicate = predicate.into();
         self
     }
 
@@ -72,39 +81,243 @@ impl ScanBuilder {
     /// non-empty predicate, the kernel cannot use stats for data skipping; prefer `false`
     /// when you need predicate-based file pruning from statistics.
     pub fn with_skip_stats(mut self, skip_stats: bool) -> Self {
-        self.inner = self.inner.with_skip_stats(skip_stats);
+        if skip_stats {
+            self.stats_materialization = Some(FileStatsMaterialization::without_stats());
+        }
+        self
+    }
+
+    pub(crate) fn with_stats_materialization(
+        mut self,
+        stats_materialization: FileStatsMaterialization,
+    ) -> Self {
+        self.stats_materialization = Some(stats_materialization);
         self
     }
 
     pub fn build(self) -> DeltaResult<Scan> {
-        Ok(Scan::from(self.inner.build()?))
+        let Self {
+            snapshot,
+            schema,
+            predicate,
+            stats_materialization,
+        } = self;
+
+        let stats_materialization = match stats_materialization {
+            Some(stats_materialization) => stats_materialization,
+            None => {
+                let scan =
+                    build_kernel_scan(snapshot.clone(), schema.clone(), predicate.clone(), None)?;
+                FileStatsMaterialization::query(StatsProjection::for_scan(&scan)?)
+            }
+        };
+        let inner = build_kernel_scan(snapshot, schema, predicate, Some(&stats_materialization))?;
+
+        Ok(Scan::new(Arc::new(inner), stats_materialization))
+    }
+}
+
+fn build_kernel_scan(
+    snapshot: Arc<KernelSnapshot>,
+    schema: Option<SchemaRef>,
+    predicate: Option<PredicateRef>,
+    stats_materialization: Option<&FileStatsMaterialization>,
+) -> DeltaResult<KernelScan> {
+    let mut builder = KernelScanBuilder::new(snapshot)
+        .with_schema_opt(schema)
+        .with_predicate(predicate);
+
+    if let Some(stats_materialization) = stats_materialization {
+        builder = with_kernel_stats_output(builder, stats_materialization);
+    }
+
+    Ok(builder.build()?)
+}
+
+fn with_kernel_stats_output(
+    builder: KernelScanBuilder,
+    materialization: &FileStatsMaterialization,
+) -> KernelScanBuilder {
+    match materialization.stats_source_policy() {
+        StatsSourcePolicy::None => builder.with_skip_stats(true),
+        StatsSourcePolicy::JsonOnly => builder,
+        StatsSourcePolicy::ParsedWithJsonFallback => match materialization.stats_projection() {
+            StatsProjection::None => builder.with_skip_stats(true),
+            StatsProjection::Full => builder.include_all_stats_columns(),
+            StatsProjection::PredicateColumns(columns) => {
+                builder.with_stats_columns(columns.iter().cloned().collect())
+            }
+            // The current kernel API has no explicit numRecords-only stats output mode.
+            // Keep the default scan output and let delta-rs materialize the narrow
+            // row-count schema from raw stats when needed.
+            StatsProjection::NumRecordsOnly => builder,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use delta_kernel::expressions::{ColumnName, Scalar};
+    use delta_kernel::schema::{DataType, StructField, StructType};
+    use delta_kernel::{Expression, PredicateRef};
+
+    use super::super::stats_projection::{
+        FileStatsMaterialization, RawStatsPolicy, StatsProjection, StatsSourcePolicy,
+    };
+    use super::*;
+    use crate::DeltaTable;
+
+    async fn synthetic_snapshot() -> DeltaResult<super::super::Snapshot> {
+        let nested = StructType::try_new([
+            StructField::nullable("leaf", DataType::INTEGER),
+            StructField::nullable("other_leaf", DataType::STRING),
+        ])?;
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([
+                StructField::nullable("value", DataType::INTEGER),
+                StructField::nullable("unreferenced_col", DataType::STRING),
+                StructField::nullable("part", DataType::STRING),
+                StructField::nullable("nested", DataType::Struct(Box::new(nested))),
+            ])
+            .with_partition_columns(["part"])
+            .await?;
+        super::super::Snapshot::try_new(table.log_store().as_ref(), Default::default(), None).await
+    }
+
+    #[tokio::test]
+    async fn scan_builder_infers_num_records_only_for_default_query_scan() -> DeltaResult<()> {
+        let snapshot = synthetic_snapshot().await?;
+        let scan = snapshot.scan_builder().build()?;
+
+        assert_eq!(
+            scan.stats_materialization().stats_projection(),
+            &StatsProjection::num_records_only()
+        );
+        assert_eq!(
+            scan.stats_materialization().raw_stats_policy(),
+            RawStatsPolicy::Omit
+        );
+        assert_eq!(
+            scan.stats_materialization().stats_source_policy(),
+            StatsSourcePolicy::ParsedWithJsonFallback
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn scan_builder_infers_predicate_columns_for_data_predicate() -> DeltaResult<()> {
+        let snapshot = synthetic_snapshot().await?;
+        let predicate: PredicateRef =
+            Arc::new(Expression::column(["value"]).gt(Scalar::Integer(10)));
+        let scan = snapshot.scan_builder().with_predicate(predicate).build()?;
+
+        assert_eq!(
+            scan.stats_materialization().stats_projection(),
+            &StatsProjection::predicate_columns([ColumnName::new(["value"])])
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn scan_builder_preserves_explicit_compatibility_materialization() -> DeltaResult<()> {
+        let snapshot = synthetic_snapshot().await?;
+        let materialization = FileStatsMaterialization::compatibility(StatsProjection::full());
+        let scan = snapshot
+            .scan_builder()
+            .with_stats_materialization(materialization.clone())
+            .build()?;
+
+        assert_eq!(scan.stats_materialization(), &materialization);
+        assert_eq!(
+            scan.stats_materialization().raw_stats_policy(),
+            RawStatsPolicy::Preserve
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn scan_builder_preserves_explicit_without_stats_materialization() -> DeltaResult<()> {
+        let snapshot = synthetic_snapshot().await?;
+        let scan = snapshot
+            .scan_builder()
+            .with_stats_materialization(FileStatsMaterialization::without_stats())
+            .build()?;
+
+        assert_eq!(
+            scan.stats_materialization().stats_projection(),
+            &StatsProjection::none()
+        );
+        assert_eq!(
+            scan.stats_materialization().stats_source_policy(),
+            StatsSourcePolicy::None
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn scan_builder_predicate_columns_helper_is_deterministic() {
+        let projection = StatsProjection::predicate_columns([
+            ColumnName::new(["value"]),
+            ColumnName::new(["unreferenced_col"]),
+        ]);
+
+        assert_eq!(
+            projection,
+            StatsProjection::PredicateColumns(BTreeSet::from([
+                ColumnName::new(["unreferenced_col"]),
+                ColumnName::new(["value"]),
+            ]))
+        );
     }
 }
 
 #[derive(Debug)]
 pub struct Scan {
     inner: Arc<KernelScan>,
+    stats_materialization: FileStatsMaterialization,
 }
 
 impl From<KernelScan> for Scan {
     fn from(inner: KernelScan) -> Self {
-        Self {
-            inner: Arc::new(inner),
-        }
+        Self::new(
+            Arc::new(inner),
+            FileStatsMaterialization::compatibility(StatsProjection::full()),
+        )
     }
 }
 
 impl From<Arc<KernelScan>> for Scan {
     fn from(inner: Arc<KernelScan>) -> Self {
-        Self { inner }
+        Self::new(
+            inner,
+            FileStatsMaterialization::compatibility(StatsProjection::full()),
+        )
     }
 }
 
 impl Scan {
+    fn new(inner: Arc<KernelScan>, stats_materialization: FileStatsMaterialization) -> Self {
+        Self {
+            inner,
+            stats_materialization,
+        }
+    }
+
     /// Get a shared reference to the inner [`KernelScan`].
     #[cfg(any(test, feature = "datafusion"))]
     pub(crate) fn inner(&self) -> &Arc<KernelScan> {
         &self.inner
+    }
+
+    pub(crate) fn stats_materialization(&self) -> &FileStatsMaterialization {
+        &self.stats_materialization
     }
 
     /// The table's root URL. Any relative paths returned from `scan_data` (or in a callback from

--- a/crates/core/src/kernel/snapshot/scan.rs
+++ b/crates/core/src/kernel/snapshot/scan.rs
@@ -74,19 +74,24 @@ impl ScanBuilder {
         self
     }
 
-    /// Skip parsing file-level statistics during kernel log replay.
+    /// Skip file statistics during kernel log replay.
     ///
-    /// When `true`, per-file min/max/null stats are not parsed; `stats_parsed` in scan
-    /// output may be null. Partition-based filtering still applies. When combined with a
-    /// non-empty predicate, the kernel cannot use stats for data skipping; prefer `false`
-    /// when you need predicate-based file pruning from statistics.
+    /// When `true`, min/max/null stats are not parsed and `stats_parsed` in scan output may
+    /// be null. Partition filtering still applies. With a predicate, stats based data skipping
+    /// is disabled. Use `false` when file pruning from statistics is required. Passing `false`
+    /// clears any previous stats materialization override and restores default inference.
     pub fn with_skip_stats(mut self, skip_stats: bool) -> Self {
         if skip_stats {
             self.stats_materialization = Some(FileStatsMaterialization::without_stats());
+        } else {
+            self.stats_materialization = None;
         }
         self
     }
 
+    /// Override the file statistics emitted from scan metadata.
+    ///
+    /// The policy controls parsed stats projection, parsed stats source, and raw JSON retention.
     pub(crate) fn with_stats_materialization(
         mut self,
         stats_materialization: FileStatsMaterialization,
@@ -105,11 +110,11 @@ impl ScanBuilder {
 
         let stats_materialization = match stats_materialization {
             Some(stats_materialization) => stats_materialization,
-            None => {
-                let scan =
-                    build_kernel_scan(snapshot.clone(), schema.clone(), predicate.clone(), None)?;
-                FileStatsMaterialization::query(StatsProjection::for_scan(&scan)?)
-            }
+            None => FileStatsMaterialization::query(StatsProjection::for_scan_inputs(
+                snapshot.as_ref(),
+                schema.as_ref(),
+                predicate.as_ref(),
+            )?),
         };
         let inner = build_kernel_scan(snapshot, schema, predicate, Some(&stats_materialization))?;
 
@@ -140,16 +145,14 @@ fn with_kernel_stats_output(
 ) -> KernelScanBuilder {
     match materialization.stats_source_policy() {
         StatsSourcePolicy::None => builder.with_skip_stats(true),
-        StatsSourcePolicy::JsonOnly => builder,
         StatsSourcePolicy::ParsedWithJsonFallback => match materialization.stats_projection() {
             StatsProjection::None => builder.with_skip_stats(true),
             StatsProjection::Full => builder.include_all_stats_columns(),
             StatsProjection::PredicateColumns(columns) => {
                 builder.with_stats_columns(columns.iter().cloned().collect())
             }
-            // The current kernel API has no explicit numRecords-only stats output mode.
-            // Keep the default scan output and let delta-rs materialize the narrow
-            // row-count schema from raw stats when needed.
+            // The kernel API has no explicit numRecords only stats output mode. Use the
+            // default scan output and materialize the row count schema when needed.
             StatsProjection::NumRecordsOnly => builder,
         },
     }
@@ -157,14 +160,12 @@ fn with_kernel_stats_output(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
     use delta_kernel::expressions::{ColumnName, Scalar};
     use delta_kernel::schema::{DataType, StructField, StructType};
     use delta_kernel::{Expression, PredicateRef};
 
     use super::super::stats_projection::{
-        FileStatsMaterialization, RawStatsPolicy, StatsProjection, StatsSourcePolicy,
+        FileStatsMaterialization, StatsProjection, StatsSourcePolicy,
     };
     use super::*;
     use crate::DeltaTable;
@@ -194,12 +195,9 @@ mod tests {
 
         assert_eq!(
             scan.stats_materialization().stats_projection(),
-            &StatsProjection::num_records_only()
+            &StatsProjection::NumRecordsOnly
         );
-        assert_eq!(
-            scan.stats_materialization().raw_stats_policy(),
-            RawStatsPolicy::Omit
-        );
+        assert!(!scan.stats_materialization().preserves_raw_stats());
         assert_eq!(
             scan.stats_materialization().stats_source_policy(),
             StatsSourcePolicy::ParsedWithJsonFallback
@@ -217,7 +215,28 @@ mod tests {
 
         assert_eq!(
             scan.stats_materialization().stats_projection(),
-            &StatsProjection::predicate_columns([ColumnName::new(["value"])])
+            &StatsProjection::PredicateColumns([ColumnName::new(["value"])].into())
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn scan_builder_rejects_predicate_on_unknown_column() -> DeltaResult<()> {
+        let snapshot = synthetic_snapshot().await?;
+        let predicate: PredicateRef =
+            Arc::new(Expression::column(["missing"]).gt(Scalar::Integer(10)));
+
+        let err = snapshot
+            .scan_builder()
+            .with_predicate(predicate)
+            .build()
+            .expect_err("predicate on an unknown column should fail scan planning");
+
+        assert!(
+            err.to_string().to_lowercase().contains("missing")
+                || err.to_string().to_lowercase().contains("unknown"),
+            "unexpected error: {err}"
         );
 
         Ok(())
@@ -233,10 +252,7 @@ mod tests {
             .build()?;
 
         assert_eq!(scan.stats_materialization(), &materialization);
-        assert_eq!(
-            scan.stats_materialization().raw_stats_policy(),
-            RawStatsPolicy::Preserve
-        );
+        assert!(scan.stats_materialization().preserves_raw_stats());
 
         Ok(())
     }
@@ -261,20 +277,26 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn scan_builder_predicate_columns_helper_is_deterministic() {
-        let projection = StatsProjection::predicate_columns([
-            ColumnName::new(["value"]),
-            ColumnName::new(["unreferenced_col"]),
-        ]);
+    #[tokio::test]
+    async fn scan_builder_with_skip_stats_false_clears_prior_skip_stats() -> DeltaResult<()> {
+        let snapshot = synthetic_snapshot().await?;
+        let scan = snapshot
+            .scan_builder()
+            .with_stats_materialization(FileStatsMaterialization::without_stats())
+            .with_skip_stats(false)
+            .build()?;
 
         assert_eq!(
-            projection,
-            StatsProjection::PredicateColumns(BTreeSet::from([
-                ColumnName::new(["unreferenced_col"]),
-                ColumnName::new(["value"]),
-            ]))
+            scan.stats_materialization().stats_projection(),
+            &StatsProjection::NumRecordsOnly
         );
+        assert_eq!(
+            scan.stats_materialization().stats_source_policy(),
+            StatsSourcePolicy::ParsedWithJsonFallback
+        );
+        assert!(!scan.stats_materialization().preserves_raw_stats());
+
+        Ok(())
     }
 }
 
@@ -311,11 +333,14 @@ impl Scan {
     }
 
     /// Get a shared reference to the inner [`KernelScan`].
-    #[cfg(any(test, feature = "datafusion"))]
+    #[cfg(feature = "datafusion")]
     pub(crate) fn inner(&self) -> &Arc<KernelScan> {
         &self.inner
     }
 
+    /// Get the stats materialization policy attached to this scan.
+    ///
+    /// The policy is used when converting kernel scan rows into output rows.
     pub(crate) fn stats_materialization(&self) -> &FileStatsMaterialization {
         &self.stats_materialization
     }

--- a/crates/core/src/kernel/snapshot/stats_projection.rs
+++ b/crates/core/src/kernel/snapshot/stats_projection.rs
@@ -28,6 +28,7 @@ pub(crate) const FIELD_NUM_RECORDS: &str = "numRecords";
 pub(crate) const FIELD_PARTITION_VALUES_PARSED: &str = "partitionValues_parsed";
 pub(crate) const FIELD_STATS: &str = "stats";
 pub(crate) const FIELD_STATS_PARSED: &str = "stats_parsed";
+#[cfg(test)]
 const STATS_VALUE_FIELDS: [&str; 3] = [FIELD_MIN_VALUES, FIELD_MAX_VALUES, FIELD_NULL_COUNT];
 const ORDERED_STATS_VALUE_FIELDS: [&str; 3] =
     [FIELD_NULL_COUNT, FIELD_MIN_VALUES, FIELD_MAX_VALUES];
@@ -361,14 +362,19 @@ fn physicalize_column_path(
 }
 
 fn stats_schema_contains_data_column(stats_schema: &StructType, column: &ColumnName) -> bool {
-    STATS_VALUE_FIELDS
+    let min_max_fields = [FIELD_MIN_VALUES, FIELD_MAX_VALUES]
         .into_iter()
         .filter_map(|field_name| stats_schema.field(field_name))
         .filter_map(|field| match field.data_type() {
             DataType::Struct(inner) => Some(inner.as_ref()),
             _ => None,
         })
-        .any(|schema| schema_contains_path(schema, column))
+        .collect::<Vec<_>>();
+
+    min_max_fields.len() == 2
+        && min_max_fields
+            .iter()
+            .all(|schema| schema_contains_path(schema, column))
 }
 
 fn display_columns(columns: &BTreeSet<ColumnName>) -> String {
@@ -574,6 +580,17 @@ mod tests {
         Snapshot::try_new(table.log_store().as_ref(), Default::default(), None).await
     }
 
+    async fn binary_snapshot() -> DeltaResult<Snapshot> {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([
+                StructField::nullable("data", DataType::BINARY),
+                StructField::nullable("value", DataType::INTEGER),
+            ])
+            .await?;
+        Snapshot::try_new(table.log_store().as_ref(), Default::default(), None).await
+    }
+
     async fn column_mapping_snapshot() -> DeltaResult<Snapshot> {
         let log_store = column_mapping_builder()?.build_storage()?;
         Snapshot::try_new(log_store.as_ref(), Default::default(), None).await
@@ -655,6 +672,19 @@ mod tests {
             assert!(inner.field("value").is_some());
             assert!(inner.field("unreferenced_col").is_none());
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stats_projection_binary_predicate_uses_num_records_only() -> TestResult {
+        let snapshot = binary_snapshot().await?;
+        let predicate: PredicateRef =
+            Arc::new(Expression::column(["data"]).eq(Scalar::Binary(b"bbb".to_vec())));
+
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
+
+        assert_eq!(projection, StatsProjection::NumRecordsOnly);
 
         Ok(())
     }

--- a/crates/core/src/kernel/snapshot/stats_projection.rs
+++ b/crates/core/src/kernel/snapshot/stats_projection.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
@@ -7,13 +5,14 @@ use arrow_schema::{
     DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
     SchemaRef as ArrowSchemaRef,
 };
-#[cfg(test)]
 use delta_kernel::PredicateRef;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::ColumnName;
+#[cfg(feature = "datafusion")]
 use delta_kernel::scan::Scan as KernelScan;
 use delta_kernel::schema::{DataType, SchemaRef as KernelSchemaRef, StructField, StructType};
 use delta_kernel::snapshot::Snapshot as KernelSnapshot;
+use delta_kernel::table_features::ColumnMappingMode;
 use tracing::debug;
 
 #[cfg(test)]
@@ -22,27 +21,52 @@ use crate::DeltaResult;
 use crate::kernel::SCAN_ROW_ARROW_SCHEMA;
 use crate::kernel::arrow::engine_ext::SnapshotExt;
 
+pub(crate) const FIELD_MAX_VALUES: &str = "maxValues";
+pub(crate) const FIELD_MIN_VALUES: &str = "minValues";
+pub(crate) const FIELD_NULL_COUNT: &str = "nullCount";
+pub(crate) const FIELD_NUM_RECORDS: &str = "numRecords";
+pub(crate) const FIELD_PARTITION_VALUES_PARSED: &str = "partitionValues_parsed";
+pub(crate) const FIELD_STATS: &str = "stats";
+pub(crate) const FIELD_STATS_PARSED: &str = "stats_parsed";
+const STATS_VALUE_FIELDS: [&str; 3] = [FIELD_MIN_VALUES, FIELD_MAX_VALUES, FIELD_NULL_COUNT];
+const ORDERED_STATS_VALUE_FIELDS: [&str; 3] =
+    [FIELD_NULL_COUNT, FIELD_MIN_VALUES, FIELD_MAX_VALUES];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum StatsProjection {
+    /// Do not materialize parsed file statistics.
     None,
+    /// Materialize the full stats schema supported by the table configuration.
     Full,
+    /// Materialize only the `numRecords` field.
     NumRecordsOnly,
+    /// Materialize `numRecords` and stats for selected physical data columns.
     PredicateColumns(BTreeSet<ColumnName>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StatsSourcePolicy {
+    /// Prefer `stats_parsed`, falling back to raw JSON `stats` when needed.
     ParsedWithJsonFallback,
-    JsonOnly,
+    /// Do not read or emit parsed stats.
     None,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RawStatsPolicy {
+    /// Preserve the raw JSON `stats` field in emitted scan rows.
     Preserve,
+    /// Omit the raw JSON `stats` field from emitted scan rows.
     Omit,
 }
 
+/// Controls file statistics materialization in scan metadata output.
+///
+/// The policy stores the parsed stats fields to emit, the source for parsed stats,
+/// and whether raw JSON stats remain in the output.
+///
+/// Query paths can emit narrow parsed stats and omit raw JSON. Compatibility paths can keep
+/// raw JSON stats for callers that convert file views back to Add actions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FileStatsMaterialization {
     stats_projection: StatsProjection,
@@ -51,6 +75,9 @@ pub(crate) struct FileStatsMaterialization {
 }
 
 impl FileStatsMaterialization {
+    /// Materialization for query paths.
+    ///
+    /// Emits only the parsed stats needed by the scan and omits raw JSON stats.
     pub(crate) fn query(stats_projection: StatsProjection) -> Self {
         Self {
             stats_projection,
@@ -59,22 +86,15 @@ impl FileStatsMaterialization {
         }
     }
 
+    /// Materialization for compatibility paths.
+    ///
+    /// Emits parsed stats and preserves raw JSON stats for callers that convert
+    /// [`LogicalFileView`](crate::kernel::LogicalFileView) back to Add actions.
     pub(crate) fn compatibility(stats_projection: StatsProjection) -> Self {
         Self {
             stats_projection,
             stats_source_policy: StatsSourcePolicy::ParsedWithJsonFallback,
             raw_stats_policy: RawStatsPolicy::Preserve,
-        }
-    }
-
-    pub(crate) fn json_only(
-        stats_projection: StatsProjection,
-        raw_stats_policy: RawStatsPolicy,
-    ) -> Self {
-        Self {
-            stats_projection,
-            stats_source_policy: StatsSourcePolicy::JsonOnly,
-            raw_stats_policy,
         }
     }
 
@@ -94,10 +114,6 @@ impl FileStatsMaterialization {
         self.stats_source_policy
     }
 
-    pub(crate) fn raw_stats_policy(&self) -> RawStatsPolicy {
-        self.raw_stats_policy
-    }
-
     pub(crate) fn preserves_raw_stats(&self) -> bool {
         self.raw_stats_policy == RawStatsPolicy::Preserve
     }
@@ -112,18 +128,79 @@ impl StatsProjection {
         Self::Full
     }
 
-    pub(crate) fn num_records_only() -> Self {
-        Self::NumRecordsOnly
-    }
+    /// Build the stats projection from scan builder inputs before constructing the kernel scan.
+    /// This matches enough of kernel scan planning to find physical data column stats without a
+    /// temporary scan.
+    pub(crate) fn for_scan_inputs(
+        snapshot: &KernelSnapshot,
+        schema: Option<&KernelSchemaRef>,
+        predicate: Option<&PredicateRef>,
+    ) -> DeltaResult<Self> {
+        let Some(predicate) = predicate else {
+            debug!(
+                projection = "num_records_only",
+                reason = "no physical predicate",
+                "stats projection selected"
+            );
+            return Ok(Self::NumRecordsOnly);
+        };
 
-    pub(crate) fn predicate_columns(columns: impl IntoIterator<Item = ColumnName>) -> Self {
-        Self::PredicateColumns(columns.into_iter().collect())
+        let snapshot_schema;
+        let logical_schema = match schema {
+            Some(schema) => schema.as_ref(),
+            None => {
+                snapshot_schema = snapshot.schema();
+                snapshot_schema.as_ref()
+            }
+        };
+        let stats_schema = snapshot.table_configuration().stats_schema()?;
+        let column_mapping_mode = snapshot.table_configuration().column_mapping_mode();
+        let requested_columns = predicate
+            .references()
+            .into_iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+
+        let columns = requested_columns
+            .iter()
+            .filter_map(|column| {
+                physicalize_column_path(logical_schema, column, column_mapping_mode)
+            })
+            .filter(|column| stats_schema_contains_data_column(stats_schema.as_ref(), column))
+            .collect::<BTreeSet<_>>();
+
+        if columns.is_empty() {
+            debug!(
+                projection = "num_records_only",
+                reason = "no physical data columns referenced",
+                requested_columns = %display_columns(&requested_columns),
+                "stats projection selected"
+            );
+            Ok(Self::NumRecordsOnly)
+        } else {
+            let filtered_columns = requested_columns
+                .iter()
+                .filter_map(|column| {
+                    physicalize_column_path(logical_schema, column, column_mapping_mode)
+                })
+                .filter(|column| !columns.contains(column))
+                .collect::<BTreeSet<_>>();
+            debug!(
+                projection = "predicate_columns",
+                requested_columns = %display_columns(&requested_columns),
+                selected_columns = %display_columns(&columns),
+                filtered_columns = %display_columns(&filtered_columns),
+                "stats projection selected"
+            );
+            Ok(Self::PredicateColumns(columns))
+        }
     }
 
     /// Builds the stats projection for a scan using physical predicate references.
     ///
     /// Use `NumRecordsOnly` when a predicate only touches partition columns,
     /// skips all files, or references no data columns.
+    #[cfg(feature = "datafusion")]
     pub(crate) fn for_scan(scan: &KernelScan) -> DeltaResult<Self> {
         let Some(predicate) = scan.physical_predicate() else {
             debug!(
@@ -151,7 +228,7 @@ impl StatsProjection {
             debug!(
                 projection = "num_records_only",
                 reason = "no physical data columns referenced",
-                requested_columns = ?requested_columns,
+                requested_columns = %display_columns(&requested_columns),
                 "stats projection selected"
             );
             Ok(Self::NumRecordsOnly)
@@ -159,12 +236,12 @@ impl StatsProjection {
             let filtered_columns = requested_columns
                 .difference(&columns)
                 .cloned()
-                .collect::<Vec<_>>();
+                .collect::<BTreeSet<_>>();
             debug!(
                 projection = "predicate_columns",
-                requested_columns = ?requested_columns,
-                selected_columns = ?columns,
-                filtered_columns = ?filtered_columns,
+                requested_columns = %display_columns(&requested_columns),
+                selected_columns = %display_columns(&columns),
+                filtered_columns = %display_columns(&filtered_columns),
                 "stats projection selected"
             );
             Ok(Self::PredicateColumns(columns))
@@ -194,7 +271,7 @@ impl StatsProjection {
         let stats_schema = self.stats_schema(snapshot)?;
         let stats_schema: ArrowSchema = stats_schema.as_ref().try_into_arrow()?;
         fields.push(Arc::new(ArrowField::new(
-            "stats_parsed",
+            FIELD_STATS_PARSED,
             ArrowDataType::Struct(stats_schema.fields().to_owned()),
             true,
         )));
@@ -202,7 +279,7 @@ impl StatsProjection {
         if let Some(partition_schema) = snapshot.table_configuration().partitions_schema()? {
             let partition_schema: ArrowSchema = partition_schema.as_ref().try_into_arrow()?;
             fields.push(Arc::new(ArrowField::new(
-                "partitionValues_parsed",
+                FIELD_PARTITION_VALUES_PARSED,
                 ArrowDataType::Struct(partition_schema.fields().to_owned()),
                 false,
             )));
@@ -214,13 +291,12 @@ impl StatsProjection {
     /// Returns whether this projection emits stats for a root physical column.
     ///
     /// A nested reference such as `nested.leaf` still emits the enclosing field
-    /// `nested` because replay looks up stats by root column name.
+    /// `nested` stores the root field name used by DataFusion file statistics.
     #[cfg(feature = "datafusion")]
     pub(crate) fn emits_top_level_column_stats(&self, physical_name: &str) -> bool {
         match self {
-            Self::None => false,
+            Self::None | Self::NumRecordsOnly => false,
             Self::Full => true,
-            Self::NumRecordsOnly => false,
             Self::PredicateColumns(columns) => columns.iter().any(|column| {
                 column
                     .path()
@@ -233,7 +309,7 @@ impl StatsProjection {
 
 fn num_records_only_stats_schema() -> DeltaResult<KernelSchemaRef> {
     Ok(Arc::new(StructType::try_new([StructField::nullable(
-        "numRecords",
+        FIELD_NUM_RECORDS,
         DataType::LONG,
     )])?))
 }
@@ -258,6 +334,48 @@ fn schema_contains_path(schema: &StructType, column: &ColumnName) -> bool {
     current.field(last).is_some()
 }
 
+fn physicalize_column_path(
+    schema: &StructType,
+    column: &ColumnName,
+    column_mapping_mode: ColumnMappingMode,
+) -> Option<ColumnName> {
+    let mut current = schema;
+    let mut physical_path = Vec::with_capacity(column.path().len());
+    let mut path = column.path().iter().peekable();
+
+    while let Some(segment) = path.next() {
+        let field = current
+            .fields()
+            .find(|field| field.name().eq_ignore_ascii_case(segment.as_str()))?;
+        physical_path.push(field.physical_name(column_mapping_mode).to_string());
+
+        if path.peek().is_some() {
+            let DataType::Struct(inner) = field.data_type() else {
+                return None;
+            };
+            current = inner;
+        }
+    }
+
+    Some(ColumnName::new(physical_path))
+}
+
+fn stats_schema_contains_data_column(stats_schema: &StructType, column: &ColumnName) -> bool {
+    STATS_VALUE_FIELDS
+        .into_iter()
+        .filter_map(|field_name| stats_schema.field(field_name))
+        .filter_map(|field| match field.data_type() {
+            DataType::Struct(inner) => Some(inner.as_ref()),
+            _ => None,
+        })
+        .any(|schema| schema_contains_path(schema, column))
+}
+
+fn display_columns(columns: &BTreeSet<ColumnName>) -> String {
+    let values = columns.iter().map(ToString::to_string).collect::<Vec<_>>();
+    format!("[{}]", values.join(", "))
+}
+
 /// Filters a full stats schema down to the subset needed for a scan projection.
 ///
 /// `numRecords` is always kept. The min, max, and null count structs are pruned
@@ -269,12 +387,12 @@ fn filter_stats_schema(
     let mut fields = Vec::with_capacity(4);
     fields.push(
         stats_schema
-            .field("numRecords")
+            .field(FIELD_NUM_RECORDS)
             .cloned()
-            .unwrap_or_else(|| StructField::nullable("numRecords", DataType::LONG)),
+            .unwrap_or_else(|| StructField::nullable(FIELD_NUM_RECORDS, DataType::LONG)),
     );
 
-    for stats_field_name in ["nullCount", "minValues", "maxValues"] {
+    for stats_field_name in ORDERED_STATS_VALUE_FIELDS {
         let Some(field) = stats_schema.field(stats_field_name) else {
             continue;
         };
@@ -363,12 +481,18 @@ mod tests {
 
     use super::*;
     use crate::test_utils::TestResult;
-    use crate::{DeltaTable, DeltaTableBuilder, TableProperty};
+    use crate::{DeltaTable, DeltaTableBuilder, DeltaTableError, TableProperty};
 
     fn column_mapping_builder() -> DeltaResult<DeltaTableBuilder> {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../test/tests/data/table_with_column_mapping");
-        let url = url::Url::from_directory_path(path.canonicalize().unwrap()).unwrap();
+        let path = path.canonicalize()?;
+        let url = url::Url::from_directory_path(&path).map_err(|_| {
+            DeltaTableError::InvalidTableLocation(format!(
+                "failed to convert {} to a directory URL",
+                path.display()
+            ))
+        })?;
         DeltaTableBuilder::from_url(url).map(|builder| builder.with_allow_http(true))
     }
 
@@ -388,6 +512,42 @@ mod tests {
             .with_partition_columns(["part"])
             .await?;
         Snapshot::try_new(table.log_store().as_ref(), Default::default(), None).await
+    }
+
+    fn nested_data_type(path: &[&str]) -> DeltaResult<DataType> {
+        let Some((field_name, child_path)) = path.split_first() else {
+            return Ok(DataType::INTEGER);
+        };
+        Ok(DataType::Struct(Box::new(StructType::try_new([
+            StructField::nullable(*field_name, nested_data_type(child_path)?),
+        ])?)))
+    }
+
+    async fn deep_nested_snapshot() -> DeltaResult<Snapshot> {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([StructField::nullable(
+                "level1",
+                nested_data_type(&["level2", "level3", "level4", "level5", "level6", "leaf"])?,
+            )])
+            .await?;
+        Snapshot::try_new(table.log_store().as_ref(), Default::default(), None).await
+    }
+
+    fn assert_struct_path(schema: &StructType, path: &[&str]) {
+        let Some((field_name, child_path)) = path.split_first() else {
+            return;
+        };
+        let field = schema
+            .field(field_name)
+            .unwrap_or_else(|| panic!("{field_name} should be projected"));
+        if child_path.is_empty() {
+            return;
+        }
+        let DataType::Struct(inner) = field.data_type() else {
+            panic!("{field_name} should be a struct");
+        };
+        assert_struct_path(inner, child_path);
     }
 
     async fn synthetic_snapshot_with_num_indexed_cols(
@@ -419,23 +579,23 @@ mod tests {
         Snapshot::try_new(log_store.as_ref(), Default::default(), None).await
     }
 
-    fn scan_with_predicate(
+    fn projection_for_predicate(
         snapshot: &Snapshot,
-        predicate: Option<PredicateRef>,
-    ) -> DeltaResult<crate::kernel::snapshot::Scan> {
-        snapshot.scan_builder().with_predicate(predicate).build()
+        predicate: Option<&PredicateRef>,
+    ) -> DeltaResult<StatsProjection> {
+        StatsProjection::for_scan_inputs(snapshot.inner.as_ref(), None, predicate)
     }
 
     #[test]
     fn file_stats_materialization_query_defaults_to_omit_raw() {
-        let projection = StatsProjection::num_records_only();
+        let projection = StatsProjection::NumRecordsOnly;
         let materialization = FileStatsMaterialization::query(projection.clone());
 
         assert_eq!(
             materialization.stats_source_policy(),
             StatsSourcePolicy::ParsedWithJsonFallback
         );
-        assert_eq!(materialization.raw_stats_policy(), RawStatsPolicy::Omit);
+        assert!(!materialization.preserves_raw_stats());
         assert_eq!(materialization.stats_projection(), &projection);
     }
 
@@ -448,7 +608,7 @@ mod tests {
             materialization.stats_source_policy(),
             StatsSourcePolicy::ParsedWithJsonFallback
         );
-        assert_eq!(materialization.raw_stats_policy(), RawStatsPolicy::Preserve);
+        assert!(materialization.preserves_raw_stats());
         assert_eq!(materialization.stats_projection(), &projection);
     }
 
@@ -460,25 +620,8 @@ mod tests {
             materialization.stats_source_policy(),
             StatsSourcePolicy::None
         );
-        assert_eq!(materialization.raw_stats_policy(), RawStatsPolicy::Omit);
+        assert!(!materialization.preserves_raw_stats());
         assert_eq!(materialization.stats_projection(), &StatsProjection::none());
-    }
-
-    #[tokio::test]
-    async fn stats_projection_no_predicate_uses_num_records_only() -> TestResult {
-        let snapshot = synthetic_snapshot().await?;
-        let scan = scan_with_predicate(&snapshot, None)?;
-
-        let projection = StatsProjection::for_scan(scan.inner().as_ref())?;
-        let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
-
-        assert_eq!(projection, StatsProjection::NumRecordsOnly);
-        assert!(stats_schema.field("numRecords").is_some());
-        assert!(stats_schema.field("minValues").is_none());
-        assert!(stats_schema.field("maxValues").is_none());
-        assert!(stats_schema.field("nullCount").is_none());
-
-        Ok(())
     }
 
     #[tokio::test]
@@ -493,59 +636,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stats_projection_partition_only_predicate_uses_num_records_only() -> TestResult {
-        let snapshot = synthetic_snapshot().await?;
-        let predicate: PredicateRef =
-            Arc::new(Expression::column(["part"]).eq(Scalar::String("A".to_string())));
-        let scan = scan_with_predicate(&snapshot, Some(predicate))?;
-
-        let projection = StatsProjection::for_scan(scan.inner().as_ref())?;
-        let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
-
-        assert_eq!(projection, StatsProjection::NumRecordsOnly);
-        assert!(stats_schema.field("numRecords").is_some());
-        assert!(stats_schema.field("minValues").is_none());
-        assert!(stats_schema.field("maxValues").is_none());
-        assert!(stats_schema.field("nullCount").is_none());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn stats_projection_static_skip_all_uses_num_records_only() -> TestResult {
-        let snapshot = synthetic_snapshot().await?;
-        let predicate: PredicateRef = Arc::new(delta_kernel::Predicate::literal(false));
-        let scan = scan_with_predicate(&snapshot, Some(predicate))?;
-
-        let projection = StatsProjection::for_scan(scan.inner().as_ref())?;
-        let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
-
-        assert_eq!(projection, StatsProjection::NumRecordsOnly);
-        assert!(stats_schema.field("numRecords").is_some());
-        assert!(stats_schema.field("minValues").is_none());
-        assert!(stats_schema.field("maxValues").is_none());
-        assert!(stats_schema.field("nullCount").is_none());
-
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn stats_projection_data_predicate_includes_only_referenced_columns() -> TestResult {
         let snapshot = synthetic_snapshot().await?;
         let predicate: PredicateRef =
             Arc::new(Expression::column(["value"]).gt(Scalar::Integer(10)));
-        let scan = scan_with_predicate(&snapshot, Some(predicate))?;
 
-        let projection = StatsProjection::for_scan(scan.inner().as_ref())?;
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
         let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
-        let stats_schema = stats_schema.to_string();
 
-        assert!(stats_schema.contains("numRecords"));
-        assert!(stats_schema.contains("minValues"));
-        assert!(stats_schema.contains("maxValues"));
-        assert!(stats_schema.contains("nullCount"));
-        assert!(stats_schema.contains("value"));
-        assert!(!stats_schema.contains("unreferenced_col"));
+        assert!(stats_schema.field("numRecords").is_some());
+        for field_name in ["minValues", "maxValues", "nullCount"] {
+            let field = stats_schema
+                .field(field_name)
+                .unwrap_or_else(|| panic!("{field_name} should be projected"));
+            let DataType::Struct(inner) = field.data_type() else {
+                panic!("{field_name} should be a struct");
+            };
+            assert!(inner.field("value").is_some());
+            assert!(inner.field("unreferenced_col").is_none());
+        }
 
         Ok(())
     }
@@ -560,9 +669,8 @@ mod tests {
             ])
             .gt(Scalar::Integer(10)),
         );
-        let scan = scan_with_predicate(&snapshot, Some(predicate))?;
 
-        let projection = StatsProjection::for_scan(scan.inner().as_ref())?;
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
         assert_eq!(
             projection,
             StatsProjection::PredicateColumns(BTreeSet::from([ColumnName::new(["value"])]))
@@ -582,9 +690,8 @@ mod tests {
             )
             .gt(Scalar::Integer(10)),
         );
-        let scan = scan_with_predicate(&snapshot, Some(predicate))?;
 
-        let projection = StatsProjection::for_scan(scan.inner().as_ref())?;
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
 
         assert_eq!(
             projection,
@@ -601,9 +708,8 @@ mod tests {
             Expression::column(["value"]).gt(Scalar::Integer(10)),
             Expression::column(["unreferenced_col"]).eq(Scalar::String("match".to_string())),
         ));
-        let scan = scan_with_predicate(&snapshot, Some(predicate))?;
 
-        let projection = StatsProjection::for_scan(scan.inner().as_ref())?;
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
 
         assert_eq!(
             projection,
@@ -622,11 +728,9 @@ mod tests {
         let predicate: PredicateRef = Arc::new(
             Expression::column(["Super Name"]).eq(Scalar::String("Timothy Lamb".to_string())),
         );
-        let scan = scan_with_predicate(&snapshot, Some(predicate))?;
 
-        let projection = StatsProjection::for_scan(scan.inner().as_ref())?;
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
         let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
-        let stats_schema = stats_schema.to_string();
 
         let logical_schema = snapshot.inner.table_configuration().logical_schema();
         let logical = logical_schema
@@ -635,8 +739,22 @@ mod tests {
         let physical =
             logical.physical_name(snapshot.inner.table_configuration().column_mapping_mode());
 
-        assert!(stats_schema.contains(physical));
-        assert!(!stats_schema.contains("Super Name"));
+        assert_eq!(
+            projection,
+            StatsProjection::PredicateColumns(BTreeSet::from([ColumnName::new([
+                physical.to_string()
+            ])]))
+        );
+        for field_name in ["minValues", "maxValues", "nullCount"] {
+            let field = stats_schema
+                .field(field_name)
+                .unwrap_or_else(|| panic!("{field_name} should be projected"));
+            let DataType::Struct(inner) = field.data_type() else {
+                panic!("{field_name} should be a struct");
+            };
+            assert!(inner.field(physical).is_some());
+            assert!(inner.field("Super Name").is_none());
+        }
 
         Ok(())
     }
@@ -647,29 +765,50 @@ mod tests {
         let snapshot = synthetic_snapshot().await?;
         let predicate: PredicateRef =
             Arc::new(Expression::column(["nested", "leaf"]).gt(Scalar::Integer(1)));
-        let scan = scan_with_predicate(&snapshot, Some(predicate))?;
 
-        let projection = StatsProjection::for_scan(scan.inner().as_ref())?;
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
         let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
-        let stats_schema = stats_schema.to_string();
 
-        assert!(stats_schema.contains("nested"));
-        assert!(stats_schema.contains("leaf"));
-        assert!(!stats_schema.contains("other_leaf"));
+        for field_name in ["minValues", "maxValues", "nullCount"] {
+            let field = stats_schema
+                .field(field_name)
+                .unwrap_or_else(|| panic!("{field_name} should be projected"));
+            let DataType::Struct(inner) = field.data_type() else {
+                panic!("{field_name} should be a struct");
+            };
+            let nested = inner.field("nested").expect("nested should be projected");
+            let DataType::Struct(nested_inner) = nested.data_type() else {
+                panic!("nested stats should be a struct");
+            };
+            assert!(nested_inner.field("leaf").is_some());
+            assert!(nested_inner.field("other_leaf").is_none());
+        }
 
         Ok(())
     }
 
-    #[cfg(feature = "datafusion")]
-    #[test]
-    fn stats_projection_emits_only_top_level_stats_fields() {
-        let projection = StatsProjection::PredicateColumns(BTreeSet::from([ColumnName::new([
-            "nested", "leaf",
-        ])]));
+    #[tokio::test]
+    async fn stats_projection_deep_nested_struct_predicate_keeps_referenced_path() -> TestResult {
+        let snapshot = deep_nested_snapshot().await?;
+        let path = [
+            "level1", "level2", "level3", "level4", "level5", "level6", "leaf",
+        ];
+        let predicate: PredicateRef = Arc::new(Expression::column(path).gt(Scalar::Integer(1)));
 
-        assert!(projection.emits_top_level_column_stats("nested"));
-        assert!(!projection.emits_top_level_column_stats("leaf"));
-        assert!(!projection.emits_top_level_column_stats("value"));
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
+        let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
+
+        for field_name in STATS_VALUE_FIELDS {
+            let field = stats_schema
+                .field(field_name)
+                .unwrap_or_else(|| panic!("{field_name} should be projected"));
+            let DataType::Struct(inner) = field.data_type() else {
+                panic!("{field_name} should be a struct");
+            };
+            assert_struct_path(inner, &path);
+        }
+
+        Ok(())
     }
 
     #[tokio::test]
@@ -678,17 +817,15 @@ mod tests {
         let predicate: PredicateRef = Arc::new(
             Expression::column(["unreferenced_col"]).eq(Scalar::String("match".to_string())),
         );
-        let scan = scan_with_predicate(&snapshot, Some(predicate))?;
 
-        let projection = StatsProjection::for_scan(scan.inner().as_ref())?;
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
         let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
-        let stats_schema = stats_schema.to_string();
 
-        assert!(stats_schema.contains("numRecords"));
-        assert!(!stats_schema.contains("unreferenced_col"));
-        assert!(!stats_schema.contains("minValues"));
-        assert!(!stats_schema.contains("maxValues"));
-        assert!(!stats_schema.contains("nullCount"));
+        assert_eq!(projection, StatsProjection::NumRecordsOnly);
+        assert!(stats_schema.field("numRecords").is_some());
+        assert!(stats_schema.field("minValues").is_none());
+        assert!(stats_schema.field("maxValues").is_none());
+        assert!(stats_schema.field("nullCount").is_none());
 
         Ok(())
     }

--- a/crates/core/src/kernel/snapshot/stats_projection.rs
+++ b/crates/core/src/kernel/snapshot/stats_projection.rs
@@ -24,12 +24,102 @@ use crate::kernel::arrow::engine_ext::SnapshotExt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum StatsProjection {
+    None,
     Full,
     NumRecordsOnly,
     PredicateColumns(BTreeSet<ColumnName>),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StatsSourcePolicy {
+    ParsedWithJsonFallback,
+    JsonOnly,
+    None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RawStatsPolicy {
+    Preserve,
+    Omit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileStatsMaterialization {
+    stats_projection: StatsProjection,
+    stats_source_policy: StatsSourcePolicy,
+    raw_stats_policy: RawStatsPolicy,
+}
+
+impl FileStatsMaterialization {
+    pub(crate) fn query(stats_projection: StatsProjection) -> Self {
+        Self {
+            stats_projection,
+            stats_source_policy: StatsSourcePolicy::ParsedWithJsonFallback,
+            raw_stats_policy: RawStatsPolicy::Omit,
+        }
+    }
+
+    pub(crate) fn compatibility(stats_projection: StatsProjection) -> Self {
+        Self {
+            stats_projection,
+            stats_source_policy: StatsSourcePolicy::ParsedWithJsonFallback,
+            raw_stats_policy: RawStatsPolicy::Preserve,
+        }
+    }
+
+    pub(crate) fn json_only(
+        stats_projection: StatsProjection,
+        raw_stats_policy: RawStatsPolicy,
+    ) -> Self {
+        Self {
+            stats_projection,
+            stats_source_policy: StatsSourcePolicy::JsonOnly,
+            raw_stats_policy,
+        }
+    }
+
+    pub(crate) fn without_stats() -> Self {
+        Self {
+            stats_projection: StatsProjection::none(),
+            stats_source_policy: StatsSourcePolicy::None,
+            raw_stats_policy: RawStatsPolicy::Omit,
+        }
+    }
+
+    pub(crate) fn stats_projection(&self) -> &StatsProjection {
+        &self.stats_projection
+    }
+
+    pub(crate) fn stats_source_policy(&self) -> StatsSourcePolicy {
+        self.stats_source_policy
+    }
+
+    pub(crate) fn raw_stats_policy(&self) -> RawStatsPolicy {
+        self.raw_stats_policy
+    }
+
+    pub(crate) fn preserves_raw_stats(&self) -> bool {
+        self.raw_stats_policy == RawStatsPolicy::Preserve
+    }
+}
+
 impl StatsProjection {
+    pub(crate) fn none() -> Self {
+        Self::None
+    }
+
+    pub(crate) fn full() -> Self {
+        Self::Full
+    }
+
+    pub(crate) fn num_records_only() -> Self {
+        Self::NumRecordsOnly
+    }
+
+    pub(crate) fn predicate_columns(columns: impl IntoIterator<Item = ColumnName>) -> Self {
+        Self::PredicateColumns(columns.into_iter().collect())
+    }
+
     /// Builds the stats projection for a scan using physical predicate references.
     ///
     /// Use `NumRecordsOnly` when a predicate only touches partition columns,
@@ -83,6 +173,7 @@ impl StatsProjection {
 
     pub(crate) fn stats_schema(&self, snapshot: &KernelSnapshot) -> DeltaResult<KernelSchemaRef> {
         match self {
+            Self::None => Ok(Arc::new(StructType::try_new([])?)),
             Self::Full => Ok(snapshot.table_configuration().stats_schema()?),
             Self::NumRecordsOnly => num_records_only_stats_schema(),
             Self::PredicateColumns(columns) => {
@@ -127,6 +218,7 @@ impl StatsProjection {
     #[cfg(feature = "datafusion")]
     pub(crate) fn emits_top_level_column_stats(&self, physical_name: &str) -> bool {
         match self {
+            Self::None => false,
             Self::Full => true,
             Self::NumRecordsOnly => false,
             Self::PredicateColumns(columns) => columns.iter().any(|column| {
@@ -332,6 +424,44 @@ mod tests {
         predicate: Option<PredicateRef>,
     ) -> DeltaResult<crate::kernel::snapshot::Scan> {
         snapshot.scan_builder().with_predicate(predicate).build()
+    }
+
+    #[test]
+    fn file_stats_materialization_query_defaults_to_omit_raw() {
+        let projection = StatsProjection::num_records_only();
+        let materialization = FileStatsMaterialization::query(projection.clone());
+
+        assert_eq!(
+            materialization.stats_source_policy(),
+            StatsSourcePolicy::ParsedWithJsonFallback
+        );
+        assert_eq!(materialization.raw_stats_policy(), RawStatsPolicy::Omit);
+        assert_eq!(materialization.stats_projection(), &projection);
+    }
+
+    #[test]
+    fn file_stats_materialization_compatibility_preserves_raw() {
+        let projection = StatsProjection::full();
+        let materialization = FileStatsMaterialization::compatibility(projection.clone());
+
+        assert_eq!(
+            materialization.stats_source_policy(),
+            StatsSourcePolicy::ParsedWithJsonFallback
+        );
+        assert_eq!(materialization.raw_stats_policy(), RawStatsPolicy::Preserve);
+        assert_eq!(materialization.stats_projection(), &projection);
+    }
+
+    #[test]
+    fn file_stats_materialization_without_stats_disables_sources() {
+        let materialization = FileStatsMaterialization::without_stats();
+
+        assert_eq!(
+            materialization.stats_source_policy(),
+            StatsSourcePolicy::None
+        );
+        assert_eq!(materialization.raw_stats_policy(), RawStatsPolicy::Omit);
+        assert_eq!(materialization.stats_projection(), &StatsProjection::none());
     }
 
     #[tokio::test]

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -28,7 +28,8 @@ use datafusion::{
     error::DataFusionError,
     execution::context::SessionState,
     logical_expr::{
-        Extension, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNode, case, col, lit, when,
+        ExprSchemable as _, Extension, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNode,
+        case, cast, col, lit, try_cast, when,
     },
     physical_plan::{ExecutionPlan, metrics::MetricBuilder},
     physical_planner::{ExtensionPlanner, PhysicalPlanner},
@@ -279,6 +280,7 @@ async fn execute(
     session: &dyn Session,
     writer_properties: Option<WriterProperties>,
     operation_id: Uuid,
+    safe_cast: bool,
 ) -> DeltaResult<(Vec<Action>, UpdateMetrics)> {
     // Validate the predicate and update expressions.
     //
@@ -343,10 +345,20 @@ async fn execute(
         .into_iter()
         .map(|field| {
             let expr = match updates.get(field.name()) {
-                Some(expr) => case(col(UPDATE_PREDICATE_COLNAME))
-                    .when(lit(true), expr.to_owned())
-                    .otherwise(col(Column::from_name(field.name())))?
-                    .alias(field.name()),
+                Some(expr) => {
+                    let target_type = field.data_type().clone();
+                    let update_expr = if expr.get_type(plan_with_metrics.schema())? == target_type {
+                        expr.to_owned()
+                    } else if safe_cast {
+                        try_cast(expr.to_owned(), target_type)
+                    } else {
+                        cast(expr.to_owned(), target_type)
+                    };
+                    case(col(UPDATE_PREDICATE_COLNAME))
+                        .when(lit(true), update_expr)
+                        .otherwise(col(Column::from_name(field.name())))?
+                        .alias(field.name())
+                }
                 None => col(Column::from_name(field.name())),
             };
             Ok::<_, DataFusionError>(expr)
@@ -495,6 +507,7 @@ impl std::future::IntoFuture for UpdateBuilder {
                 &state,
                 this.writer_properties,
                 operation_id,
+                this.safe_cast,
             )
             .await?;
 

--- a/crates/core/src/operations/update/tests.rs
+++ b/crates/core/src/operations/update/tests.rs
@@ -595,6 +595,33 @@ async fn test_expected_failures() {
 }
 
 #[tokio::test]
+async fn test_update_safe_cast_converts_invalid_values_to_null() {
+    let table = prepare_values_table().await;
+    let (table, metrics) = table
+        .update()
+        .with_safe_cast(true)
+        .with_update("value", lit("a string"))
+        .await
+        .unwrap();
+
+    assert_eq!(metrics.num_updated_rows, 5);
+
+    let expected = [
+        "+-------+",
+        "| value |",
+        "+-------+",
+        "|       |",
+        "|       |",
+        "|       |",
+        "|       |",
+        "|       |",
+        "+-------+",
+    ];
+    let actual = get_data(&table).await;
+    assert_batches_sorted_eq!(&expected, &actual);
+}
+
+#[tokio::test]
 async fn test_update_with_array() {
     let schema = StructType::try_new(vec![
         StructField::new(

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use arrow::array::new_null_array;
 use arrow::compute::concat_batches;
 use arrow::datatypes::Schema as ArrowSchema;
 use arrow::record_batch::RecordBatch;
@@ -18,6 +19,7 @@ use super::DeltaTableConfig;
 #[cfg(test)]
 use crate::kernel::Action;
 use crate::kernel::arrow::engine_ext::{ExpressionEvaluatorExt, SnapshotExt};
+use crate::kernel::snapshot::FIELD_STATS_PARSED;
 use crate::kernel::{
     ARROW_HANDLER, DataType, EagerSnapshot, LogDataHandler, Metadata, Protocol, Snapshot,
     TombstoneView, Version,
@@ -300,8 +302,8 @@ impl Snapshot {
             return Ok(vec![]);
         }
 
-        let input_schema = self.inner.scan_row_parsed_schema_arrow()?;
-        let input_schema = Arc::new(input_schema.as_ref().try_into_kernel()?);
+        let input_arrow_schema = self.inner.scan_row_parsed_schema_arrow()?;
+        let input_schema = Arc::new(input_arrow_schema.as_ref().try_into_kernel()?);
         let evaluator = ARROW_HANDLER.new_expression_evaluator(
             input_schema,
             expression.into(),
@@ -309,7 +311,8 @@ impl Snapshot {
         )?;
 
         let evaluated_batches = files.iter().map(|file| {
-            let batch = evaluator.evaluate_arrow(file.clone())?;
+            let file = add_missing_stats_parsed(file, input_arrow_schema.as_ref())?;
+            let batch = evaluator.evaluate_arrow(file)?;
             if flatten {
                 Ok(batch.normalize(".", None)?)
             } else {
@@ -425,6 +428,27 @@ impl EagerSnapshot {
 /// Target number of rows per coalesced batch. Matches DataFusion's default batch size.
 const COALESCE_TARGET_BATCH_SIZE: usize = 8192;
 
+fn add_missing_stats_parsed(
+    batch: &RecordBatch,
+    input_schema: &ArrowSchema,
+) -> DeltaResult<RecordBatch> {
+    if batch.schema().field_with_name(FIELD_STATS_PARSED).is_ok() {
+        return Ok(batch.clone());
+    }
+
+    let stats_field = input_schema.field_with_name(FIELD_STATS_PARSED)?.clone();
+    let mut fields = batch.schema().fields().to_vec();
+    fields.push(Arc::new(stats_field.clone()));
+
+    let mut columns = batch.columns().to_vec();
+    columns.push(new_null_array(stats_field.data_type(), batch.num_rows()));
+
+    Ok(RecordBatch::try_new(
+        Arc::new(ArrowSchema::new(fields)),
+        columns,
+    )?)
+}
+
 /// Coalesce many small [RecordBatch]es into fewer, larger ones.
 ///
 /// tables with many small commits can produce thousands of
@@ -472,7 +496,7 @@ mod tests {
     #[cfg(feature = "datafusion")]
     use crate::writer::test_utils::get_record_batch;
     use crate::{DeltaResult, DeltaTable};
-    use arrow_array::Int32Array;
+    use arrow_array::{Array, Int32Array};
 
     /// <https://github.com/delta-io/delta-rs/issues/3918>
     #[tokio::test]
@@ -529,6 +553,37 @@ mod tests {
         let concatenated = concat_batches(flattened_batches[0].schema_ref(), &flattened_batches)?;
         let single = snapshot.add_actions_table(true)?;
         assert_eq!(concatenated, single);
+        Ok(())
+    }
+
+    #[cfg(feature = "datafusion")]
+    #[tokio::test]
+    async fn test_add_actions_batches_skip_stats_returns_null_stats() -> DeltaResult<()> {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(get_delta_schema().fields().cloned())
+            .await?;
+        let table = table
+            .write(vec![get_record_batch(None, false)])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let mut config = DeltaTableConfig::default();
+        config.skip_stats = true;
+        let log_store = table.log_store();
+        let snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, None).await?;
+        let batches = snapshot.snapshot().add_actions_batches(true)?;
+
+        assert!(!batches.is_empty());
+        let batch = concat_batches(batches[0].schema_ref(), &batches)?;
+        for column_name in ["num_records", "min.value", "max.value"] {
+            let column = batch
+                .column_by_name(column_name)
+                .unwrap_or_else(|| panic!("expected add actions output to contain {column_name}"));
+            assert_eq!(column.null_count(), batch.num_rows());
+            assert!((0..batch.num_rows()).all(|row| column.is_null(row)));
+        }
+
         Ok(())
     }
 

--- a/python/tests/test_update.py
+++ b/python/tests/test_update.py
@@ -129,7 +129,7 @@ def test_update_wrong_types_cast(tmp_path: pathlib.Path, sample_table: Table):
     with pytest.raises(Exception) as excinfo:
         dt.update(updates={"deleted": "'hello_world'"})
 
-    expected = """Generic DeltaTable error: type_coercion\ncaused by\nError during planning: Failed to coerce then (Utf8) and else (Boolean) to common types in CASE WHEN expression"""
+    expected = """Generic DeltaTable error: Optimizer rule 'simplify_expressions' failed\ncaused by\nArrow error: Cast error: Cannot cast value 'hello_world' to value of Boolean type"""
     assert str(excinfo.value) == expected
 
 


### PR DESCRIPTION
Adds `StatsProjection` and `FileStatsMaterialization` enabling scan paths to choose: full stats, `numRecords` only, predicate scoped stats, no stats, or raw json preservation for compat.

Scan row materialization prefers existing `stats_parsed` from checkpoints and falls back to raw json when needed. Query oriented paths can omit raw json while compat paths (`Snapshot::files`, `file_views`, eager materialization) still preserve it for add action round trips.

This is another foundational PR and is **not** the full raw json memory fix. My plan is to land the next follow up after `EagerSnapshot` removal and will wire query paths to omit raw json by default.

part of #4015 