### PR TITLE
fix: reduce duplicate validation memory

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -587,6 +587,7 @@ pub struct TableProviderBuilder {
     snapshot: Option<SnapshotWrapper>,
     session: Option<Arc<dyn Session>>,
     file_column: Option<String>,
+    row_index_column: Option<String>,
     table_version: Option<Version>,
     /// Predicates used only for file skipping in kernel log replay
     file_skipping_predicates: Option<Vec<Expr>>,
@@ -600,6 +601,7 @@ impl fmt::Debug for TableProviderBuilder {
             .field("snapshot", &self.snapshot)
             .field("has_session", &self.session.is_some())
             .field("file_column", &self.file_column)
+            .field("row_index_column", &self.row_index_column)
             .field("table_version", &self.table_version)
             .field("file_skipping_predicates", &self.file_skipping_predicates)
             .field("file_selection", &self.file_selection)
@@ -620,6 +622,7 @@ impl TableProviderBuilder {
             snapshot: None,
             session: None,
             file_column: None,
+            row_index_column: None,
             table_version: None,
             file_skipping_predicates: None,
             file_selection: None,
@@ -668,6 +671,12 @@ impl TableProviderBuilder {
         self
     }
 
+    /// Add a row index column to scan output.
+    pub(crate) fn with_row_index_column(mut self, row_index_column: impl ToString) -> Self {
+        self.row_index_column = Some(row_index_column.to_string());
+        self
+    }
+
     /// Add predicates applied only during file skipping.
     ///
     /// There are cases where we may want to skip files that definitely do
@@ -697,6 +706,7 @@ impl TableProviderBuilder {
             snapshot,
             session,
             file_column,
+            row_index_column,
             table_version,
             file_skipping_predicates,
             file_selection,
@@ -745,6 +755,9 @@ impl TableProviderBuilder {
         }
 
         let mut provider = next::DeltaScan::new(snapshot, config)?;
+        if let Some(row_index_column) = row_index_column {
+            provider = provider.with_row_index_column(row_index_column)?;
+        }
         if let Some(log_store) = log_store {
             provider = provider.with_log_store(log_store);
         }

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -29,7 +29,7 @@ use std::any::Any;
 use std::collections::HashSet;
 use std::{borrow::Cow, sync::Arc};
 
-use arrow::datatypes::{Schema, SchemaRef};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::{TableType, sink::DataSinkExec};
 use datafusion::logical_expr::{TableProviderFilterPushDown, dml::InsertOp};
@@ -277,6 +277,7 @@ pub struct DeltaScan {
     scan_schema: SchemaRef,
     /// Provider/public schema, including configured file id capability when enabled.
     full_schema: SchemaRef,
+    row_index_column: Option<String>,
     #[serde(skip)]
     file_skipping_predicate: Option<Vec<Expr>>,
     #[serde(skip)]
@@ -316,6 +317,7 @@ impl DeltaScan {
             config,
             scan_schema,
             full_schema,
+            row_index_column: None,
             file_skipping_predicate: None,
             log_store: None,
             read_operation_id: None,
@@ -334,6 +336,25 @@ impl DeltaScan {
     pub(crate) fn with_file_selection(mut self, selection: FileSelection) -> Self {
         self.file_selection = Some(selection);
         self
+    }
+
+    pub(crate) fn with_row_index_column(mut self, column: impl ToString) -> Result<Self> {
+        let column = column.to_string();
+        if self.full_schema.field_with_name(&column).is_ok() {
+            return Err(DataFusionError::Plan(format!(
+                "DeltaScan row index column '{column}' conflicts with an existing scan column"
+            )));
+        }
+
+        let mut fields = self.full_schema.fields().to_vec();
+        fields.push(Arc::new(Field::new(
+            column.clone(),
+            DataType::UInt64,
+            false,
+        )));
+        self.full_schema = Arc::new(Schema::new(fields));
+        self.row_index_column = Some(column);
+        Ok(self)
     }
 
     /// Restrict reads to the provided add actions by normalizing them into a
@@ -461,6 +482,7 @@ impl TableProvider for DeltaScan {
             self.scan_schema.clone(),
             self.full_schema.clone(),
             &self.config,
+            self.row_index_column.as_deref(),
             projection,
             filters,
         )?;

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -11,9 +11,9 @@ use std::task::{Context, Poll};
 
 use arrow::array::{RecordBatch, StringArray};
 use arrow::compute::filter_record_batch;
-use arrow::datatypes::{SchemaRef, UInt16Type};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, UInt16Type};
 use arrow_array::StringViewArray;
-use arrow_array::{Array, BooleanArray};
+use arrow_array::{Array, ArrayRef, BooleanArray, UInt64Array};
 use dashmap::DashMap;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::error::{DataFusionError, Result};
@@ -118,6 +118,8 @@ pub struct DeltaScanExec {
     input_file_id_column: String,
     /// User-visible file-id column name when projected in the output.
     file_id_column: Option<String>,
+    /// Row index column name visible in projected output.
+    row_index_column: Option<String>,
     /// plan properties
     properties: Arc<PlanProperties>,
     /// Aggregated partition column statistics
@@ -134,6 +136,9 @@ impl DisplayAs for DeltaScanExec {
                 write!(f, "DeltaScanExec")?;
                 if let Some(file_id_column) = &self.file_id_column {
                     write!(f, ": file_id_column={file_id_column}")?;
+                }
+                if let Some(row_index_column) = &self.row_index_column {
+                    write!(f, ": row_index_column={row_index_column}")?;
                 }
                 Ok(())
             }
@@ -155,7 +160,17 @@ impl DeltaScanExec {
             .contract
             .retain_file_id
             .then(|| scan_plan.contract.file_id_field.name().to_owned());
-        let output_schema = scan_plan.effective_schema(file_id_column.is_some());
+        let row_index_column = scan_plan.contract.retain_row_index.then(|| {
+            scan_plan
+                .contract
+                .row_index_field
+                .as_ref()
+                .expect("row index field")
+                .name()
+                .to_owned()
+        });
+        let output_schema =
+            scan_plan.effective_schema(file_id_column.is_some(), row_index_column.is_some());
         let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema),
             input.properties().partitioning.clone(),
@@ -171,6 +186,7 @@ impl DeltaScanExec {
             metrics,
             input_file_id_column,
             file_id_column,
+            row_index_column,
             properties,
         }
     }
@@ -279,6 +295,12 @@ impl ExecutionPlan for DeltaScanExec {
         target_partitions: usize,
         config: &ConfigOptions,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        if self.row_index_column.is_some() {
+            // DeltaScanStream stores row ordinal counters per execution partition. Repartitioning
+            // can split a file's rows across streams and break ordinal contiguity.
+            return Ok(None);
+        }
+
         if let Some(input) = self.input.repartitioned(target_partitions, config)? {
             Ok(Some(Arc::new(Self {
                 input,
@@ -303,6 +325,8 @@ impl ExecutionPlan for DeltaScanExec {
             selection_vectors: Arc::clone(&self.selection_vectors),
             input_file_id_column: self.input_file_id_column.clone(),
             file_id_column: self.file_id_column.clone(),
+            row_index_column: self.row_index_column.clone(),
+            row_index_by_file: HashMap::new(),
             pending: VecDeque::new(),
             schema_adapter: super::SchemaAdapter::new(Arc::clone(
                 &self.scan_plan.contract.result_schema,
@@ -411,6 +435,13 @@ struct DeltaScanStream {
     input_file_id_column: String,
     /// User-visible file-id column name when projected in the output.
     file_id_column: Option<String>,
+    /// Row index column name visible in projected output.
+    row_index_column: Option<String>,
+    /// Per file ordinal state for this execution partition.
+    ///
+    /// `DataSourceExec` assigns whole `PartitionedFile`s to file groups. Each physical file has
+    /// one scan stream partition owner.
+    row_index_by_file: HashMap<String, u64>,
     pending: VecDeque<RecordBatch>,
     /// Cached schema adapter for efficient batch adaptation across batches
     schema_adapter: super::SchemaAdapter,
@@ -481,7 +512,7 @@ impl DeltaScanStream {
             batch
         };
 
-        if let Some(file_id_column) = &self.file_id_column {
+        let result = if let Some(file_id_column) = &self.file_id_column {
             super::finalize_transformed_batch(
                 result,
                 &self.scan_plan,
@@ -495,7 +526,50 @@ impl DeltaScanStream {
                 None,
                 &mut self.schema_adapter,
             )
-        }
+        }?;
+
+        self.append_row_index(result, &file_id)
+    }
+
+    fn append_row_index(&mut self, batch: RecordBatch, file_id: &str) -> Result<RecordBatch> {
+        let Some(row_index_column) = self.row_index_column.clone() else {
+            return Ok(batch);
+        };
+
+        let row_count = u64::try_from(batch.num_rows()).map_err(|_| {
+            internal_datafusion_err!("batch row count does not fit u64 while assigning row indexes")
+        })?;
+        let next_row_index = self
+            .row_index_by_file
+            .entry(file_id.to_string())
+            .or_default();
+        let end = next_row_index.checked_add(row_count).ok_or_else(|| {
+            internal_datafusion_err!(
+                "row index overflow while assigning row indexes for file '{file_id}'"
+            )
+        })?;
+
+        let values = if row_count == 0 {
+            Vec::new()
+        } else {
+            ((*next_row_index + 1)..=end).collect()
+        };
+        *next_row_index = end;
+
+        let row_index: ArrayRef = Arc::new(UInt64Array::from(values));
+        let mut columns = batch.columns().to_vec();
+        columns.push(row_index);
+        let mut fields = batch.schema().fields().to_vec();
+        fields.push(Arc::new(Field::new(
+            row_index_column,
+            DataType::UInt64,
+            false,
+        )));
+
+        Ok(RecordBatch::try_new(
+            Arc::new(Schema::new(fields)),
+            columns,
+        )?)
     }
 }
 
@@ -542,8 +616,10 @@ impl Stream for DeltaScanStream {
 
 impl RecordBatchStream for DeltaScanStream {
     fn schema(&self) -> SchemaRef {
-        self.scan_plan
-            .effective_schema(self.file_id_column.is_some())
+        self.scan_plan.effective_schema(
+            self.file_id_column.is_some(),
+            self.row_index_column.is_some(),
+        )
     }
 }
 
@@ -655,7 +731,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::array::AsArray;
-    use arrow::datatypes::DataType;
+    use arrow::datatypes::{DataType, UInt64Type};
     use arrow_array::Array;
     use arrow_array::ArrayAccessor;
     use datafusion::{
@@ -1308,6 +1384,34 @@ mod tests {
         Ok((kernel_type, Arc::new(scan_plan)))
     }
 
+    async fn int32_scan_plan() -> TestResult<(KernelDataType, Arc<KernelScanPlan>)> {
+        use arrow::datatypes::{Field, Schema};
+
+        let table = TestTables::Simple.table_builder()?.load().await?;
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .as_any()
+            .downcast_ref::<DeltaScanExec>()
+            .expect("Expected DeltaScanExec");
+
+        let kernel_type = Arc::clone(exec.scan_plan.scan.logical_schema()).into();
+
+        let mut scan_plan = exec.scan_plan.as_ref().clone();
+        scan_plan.contract.result_schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int32,
+            false,
+        )]));
+        scan_plan.contract.output_schema = Arc::clone(&scan_plan.contract.result_schema);
+        scan_plan.contract.result_projection = None;
+        scan_plan.parquet_read_schema = Arc::clone(&scan_plan.contract.result_schema);
+
+        Ok((kernel_type, Arc::new(scan_plan)))
+    }
+
     fn selection_vectors_f1_f2() -> Arc<DashMap<String, Vec<bool>>> {
         let selection_vectors: Arc<DashMap<String, Vec<bool>>> = Arc::new(DashMap::new());
         selection_vectors.insert("f1".to_string(), vec![true, false]);
@@ -1384,9 +1488,72 @@ mod tests {
             selection_vectors,
             input_file_id_column,
             file_id_column,
+            row_index_column: None,
+            row_index_by_file: HashMap::new(),
             pending: VecDeque::new(),
             schema_adapter,
         }
+    }
+
+    fn row_ordinals(batch: &RecordBatch, column: &str) -> Vec<u64> {
+        batch
+            .column_by_name(column)
+            .expect("row ordinal column")
+            .as_primitive::<UInt64Type>()
+            .values()
+            .to_vec()
+    }
+
+    #[tokio::test]
+    async fn test_batch_project_resets_row_ordinals_per_file() -> TestResult {
+        let (kernel_type, scan_plan) = int32_scan_plan().await?;
+        let batch = value_and_file_id_batch(
+            &[10, 11, 20, 21],
+            &[Some("f1"), Some("f1"), Some("f2"), Some("f2")],
+            false,
+        )?;
+
+        let mut stream = test_scan_stream(
+            scan_plan,
+            kernel_type,
+            Arc::new(DashMap::new()),
+            Vec::new(),
+            None,
+        );
+        stream.row_index_column = Some("row_ordinal".to_string());
+
+        let outputs = stream.batch_project(batch)?;
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(row_ordinals(&outputs[0], "row_ordinal"), vec![1, 2]);
+        assert_eq!(row_ordinals(&outputs[1], "row_ordinal"), vec![1, 2]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_poll_next_continues_row_ordinals_across_batches_for_same_file() -> TestResult {
+        use futures::StreamExt;
+
+        let (kernel_type, scan_plan) = int32_scan_plan().await?;
+        let first = value_and_file_id_batch(&[10, 11], &[Some("f1"), Some("f1")], false)?;
+        let second = value_and_file_id_batch(&[12, 13], &[Some("f1"), Some("f1")], false)?;
+
+        let mut stream = test_scan_stream(
+            scan_plan,
+            kernel_type,
+            Arc::new(DashMap::new()),
+            vec![first, second],
+            None,
+        );
+        stream.row_index_column = Some("row_ordinal".to_string());
+
+        let batch1 = stream.next().await.transpose()?.expect("first batch");
+        let batch2 = stream.next().await.transpose()?.expect("second batch");
+        assert!(stream.next().await.is_none());
+        assert_eq!(row_ordinals(&batch1, "row_ordinal"), vec![1, 2]);
+        assert_eq!(row_ordinals(&batch2, "row_ordinal"), vec![3, 4]);
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -104,11 +104,11 @@ impl DisplayAs for DeltaScanMetaExec {
 impl DeltaScanMetaExec {
     fn make_properties(
         scan_plan: &KernelScanPlan,
-        include_file_id: bool,
         partition_count: usize,
+        include_file_id: bool,
     ) -> PlanProperties {
         PlanProperties::new(
-            EquivalenceProperties::new(scan_plan.effective_schema(include_file_id)),
+            EquivalenceProperties::new(scan_plan.effective_schema(include_file_id, false)),
             Partitioning::UnknownPartitioning(partition_count),
             EmissionType::Incremental,
             Boundedness::Bounded,
@@ -123,10 +123,11 @@ impl DeltaScanMetaExec {
         file_id_field: Option<FieldRef>,
         metrics: ExecutionPlanMetricsSet,
     ) -> Self {
+        let include_file_id = file_id_field.is_some();
         let properties = Arc::new(Self::make_properties(
             scan_plan.as_ref(),
-            file_id_field.is_some(),
             input.len(),
+            include_file_id,
         ));
         Self {
             scan_plan,
@@ -234,8 +235,8 @@ impl ExecutionPlan for DeltaScanMetaExec {
             .collect();
         let properties = Arc::new(Self::make_properties(
             self.scan_plan.as_ref(),
-            self.file_id_field.is_some(),
             new_input.len(),
+            self.file_id_field.is_some(),
         ));
 
         Ok(Some(Arc::new(Self {
@@ -486,7 +487,7 @@ impl Stream for DeltaScanMetaStream {
 impl RecordBatchStream for DeltaScanMetaStream {
     fn schema(&self) -> SchemaRef {
         self.scan_plan
-            .effective_schema(self.file_id_field.is_some())
+            .effective_schema(self.file_id_field.is_some(), false)
     }
 }
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -90,7 +90,7 @@ pub(super) async fn execution_plan(
         replay_files(engine, &scan_plan, config.clone(), stream, file_selection).await?;
 
     let file_id_field = scan_plan.contract.file_id_field.clone();
-    if scan_plan.is_metadata_only() {
+    if scan_plan.is_metadata_only() && !scan_plan.contract.retain_row_index {
         let map_file = |f: &ScanFileContext| {
             Ok((
                 f.file_url.to_string(),
@@ -412,17 +412,43 @@ const MAX_PARTITION_DICT_CARDINALITY: usize = (u16::MAX as usize) + 1;
 fn partitioned_files_to_file_groups(
     files: impl IntoIterator<Item = PartitionedFile>,
 ) -> Vec<FileGroup> {
-    let max_files_per_group = MAX_PARTITION_DICT_CARDINALITY;
+    partitioned_files_to_file_groups_with_limit(files, MAX_PARTITION_DICT_CARDINALITY)
+}
 
-    files
+fn partitioned_files_to_file_groups_with_limit(
+    files: impl IntoIterator<Item = PartitionedFile>,
+    max_files_per_group: usize,
+) -> Vec<FileGroup> {
+    let file_groups = files
         .into_iter()
+        // Each `PartitionedFile` is assigned to exactly one file group. DeltaScanStream stores
+        // row ordinal counters per execution partition. Whole file ownership is required for
+        // scan row ordinals.
         // Partition values are dictionary encoded using a UInt16 key (DataFusion's default
         // `wrap_partition_type_in_dict`). Keep file groups small enough that the file-id partition
         // dictionary doesn't exceed the key space (one distinct value per file).
         .chunks(max_files_per_group)
         .into_iter()
-        .map(|chunk| chunk.collect())
-        .collect()
+        .map(|chunk| chunk.collect::<FileGroup>())
+        .collect_vec();
+
+    #[cfg(debug_assertions)]
+    {
+        let mut owner_by_path = HashMap::new();
+        for (partition, group) in file_groups.iter().enumerate() {
+            for file in group.iter() {
+                let path = file.object_meta.location.to_string();
+                if let Some(previous_partition) = owner_by_path.insert(path.clone(), partition) {
+                    debug_assert_eq!(
+                        previous_partition, partition,
+                        "file {path} was assigned to multiple scan partitions; row indexes require whole file ownership"
+                    );
+                }
+            }
+        }
+    }
+
+    file_groups
 }
 
 async fn get_read_plan(
@@ -654,6 +680,19 @@ mod tests {
         assert_eq!(groups.len(), 2);
         assert_eq!(groups[0].len(), MAX_PARTITION_DICT_CARDINALITY);
         assert_eq!(groups[1].len(), 1);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "row indexes require whole file ownership")]
+    fn test_partitioned_files_to_file_groups_rejects_split_file_across_groups_in_debug() {
+        let files = vec![
+            PartitionedFile::new("memory:///same.parquet", 0),
+            PartitionedFile::new("memory:///other.parquet", 0),
+            PartitionedFile::new("memory:///same.parquet", 0),
+        ];
+
+        let _ = partitioned_files_to_file_groups_with_limit(files, 1);
     }
 
     #[test]

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
@@ -16,7 +16,7 @@
 use std::sync::Arc;
 
 use arrow::datatypes::{Schema, SchemaRef};
-use arrow_schema::{DataType, FieldRef, SchemaBuilder};
+use arrow_schema::{DataType, Field, FieldRef, SchemaBuilder};
 use datafusion::common::error::Result;
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::common::{HashMap, HashSet, plan_err};
@@ -61,6 +61,10 @@ pub(crate) struct ProjectedScanContract {
     pub(crate) file_id_field: FieldRef,
     /// Whether the scan must preserve file-id in its output for projection or filter semantics.
     pub(crate) retain_file_id: bool,
+    /// Row index field produced by the scan.
+    pub(crate) row_index_field: Option<FieldRef>,
+    /// Whether scan output includes row index.
+    pub(crate) retain_row_index: bool,
 }
 
 impl ProjectedScanContract {
@@ -68,6 +72,7 @@ impl ProjectedScanContract {
         table_schema: SchemaRef,
         provider_schema: SchemaRef,
         config: &DeltaScanConfig,
+        row_index_column: Option<&str>,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
     ) -> Result<Self> {
@@ -86,6 +91,19 @@ impl ProjectedScanContract {
             false
         };
 
+        let row_index_field = row_index_column
+            .map(|name| Arc::new(Field::new(name, DataType::UInt64, false)) as FieldRef);
+        let row_index_idx = row_index_column.and_then(|name| provider_schema.index_of(name).ok());
+
+        let query_projects_row_index = if let Some(row_index_idx) = row_index_idx {
+            match projection {
+                None => true,
+                Some(projection) => projection.iter().any(|idx| *idx == row_index_idx),
+            }
+        } else {
+            false
+        };
+
         let filters_reference_file_id = provider_exposes_file_id
             && filters.iter().any(|filter| {
                 filter
@@ -95,11 +113,21 @@ impl ProjectedScanContract {
             });
         let retain_file_id =
             provider_exposes_file_id && (query_projects_file_id || filters_reference_file_id);
+        let filters_reference_row_index = row_index_column.is_some_and(|row_index_column| {
+            filters.iter().any(|filter| {
+                filter
+                    .column_refs()
+                    .iter()
+                    .any(|column| column.name == row_index_column)
+            })
+        });
+        let retain_row_index =
+            row_index_field.is_some() && (query_projects_row_index || filters_reference_row_index);
 
         let requested_data_projection = projection.map(|projection| {
             projection
                 .iter()
-                .filter(|&&idx| Some(idx) != file_id_idx)
+                .filter(|&&idx| Some(idx) != file_id_idx && Some(idx) != row_index_idx)
                 .copied()
                 .collect_vec()
         });
@@ -120,7 +148,10 @@ impl ProjectedScanContract {
             .collect();
         let missing_columns: Vec<_> = columns_in_filters
             .difference(&columns_in_result)
-            .filter(|column| column.as_str() != file_id_field.name().as_str())
+            .filter(|column| {
+                column.as_str() != file_id_field.name().as_str()
+                    && row_index_column != Some(column.as_str())
+            })
             .cloned()
             .sorted()
             .collect();
@@ -149,6 +180,13 @@ impl ProjectedScanContract {
         let output_schema = if retain_file_id {
             let mut schema_builder = SchemaBuilder::from(result_schema.as_ref());
             schema_builder.push(file_id_field.clone());
+            if retain_row_index {
+                schema_builder.push(row_index_field.as_ref().expect("row index field").clone());
+            }
+            Arc::new(schema_builder.finish())
+        } else if retain_row_index {
+            let mut schema_builder = SchemaBuilder::from(result_schema.as_ref());
+            schema_builder.push(row_index_field.as_ref().expect("row index field").clone());
             Arc::new(schema_builder.finish())
         } else {
             result_schema.clone()
@@ -162,6 +200,8 @@ impl ProjectedScanContract {
             result_projection,
             file_id_field,
             retain_file_id,
+            row_index_field,
+            retain_row_index,
         })
     }
 }
@@ -206,6 +246,7 @@ impl KernelScanPlan {
             table_schema,
             provider_schema,
             config,
+            None,
             projection,
             filters,
         )?;
@@ -286,9 +327,12 @@ impl KernelScanPlan {
         self.scan.snapshot().table_configuration()
     }
 
-    // Scan output schema depends on whether execution must preserve file id for this request.
-    pub(crate) fn effective_schema(&self, include_file_id: bool) -> SchemaRef {
-        if include_file_id {
+    pub(crate) fn effective_schema(
+        &self,
+        include_file_id: bool,
+        include_row_index: bool,
+    ) -> SchemaRef {
+        if include_file_id || include_row_index {
             self.contract.output_schema.clone()
         } else {
             self.contract.result_schema.clone()
@@ -1000,6 +1044,7 @@ mod tests {
             table_schema,
             provider_schema,
             &config,
+            None,
             Some(&projection),
             &[],
         )?;
@@ -1047,6 +1092,7 @@ mod tests {
             table_schema,
             provider_schema,
             &config,
+            None,
             Some(&projection),
             &filters,
         )?;
@@ -1097,6 +1143,7 @@ mod tests {
             table_schema,
             provider_schema,
             &config,
+            None,
             Some(&projection),
             &filters,
         )?;

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -29,7 +29,7 @@
 //! ````
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::ops::{Deref, Not};
+use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -43,12 +43,11 @@ use datafusion::common::{
 use datafusion::datasource::provider_as_source;
 use datafusion::error::Result as DataFusionResult;
 use datafusion::execution::session_state::SessionStateBuilder;
-use datafusion::functions_window::expr_fn::row_number;
 use datafusion::logical_expr::build_join_schema;
 use datafusion::logical_expr::simplify::SimplifyContext;
 use datafusion::logical_expr::utils::split_conjunction_owned;
 use datafusion::logical_expr::{
-    Expr, ExprFunctionExt, JoinType, col, conditional_expressions::CaseBuilder, lit, when,
+    Expr, JoinType, col, conditional_expressions::CaseBuilder, lit, when,
 };
 use datafusion::logical_expr::{
     Extension, LogicalPlan, LogicalPlanBuilder, UNNAMED_TABLE, UserDefinedLogicalNode,
@@ -72,7 +71,9 @@ use tracing::*;
 use uuid::Uuid;
 
 use self::barrier::{MergeBarrier, MergeBarrierExec};
-use self::validation::{MergeValidation, MergeValidationExec};
+use self::validation::{
+    MergeValidation, MergeValidationExec, build_duplicate_match_validation_plan,
+};
 use super::{CustomExecuteHandler, Operation};
 use crate::delta_datafusion::expr::fmt_expr_to_sql;
 use crate::delta_datafusion::logical::MetricObserver;
@@ -111,7 +112,6 @@ const TARGET_COLUMN: &str = "__delta_rs_target";
 const OPERATION_COLUMN: &str = "__delta_rs_operation";
 const DELETE_COLUMN: &str = "__delta_rs_delete";
 const TARGET_ROW_ORDINAL_IN_FILE_COLUMN: &str = "__delta_rs_target_row_ordinal_in_file";
-const TARGET_MATCH_ROW_RANK_COLUMN: &str = "__delta_rs_target_match_row_rank";
 pub(crate) const TARGET_INSERT_COLUMN: &str = "__delta_rs_target_insert";
 pub(crate) const TARGET_UPDATE_COLUMN: &str = "__delta_rs_target_update";
 pub(crate) const TARGET_DELETE_COLUMN: &str = "__delta_rs_target_delete";
@@ -543,8 +543,8 @@ enum OperationType {
     Copy,
 }
 
-// This enum models whether a matched source/target pair participated in a duplicate relevant
-// WHEN MATCHED clause, not the final write path operation chosen for the row.
+// Records whether a matched pair entered duplicate validation, not the final write path operation
+// chosen for the row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
 enum MatchParticipationClass {
@@ -807,6 +807,11 @@ impl ExtensionPlanner for MergeMetricExtensionPlanner {
     }
 }
 
+const DUPLICATE_MATCH_MARKER_COLUMNS: &[&str] = &[
+    TARGET_ROW_ORDINAL_IN_FILE_COLUMN,
+    TARGET_MATCH_CARDINALITY_CLASS_COLUMN,
+];
+
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, fields(operation = "merge", version = snapshot.version(), table_uri = %log_store.root_url()))]
 async fn execute(
@@ -965,6 +970,7 @@ async fn execute(
     // Apply the early filter only to file skipping.
     let file_skipping_predicates =
         build_file_skipping_predicates(target_subset_filter, target_alias.as_deref());
+    let needs_duplicate_match_validation = !match_operations.is_empty();
 
     let target_provider = {
         let mut builder = DeltaScanNext::builder()
@@ -972,6 +978,10 @@ async fn execute(
             .with_log_store(log_store.clone())
             .with_session(state.clone().into())
             .with_file_column(file_column.as_str());
+
+        if needs_duplicate_match_validation {
+            builder = builder.with_row_index_column(TARGET_ROW_ORDINAL_IN_FILE_COLUMN);
+        }
 
         if !file_skipping_predicates.is_empty() {
             builder = builder.with_file_skipping_predicates(file_skipping_predicates);
@@ -996,12 +1006,6 @@ async fn execute(
         }),
     });
     let target = DataFrame::new(state.clone(), target);
-    let target = target.with_column(
-        TARGET_ROW_ORDINAL_IN_FILE_COLUMN,
-        row_number()
-            .partition_by(vec![col(file_column.as_str())])
-            .build()?,
-    )?;
     let target = target.with_column(TARGET_COLUMN, lit(true))?;
 
     let join = source.join(target, JoinType::Full, &[], &[], Some(predicate.clone()))?;
@@ -1201,6 +1205,8 @@ async fn execute(
     let projection = join.with_column(OPERATION_COLUMN, case)?;
 
     let mut new_columns = vec![];
+    let mut merge_value_column_names = Vec::new();
+    let mut cdc_target_preimage_column_names = Vec::new();
 
     let mut write_projection = Vec::new();
     let mut write_projection_with_cdf = Vec::new();
@@ -1272,11 +1278,24 @@ async fn execute(
         .end()?;
 
         let name = "__delta_rs_c_".to_owned() + delta_field.name();
+        merge_value_column_names.push(name.clone());
 
         write_projection.push(cast(
             Expr::Column(Column::from_name(name.clone())).alias(delta_field.name()),
             cast_type.clone(),
         ));
+
+        let cdc_target_preimage_name = "__delta_rs_target_c_".to_owned() + delta_field.name();
+        let cdc_target_preimage = null_target_column.clone().unwrap_or_else(|| {
+            cast(
+                Expr::Column(Column::new(qualifier.clone(), delta_field.name())),
+                cast_type.clone(),
+            )
+        });
+        if should_cdc {
+            cdc_target_preimage_column_names.push(cdc_target_preimage_name.clone());
+            new_columns.push((cdc_target_preimage_name.clone(), cdc_target_preimage));
+        }
 
         write_projection_with_cdf.push(
             when(
@@ -1286,10 +1305,10 @@ async fn execute(
                     cast_type.clone(),
                 ),
             )
-            .otherwise(null_target_column.unwrap_or(cast(
-                Expr::Column(Column::new(qualifier, delta_field.name())),
+            .otherwise(cast(
+                Expr::Column(Column::from_name(cdc_target_preimage_name)),
                 cast_type,
-            )))? // We take the column from target table but in case of schema evolution we assign the column as null
+            ))?
             .alias(delta_field.name()),
         );
         new_columns.push((name, case));
@@ -1405,54 +1424,42 @@ async fn execute(
         LogicalPlanBuilder::from(plan).project(fields)?.build()?
     };
 
-    let new_columns = if !match_operations.is_empty() {
-        let mut cardinality_when = Vec::with_capacity(ops.len());
-        let mut cardinality_then = Vec::with_capacity(ops.len());
-
-        for (idx, (_, _, cardinality_class)) in ops.iter().enumerate() {
-            cardinality_when.push(lit(idx as i32));
-            cardinality_then.push(lit(*cardinality_class as i32));
+    // Limit the merge output to columns used by duplicate validation and CDC.
+    // Later projections only need internal merge columns.
+    let new_columns = {
+        let mut fields = vec![
+            col(file_column.as_str()),
+            col(SOURCE_COLUMN),
+            col(TARGET_COLUMN),
+            col(OPERATION_COLUMN),
+            col(DELETE_COLUMN),
+            col(TARGET_INSERT_COLUMN),
+            col(TARGET_UPDATE_COLUMN),
+            col(TARGET_DELETE_COLUMN),
+            col(TARGET_COPY_COLUMN),
+        ];
+        if needs_duplicate_match_validation {
+            fields.push(col(TARGET_ROW_ORDINAL_IN_FILE_COLUMN));
         }
 
-        let cardinality_class = CaseBuilder::new(
-            Some(Box::new(col(OPERATION_COLUMN))),
-            cardinality_when,
-            cardinality_then,
-            Some(Box::new(lit(0))),
-        )
-        .end()?;
+        fields.extend(
+            merge_value_column_names
+                .iter()
+                .map(|name| Expr::Column(Column::from_name(name.clone()))),
+        );
+        fields.extend(
+            cdc_target_preimage_column_names
+                .iter()
+                .map(|name| Expr::Column(Column::from_name(name.clone()))),
+        );
 
-        let match_row_rank = row_number()
-            .partition_by(vec![
-                col(file_column.as_str()),
-                col(TARGET_ROW_ORDINAL_IN_FILE_COLUMN),
-            ])
-            .order_by(vec![
-                col(TARGET_MATCH_CARDINALITY_CLASS_COLUMN).sort(false, false),
-            ])
-            .build()?;
+        LogicalPlanBuilder::from(new_columns)
+            .project(fields)?
+            .build()?
+    };
 
-        let new_columns = DataFrame::new(state.clone(), new_columns)
-            .with_column(TARGET_MATCH_CARDINALITY_CLASS_COLUMN, cardinality_class)?
-            .with_column(TARGET_MATCH_ROW_RANK_COLUMN, match_row_rank)?
-            .into_unoptimized_plan();
-
-        let validated = LogicalPlan::Extension(Extension {
-            node: Arc::new(MergeValidation {
-                input: new_columns,
-                file_expr: col(file_column.as_str()),
-                file_column: Arc::clone(&file_column),
-                row_ordinal_column: Arc::new(TARGET_ROW_ORDINAL_IN_FILE_COLUMN.to_string()),
-            }),
-        });
-
-        DataFrame::new(state.clone(), validated)
-            .filter(
-                matched
-                    .and(col(TARGET_MATCH_ROW_RANK_COLUMN).gt(lit(1_u64)))
-                    .not(),
-            )?
-            .into_unoptimized_plan()
+    let new_columns = if !match_operations.is_empty() {
+        build_duplicate_match_validation_plan(new_columns, &state, &ops, Arc::clone(&file_column))?
     } else {
         new_columns
     };
@@ -1873,14 +1880,16 @@ mod tests {
     use dashmap::DashSet;
     use datafusion::assert_batches_sorted_eq;
     use datafusion::common::{Column, ScalarValue, TableReference, ToDFSchema};
+    use datafusion::datasource::provider_as_source;
     use datafusion::logical_expr::Expr;
     use datafusion::logical_expr::col;
     use datafusion::logical_expr::expr::BinaryExpr;
     use datafusion::logical_expr::expr::Placeholder;
     use datafusion::logical_expr::lit;
-    use datafusion::physical_plan::collect;
+    use datafusion::logical_expr::{Extension, LogicalPlan, LogicalPlanBuilder};
     use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
     use datafusion::physical_plan::metrics::MetricBuilder;
+    use datafusion::physical_plan::{collect, displayable};
     use datafusion::prelude::*;
     use delta_kernel::engine::arrow_conversion::TryIntoKernel;
     use delta_kernel::schema::StructType;
@@ -1888,13 +1897,23 @@ mod tests {
     use pretty_assertions::assert_eq;
     use regex::Regex;
     use serde_json::json;
+    use std::collections::HashMap;
     use std::ops::Neg;
     use std::sync::Arc;
     use url::Url;
 
-    use crate::delta_datafusion::{DataFusionMixins, PATH_COLUMN, resolve_file_column_name};
+    use crate::delta_datafusion::{
+        DataFusionMixins, DeltaScanNext, PATH_COLUMN, resolve_file_column_name,
+    };
 
-    use super::MergeMetrics;
+    use super::validation::MergeValidation;
+    use super::{
+        DELETE_COLUMN, MatchParticipationClass, MergeMetrics, OPERATION_COLUMN, OperationType,
+        SOURCE_COLUMN, TARGET_COLUMN, TARGET_COPY_COLUMN, TARGET_DELETE_COLUMN,
+        TARGET_INSERT_COLUMN, TARGET_MATCH_CARDINALITY_CLASS_COLUMN,
+        TARGET_ROW_ORDINAL_IN_FILE_COLUMN, TARGET_UPDATE_COLUMN,
+        build_duplicate_match_validation_plan,
+    };
 
     pub(crate) async fn setup_table(partitions: Option<Vec<&str>>) -> DeltaTable {
         let table_schema = get_delta_schema();
@@ -2106,6 +2125,108 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_duplicate_match_validation_plan_drops_validation_marker_columns() {
+        let input = duplicate_match_validation_input_plan();
+        let ops = vec![
+            (
+                HashMap::new(),
+                OperationType::Update,
+                MatchParticipationClass::MatchedAction,
+            ),
+            (
+                HashMap::new(),
+                OperationType::Copy,
+                MatchParticipationClass::MatchedNoop,
+            ),
+            (
+                HashMap::new(),
+                OperationType::Copy,
+                MatchParticipationClass::Ignore,
+            ),
+        ];
+        let state = SessionContext::new().state();
+
+        let plan = build_duplicate_match_validation_plan(
+            input,
+            &state,
+            &ops,
+            Arc::new(PATH_COLUMN.to_string()),
+        )
+        .expect("duplicate validation plan builds");
+
+        let validation = find_merge_validation(&plan).expect("plan contains validation");
+        let validation_input = format!("{}", validation.input.display_indent());
+        assert!(
+            validation_input.contains(TARGET_MATCH_CARDINALITY_CLASS_COLUMN),
+            "validation input includes cardinality before marker columns are projected away: {validation_input}"
+        );
+        assert_eq!(
+            count_unions(&validation.input),
+            0,
+            "validation input remains one upstream plan"
+        );
+        assert_eq!(
+            count_unions(&plan),
+            0,
+            "duplicate validation does not duplicate the upstream merge input"
+        );
+        assert!(
+            !format!("{plan:?}").contains("Window"),
+            "duplicate validation deduplicates in MergeValidationStream without a rank window"
+        );
+
+        let field_names = plan
+            .schema()
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect::<Vec<_>>();
+        assert!(!field_names.contains(&TARGET_ROW_ORDINAL_IN_FILE_COLUMN));
+        assert!(!field_names.contains(&TARGET_MATCH_CARDINALITY_CLASS_COLUMN));
+    }
+
+    #[tokio::test]
+    async fn test_target_row_ordinal_scan_plan_has_no_window_or_sort() {
+        let schema = get_arrow_schema(&None);
+        let table = setup_table(None).await;
+        let table = write_data(table, &schema).await;
+        let state = SessionContext::new().state();
+
+        let target_provider = provider_as_source(
+            DeltaScanNext::builder()
+                .with_eager_snapshot(table.snapshot().unwrap().snapshot().clone())
+                .with_log_store(table.log_store.clone())
+                .with_session(state.clone().into())
+                .with_file_column(PATH_COLUMN)
+                .with_row_index_column(TARGET_ROW_ORDINAL_IN_FILE_COLUMN)
+                .await
+                .expect("target provider builds"),
+        );
+        let target =
+            LogicalPlanBuilder::scan(TableReference::bare("target"), target_provider, None)
+                .expect("scan builds")
+                .build()
+                .expect("scan plan builds");
+
+        assert!(
+            target
+                .schema()
+                .field_with_unqualified_name(TARGET_ROW_ORDINAL_IN_FILE_COLUMN)
+                .is_ok(),
+            "scan exposes the target row ordinal column"
+        );
+
+        let physical = state
+            .create_physical_plan(&target)
+            .await
+            .expect("physical plan builds");
+        let plan = displayable(physical.as_ref()).indent(true).to_string();
+        assert!(plan.contains("DeltaScanExec"));
+        assert!(!plan.contains("BoundedWindowAggExec"));
+        assert!(!plan.contains("SortExec"));
+    }
+
     #[tokio::test]
     async fn test_merge_rewrite_removes_old_file_and_avoids_duplicate_rows() {
         let (table, source) = setup().await;
@@ -2188,6 +2309,40 @@ mod tests {
             duplicate_count, 0,
             "Expected merge output without duplicate rows"
         );
+    }
+
+    fn duplicate_match_validation_input_plan() -> LogicalPlan {
+        LogicalPlanBuilder::empty(false)
+            .project(vec![
+                lit(ScalarValue::Boolean(None)).alias(SOURCE_COLUMN),
+                lit(ScalarValue::Boolean(None)).alias(TARGET_COLUMN),
+                lit(ScalarValue::Int32(None)).alias(OPERATION_COLUMN),
+                lit(ScalarValue::Utf8(None)).alias(PATH_COLUMN),
+                lit(ScalarValue::UInt64(None)).alias(TARGET_ROW_ORDINAL_IN_FILE_COLUMN),
+                lit(ScalarValue::Boolean(Some(false))).alias(DELETE_COLUMN),
+                lit(ScalarValue::Boolean(Some(false))).alias(TARGET_INSERT_COLUMN),
+                lit(ScalarValue::Boolean(Some(false))).alias(TARGET_UPDATE_COLUMN),
+                lit(ScalarValue::Boolean(Some(false))).alias(TARGET_DELETE_COLUMN),
+                lit(ScalarValue::Boolean(Some(false))).alias(TARGET_COPY_COLUMN),
+            ])
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
+    fn find_merge_validation(plan: &LogicalPlan) -> Option<&MergeValidation> {
+        if let LogicalPlan::Extension(Extension { node }) = plan
+            && let Some(validation) = node.as_any().downcast_ref::<MergeValidation>()
+        {
+            return Some(validation);
+        }
+
+        plan.inputs().into_iter().find_map(find_merge_validation)
+    }
+
+    fn count_unions(plan: &LogicalPlan) -> usize {
+        let current = usize::from(matches!(plan, LogicalPlan::Union(_)));
+        current + plan.inputs().into_iter().map(count_unions).sum::<usize>()
     }
 
     async fn assert_merge_encoded_partition_value_removes_original_file(

--- a/crates/core/src/operations/merge/validation.rs
+++ b/crates/core/src/operations/merge/validation.rs
@@ -1,22 +1,31 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use arrow::array::{Array, Int32Array, RecordBatch, UInt64Array};
+use arrow::array::{Array, ArrayRef, BooleanArray, Int32Array, RecordBatch, UInt64Array};
+use arrow::compute::{filter_record_batch, take};
 use arrow::datatypes::SchemaRef;
-use datafusion::common::{DataFusionError, Result as DataFusionResult};
-use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+use datafusion::common::{Column, DataFusionError, Result as DataFusionResult};
+use datafusion::execution::context::SessionState;
+use datafusion::logical_expr::{
+    Expr, Extension, LogicalPlan, UserDefinedLogicalNodeCore, col,
+    conditional_expressions::CaseBuilder, lit,
+};
 use datafusion::physical_expr::Distribution;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, RecordBatchStream,
     SendableRecordBatchStream,
 };
+use datafusion::prelude::DataFrame;
 use futures::{Stream, StreamExt};
 
 use crate::DeltaTableError;
 use crate::delta_datafusion::get_path_column;
-use crate::operations::merge::{MatchParticipationClass, TARGET_MATCH_CARDINALITY_CLASS_COLUMN};
+use crate::operations::merge::{
+    DUPLICATE_MATCH_MARKER_COLUMNS, MatchParticipationClass, OPERATION_COLUMN, OperationType,
+    TARGET_MATCH_CARDINALITY_CLASS_COLUMN, TARGET_ROW_ORDINAL_IN_FILE_COLUMN,
+};
 
 #[derive(Debug)]
 pub(crate) struct MergeValidationExec {
@@ -116,6 +125,8 @@ impl DisplayAs for MergeValidationExec {
 struct TargetMatchState {
     matched_action_count: i32,
     unconditional_delete_count: i32,
+    emitted_winner: bool,
+    buffered_noop: Option<RecordBatch>,
 }
 
 struct MergeValidationStream {
@@ -126,6 +137,8 @@ struct MergeValidationStream {
     file_id_by_path: HashMap<String, usize>,
     file_paths: Vec<String>,
     target_row_state: HashMap<(usize, u64), TargetMatchState>,
+    buffered_noop_order: Vec<(usize, u64)>,
+    pending_output: VecDeque<RecordBatch>,
 }
 
 impl MergeValidationStream {
@@ -143,6 +156,8 @@ impl MergeValidationStream {
             file_id_by_path: HashMap::new(),
             file_paths: Vec::new(),
             target_row_state: HashMap::new(),
+            buffered_noop_order: Vec::new(),
+            pending_output: VecDeque::new(),
         }
     }
 
@@ -158,7 +173,7 @@ impl MergeValidationStream {
         }
     }
 
-    fn validate_batch(&mut self, batch: &RecordBatch) -> DataFusionResult<()> {
+    fn validate_batch(&mut self, batch: &RecordBatch) -> DataFusionResult<Option<RecordBatch>> {
         let file_dictionary =
             get_path_column(batch, self.file_column.as_str()).map_err(DataFusionError::from)?;
         let file_keys = file_dictionary.keys();
@@ -203,11 +218,20 @@ impl MergeValidationStream {
                 )))
             })?;
 
+        let mut keep_mask = vec![true; batch.num_rows()];
+
         for row in 0..batch.num_rows() {
-            if file_keys.is_null(row)
-                || row_ordinal_array.is_null(row)
-                || cardinality_class_array.is_null(row)
-            {
+            if cardinality_class_array.is_null(row) {
+                continue;
+            }
+
+            let cardinality_class = cardinality_class_array.value(row);
+
+            if !is_candidate_match(cardinality_class) {
+                continue;
+            }
+
+            if file_keys.is_null(row) || row_ordinal_array.is_null(row) {
                 continue;
             }
 
@@ -216,13 +240,10 @@ impl MergeValidationStream {
                 continue;
             };
 
+            keep_mask[row] = false;
             let row_ordinal = row_ordinal_array.value(row);
-            let cardinality_class = cardinality_class_array.value(row);
-
-            let state = self
-                .target_row_state
-                .entry((file_id, row_ordinal))
-                .or_default();
+            let key = (file_id, row_ordinal);
+            let state = self.target_row_state.entry(key).or_default();
 
             if cardinality_class == MatchParticipationClass::MatchedAction as i32 {
                 state.matched_action_count += 1;
@@ -243,26 +264,85 @@ impl MergeValidationStream {
                     )),
                 )));
             }
+
+            if cardinality_class == MatchParticipationClass::MatchedNoop as i32 {
+                if !state.emitted_winner && state.buffered_noop.is_none() {
+                    state.buffered_noop = Some(take_row(batch, row)?);
+                    self.buffered_noop_order.push(key);
+                }
+            } else if !state.emitted_winner {
+                state.emitted_winner = true;
+                state.buffered_noop = None;
+                keep_mask[row] = true;
+            }
         }
 
-        Ok(())
+        if keep_mask.iter().all(|keep| *keep) {
+            Ok(Some(batch.clone()))
+        } else if keep_mask.iter().any(|keep| *keep) {
+            Ok(Some(filter_record_batch(
+                batch,
+                &BooleanArray::from(keep_mask),
+            )?))
+        } else {
+            Ok(None)
+        }
     }
+
+    fn queue_buffered_noops(&mut self) {
+        for key in self.buffered_noop_order.drain(..) {
+            if let Some(state) = self.target_row_state.get_mut(&key)
+                && !state.emitted_winner
+                && let Some(batch) = state.buffered_noop.take()
+            {
+                self.pending_output.push_back(batch);
+            }
+        }
+    }
+}
+
+fn is_candidate_match(cardinality_class: i32) -> bool {
+    cardinality_class == MatchParticipationClass::MatchedNoop as i32
+        || cardinality_class == MatchParticipationClass::MatchedUnconditionalDelete as i32
+        || cardinality_class == MatchParticipationClass::MatchedAction as i32
+}
+
+fn take_row(batch: &RecordBatch, row: usize) -> DataFusionResult<RecordBatch> {
+    let indices = UInt64Array::from(vec![row as u64]);
+    let columns = batch
+        .columns()
+        .iter()
+        .map(|column| Ok(take(column.as_ref(), &indices, None)?))
+        .collect::<DataFusionResult<Vec<ArrayRef>>>()?;
+
+    Ok(RecordBatch::try_new(batch.schema(), columns)?)
 }
 
 impl Stream for MergeValidationStream {
     type Item = DataFusionResult<RecordBatch>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.input.poll_next_unpin(cx) {
-            Poll::Ready(Some(Ok(batch))) => {
-                if let Err(err) = self.validate_batch(&batch) {
-                    return Poll::Ready(Some(Err(err)));
-                }
-                Poll::Ready(Some(Ok(batch)))
+        loop {
+            if let Some(batch) = self.pending_output.pop_front() {
+                return Poll::Ready(Some(Ok(batch)));
             }
-            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+
+            match self.input.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(batch))) => match self.validate_batch(&batch) {
+                    Ok(Some(batch)) => return Poll::Ready(Some(Ok(batch))),
+                    Ok(None) => continue,
+                    Err(err) => return Poll::Ready(Some(Err(err))),
+                },
+                Poll::Ready(Some(Err(err))) => return Poll::Ready(Some(Err(err))),
+                Poll::Ready(None) => {
+                    self.queue_buffered_noops();
+                    if let Some(batch) = self.pending_output.pop_front() {
+                        return Poll::Ready(Some(Ok(batch)));
+                    }
+                    return Poll::Ready(None);
+                }
+                Poll::Pending => return Poll::Pending,
+            }
         }
     }
 
@@ -275,6 +355,50 @@ impl RecordBatchStream for MergeValidationStream {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
+}
+
+pub(super) fn build_duplicate_match_validation_plan(
+    input: LogicalPlan,
+    state: &SessionState,
+    ops: &[(
+        HashMap<Column, Expr>,
+        OperationType,
+        MatchParticipationClass,
+    )],
+    file_column: Arc<String>,
+) -> DataFusionResult<LogicalPlan> {
+    let mut cardinality_when = Vec::with_capacity(ops.len());
+    let mut cardinality_then = Vec::with_capacity(ops.len());
+
+    for (idx, (_, _, cardinality_class)) in ops.iter().enumerate() {
+        cardinality_when.push(lit(idx as i32));
+        cardinality_then.push(lit(*cardinality_class as i32));
+    }
+
+    let cardinality_class = CaseBuilder::new(
+        Some(Box::new(col(OPERATION_COLUMN))),
+        cardinality_when,
+        cardinality_then,
+        Some(Box::new(lit(0))),
+    )
+    .end()?;
+
+    let input = DataFrame::new(state.clone(), input)
+        .with_column(TARGET_MATCH_CARDINALITY_CLASS_COLUMN, cardinality_class)?
+        .into_unoptimized_plan();
+
+    let validated = LogicalPlan::Extension(Extension {
+        node: Arc::new(MergeValidation {
+            input,
+            file_expr: col(file_column.as_str()),
+            file_column: Arc::clone(&file_column),
+            row_ordinal_column: Arc::new(TARGET_ROW_ORDINAL_IN_FILE_COLUMN.to_string()),
+        }),
+    });
+
+    Ok(DataFrame::new(state.clone(), validated)
+        .drop_columns(DUPLICATE_MATCH_MARKER_COLUMNS)?
+        .into_unoptimized_plan())
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, PartialOrd)]
@@ -327,6 +451,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema, UInt16Type};
     use arrow_array::builder::StringDictionaryBuilder;
     use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+    use futures::TryStreamExt;
 
     use crate::delta_datafusion::PATH_COLUMN;
     use crate::operations::merge::TARGET_ROW_ORDINAL_IN_FILE_COLUMN;
@@ -378,6 +503,54 @@ mod tests {
     fn empty_stream(schema: SchemaRef) -> SendableRecordBatchStream {
         let stream = futures::stream::iter(Vec::<DataFusionResult<RecordBatch>>::new());
         Box::pin(RecordBatchStreamAdapter::new(schema, Box::pin(stream)))
+    }
+
+    fn stream_from_batches(batches: Vec<RecordBatch>) -> SendableRecordBatchStream {
+        let schema = batches
+            .first()
+            .expect("expected at least one batch")
+            .schema();
+        let stream = futures::stream::iter(batches.into_iter().map(Ok));
+        Box::pin(RecordBatchStreamAdapter::new(schema, Box::pin(stream)))
+    }
+
+    async fn collect_validated(batches: Vec<RecordBatch>) -> DataFusionResult<Vec<RecordBatch>> {
+        let schema = batches
+            .first()
+            .expect("expected at least one batch")
+            .schema();
+        let stream = MergeValidationStream::new(
+            stream_from_batches(batches),
+            schema,
+            Arc::new(PATH_COLUMN.to_string()),
+            Arc::new(TARGET_ROW_ORDINAL_IN_FILE_COLUMN.to_string()),
+        );
+
+        stream.try_collect::<Vec<_>>().await
+    }
+
+    fn output_rows(batches: &[RecordBatch]) -> Vec<(u64, i32)> {
+        batches
+            .iter()
+            .flat_map(|batch| {
+                let ordinals = batch
+                    .column_by_name(TARGET_ROW_ORDINAL_IN_FILE_COLUMN)
+                    .expect("ordinal column exists")
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .expect("ordinal column is UInt64");
+                let classes = batch
+                    .column_by_name(TARGET_MATCH_CARDINALITY_CLASS_COLUMN)
+                    .expect("class column exists")
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .expect("class column is Int32");
+
+                (0..batch.num_rows())
+                    .map(|row| (ordinals.value(row), classes.value(row)))
+                    .collect::<Vec<_>>()
+            })
+            .collect()
     }
 
     fn validate(b: &RecordBatch) -> DataFusionResult<()> {
@@ -473,6 +646,32 @@ mod tests {
     }
 
     #[test]
+    fn test_ignore_rows_do_not_allocate_validation_state() {
+        let b = batch(
+            vec![10, 11],
+            vec![
+                MatchParticipationClass::Ignore as i32,
+                MatchParticipationClass::Ignore as i32,
+            ],
+        );
+        let schema = b.schema();
+        let mut s = MergeValidationStream::new(
+            empty_stream(schema.clone()),
+            schema,
+            Arc::new(PATH_COLUMN.to_string()),
+            Arc::new(TARGET_ROW_ORDINAL_IN_FILE_COLUMN.to_string()),
+        );
+
+        s.validate_batch(&b).expect("ignore rows pass validation");
+
+        assert_eq!(
+            s.target_row_state.len(),
+            0,
+            "ignore rows are irrelevant to duplicate validation state"
+        );
+    }
+
+    #[test]
     fn test_one_matched_action_and_one_matched_noop_passes() {
         let b = batch(
             vec![10, 10],
@@ -536,5 +735,28 @@ mod tests {
 
         validate_batches(&[first, second])
             .expect("dictionary keys must be remapped per batch before cross batch validation");
+    }
+
+    #[tokio::test]
+    async fn test_cross_batch_dedup_outputs_highest_priority_match() {
+        let first = batch(
+            vec![7, 8, 9],
+            vec![
+                MatchParticipationClass::MatchedNoop as i32,
+                MatchParticipationClass::Ignore as i32,
+                MatchParticipationClass::MatchedNoop as i32,
+            ],
+        );
+        let second = batch(vec![7], vec![MatchParticipationClass::MatchedAction as i32]);
+
+        let output = collect_validated(vec![first, second])
+            .await
+            .expect("validation passes");
+        let rows = output_rows(&output);
+
+        assert_eq!(rows.iter().filter(|(ordinal, _)| *ordinal == 7).count(), 1);
+        assert!(rows.contains(&(7, MatchParticipationClass::MatchedAction as i32)));
+        assert!(rows.contains(&(8, MatchParticipationClass::Ignore as i32)));
+        assert!(rows.contains(&(9, MatchParticipationClass::MatchedNoop as i32)));
     }
 }

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -2922,6 +2922,38 @@ def test_merge(tmp_path: pathlib.Path):
 
 
 @pytest.mark.pyarrow
+def test_merge_streamed_exec_does_not_rescan_single_use_source(tmp_path: pathlib.Path):
+    import pyarrow as pa
+
+    target = pa.table({"id": [1, 2], "value": [10, 20]})
+    write_deltalake(str(tmp_path), target)
+
+    dt = DeltaTable(str(tmp_path))
+    source_batch = pa.record_batch({"id": [2, 3], "value": [200, 300]})
+    source = pa.RecordBatchReader.from_batches(source_batch.schema, [source_batch])
+
+    metrics = (
+        dt.merge(
+            source=source,
+            predicate="target.id = source.id",
+            source_alias="source",
+            target_alias="target",
+            streamed_exec=True,
+        )
+        .when_matched_update_all()
+        .when_not_matched_insert_all()
+        .execute()
+    )
+
+    result = dt.to_pyarrow_table().sort_by([("id", "ascending")])
+    expected = pa.table({"id": [1, 2, 3], "value": [10, 200, 300]})
+
+    assert metrics["num_target_rows_updated"] == 1
+    assert metrics["num_target_rows_inserted"] == 1
+    assert result.equals(expected)
+
+
+@pytest.mark.pyarrow
 def test_merge_with_spill_config(tmp_path: pathlib.Path):
     """Verify merge accepts and uses spill configuration without error."""
     import pyarrow as pa


### PR DESCRIPTION
Fixes #4422.

Duplicate match validation introduced a buffered `row_number()` window over the join output, which held the full target side in memory.

The patch here is to compute target row ordinals inside `DeltaScanStream` instead. Keep validation on one streaming path, retain state only for matched rows that can produce duplicate errors. Preserve streamed source behavior for single use `RecordBatchReader` inputs.

Memory improvement (manual repro):
- 300k target / 5k source: ~109 MB (was ~861 MB on 1.5.1)
- 1M target / 10k source: ~243 MB

Tests cover scan ordinals, validation, plan shape, and python streamed source regression.