### PR TITLE
refactor: remove DeltaTableProvider

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -53,7 +53,7 @@ use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use either::Either;
 
 use crate::delta_datafusion::expr::parse_predicate_expression;
-use crate::delta_datafusion::table_provider::DeltaScanWire;
+use crate::delta_datafusion::table_provider::{DeltaScan, DeltaScanWire};
 use crate::ensure_table_uri;
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::{Add, EagerSnapshot, LogDataHandler, Snapshot};
@@ -73,8 +73,7 @@ pub(crate) use data_validation::{
 pub(crate) use find_files::*;
 pub(crate) use table_provider::next::normalize_path_as_file_id;
 pub use table_provider::{
-    DeltaScan, DeltaScanConfig, DeltaScanConfigBuilder, DeltaTableProvider, TableProviderBuilder,
-    next::DeltaScanExec,
+    DeltaScanConfig, DeltaScanConfigBuilder, TableProviderBuilder, next::DeltaScanExec,
 };
 pub(crate) use table_provider::{
     next::FILE_ID_COLUMN_DEFAULT, resolve_file_column_name, update_datafusion_session,
@@ -620,14 +619,8 @@ mod tests {
     use arrow::array::StructArray;
     use arrow::datatypes::{Field, Schema};
     use datafusion::assert_batches_sorted_eq;
-    use datafusion::config::TableParquetOptions;
-    use datafusion::datasource::physical_plan::{FileScanConfig, ParquetSource};
-    use datafusion::datasource::source::DataSourceExec;
-    use datafusion::logical_expr::lit;
     use datafusion::physical_plan::empty::EmptyExec;
-    use datafusion::physical_plan::{ExecutionPlanVisitor, PhysicalExpr, visit_execution_plan};
-    use datafusion::prelude::{SessionConfig, col};
-    use datafusion_datasource::file::FileSource as _;
+    use datafusion::prelude::SessionConfig;
     use datafusion_proto::physical_plan::AsExecutionPlan;
     use datafusion_proto::protobuf;
     use delta_kernel::schema::ArrayType;
@@ -1238,131 +1231,6 @@ mod tests {
             .unwrap();
 
         df.collect().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_delta_scan_builder_no_scan_config() {
-        let arr: Arc<dyn Array> = Arc::new(arrow::array::StringArray::from(vec!["s"]));
-        let batch = RecordBatch::try_from_iter_with_nullable(vec![("a", arr, false)]).unwrap();
-        let table = DeltaTable::new_in_memory()
-            .write(vec![batch])
-            .with_save_mode(crate::protocol::SaveMode::Append)
-            .await
-            .unwrap();
-
-        let ctx = SessionContext::new();
-        let state = ctx.state();
-        let scan = table_provider::DeltaScanBuilder::new(
-            table.snapshot().unwrap().snapshot(),
-            table.log_store(),
-            &state,
-        )
-        .with_filter(Some(col("a").eq(lit("s"))))
-        .build()
-        .await
-        .unwrap();
-
-        let mut visitor = ParquetVisitor::default();
-        visit_execution_plan(&scan, &mut visitor).unwrap();
-
-        assert_eq!(visitor.predicate.unwrap().to_string(), "a@0 = s");
-    }
-
-    #[tokio::test]
-    async fn test_delta_scan_builder_scan_config_disable_pushdown() {
-        let arr: Arc<dyn Array> = Arc::new(arrow::array::StringArray::from(vec!["s"]));
-        let batch = RecordBatch::try_from_iter_with_nullable(vec![("a", arr, false)]).unwrap();
-        let table = DeltaTable::new_in_memory()
-            .write(vec![batch])
-            .with_save_mode(crate::protocol::SaveMode::Append)
-            .await
-            .unwrap();
-
-        let snapshot = table.snapshot().unwrap();
-        let ctx = SessionContext::new();
-        let state = ctx.state();
-        let scan =
-            table_provider::DeltaScanBuilder::new(snapshot.snapshot(), table.log_store(), &state)
-                .with_filter(Some(col("a").eq(lit("s"))))
-                .with_scan_config(
-                    DeltaScanConfigBuilder::new()
-                        .with_parquet_pushdown(false)
-                        .build(snapshot.snapshot())
-                        .unwrap(),
-                )
-                .build()
-                .await
-                .unwrap();
-
-        let mut visitor = ParquetVisitor::default();
-        visit_execution_plan(&scan, &mut visitor).unwrap();
-
-        assert!(visitor.predicate.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_delta_scan_applies_parquet_options() {
-        let arr: Arc<dyn Array> = Arc::new(arrow::array::StringArray::from(vec!["s"]));
-        let batch = RecordBatch::try_from_iter_with_nullable(vec![("a", arr, false)]).unwrap();
-        let table = DeltaTable::new_in_memory()
-            .write(vec![batch])
-            .with_save_mode(crate::protocol::SaveMode::Append)
-            .await
-            .unwrap();
-
-        let snapshot = table.snapshot().unwrap();
-
-        let mut config = SessionConfig::default();
-        config.options_mut().execution.parquet.pushdown_filters = true;
-        let ctx = SessionContext::new_with_config(config);
-        let state = ctx.state();
-
-        let scan =
-            table_provider::DeltaScanBuilder::new(snapshot.snapshot(), table.log_store(), &state)
-                .build()
-                .await
-                .unwrap();
-
-        let mut visitor = ParquetVisitor::default();
-        visit_execution_plan(&scan, &mut visitor).unwrap();
-
-        assert_eq!(ctx.copied_table_options().parquet, visitor.options.unwrap());
-    }
-
-    /// Extracts fields from the parquet scan
-    #[derive(Default)]
-    struct ParquetVisitor {
-        predicate: Option<Arc<dyn PhysicalExpr>>,
-        options: Option<TableParquetOptions>,
-    }
-
-    impl ExecutionPlanVisitor for ParquetVisitor {
-        type Error = DataFusionError;
-
-        fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
-            let Some(datasource_exec) = plan.as_any().downcast_ref::<DataSourceExec>() else {
-                return Ok(true);
-            };
-
-            let Some(scan_config) = datasource_exec
-                .data_source()
-                .as_any()
-                .downcast_ref::<FileScanConfig>()
-            else {
-                return Ok(true);
-            };
-
-            if let Some(parquet_source) = scan_config
-                .file_source
-                .as_any()
-                .downcast_ref::<ParquetSource>()
-            {
-                self.options = Some(parquet_source.table_parquet_options().clone());
-                self.predicate = parquet_source.filter();
-            }
-
-            Ok(true)
-        }
     }
 
     // Run a query that filters out all files and sorts.

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -1,64 +1,33 @@
 use std::any::Any;
-use std::borrow::Cow;
-use std::collections::BTreeSet;
 use std::fmt;
 use std::sync::Arc;
 
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use arrow::error::ArrowError;
-use chrono::{DateTime, TimeZone, Utc};
+use arrow::datatypes::{Schema, SchemaRef};
 use datafusion::catalog::TableProvider;
-use datafusion::catalog::memory::DataSourceExec;
-use datafusion::common::pruning::PruningStatistics;
-use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
-use datafusion::common::{Column, DFSchemaRef, Result, Statistics, ToDFSchema};
-use datafusion::config::{ConfigOptions, TableParquetOptions};
-use datafusion::datasource::TableType;
-use datafusion::datasource::physical_plan::FileGroup;
-use datafusion::datasource::physical_plan::{FileScanConfigBuilder, ParquetSource};
-use datafusion::datasource::sink::DataSinkExec;
-use datafusion::datasource::table_schema::TableSchema;
+use datafusion::common::tree_node::TreeNode;
+use datafusion::common::{DFSchemaRef, Result, Statistics};
+use datafusion::config::ConfigOptions;
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::logical_expr::dml::InsertOp;
 use datafusion::logical_expr::simplify::SimplifyContext;
-use datafusion::logical_expr::utils::split_conjunction;
-use datafusion::logical_expr::{BinaryExpr, LogicalPlan, Operator};
 use datafusion::optimizer::simplify_expressions::ExprSimplifier;
-use datafusion::physical_optimizer::pruning::PruningPredicate;
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
-use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
+use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, PlanProperties,
 };
-use datafusion::{
-    catalog::Session,
-    common::{HashMap, HashSet},
-    datasource::listing::PartitionedFile,
-    logical_expr::{TableProviderFilterPushDown, utils::conjunction},
-    prelude::Expr,
-    scalar::ScalarValue,
-};
-use futures::TryStreamExt as _;
+use datafusion::{catalog::Session, common::HashSet, prelude::Expr};
 use futures::future::BoxFuture;
-use object_store::ObjectMeta;
 use serde::{Deserialize, Serialize};
 use url::Url;
 use uuid::Uuid;
 
-use crate::delta_datafusion::file_id::{file_id_data_type, wrap_file_id_value};
 use crate::delta_datafusion::table_provider::next::SnapshotWrapper;
-use crate::delta_datafusion::{
-    DataFusionMixins as _, DeltaSessionExt, FindFilesExprProperties, get_null_of_arrow_type,
-    to_correct_scalar_value,
-};
-use crate::kernel::transaction::PROTOCOL;
-use crate::kernel::{Add, EagerSnapshot, Snapshot, Version};
-use crate::logstore::LogStore;
-use crate::logstore::LogStoreExt as _;
-use crate::protocol::SaveMode;
+use crate::delta_datafusion::{DataFusionMixins as _, FindFilesExprProperties};
+use crate::kernel::{EagerSnapshot, Snapshot, Version};
+use crate::logstore::{LogStore, LogStoreExt as _};
 use crate::table::normalize_table_url;
-use crate::{DeltaResult, DeltaTable, DeltaTableError, logstore::LogStoreRef};
+use crate::{DeltaResult, DeltaTable, DeltaTableError};
 
 mod data_sink;
 pub(crate) mod next;
@@ -164,7 +133,7 @@ impl DeltaScanConfigBuilder {
         self
     }
 
-    /// Use the provided [SchemaRef] for the [DeltaScan]
+    /// Use the provided [SchemaRef] for the [`crate::delta_datafusion::DeltaScanNext`]
     pub fn with_schema(mut self, schema: SchemaRef) -> Self {
         self.schema = Some(schema);
         self
@@ -192,7 +161,7 @@ impl DeltaScanConfigBuilder {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-/// Include additional metadata columns during a [`DeltaScan`]
+/// Include additional metadata columns during a [`crate::delta_datafusion::DeltaScanNext`]
 pub struct DeltaScanConfig {
     /// Include the source path for each record
     pub file_column_name: Option<String>,
@@ -253,7 +222,7 @@ impl DeltaScanConfig {
         self
     }
 
-    /// Use the provided [SchemaRef] for the [DeltaScan]
+    /// Use the provided [SchemaRef] for the [`crate::delta_datafusion::DeltaScanNext`]
     ///
     /// This schema will be used when reading data from the underlying files.
     /// The column names must match those in the table schema, but can have
@@ -261,319 +230,6 @@ impl DeltaScanConfig {
     pub fn with_schema(mut self, schema: SchemaRef) -> Self {
         self.schema = Some(schema);
         self
-    }
-}
-
-pub(crate) struct DeltaScanBuilder<'a> {
-    snapshot: &'a EagerSnapshot,
-    log_store: LogStoreRef,
-    filter: Option<Expr>,
-    session: &'a dyn Session,
-    projection: Option<&'a Vec<usize>>,
-    limit: Option<usize>,
-    files: Option<&'a [Add]>,
-    config: Option<DeltaScanConfig>,
-}
-
-impl<'a> DeltaScanBuilder<'a> {
-    pub fn new(
-        snapshot: &'a EagerSnapshot,
-        log_store: LogStoreRef,
-        session: &'a dyn Session,
-    ) -> Self {
-        DeltaScanBuilder {
-            snapshot,
-            log_store,
-            filter: None,
-            session,
-            projection: None,
-            limit: None,
-            files: None,
-            config: None,
-        }
-    }
-
-    pub fn with_filter(mut self, filter: Option<Expr>) -> Self {
-        self.filter = filter;
-        self
-    }
-
-    pub fn with_files(mut self, files: &'a [Add]) -> Self {
-        self.files = Some(files);
-        self
-    }
-
-    pub fn with_projection(mut self, projection: Option<&'a Vec<usize>>) -> Self {
-        self.projection = projection;
-        self
-    }
-
-    pub fn with_limit(mut self, limit: Option<usize>) -> Self {
-        self.limit = limit;
-        self
-    }
-
-    pub fn with_scan_config(mut self, config: DeltaScanConfig) -> Self {
-        self.config = Some(config);
-        self
-    }
-
-    pub async fn build(self) -> DeltaResult<DeltaScan> {
-        PROTOCOL.can_read_from(self.snapshot)?;
-        let config = match self.config {
-            Some(config) => config,
-            None => DeltaScanConfigBuilder::new().build(self.snapshot)?,
-        };
-
-        let schema = match config.schema.clone() {
-            Some(value) => value,
-            None => self.snapshot.read_schema(),
-        };
-
-        let logical_schema = df_logical_schema(
-            self.snapshot,
-            &config.file_column_name,
-            Some(schema.clone()),
-        )?;
-
-        let logical_schema = if let Some(used_columns) = self.projection {
-            let mut fields = Vec::with_capacity(used_columns.len());
-            for idx in used_columns {
-                fields.push(logical_schema.field(*idx).to_owned());
-            }
-            // partition filters with Exact pushdown were removed from projection by DF optimizer,
-            // we need to add them back for the predicate pruning to work
-            if let Some(expr) = &self.filter {
-                // Avoid non-determinism of HashSet (affects the expressions in pushed-down filters)
-                let column_refs = expr.column_refs().into_iter().collect::<BTreeSet<_>>();
-                for c in column_refs {
-                    let idx = logical_schema.index_of(c.name.as_str())?;
-                    if !used_columns.contains(&idx) {
-                        fields.push(logical_schema.field(idx).to_owned());
-                    }
-                }
-            }
-            Arc::new(Schema::new(fields))
-        } else {
-            logical_schema
-        };
-
-        let df_schema = Arc::new(logical_schema.clone().to_dfschema()?);
-
-        let logical_filter = self
-            .filter
-            .clone()
-            .map(|expr| simplify_expr(self.session, df_schema.clone(), expr))
-            .transpose()?;
-        // only inexact filters should be pushed down to the data source, doing otherwise
-        // will make stats inexact and disable datafusion optimizations like AggregateStatistics
-        let pushdown_filter = self
-            .filter
-            .and_then(|expr| {
-                let predicates = split_conjunction(&expr);
-                let pushdown_filters =
-                    get_pushdown_filters(&predicates, self.snapshot.metadata().partition_columns());
-
-                let filtered_predicates = predicates
-                    .into_iter()
-                    .zip(pushdown_filters.into_iter())
-                    .filter_map(|(filter, pushdown)| {
-                        if pushdown == TableProviderFilterPushDown::Inexact {
-                            Some(filter.clone())
-                        } else {
-                            None
-                        }
-                    });
-                conjunction(filtered_predicates)
-            })
-            .map(|expr| simplify_expr(self.session, df_schema.clone(), expr))
-            .transpose()?;
-
-        // Perform Pruning of files to scan
-        let (files, files_scanned, files_pruned, _) = match self.files {
-            Some(files) => {
-                let files = files.to_owned();
-                let files_scanned = files.len();
-                (files, files_scanned, 0, None)
-            }
-            None => {
-                // early return in case we have no push down filters or limit
-                if logical_filter.is_none() && self.limit.is_none() {
-                    let files = self
-                        .snapshot
-                        .file_views(&self.log_store, None)
-                        .map_ok(|f| f.to_add())
-                        .try_collect::<Vec<_>>()
-                        .await?;
-                    let files_scanned = files.len();
-                    (files, files_scanned, 0, None)
-                } else {
-                    let num_containers = self.snapshot.num_containers();
-
-                    let files_to_prune = if let Some(predicate) = &logical_filter {
-                        let pruning_predicate =
-                            PruningPredicate::try_new(predicate.clone(), logical_schema.clone())?;
-                        pruning_predicate.prune(self.snapshot)?
-                    } else {
-                        vec![true; num_containers]
-                    };
-
-                    // needed to enforce limit and deal with missing statistics
-                    // rust port of https://github.com/delta-io/delta/pull/1495
-                    let mut pruned_without_stats = Vec::new();
-                    let mut rows_collected = 0;
-                    let mut files = Vec::with_capacity(num_containers);
-
-                    let file_actions: Vec<_> = self
-                        .snapshot
-                        .file_views(&self.log_store, None)
-                        .map_ok(|f| f.to_add())
-                        .try_collect::<Vec<_>>()
-                        .await?;
-
-                    for (action, keep) in
-                        file_actions.into_iter().zip(files_to_prune.iter().cloned())
-                    {
-                        // prune file based on predicate pushdown
-                        if keep {
-                            // prune file based on limit pushdown
-                            if let Some(limit) = self.limit {
-                                if let Some(stats) = action.get_stats()? {
-                                    if rows_collected <= limit as i64 {
-                                        rows_collected += stats.num_records;
-                                        files.push(action.to_owned());
-                                    } else {
-                                        break;
-                                    }
-                                } else {
-                                    // some files are missing stats; skipping but storing them
-                                    // in a list in case we can't reach the target limit
-                                    pruned_without_stats.push(action.to_owned());
-                                }
-                            } else {
-                                files.push(action.to_owned());
-                            }
-                        }
-                    }
-
-                    if let Some(limit) = self.limit
-                        && rows_collected < limit as i64
-                    {
-                        files.extend(pruned_without_stats);
-                    }
-
-                    let files_scanned = files.len();
-                    let files_pruned = num_containers - files_scanned;
-                    (files, files_scanned, files_pruned, Some(files_to_prune))
-                }
-            }
-        };
-
-        // TODO we group files together by their partition values. If the table is partitioned
-        // and partitions are somewhat evenly distributed, probably not the worst choice ...
-        // However we may want to do some additional balancing in case we are far off from the above.
-        let mut file_groups: HashMap<Vec<ScalarValue>, Vec<PartitionedFile>> = HashMap::new();
-
-        let table_partition_cols = &self.snapshot.metadata().partition_columns();
-
-        for action in files.iter() {
-            let mut part = partitioned_file_from_action(action, table_partition_cols, &schema);
-
-            if config.file_column_name.is_some() {
-                let partition_value = if config.wrap_partition_values {
-                    wrap_file_id_value(action.path.clone())
-                } else {
-                    ScalarValue::Utf8(Some(action.path.clone()))
-                };
-                part.partition_values.push(partition_value);
-            }
-
-            file_groups
-                .entry(part.partition_values.clone())
-                .or_default()
-                .push(part);
-        }
-
-        let file_schema = Arc::new(Schema::new(
-            schema
-                .fields()
-                .iter()
-                .filter(|f| !table_partition_cols.contains(f.name()))
-                .cloned()
-                .collect::<Vec<arrow::datatypes::FieldRef>>(),
-        ));
-
-        let mut table_partition_cols = table_partition_cols
-            .iter()
-            .map(|name| schema.field_with_name(name).map(|f| f.to_owned()))
-            .collect::<Result<Vec<_>, ArrowError>>()?;
-
-        if let Some(file_column_name) = &config.file_column_name {
-            let field_name_datatype = if config.wrap_partition_values {
-                file_id_data_type()
-            } else {
-                DataType::Utf8
-            };
-            table_partition_cols.push(Field::new(
-                file_column_name.clone(),
-                field_name_datatype,
-                false,
-            ));
-        }
-
-        let parquet_options = TableParquetOptions {
-            global: self.session.config().options().execution.parquet.clone(),
-            ..Default::default()
-        };
-
-        let partition_fields: Vec<Arc<Field>> =
-            table_partition_cols.into_iter().map(Arc::new).collect();
-        let table_schema = TableSchema::new(file_schema, partition_fields);
-
-        let mut file_source =
-            ParquetSource::new(table_schema).with_table_parquet_options(parquet_options);
-
-        // Sometimes (i.e Merge) we want to prune files that don't make the
-        // filter and read the entire contents for files that do match the
-        // filter
-        if let Some(predicate) = pushdown_filter
-            && config.enable_parquet_pushdown
-        {
-            file_source = file_source.with_predicate(predicate);
-        };
-
-        let file_scan_config =
-            FileScanConfigBuilder::new(self.log_store.object_store_url(), Arc::new(file_source))
-                .with_file_groups(
-                    // If all files were filtered out, we still need to emit at least one partition to
-                    // pass datafusion sanity checks.
-                    //
-                    // See https://github.com/apache/datafusion/issues/11322
-                    if file_groups.is_empty() {
-                        vec![FileGroup::from(vec![])]
-                    } else {
-                        file_groups.into_values().map(FileGroup::from).collect()
-                    },
-                )
-                .with_projection_indices(self.projection.cloned())?
-                .with_limit(self.limit)
-                .build();
-
-        let metrics = ExecutionPlanMetricsSet::new();
-        MetricBuilder::new(&metrics)
-            .global_counter("files_scanned")
-            .add(files_scanned);
-        MetricBuilder::new(&metrics)
-            .global_counter("files_pruned")
-            .add(files_pruned);
-
-        Ok(DeltaScan {
-            table_url: self.log_store.root_url().clone(),
-            parquet_scan: DataSourceExec::from_data_source(file_scan_config),
-            config,
-            logical_schema,
-            metrics,
-        })
     }
 }
 
@@ -591,7 +247,6 @@ pub struct TableProviderBuilder {
     table_version: Option<Version>,
     /// Predicates used only for file skipping in kernel log replay
     file_skipping_predicates: Option<Vec<Expr>>,
-    file_selection: Option<next::FileSelection>,
 }
 
 impl fmt::Debug for TableProviderBuilder {
@@ -604,7 +259,6 @@ impl fmt::Debug for TableProviderBuilder {
             .field("row_index_column", &self.row_index_column)
             .field("table_version", &self.table_version)
             .field("file_skipping_predicates", &self.file_skipping_predicates)
-            .field("file_selection", &self.file_selection)
             .finish()
     }
 }
@@ -625,7 +279,6 @@ impl TableProviderBuilder {
             row_index_column: None,
             table_version: None,
             file_skipping_predicates: None,
-            file_selection: None,
         }
     }
 
@@ -694,12 +347,6 @@ impl TableProviderBuilder {
         self
     }
 
-    /// Limit scan planning to an explicit set of file identifiers.
-    pub(crate) fn with_file_selection(mut self, file_selection: next::FileSelection) -> Self {
-        self.file_selection = Some(file_selection);
-        self
-    }
-
     pub async fn build(self) -> Result<next::DeltaScan> {
         let TableProviderBuilder {
             log_store,
@@ -709,7 +356,6 @@ impl TableProviderBuilder {
             row_index_column,
             table_version,
             file_skipping_predicates,
-            file_selection,
         } = self;
 
         let mut config = session
@@ -771,10 +417,6 @@ impl TableProviderBuilder {
                 visitor.result?;
             }
             provider = provider.with_file_skipping_predicate(skipping);
-        }
-
-        if let Some(file_selection) = file_selection {
-            provider = provider.with_file_selection(file_selection);
         }
 
         Ok(provider)
@@ -845,132 +487,13 @@ pub(crate) fn update_datafusion_session(
     )
 }
 
-// TODO: implement this for Snapshot, not for DeltaTable since DeltaTable has unknown load state.
-// the unwraps in the schema method are a dead giveaway ..
-
-/// A Delta table provider that enables additional metadata columns to be included during the scan
+/// Physical scan wrapper used by DataFusion plan serialization.
+///
+/// Kept for physical extension codec compatibility. Construct Delta table providers with
+/// [`DeltaTable::table_provider`], [`TableProviderBuilder`], or
+/// [`crate::delta_datafusion::DeltaScanNext`].
 #[derive(Debug)]
-pub struct DeltaTableProvider {
-    snapshot: EagerSnapshot,
-    log_store: LogStoreRef,
-    config: DeltaScanConfig,
-    schema: Arc<Schema>,
-    files: Option<Vec<Add>>,
-}
-
-impl DeltaTableProvider {
-    /// Build a DeltaTableProvider
-    pub fn try_new(
-        snapshot: EagerSnapshot,
-        log_store: LogStoreRef,
-        config: DeltaScanConfig,
-    ) -> DeltaResult<Self> {
-        Ok(DeltaTableProvider {
-            schema: df_logical_schema(&snapshot, &config.file_column_name, config.schema.clone())?,
-            snapshot,
-            log_store,
-            config,
-            files: None,
-        })
-    }
-
-    /// Define which files to consider while building a scan, for advanced usecases
-    pub fn with_files(mut self, files: Vec<Add>) -> DeltaTableProvider {
-        self.files = Some(files);
-        self
-    }
-}
-
-#[async_trait::async_trait]
-impl TableProvider for DeltaTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn schema(&self) -> Arc<Schema> {
-        self.schema.clone()
-    }
-
-    fn table_type(&self) -> TableType {
-        TableType::Base
-    }
-
-    fn get_table_definition(&self) -> Option<&str> {
-        None
-    }
-
-    fn get_logical_plan(&self) -> Option<Cow<'_, LogicalPlan>> {
-        None
-    }
-
-    async fn scan(
-        &self,
-        session: &dyn Session,
-        projection: Option<&Vec<usize>>,
-        filters: &[Expr],
-        limit: Option<usize>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        session.ensure_log_store_registered(self.log_store.as_ref())?;
-        let filter_expr = conjunction(filters.iter().cloned());
-
-        let mut scan = DeltaScanBuilder::new(&self.snapshot, self.log_store.clone(), session)
-            .with_projection(projection)
-            .with_limit(limit)
-            .with_filter(filter_expr)
-            .with_scan_config(self.config.clone());
-
-        if let Some(files) = &self.files {
-            scan = scan.with_files(files);
-        }
-        Ok(Arc::new(scan.build().await?))
-    }
-
-    fn supports_filters_pushdown(
-        &self,
-        filter: &[&Expr],
-    ) -> Result<Vec<TableProviderFilterPushDown>> {
-        Ok(get_pushdown_filters(
-            filter,
-            self.snapshot.metadata().partition_columns(),
-        ))
-    }
-
-    /// Insert the data into the delta table
-    /// Insert operation is only supported for Append and Overwrite
-    /// Return the execution plan
-    async fn insert_into(
-        &self,
-        state: &dyn Session,
-        input: Arc<dyn ExecutionPlan>,
-        insert_op: InsertOp,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        state.ensure_log_store_registered(self.log_store.as_ref())?;
-
-        let save_mode = match insert_op {
-            InsertOp::Append => SaveMode::Append,
-            InsertOp::Overwrite => SaveMode::Overwrite,
-            InsertOp::Replace => {
-                return Err(DataFusionError::Plan(
-                    "Replace operation is not supported for DeltaTableProvider".to_string(),
-                ));
-            }
-        };
-
-        let data_sink =
-            data_sink::DeltaDataSink::new(self.log_store.clone(), self.snapshot.clone(), save_mode);
-
-        Ok(Arc::new(DataSinkExec::new(
-            input,
-            Arc::new(data_sink),
-            None,
-        )))
-    }
-}
-
-// TODO: this will likely also need to perform column mapping later when we support reader protocol v2
-/// A wrapper for parquet scans
-#[derive(Debug)]
-pub struct DeltaScan {
+pub(super) struct DeltaScan {
     /// The normalized [Url] of the ObjectStore root
     table_url: Url,
     /// Column that contains an index that maps to the original metadata Add
@@ -1109,43 +632,6 @@ impl ExecutionPlan for DeltaScan {
     }
 }
 
-/// The logical schema for a Deltatable is different from the protocol level schema since partition
-/// columns must appear at the end of the schema. This is to align with how partition are handled
-/// at the physical level
-fn df_logical_schema(
-    snapshot: &EagerSnapshot,
-    file_column_name: &Option<String>,
-    schema: Option<SchemaRef>,
-) -> DeltaResult<SchemaRef> {
-    let input_schema = match schema {
-        Some(schema) => schema,
-        None => snapshot.input_schema(),
-    };
-    let table_partition_cols = snapshot.metadata().partition_columns();
-
-    let mut fields: Vec<Arc<Field>> = input_schema
-        .fields()
-        .iter()
-        .filter(|f| !table_partition_cols.contains(f.name()))
-        .cloned()
-        .collect();
-
-    for partition_col in table_partition_cols.iter() {
-        fields.push(Arc::new(
-            input_schema
-                .field_with_name(partition_col)
-                .unwrap()
-                .to_owned(),
-        ));
-    }
-
-    if let Some(file_column_name) = file_column_name {
-        fields.push(Arc::new(Field::new(file_column_name, DataType::Utf8, true)));
-    }
-
-    Ok(Arc::new(Schema::new(fields)))
-}
-
 pub(crate) fn simplify_expr(
     session: &dyn Session,
     df_schema: DFSchemaRef,
@@ -1165,123 +651,6 @@ pub(crate) fn simplify_expr(
     session.create_physical_expr(simplifier.simplify(expr)?, df_schema.as_ref())
 }
 
-fn get_pushdown_filters(
-    filter: &[&Expr],
-    partition_cols: &[String],
-) -> Vec<TableProviderFilterPushDown> {
-    filter
-        .iter()
-        .cloned()
-        .map(|expr| {
-            let applicable = expr_is_exact_predicate_for_cols(partition_cols, expr);
-            if !expr.column_refs().is_empty() && applicable {
-                TableProviderFilterPushDown::Exact
-            } else {
-                TableProviderFilterPushDown::Inexact
-            }
-        })
-        .collect()
-}
-
-// inspired from datafusion::listing::helpers, but adapted to only stats based pruning
-fn expr_is_exact_predicate_for_cols(partition_cols: &[String], expr: &Expr) -> bool {
-    let mut is_applicable = true;
-    expr.apply(|expr| match expr {
-        Expr::Column(Column { name, .. }) => {
-            is_applicable &= partition_cols.contains(name);
-
-            // TODO: decide if we should constrain this to Utf8 columns (including views, dicts etc)
-
-            if is_applicable {
-                Ok(TreeNodeRecursion::Jump)
-            } else {
-                Ok(TreeNodeRecursion::Stop)
-            }
-        }
-        Expr::BinaryExpr(BinaryExpr { op, .. }) => {
-            is_applicable &= matches!(
-                op,
-                Operator::And
-                    | Operator::Or
-                    | Operator::NotEq
-                    | Operator::Eq
-                    | Operator::Gt
-                    | Operator::GtEq
-                    | Operator::Lt
-                    | Operator::LtEq
-            );
-            if is_applicable {
-                Ok(TreeNodeRecursion::Continue)
-            } else {
-                Ok(TreeNodeRecursion::Stop)
-            }
-        }
-        Expr::Literal(_, _)
-        | Expr::Not(_)
-        | Expr::IsNotNull(_)
-        | Expr::IsNull(_)
-        | Expr::Between(_)
-        | Expr::InList(_) => Ok(TreeNodeRecursion::Continue),
-        _ => {
-            is_applicable = false;
-            Ok(TreeNodeRecursion::Stop)
-        }
-    })
-    .unwrap();
-    is_applicable
-}
-
-fn partitioned_file_from_action(
-    action: &Add,
-    partition_columns: &[String],
-    schema: &Schema,
-) -> PartitionedFile {
-    let partition_values = partition_columns
-        .iter()
-        .map(|part| {
-            action
-                .partition_values
-                .get(part)
-                .map(|val| {
-                    schema
-                        .field_with_name(part)
-                        .map(|field| match val {
-                            Some(value) => to_correct_scalar_value(
-                                &serde_json::Value::String(value.to_string()),
-                                field.data_type(),
-                            )
-                            .unwrap_or(Some(ScalarValue::Null))
-                            .unwrap_or(ScalarValue::Null),
-                            None => get_null_of_arrow_type(field.data_type())
-                                .unwrap_or(ScalarValue::Null),
-                        })
-                        .unwrap_or(ScalarValue::Null)
-                })
-                .unwrap_or(ScalarValue::Null)
-        })
-        .collect::<Vec<_>>();
-
-    let ts_secs = action.modification_time / 1000;
-    let ts_ns = (action.modification_time % 1000) * 1_000_000;
-    let last_modified = Utc.from_utc_datetime(
-        &DateTime::from_timestamp(ts_secs, ts_ns as u32)
-            .unwrap()
-            .naive_utc(),
-    );
-    PartitionedFile {
-        object_meta: ObjectMeta {
-            last_modified,
-            ..action.try_into().unwrap()
-        },
-        partition_values,
-        range: None,
-        statistics: None,
-        ordering: None,
-        extensions: None,
-        metadata_size_hint: None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::kernel::{DataType, PrimitiveType, StructField, StructType};
@@ -1293,14 +662,10 @@ mod tests {
     use arrow::array::{ArrayRef, Int64Array, StringArray, StringViewArray};
     use arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
-    use chrono::{TimeZone, Utc};
-    use datafusion::common::ScalarValue;
     use datafusion::datasource::MemTable;
-    use datafusion::datasource::listing::PartitionedFile;
     use datafusion::execution::context::SessionState;
     use datafusion::logical_expr::dml::InsertOp;
     use datafusion::physical_plan::collect_partitioned;
-    use object_store::path::Path;
     use std::sync::Arc;
     use url::Url;
 
@@ -1629,10 +994,10 @@ mod tests {
 
         let provider = next::DeltaScan::builder()
             .with_snapshot(snapshot)
-            .with_file_selection(next::FileSelection::new([missing_file_id]))
             .build()
             .await
-            .unwrap();
+            .unwrap()
+            .with_file_selection(next::FileSelection::new([missing_file_id]));
 
         let session = Arc::new(crate::delta_datafusion::create_session().into_inner());
         let state = session.state_ref().read().clone();
@@ -1642,48 +1007,5 @@ mod tests {
             err_str.contains("File selection contains"),
             "unexpected error: {err_str}"
         );
-    }
-
-    #[test]
-    fn test_partitioned_file_from_action() {
-        let mut partition_values = std::collections::HashMap::new();
-        partition_values.insert("month".to_string(), Some("1".to_string()));
-        partition_values.insert("year".to_string(), Some("2015".to_string()));
-        let action = Add {
-            path: "year=2015/month=1/part-00000-4dcb50d3-d017-450c-9df7-a7257dbd3c5d-c000.snappy.parquet".to_string(),
-            size: 10644,
-            partition_values,
-            modification_time: 1660497727833,
-            data_change: true,
-            stats: None,
-            deletion_vector: None,
-            tags: None,
-            base_row_id: None,
-            default_row_commit_version: None,
-            clustering_provider: None,
-        };
-        let schema = Schema::new(vec![
-            Field::new("year", ArrowDataType::Int64, true),
-            Field::new("month", ArrowDataType::Int64, true),
-        ]);
-
-        let part_columns = vec!["year".to_string(), "month".to_string()];
-        let file = partitioned_file_from_action(&action, &part_columns, &schema);
-        let ref_file = PartitionedFile {
-            object_meta: object_store::ObjectMeta {
-                location: Path::from("year=2015/month=1/part-00000-4dcb50d3-d017-450c-9df7-a7257dbd3c5d-c000.snappy.parquet".to_string()),
-                last_modified: Utc.timestamp_millis_opt(1660497727833).unwrap(),
-                size: 10644,
-                e_tag: None,
-                version: None,
-            },
-            partition_values: [ScalarValue::Int64(Some(2015)), ScalarValue::Int64(Some(1))].to_vec(),
-            range: None,
-            statistics: None,
-            ordering: None,
-            extensions: None,
-            metadata_size_hint: None,
-        };
-        assert_eq!(file.partition_values, ref_file.partition_values)
     }
 }

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -113,6 +113,7 @@ impl FileSelection {
     /// - [`FileSelection::from_file_paths`]
     /// - [`FileSelection::from_adds`]
     /// - [`normalize_path_as_file_id`]
+    #[cfg(test)]
     pub(crate) fn new(file_ids: impl IntoIterator<Item = String>) -> Self {
         Self {
             file_ids: file_ids.into_iter().collect(),

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -25,7 +25,7 @@ use datafusion_proto::bytes::{
     logical_plan_from_bytes_with_extension_codec, logical_plan_to_bytes_with_extension_codec,
 };
 use deltalake_core::DeltaTableBuilder;
-use deltalake_core::delta_datafusion::{DeltaScan, DeltaTableFactory};
+use deltalake_core::delta_datafusion::DeltaTableFactory;
 use deltalake_core::kernel::{
     ColumnMetadataKey, DataType, MapType, MetadataValue, PrimitiveType, StructField, StructType,
 };
@@ -136,11 +136,6 @@ mod local {
             if let Some(exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
                 let files = get_scanned_files(exec);
                 self.scanned_files.extend(files);
-            } else if let Some(exec) = plan.as_any().downcast_ref::<DeltaScan>() {
-                self.keep_count = exec
-                    .metrics()
-                    .and_then(|m| m.sum_by_name("files_scanned").map(|v| v.as_usize()))
-                    .unwrap_or_default();
             } else if let Some(exec) = plan.as_any().downcast_ref::<DeltaScanExec>() {
                 self.keep_count = exec
                     .metrics()


### PR DESCRIPTION
Friends, we gather today not in` #[deprecated]` but in cargo rm to say goodbye to `DeltaTableProvider`. A humble struct that asked only for an `ObjectStore` and some files, and in return gave us rows, oh so many rows. 

It is survived by `TableProviderBuilder`, who is younger and frankly a little smug about it, and by `DeltaScanNext`, who insists on the "Next" suffix even though there is no longer a previous one. The old physical scan wrapper lives on internally, kept around solely so the DataFusion physical extension codec doesn't have a breakdown.

Somewhere, a `Cargo.lock` pinned to a 2023 commit still calls `::with_files` and does not yet know, please be gentle when it opens its next PR. Ashes to ashes, dust to dust, deprecated to deleted. 🪦

cc: @rtyler @hntd187 @ion-elgreco @roeap 

part of #4239 