### PR TITLE
fix(core): reject unsupported column mapping writes

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -153,6 +153,10 @@ name = "command_vacuum"
 required-features = ["datafusion"]
 
 [[test]]
+name = "column_mapping_guardrails"
+required-features = ["datafusion"]
+
+[[test]]
 name = "commit_info_format"
 required-features = ["datafusion"]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -154,7 +154,6 @@ required-features = ["datafusion"]
 
 [[test]]
 name = "column_mapping_guardrails"
-required-features = ["datafusion"]
 
 [[test]]
 name = "commit_info_format"

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -8,6 +8,12 @@ use crate::kernel::transaction::{CommitBuilderError, TransactionError};
 /// A result returned by delta-rs
 pub type DeltaResult<T, E = DeltaTableError> = Result<T, E>;
 
+pub(crate) fn unsupported_column_mapping_write(operation: &str) -> DeltaTableError {
+    DeltaTableError::Generic(format!(
+        "column mapping writes are not supported for {operation} yet"
+    ))
+}
+
 /// Delta Table specific error
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug)]

--- a/crates/core/src/operations/add_column.rs
+++ b/crates/core/src/operations/add_column.rs
@@ -3,10 +3,12 @@
 use std::sync::Arc;
 
 use delta_kernel::schema::StructType;
+use delta_kernel::table_features::ColumnMappingMode;
 use futures::future::BoxFuture;
 use itertools::Itertools;
 
 use super::{CustomExecuteHandler, Operation};
+use crate::errors::unsupported_column_mapping_write;
 use crate::kernel::schema::merge_delta_struct;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{
@@ -79,6 +81,9 @@ impl std::future::IntoFuture for AddColumnBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), false, None).await?;
+            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+                return Err(unsupported_column_mapping_write("ADD COLUMN"));
+            }
 
             let mut metadata = snapshot.metadata().clone();
             let fields = match this.fields.clone() {

--- a/crates/core/src/operations/create.rs
+++ b/crates/core/src/operations/create.rs
@@ -4,14 +4,14 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::schema::MetadataValue;
+use delta_kernel::schema::{ColumnMetadataKey, MetadataValue};
 use futures::TryStreamExt as _;
 use futures::future::BoxFuture;
 use serde_json::Value;
 use uuid::Uuid;
 
 use super::{CustomExecuteHandler, Operation};
-use crate::errors::{DeltaResult, DeltaTableError};
+use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL, TableReference};
 use crate::kernel::{
     Action, DataType, MetadataExt, ProtocolExt as _, ProtocolInner, StructField, StructType,
@@ -48,6 +48,30 @@ impl From<CreateError> for DeltaTableError {
             source: Box::new(err),
         }
     }
+}
+
+fn data_type_has_column_mapping_metadata(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Array(array) => data_type_has_column_mapping_metadata(array.element_type()),
+        DataType::Map(map) => {
+            data_type_has_column_mapping_metadata(map.key_type())
+                || data_type_has_column_mapping_metadata(map.value_type())
+        }
+        DataType::Struct(fields) | DataType::Variant(fields) => {
+            fields.fields().any(field_has_column_mapping_metadata)
+        }
+        DataType::Primitive(_) => false,
+    }
+}
+
+fn field_has_column_mapping_metadata(field: &StructField) -> bool {
+    field
+        .metadata()
+        .contains_key(ColumnMetadataKey::ColumnMappingId.as_ref())
+        || field
+            .metadata()
+            .contains_key(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref())
+        || data_type_has_column_mapping_metadata(field.data_type())
 }
 
 /// Build an operation to create a new [DeltaTable]
@@ -258,6 +282,20 @@ impl CreateBuilder {
         }
         if self.columns.is_empty() {
             return Err(CreateError::MissingSchema.into());
+        }
+        if self
+            .configuration
+            .get(TableProperty::ColumnMappingMode.as_ref())
+            .is_some_and(|value| value.is_some())
+        {
+            return Err(unsupported_column_mapping_write(
+                "CREATE TABLE with delta.columnMapping.mode",
+            ));
+        }
+        if self.columns.iter().any(field_has_column_mapping_metadata) {
+            return Err(unsupported_column_mapping_write(
+                "CREATE TABLE with column mapping metadata",
+            ));
         }
 
         let (storage_url, table) = if let Some(log_store) = self.log_store {

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -51,6 +51,7 @@ use datafusion::optimizer::simplify_expressions::simplify_predicates;
 use datafusion::physical_plan::{ExecutionPlan, metrics::MetricBuilder};
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 use datafusion::prelude::Expr;
+use delta_kernel::table_features::ColumnMappingMode;
 use futures::future::BoxFuture;
 use futures::{StreamExt as _, TryStreamExt, stream};
 use parquet::file::properties::WriterProperties;
@@ -73,7 +74,7 @@ use crate::delta_datafusion::{
     Expression, add_actions_partition_mem_table, create_session, resolve_session_state,
     scan_files_where_matches, update_datafusion_session,
 };
-use crate::errors::{DeltaResult, DeltaTableError};
+use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
 use crate::kernel::{Action, EagerSnapshot, LogicalFileView, resolve_snapshot};
 use crate::logstore::{LogStore, LogStoreRef};
@@ -295,6 +296,9 @@ impl std::future::IntoFuture for DeleteBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
+            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+                return Err(unsupported_column_mapping_write("DELETE"));
+            }
             PROTOCOL.check_append_only(&snapshot)?;
             PROTOCOL.can_write_to(&snapshot)?;
 

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -64,6 +64,7 @@ use datafusion::{
 
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow as _, TryIntoKernel as _};
 use delta_kernel::schema::{ColumnMetadataKey, StructType};
+use delta_kernel::table_features::ColumnMappingMode;
 use filter::try_construct_early_filter;
 use futures::future::BoxFuture;
 use parquet::file::properties::WriterProperties;
@@ -85,6 +86,7 @@ use crate::delta_datafusion::{
     resolve_session_state, update_datafusion_session,
 };
 use crate::delta_datafusion::{Expression, into_expr, maybe_into_expr};
+use crate::errors::unsupported_column_mapping_write;
 use crate::kernel::schema::cast::{merge_arrow_field, merge_arrow_schema};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
 use crate::kernel::{Action, EagerSnapshot, StructTypeExt, new_metadata, resolve_snapshot};
@@ -1803,6 +1805,9 @@ impl std::future::IntoFuture for MergeBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
+            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+                return Err(unsupported_column_mapping_write("MERGE"));
+            }
 
             PROTOCOL.can_write_to(&snapshot)?;
 

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -32,6 +32,7 @@ use datafusion::catalog::Session;
 use datafusion::execution::context::{SessionContext, SessionState};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::Scalar;
+use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
@@ -52,7 +53,7 @@ use crate::delta_datafusion::{
     DataFusionMixins, DeltaScanConfig, DeltaScanNext, SessionFallbackPolicy, SessionResolveContext,
     create_session_state_with_spill_config, resolve_session_state, update_datafusion_session,
 };
-use crate::errors::{DeltaResult, DeltaTableError};
+use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, DEFAULT_RETRIES, PROTOCOL};
 use crate::kernel::{Action, Add, DataType, PartitionsExt, Remove, StructType, Version};
 use crate::kernel::{EagerSnapshot, resolve_snapshot};
@@ -415,6 +416,9 @@ impl<'a> std::future::IntoFuture for OptimizeBuilder<'a> {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
+            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+                return Err(unsupported_column_mapping_write("OPTIMIZE"));
+            }
             PROTOCOL.can_write_to(&snapshot)?;
 
             let operation_id = this.get_operation_id();

--- a/crates/core/src/operations/set_tbl_properties.rs
+++ b/crates/core/src/operations/set_tbl_properties.rs
@@ -8,10 +8,12 @@ use futures::future::BoxFuture;
 use super::{CustomExecuteHandler, Operation};
 use crate::DeltaResult;
 use crate::DeltaTable;
+use crate::errors::unsupported_column_mapping_write;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{Action, EagerSnapshot, MetadataExt as _, ProtocolExt as _, resolve_snapshot};
 use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
+use crate::table::config::TableProperty;
 
 /// Remove constraints from the table
 pub struct SetTablePropertiesBuilder {
@@ -94,6 +96,12 @@ impl std::future::IntoFuture for SetTablePropertiesBuilder {
 
             let current_protocol = snapshot.protocol();
             let properties = this.properties;
+
+            if properties.contains_key(TableProperty::ColumnMappingMode.as_ref()) {
+                return Err(unsupported_column_mapping_write(
+                    "SET TBLPROPERTIES delta.columnMapping.mode",
+                ));
+            }
 
             let new_protocol = current_protocol
                 .clone()

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -34,6 +34,7 @@ use datafusion::{
     physical_planner::{ExtensionPlanner, PhysicalPlanner},
     prelude::Expr,
 };
+use delta_kernel::table_features::ColumnMappingMode;
 use futures::{StreamExt as _, TryStreamExt as _, future::BoxFuture, stream};
 use itertools::Itertools as _;
 use parquet::file::properties::WriterProperties;
@@ -49,6 +50,7 @@ use super::{
 use crate::delta_datafusion::{
     DeltaScanConfig, Expression, scan_files_where_matches, update_datafusion_session,
 };
+use crate::errors::unsupported_column_mapping_write;
 use crate::kernel::resolve_snapshot;
 use crate::logstore::LogStoreRef;
 use crate::operations::cdc::*;
@@ -445,6 +447,9 @@ impl std::future::IntoFuture for UpdateBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
+            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+                return Err(unsupported_column_mapping_write("UPDATE"));
+            }
             PROTOCOL.check_append_only(&snapshot)?;
             PROTOCOL.can_write_to(&snapshot)?;
 

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -36,6 +36,7 @@ use datafusion::common::Result;
 use datafusion::datasource::{MemTable, provider_as_source};
 use datafusion::logical_expr::{LogicalPlan, LogicalPlanBuilder, UNNAMED_TABLE};
 use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
+use delta_kernel::table_features::ColumnMappingMode;
 use futures::future::BoxFuture;
 use parquet::file::properties::WriterProperties;
 use serde::{Deserialize, Serialize};
@@ -54,7 +55,7 @@ use crate::delta_datafusion::{
     DeltaSessionExt, SessionFallbackPolicy, SessionResolveContext, create_session,
     resolve_session_state, update_datafusion_session,
 };
-use crate::errors::{DeltaResult, DeltaTableError};
+use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::schema::cast::normalize_for_delta;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL, TableReference};
 use crate::kernel::{Action, EagerSnapshot, StructType};
@@ -386,6 +387,10 @@ impl WriteBuilder {
 
         match &self.snapshot {
             Some(snapshot) => {
+                if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+                    return Err(unsupported_column_mapping_write("WRITE"));
+                }
+
                 if self.mode == SaveMode::Overwrite {
                     PROTOCOL.check_append_only(snapshot)?;
                     if !snapshot.load_config().require_files {

--- a/crates/core/src/writer/json.rs
+++ b/crates/core/src/writer/json.rs
@@ -7,7 +7,6 @@ use arrow::record_batch::*;
 use bytes::Bytes;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::Scalar;
-use delta_kernel::table_features::ColumnMappingMode;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use object_store::path::Path;
@@ -22,9 +21,9 @@ use super::utils::{
     arrow_schema_without_partitions, next_data_path, record_batch_from_message,
     record_batch_without_partitions,
 };
-use super::{DeltaWriter, DeltaWriterError, WriteMode};
+use super::{DeltaWriter, DeltaWriterError, WriteMode, ensure_legacy_writer_supports_table};
 use crate::DeltaTable;
-use crate::errors::{DeltaTableError, unsupported_column_mapping_write};
+use crate::errors::DeltaTableError;
 use crate::kernel::{Add, PartitionsExt, scalars::ScalarExt};
 use crate::logstore::ObjectStoreRetryExt;
 use crate::parquet_utils::default_writer_properties;
@@ -196,6 +195,8 @@ impl JsonWriter {
             .with_storage_options(storage_options.unwrap_or_default())
             .load()
             .await?;
+        ensure_legacy_writer_supports_table(&table, "JsonWriter")?;
+
         // Initialize writer properties for the underlying arrow writer
         let writer_properties = default_writer_properties(parquet::basic::Compression::SNAPPY);
 
@@ -210,14 +211,7 @@ impl JsonWriter {
 
     /// Creates a JsonWriter to write to the given table
     pub fn for_table(table: &DeltaTable) -> Result<JsonWriter, DeltaTableError> {
-        if table
-            .snapshot()?
-            .table_config()
-            .column_mapping_mode
-            .is_some_and(|mode| mode != ColumnMappingMode::None)
-        {
-            return Err(unsupported_column_mapping_write("JsonWriter"));
-        }
+        ensure_legacy_writer_supports_table(table, "JsonWriter")?;
 
         // Initialize an arrow schema ref from the delta table schema
         let metadata = table.snapshot()?.metadata();

--- a/crates/core/src/writer/json.rs
+++ b/crates/core/src/writer/json.rs
@@ -23,12 +23,12 @@ use super::utils::{
 };
 use super::{DeltaWriter, DeltaWriterError, WriteMode};
 use crate::DeltaTable;
-use crate::errors::DeltaTableError;
+use crate::errors::{DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::{Add, PartitionsExt, scalars::ScalarExt};
 use crate::logstore::ObjectStoreRetryExt;
 use crate::parquet_utils::default_writer_properties;
 use crate::table::builder::DeltaTableBuilder;
-use crate::table::config::TablePropertiesExt as _;
+use crate::table::config::{TablePropertiesExt as _, TableProperty};
 use crate::writer::utils::ShareableBuffer;
 
 type BadValue = (Value, ParquetError);
@@ -209,6 +209,15 @@ impl JsonWriter {
 
     /// Creates a JsonWriter to write to the given table
     pub fn for_table(table: &DeltaTable) -> Result<JsonWriter, DeltaTableError> {
+        if table
+            .snapshot()?
+            .metadata()
+            .configuration()
+            .contains_key(TableProperty::ColumnMappingMode.as_ref())
+        {
+            return Err(unsupported_column_mapping_write("JsonWriter"));
+        }
+
         // Initialize an arrow schema ref from the delta table schema
         let metadata = table.snapshot()?.metadata();
         let partition_columns = metadata.partition_columns().into();

--- a/crates/core/src/writer/json.rs
+++ b/crates/core/src/writer/json.rs
@@ -7,6 +7,7 @@ use arrow::record_batch::*;
 use bytes::Bytes;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::Scalar;
+use delta_kernel::table_features::ColumnMappingMode;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use object_store::path::Path;
@@ -28,7 +29,7 @@ use crate::kernel::{Add, PartitionsExt, scalars::ScalarExt};
 use crate::logstore::ObjectStoreRetryExt;
 use crate::parquet_utils::default_writer_properties;
 use crate::table::builder::DeltaTableBuilder;
-use crate::table::config::{TablePropertiesExt as _, TableProperty};
+use crate::table::config::TablePropertiesExt as _;
 use crate::writer::utils::ShareableBuffer;
 
 type BadValue = (Value, ParquetError);
@@ -211,9 +212,9 @@ impl JsonWriter {
     pub fn for_table(table: &DeltaTable) -> Result<JsonWriter, DeltaTableError> {
         if table
             .snapshot()?
-            .metadata()
-            .configuration()
-            .contains_key(TableProperty::ColumnMappingMode.as_ref())
+            .table_config()
+            .column_mapping_mode
+            .is_some_and(|mode| mode != ColumnMappingMode::None)
         {
             return Err(unsupported_column_mapping_write("JsonWriter"));
         }

--- a/crates/core/src/writer/mod.rs
+++ b/crates/core/src/writer/mod.rs
@@ -7,7 +7,7 @@ use parquet::errors::ParquetError;
 use serde_json::Value;
 
 use crate::DeltaTable;
-use crate::errors::DeltaTableError;
+use crate::errors::{DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{Action, Add, Version};
 use crate::protocol::{ColumnCountStat, DeltaOperation, SaveMode};
@@ -22,6 +22,22 @@ pub mod utils;
 
 #[cfg(test)]
 pub mod test_utils;
+
+pub(crate) fn ensure_legacy_writer_supports_table(
+    table: &DeltaTable,
+    operation: &str,
+) -> Result<(), DeltaTableError> {
+    if table
+        .snapshot()?
+        .table_config()
+        .column_mapping_mode
+        .is_some_and(|mode| mode != delta_kernel::table_features::ColumnMappingMode::None)
+    {
+        return Err(unsupported_column_mapping_write(operation));
+    }
+
+    Ok(())
+}
 
 /// Enum representing an error when calling [`DeltaWriter`].
 #[derive(thiserror::Error, Debug)]

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -15,6 +15,7 @@ use arrow_select::take::take;
 use bytes::Bytes;
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow, TryIntoKernel};
 use delta_kernel::expressions::Scalar;
+use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use indexmap::IndexMap;
 use object_store::{ObjectStore, path::Path};
@@ -39,7 +40,6 @@ use crate::logstore::ObjectStoreRetryExt;
 use crate::parquet_utils::default_writer_properties;
 use crate::table::builder::DeltaTableBuilder;
 use crate::table::config::DEFAULT_NUM_INDEX_COLS;
-use crate::table::config::TableProperty;
 
 /// Writes messages to a delta lake table.
 pub struct RecordBatchWriter {
@@ -124,9 +124,9 @@ impl RecordBatchWriter {
     pub fn for_table(table: &DeltaTable) -> Result<Self, DeltaTableError> {
         if table
             .snapshot()?
-            .metadata()
-            .configuration()
-            .contains_key(TableProperty::ColumnMappingMode.as_ref())
+            .table_config()
+            .column_mapping_mode
+            .is_some_and(|mode| mode != ColumnMappingMode::None)
         {
             return Err(unsupported_column_mapping_write("RecordBatchWriter"));
         }

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -15,7 +15,6 @@ use arrow_select::take::take;
 use bytes::Bytes;
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow, TryIntoKernel};
 use delta_kernel::expressions::Scalar;
-use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use indexmap::IndexMap;
 use object_store::{ObjectStore, path::Path};
@@ -28,9 +27,9 @@ use super::utils::{
     ShareableBuffer, arrow_schema_without_partitions, next_data_path,
     record_batch_without_partitions,
 };
-use super::{DeltaWriter, DeltaWriterError, WriteMode};
+use super::{DeltaWriter, DeltaWriterError, WriteMode, ensure_legacy_writer_supports_table};
 use crate::DeltaTable;
-use crate::errors::{DeltaTableError, unsupported_column_mapping_write};
+use crate::errors::DeltaTableError;
 use crate::kernel::schema::cast::normalize_for_delta;
 use crate::kernel::schema::merge_arrow_schema;
 use crate::kernel::transaction::CommitProperties;
@@ -122,14 +121,7 @@ impl RecordBatchWriter {
 
     /// Creates a [`RecordBatchWriter`] to write data to provided Delta Table
     pub fn for_table(table: &DeltaTable) -> Result<Self, DeltaTableError> {
-        if table
-            .snapshot()?
-            .table_config()
-            .column_mapping_mode
-            .is_some_and(|mode| mode != ColumnMappingMode::None)
-        {
-            return Err(unsupported_column_mapping_write("RecordBatchWriter"));
-        }
+        ensure_legacy_writer_supports_table(table, "RecordBatchWriter")?;
 
         // Initialize an arrow schema ref from the delta table schema
         let metadata = table.snapshot()?.metadata();

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -29,7 +29,7 @@ use super::utils::{
 };
 use super::{DeltaWriter, DeltaWriterError, WriteMode};
 use crate::DeltaTable;
-use crate::errors::DeltaTableError;
+use crate::errors::{DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::schema::cast::normalize_for_delta;
 use crate::kernel::schema::merge_arrow_schema;
 use crate::kernel::transaction::CommitProperties;
@@ -39,6 +39,7 @@ use crate::logstore::ObjectStoreRetryExt;
 use crate::parquet_utils::default_writer_properties;
 use crate::table::builder::DeltaTableBuilder;
 use crate::table::config::DEFAULT_NUM_INDEX_COLS;
+use crate::table::config::TableProperty;
 
 /// Writes messages to a delta lake table.
 pub struct RecordBatchWriter {
@@ -121,6 +122,15 @@ impl RecordBatchWriter {
 
     /// Creates a [`RecordBatchWriter`] to write data to provided Delta Table
     pub fn for_table(table: &DeltaTable) -> Result<Self, DeltaTableError> {
+        if table
+            .snapshot()?
+            .metadata()
+            .configuration()
+            .contains_key(TableProperty::ColumnMappingMode.as_ref())
+        {
+            return Err(unsupported_column_mapping_write("RecordBatchWriter"));
+        }
+
         // Initialize an arrow schema ref from the delta table schema
         let metadata = table.snapshot()?.metadata();
         let arrow_schema: ArrowSchema = (&metadata.parse_schema()?).try_into_arrow()?;

--- a/crates/core/tests/column_mapping_guardrails.rs
+++ b/crates/core/tests/column_mapping_guardrails.rs
@@ -1,0 +1,244 @@
+#![cfg(feature = "datafusion")]
+
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arrow_array::{RecordBatch, StringArray};
+use arrow_schema::{DataType as ArrowDataType, Field, Schema};
+use datafusion::prelude::{SessionContext, lit};
+use deltalake_core::kernel::{
+    ColumnMetadataKey, DataType, MetadataValue, StructField, TableFeatures,
+};
+use deltalake_core::protocol::SaveMode;
+use deltalake_core::writer::{JsonWriter, RecordBatchWriter};
+use deltalake_core::{DeltaTable, DeltaTableError, open_table};
+use tempfile::TempDir;
+use url::Url;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+fn assert_unsupported_column_mapping_write(err: &DeltaTableError, operation: &str) {
+    let message = err.to_string();
+    assert!(
+        message.contains("column mapping writes are not supported"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains(operation),
+        "expected operation `{operation}` in error: {message}"
+    );
+}
+
+fn column_mapping_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("Company Very Short", ArrowDataType::Utf8, true),
+        Field::new("Super Name", ArrowDataType::Utf8, true),
+    ]));
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(vec!["BMS"])),
+            Arc::new(StringArray::from(vec!["New Customer"])),
+        ],
+    )
+    .unwrap()
+}
+
+fn simple_fields() -> Vec<StructField> {
+    vec![StructField::nullable("id", DataType::INTEGER)]
+}
+
+async fn simple_table() -> TestResult<DeltaTable> {
+    Ok(DeltaTable::new_in_memory()
+        .create()
+        .with_columns(simple_fields())
+        .await?)
+}
+
+async fn copied_column_mapping_table() -> TestResult<(TempDir, PathBuf, DeltaTable)> {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../test/tests/data/table_with_column_mapping");
+    let temp_dir = tempfile::tempdir()?;
+    fs_extra::dir::copy(&fixture, temp_dir.path(), &Default::default())?;
+    let table_path = temp_dir.path().join("table_with_column_mapping");
+    let table_url = Url::from_directory_path(table_path.canonicalize()?).unwrap();
+    let table = open_table(table_url).await?;
+
+    Ok((temp_dir, table_path, table))
+}
+
+fn collect_data_files(root: &Path) -> TestResult<BTreeSet<PathBuf>> {
+    fn visit(root: &Path, dir: &Path, files: &mut BTreeSet<PathBuf>) -> TestResult {
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|name| name == "_delta_log") {
+                    continue;
+                }
+                visit(root, &path, files)?;
+            } else {
+                files.insert(path.strip_prefix(root)?.to_path_buf());
+            }
+        }
+        Ok(())
+    }
+
+    let mut files = BTreeSet::new();
+    visit(root, root, &mut files)?;
+    Ok(files)
+}
+
+#[tokio::test]
+async fn column_mapping_guardrails_write_builder_rejects_before_files() -> TestResult {
+    let (_temp_dir, table_path, table) = copied_column_mapping_table().await?;
+    let before = collect_data_files(&table_path)?;
+
+    let err = table
+        .clone()
+        .write(vec![column_mapping_batch()])
+        .await
+        .expect_err("append should reject column-mapped tables");
+    assert_unsupported_column_mapping_write(&err, "WRITE");
+    assert_eq!(before, collect_data_files(&table_path)?);
+
+    let err = table
+        .write(vec![column_mapping_batch()])
+        .with_save_mode(SaveMode::Overwrite)
+        .await
+        .expect_err("overwrite should reject column-mapped tables");
+    assert_unsupported_column_mapping_write(&err, "WRITE");
+    assert_eq!(before, collect_data_files(&table_path)?);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn column_mapping_guardrails_legacy_writers_reject() -> TestResult {
+    let (_temp_dir, _table_path, table) = copied_column_mapping_table().await?;
+
+    let err = RecordBatchWriter::for_table(&table)
+        .expect_err("record batch writer should reject column-mapped tables");
+    assert_unsupported_column_mapping_write(&err, "RecordBatchWriter");
+
+    let err =
+        JsonWriter::for_table(&table).expect_err("json writer should reject column-mapped tables");
+    assert_unsupported_column_mapping_write(&err, "JsonWriter");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn column_mapping_guardrails_dml_rejects_before_files() -> TestResult {
+    let (_temp_dir, table_path, table) = copied_column_mapping_table().await?;
+    let before = collect_data_files(&table_path)?;
+
+    let err = table
+        .clone()
+        .update()
+        .with_update("Super Name", lit("Updated"))
+        .await
+        .expect_err("update should reject column-mapped tables");
+    assert_unsupported_column_mapping_write(&err, "UPDATE");
+    assert_eq!(before, collect_data_files(&table_path)?);
+
+    let err = table
+        .clone()
+        .delete()
+        .with_predicate(lit(true))
+        .await
+        .expect_err("delete should reject column-mapped tables");
+    assert_unsupported_column_mapping_write(&err, "DELETE");
+    assert_eq!(before, collect_data_files(&table_path)?);
+
+    let ctx = SessionContext::new();
+    let source = ctx.read_batch(column_mapping_batch())?;
+    let err = table
+        .clone()
+        .merge(source, lit(true))
+        .await
+        .expect_err("merge should reject column-mapped tables");
+    assert_unsupported_column_mapping_write(&err, "MERGE");
+    assert_eq!(before, collect_data_files(&table_path)?);
+
+    let err = table
+        .optimize()
+        .await
+        .expect_err("optimize should reject column-mapped tables");
+    assert_unsupported_column_mapping_write(&err, "OPTIMIZE");
+    assert_eq!(before, collect_data_files(&table_path)?);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn column_mapping_guardrails_metadata_operations() -> TestResult {
+    let (_temp_dir, table_path, table) = copied_column_mapping_table().await?;
+    let before = collect_data_files(&table_path)?;
+
+    let err = table
+        .add_columns()
+        .with_fields([StructField::nullable("new_col", DataType::STRING)])
+        .await
+        .expect_err("add column should reject column-mapped tables");
+    assert_unsupported_column_mapping_write(&err, "ADD COLUMN");
+    assert_eq!(before, collect_data_files(&table_path)?);
+
+    let table = simple_table().await?;
+    let err = table
+        .set_tbl_properties()
+        .with_properties(HashMap::from([(
+            "delta.columnMapping.mode".to_string(),
+            "name".to_string(),
+        )]))
+        .await
+        .expect_err("setting column mapping mode should be rejected");
+    assert_unsupported_column_mapping_write(&err, "SET TBLPROPERTIES");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn column_mapping_guardrails_create_rejects_activation_and_reserved_metadata() -> TestResult {
+    let err = DeltaTable::new_in_memory()
+        .create()
+        .with_columns(simple_fields())
+        .with_configuration([("delta.columnMapping.mode", Some("name"))])
+        .await
+        .expect_err("create should reject column mapping mode");
+    assert_unsupported_column_mapping_write(&err, "CREATE TABLE");
+
+    let mapped_field = StructField::nullable("id", DataType::INTEGER).with_metadata([
+        (
+            ColumnMetadataKey::ColumnMappingId.as_ref(),
+            MetadataValue::Number(1),
+        ),
+        (
+            ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+            MetadataValue::String("col-id".to_string()),
+        ),
+    ]);
+
+    let err = DeltaTable::new_in_memory()
+        .create()
+        .with_columns([mapped_field])
+        .await
+        .expect_err("create should reject column mapping metadata");
+    assert_unsupported_column_mapping_write(&err, "CREATE TABLE");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn column_mapping_guardrails_add_feature_still_allows_column_mapping() -> TestResult {
+    simple_table()
+        .await?
+        .add_feature()
+        .with_feature(TableFeatures::ColumnMapping)
+        .with_allow_protocol_versions_increase(true)
+        .await?;
+
+    Ok(())
+}

--- a/crates/core/tests/column_mapping_guardrails.rs
+++ b/crates/core/tests/column_mapping_guardrails.rs
@@ -1,16 +1,9 @@
-#![cfg(feature = "datafusion")]
-
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
-use arrow_array::{RecordBatch, StringArray};
-use arrow_schema::{DataType as ArrowDataType, Field, Schema};
-use datafusion::prelude::{SessionContext, lit};
 use deltalake_core::kernel::{
     ColumnMetadataKey, DataType, MetadataValue, StructField, TableFeatures,
 };
-use deltalake_core::protocol::SaveMode;
 use deltalake_core::writer::{JsonWriter, RecordBatchWriter};
 use deltalake_core::{DeltaTable, DeltaTableError, open_table};
 use tempfile::TempDir;
@@ -30,7 +23,13 @@ fn assert_unsupported_column_mapping_write(err: &DeltaTableError, operation: &st
     );
 }
 
-fn column_mapping_batch() -> RecordBatch {
+#[cfg(feature = "datafusion")]
+fn column_mapping_batch() -> arrow_array::RecordBatch {
+    use std::sync::Arc;
+
+    use arrow_array::{RecordBatch, StringArray};
+    use arrow_schema::{DataType as ArrowDataType, Field, Schema};
+
     let schema = Arc::new(Schema::new(vec![
         Field::new("Company Very Short", ArrowDataType::Utf8, true),
         Field::new("Super Name", ArrowDataType::Utf8, true),
@@ -91,8 +90,11 @@ fn collect_data_files(root: &Path) -> TestResult<BTreeSet<PathBuf>> {
     Ok(files)
 }
 
+#[cfg(feature = "datafusion")]
 #[tokio::test]
 async fn column_mapping_guardrails_write_builder_rejects_before_files() -> TestResult {
+    use deltalake_core::protocol::SaveMode;
+
     let (_temp_dir, table_path, table) = copied_column_mapping_table().await?;
     let before = collect_data_files(&table_path)?;
 
@@ -130,8 +132,11 @@ async fn column_mapping_guardrails_legacy_writers_reject() -> TestResult {
     Ok(())
 }
 
+#[cfg(feature = "datafusion")]
 #[tokio::test]
 async fn column_mapping_guardrails_dml_rejects_before_files() -> TestResult {
+    use datafusion::prelude::{SessionContext, lit};
+
     let (_temp_dir, table_path, table) = copied_column_mapping_table().await?;
     let before = collect_data_files(&table_path)?;
 

--- a/crates/core/tests/column_mapping_guardrails.rs
+++ b/crates/core/tests/column_mapping_guardrails.rs
@@ -119,7 +119,9 @@ async fn column_mapping_guardrails_write_builder_rejects_before_files() -> TestR
 
 #[tokio::test]
 async fn column_mapping_guardrails_legacy_writers_reject() -> TestResult {
-    let (_temp_dir, _table_path, table) = copied_column_mapping_table().await?;
+    let (_temp_dir, table_path, table) = copied_column_mapping_table().await?;
+    let table_url = Url::from_directory_path(table_path.canonicalize()?).unwrap();
+    let arrow_schema = table.snapshot()?.snapshot().arrow_schema();
 
     let err = RecordBatchWriter::for_table(&table)
         .expect_err("record batch writer should reject column-mapped tables");
@@ -127,6 +129,11 @@ async fn column_mapping_guardrails_legacy_writers_reject() -> TestResult {
 
     let err =
         JsonWriter::for_table(&table).expect_err("json writer should reject column-mapped tables");
+    assert_unsupported_column_mapping_write(&err, "JsonWriter");
+
+    let err = JsonWriter::try_new(table_url, arrow_schema, None, None)
+        .await
+        .expect_err("json writer by URI should reject column-mapped tables");
     assert_unsupported_column_mapping_write(&err, "JsonWriter");
 
     Ok(())


### PR DESCRIPTION
## What changed

This PR adds defensive guardrails for Delta tables with `columnMapping.mode` enabled.

Unsupported write and metadata mutation paths now fail fast with a clear error before planning rewrites, writing data files, or committing unsafe metadata changes.

Covered paths:

- `WRITE`
- `CREATE TABLE` with column mapping mode or reserved column mapping metadata
- `ADD COLUMN`
- `SET TBLPROPERTIES delta.columnMapping.mode`
- `UPDATE`
- `DELETE`
- `MERGE`
- `OPTIMIZE`
- legacy `RecordBatchWriter`
- legacy `JsonWriter`

This PR does not enable column-mapped writes and does not add `ColumnMapping` to the global writer protocol support set.

## Why

Column-mapped table support needs to be introduced in smaller, reviewable steps. Before adding append/write support, unsupported paths should have a clear safety boundary so they cannot proceed into logical-schema write code or metadata updates that are not column-mapping aware.

## Validation

```bash
cargo fmt -- --check
make check-rust
make check-python
make develop
make unit-test
cargo test -p deltalake-core --features datafusion --test column_mapping_guardrails -- --nocapture
cargo test -p deltalake-core --features datafusion --lib add_feature -- --nocapture
```

## AI disclosure

I used Codex to help inspect the affected write paths and draft the guardrail tests. I reviewed the resulting changes and validated them locally with the commands above.
