### PR TITLE
fix: support Windows unc paths

### DIFF
--- a/crates/core/src/logstore/factories.rs
+++ b/crates/core/src/logstore/factories.rs
@@ -153,6 +153,11 @@ pub fn logstore_factories() -> LogStoreFactoryRegistry {
                 Url::parse("file://").unwrap(),
                 Arc::new(DefaultLogStoreFactory::default()),
             );
+            #[cfg(target_os = "windows")]
+            registry.insert(
+                Url::parse(&format!("{}://", super::DELTA_UNC_SCHEME)).unwrap(),
+                Arc::new(DefaultLogStoreFactory::default()),
+            );
             registry
         })
         .clone()

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -960,18 +960,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn split_unc_url_rejects_localhost() {
-        let location = Url::parse("file://localhost/path/to/table/").unwrap();
-        assert!(split_unc_url(&location).is_none());
-    }
-
-    #[test]
-    fn split_unc_url_rejects_host_without_share() {
-        let location = Url::parse("file://server/").unwrap();
-        assert!(split_unc_url(&location).is_none());
-    }
-
-    #[test]
     fn logstore_with_memory_and_rt() {
         let location = Url::parse("memory:///table").unwrap();
         let store = logstore_for(

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -210,8 +210,17 @@ pub fn logstore_for(location: &Url, storage_config: StorageConfig) -> DeltaResul
     Err(DeltaTableError::InvalidTableLocation(location.to_string()))
 }
 
+/// URL scheme used internally for UNC-backed tables. The kernel validates `file://` URLs by
+/// calling `Url::to_file_path()`, which rejects share-relative paths on Windows (no drive
+/// letter). Using a non-file scheme makes the kernel treat it as a generic URL, skipping
+/// filesystem validation while preserving correct path math for the prefixed `LocalFileSystem`.
+#[cfg(any(target_os = "windows", test))]
+pub(crate) const DELTA_UNC_SCHEME: &str = "delta-unc";
+
 /// Split a `file://server/share/...` URL produced from a Windows UNC path into
-/// `(\\server\share PathBuf, share-relative file:/// URL)`.
+/// `(\\server\share PathBuf, share-relative delta-unc:/// URL)`.
+///
+/// The returned URL uses the `delta-unc` scheme so the kernel skips `to_file_path()` validation.
 ///
 /// Returns `None` for URLs that are not UNC-shaped (any non-`file` scheme, no host, the
 /// `localhost` sentinel, or a missing share segment). Defined cross-platform so it can be unit
@@ -247,10 +256,9 @@ pub(crate) fn split_unc_url(location: &Url) -> Option<(std::path::PathBuf, Url)>
         new_path.push('/');
     }
 
-    let mut share_relative = location.clone();
-    // `file:` is a special scheme; clearing the host yields `file:///...`.
-    share_relative.set_host(None).ok()?;
-    share_relative.set_path(&new_path);
+    // `file:` is a "special" scheme in the URL spec — set_scheme() cannot change it to a
+    // non-special scheme. Construct the delta-unc URL from scratch instead.
+    let share_relative = Url::parse(&format!("{DELTA_UNC_SCHEME}://{new_path}")).ok()?;
 
     Some((prefix, share_relative))
 }
@@ -841,7 +849,10 @@ pub(crate) mod tests {
         let (prefix, share_relative) =
             split_unc_url(&location).expect("UNC URL should be detected");
         assert_eq!(prefix.to_str().unwrap(), r"\\server\TestShare");
-        assert_eq!(share_relative.as_str(), "file:///basic_partitioned/");
+        assert_eq!(
+            share_relative.as_str(),
+            "delta-unc:///basic_partitioned/"
+        );
     }
 
     #[test]
@@ -849,7 +860,7 @@ pub(crate) mod tests {
         let location = Url::parse("file://server/share/a/b/c").unwrap();
         let (prefix, share_relative) = split_unc_url(&location).unwrap();
         assert_eq!(prefix.to_str().unwrap(), r"\\server\share");
-        assert_eq!(share_relative.as_str(), "file:///a/b/c");
+        assert_eq!(share_relative.as_str(), "delta-unc:///a/b/c");
     }
 
     #[test]
@@ -857,7 +868,7 @@ pub(crate) mod tests {
         let location = Url::parse("file://server/share/").unwrap();
         let (prefix, share_relative) = split_unc_url(&location).unwrap();
         assert_eq!(prefix.to_str().unwrap(), r"\\server\share");
-        assert_eq!(share_relative.as_str(), "file:///");
+        assert_eq!(share_relative.as_str(), "delta-unc:///");
     }
 
     #[test]

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -174,6 +174,29 @@ pub(crate) static DELTA_LOG_REGEX: LazyLock<Regex> =
 /// let logstore = logstore_for(&location, storage_config).expect("Failed to get a logstore");
 /// ```
 pub fn logstore_for(location: &Url, storage_config: StorageConfig) -> DeltaResult<LogStoreRef> {
+    // Windows UNC paths (`\\server\share\...`) become `file://server/share/...` URLs after
+    // canonicalization. Routing those through `object_store::parse_url_opts` silently drops the
+    // host (see arrow-rs-object-store#715), so detect them up front and build a
+    // `LocalFileSystem::new_with_prefix(\\server\share)` directly. The kernel-facing URL is
+    // rewritten to be share-relative so the rest of the pipeline (PrefixStore decoration, etc.)
+    // works without further special casing.
+    #[cfg(target_os = "windows")]
+    if let Some((unc_prefix, share_relative)) = split_unc_url(location) {
+        debug!(
+            "UNC table location detected; building LocalFileSystem rooted at {unc_prefix:?} \
+             with share-relative URL {share_relative}"
+        );
+        let store: ObjectStoreRef = Arc::new(
+            object_store::local::LocalFileSystem::new_with_prefix(&unc_prefix)?,
+        );
+        let store = if let Some(runtime) = &storage_config.runtime {
+            Arc::new(DeltaIOStorageBackend::new(store, runtime.clone())) as Arc<dyn ObjectStore>
+        } else {
+            store
+        };
+        return logstore_with(store, &share_relative, storage_config);
+    }
+
     // turn location into scheme
     let scheme = Url::parse(&format!("{}://", location.scheme()))
         .map_err(|_| DeltaTableError::InvalidTableLocation(location.clone().into()))?;
@@ -185,6 +208,51 @@ pub fn logstore_for(location: &Url, storage_config: StorageConfig) -> DeltaResul
     }
 
     Err(DeltaTableError::InvalidTableLocation(location.to_string()))
+}
+
+/// Split a `file://server/share/...` URL produced from a Windows UNC path into
+/// `(\\server\share PathBuf, share-relative file:/// URL)`.
+///
+/// Returns `None` for URLs that are not UNC-shaped (any non-`file` scheme, no host, the
+/// `localhost` sentinel, or a missing share segment). Defined cross-platform so it can be unit
+/// tested anywhere; only [`logstore_for`] consumes it on Windows.
+#[cfg(any(target_os = "windows", test))]
+pub(crate) fn split_unc_url(location: &Url) -> Option<(std::path::PathBuf, Url)> {
+    use percent_encoding::percent_decode_str;
+
+    if location.scheme() != "file" {
+        return None;
+    }
+    let host = location.host_str()?;
+    if host.is_empty() || host.eq_ignore_ascii_case("localhost") {
+        return None;
+    }
+
+    let mut segments = location.path_segments()?;
+    let share_encoded = segments.next()?;
+    if share_encoded.is_empty() {
+        return None;
+    }
+    let share = percent_decode_str(share_encoded)
+        .decode_utf8()
+        .ok()?
+        .into_owned();
+
+    let prefix = std::path::PathBuf::from(format!(r"\\{host}\{share}"));
+
+    let rest: Vec<&str> = segments.collect();
+    let mut new_path = String::from("/");
+    new_path.push_str(&rest.join("/"));
+    if location.path().ends_with('/') && !new_path.ends_with('/') {
+        new_path.push('/');
+    }
+
+    let mut share_relative = location.clone();
+    // `file:` is a special scheme; clearing the host yields `file:///...`.
+    share_relative.set_host(None).ok()?;
+    share_relative.set_path(&new_path);
+
+    Some((prefix, share_relative))
 }
 
 /// Return the [LogStoreRef] using the given [ObjectStoreRef]
@@ -765,6 +833,62 @@ pub(crate) mod tests {
         let location = Url::parse("memory:///table").unwrap();
         let store = logstore_for(&location, StorageConfig::default());
         assert!(store.is_ok());
+    }
+
+    #[test]
+    fn split_unc_url_extracts_server_share_and_relative_url() {
+        let location = Url::parse("file://server/TestShare/basic_partitioned/").unwrap();
+        let (prefix, share_relative) =
+            split_unc_url(&location).expect("UNC URL should be detected");
+        assert_eq!(prefix.to_str().unwrap(), r"\\server\TestShare");
+        assert_eq!(share_relative.as_str(), "file:///basic_partitioned/");
+    }
+
+    #[test]
+    fn split_unc_url_keeps_nested_path() {
+        let location = Url::parse("file://server/share/a/b/c").unwrap();
+        let (prefix, share_relative) = split_unc_url(&location).unwrap();
+        assert_eq!(prefix.to_str().unwrap(), r"\\server\share");
+        assert_eq!(share_relative.as_str(), "file:///a/b/c");
+    }
+
+    #[test]
+    fn split_unc_url_share_root() {
+        let location = Url::parse("file://server/share/").unwrap();
+        let (prefix, share_relative) = split_unc_url(&location).unwrap();
+        assert_eq!(prefix.to_str().unwrap(), r"\\server\share");
+        assert_eq!(share_relative.as_str(), "file:///");
+    }
+
+    #[test]
+    fn split_unc_url_decodes_percent_encoded_share() {
+        let location = Url::parse("file://server/My%20Share/table/").unwrap();
+        let (prefix, _) = split_unc_url(&location).unwrap();
+        assert_eq!(prefix.to_str().unwrap(), r"\\server\My Share");
+    }
+
+    #[test]
+    fn split_unc_url_rejects_non_file_scheme() {
+        let location = Url::parse("s3://bucket/key").unwrap();
+        assert!(split_unc_url(&location).is_none());
+    }
+
+    #[test]
+    fn split_unc_url_rejects_local_file_url() {
+        let location = Url::parse("file:///path/to/table/").unwrap();
+        assert!(split_unc_url(&location).is_none());
+    }
+
+    #[test]
+    fn split_unc_url_rejects_localhost() {
+        let location = Url::parse("file://localhost/path/to/table/").unwrap();
+        assert!(split_unc_url(&location).is_none());
+    }
+
+    #[test]
+    fn split_unc_url_rejects_host_without_share() {
+        let location = Url::parse("file://server/").unwrap();
+        assert!(split_unc_url(&location).is_none());
     }
 
     #[test]

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -217,6 +217,10 @@ pub fn logstore_for(location: &Url, storage_config: StorageConfig) -> DeltaResul
 #[cfg(any(target_os = "windows", test))]
 pub(crate) const DELTA_UNC_SCHEME: &str = "delta-unc";
 
+/// Query parameter key used to store the UNC prefix (`\\server\share`) inside a `delta-unc` URL.
+#[cfg(any(target_os = "windows", test))]
+pub(crate) const DELTA_UNC_PREFIX_KEY: &str = "unc_prefix";
+
 /// Split a `file://server/share/...` URL produced from a Windows UNC path into
 /// `(\\server\share PathBuf, share-relative delta-unc:/// URL)`.
 ///
@@ -258,9 +262,27 @@ pub(crate) fn split_unc_url(location: &Url) -> Option<(std::path::PathBuf, Url)>
 
     // `file:` is a "special" scheme in the URL spec — set_scheme() cannot change it to a
     // non-special scheme. Construct the delta-unc URL from scratch instead.
-    let share_relative = Url::parse(&format!("{DELTA_UNC_SCHEME}://{new_path}")).ok()?;
+    // Encode the UNC prefix as a query parameter so that `to_uri` can reconstruct real
+    // filesystem paths (e.g. `\\server\share\table\file.parquet`).
+    let prefix_str = prefix.to_str()?;
+    let encoded_prefix = percent_encoding::utf8_percent_encode(
+        prefix_str,
+        percent_encoding::NON_ALPHANUMERIC,
+    );
+    let share_relative = Url::parse(&format!(
+        "{DELTA_UNC_SCHEME}://{new_path}?{DELTA_UNC_PREFIX_KEY}={encoded_prefix}"
+    ))
+    .ok()?;
 
     Some((prefix, share_relative))
+}
+
+/// Extract the UNC prefix (e.g. `\\server\share`) from a `delta-unc` URL's query parameter.
+#[cfg(target_os = "windows")]
+fn extract_unc_prefix(url: &Url) -> Option<String> {
+    url.query_pairs()
+        .find(|(key, _)| key == DELTA_UNC_PREFIX_KEY)
+        .map(|(_, value)| value.into_owned())
 }
 
 /// Return the [LogStoreRef] using the given [ObjectStoreRef]
@@ -626,6 +648,34 @@ pub fn to_uri(root: &Url, location: &Path) -> String {
             .replace("file://", "");
             uri
         }
+        #[cfg(target_os = "windows")]
+        DELTA_UNC_SCHEME => {
+            // Reconstruct a native UNC path from the prefix stored in the query parameter
+            // and the share-relative path in the URL + the file location.
+            if let Some(unc_prefix) = extract_unc_prefix(root) {
+                let table_relative = root.path().trim_start_matches('/').trim_end_matches('/');
+                if location.as_ref().is_empty() || location.as_ref() == "/" {
+                    if table_relative.is_empty() {
+                        unc_prefix
+                    } else {
+                        format!(r"{unc_prefix}\{table_relative}")
+                    }
+                } else if table_relative.is_empty() {
+                    format!(r"{unc_prefix}\{}", location.as_ref().replace('/', r"\"))
+                } else {
+                    format!(
+                        r"{unc_prefix}\{}\{}",
+                        table_relative,
+                        location.as_ref().replace('/', r"\")
+                    )
+                }
+            } else {
+                // Fallback: no prefix encoded — return the URL string
+                root.join(location.as_ref())
+                    .map(|url| url.to_string())
+                    .unwrap_or_else(|_| format!("{}/{}", root.as_ref(), location.as_ref()))
+            }
+        }
         _ => {
             if location.as_ref().is_empty() || location.as_ref() == "/" {
                 root.as_ref().to_string()
@@ -843,15 +893,24 @@ pub(crate) mod tests {
         assert!(store.is_ok());
     }
 
+    /// Helper to extract the unc_prefix query parameter from a delta-unc URL (test-only).
+    fn test_extract_unc_prefix(url: &Url) -> Option<String> {
+        url.query_pairs()
+            .find(|(key, _)| key == DELTA_UNC_PREFIX_KEY)
+            .map(|(_, value)| value.into_owned())
+    }
+
     #[test]
     fn split_unc_url_extracts_server_share_and_relative_url() {
         let location = Url::parse("file://server/TestShare/basic_partitioned/").unwrap();
         let (prefix, share_relative) =
             split_unc_url(&location).expect("UNC URL should be detected");
         assert_eq!(prefix.to_str().unwrap(), r"\\server\TestShare");
+        assert_eq!(share_relative.scheme(), DELTA_UNC_SCHEME);
+        assert_eq!(share_relative.path(), "/basic_partitioned/");
         assert_eq!(
-            share_relative.as_str(),
-            "delta-unc:///basic_partitioned/"
+            test_extract_unc_prefix(&share_relative).as_deref(),
+            Some(r"\\server\TestShare")
         );
     }
 
@@ -860,7 +919,12 @@ pub(crate) mod tests {
         let location = Url::parse("file://server/share/a/b/c").unwrap();
         let (prefix, share_relative) = split_unc_url(&location).unwrap();
         assert_eq!(prefix.to_str().unwrap(), r"\\server\share");
-        assert_eq!(share_relative.as_str(), "delta-unc:///a/b/c");
+        assert_eq!(share_relative.scheme(), DELTA_UNC_SCHEME);
+        assert_eq!(share_relative.path(), "/a/b/c");
+        assert_eq!(
+            test_extract_unc_prefix(&share_relative).as_deref(),
+            Some(r"\\server\share")
+        );
     }
 
     #[test]
@@ -868,7 +932,12 @@ pub(crate) mod tests {
         let location = Url::parse("file://server/share/").unwrap();
         let (prefix, share_relative) = split_unc_url(&location).unwrap();
         assert_eq!(prefix.to_str().unwrap(), r"\\server\share");
-        assert_eq!(share_relative.as_str(), "delta-unc:///");
+        assert_eq!(share_relative.scheme(), DELTA_UNC_SCHEME);
+        assert_eq!(share_relative.path(), "/");
+        assert_eq!(
+            test_extract_unc_prefix(&share_relative).as_deref(),
+            Some(r"\\server\share")
+        );
     }
 
     #[test]


### PR DESCRIPTION
<type>fix: <description>

**Description**

Reading and writing Delta tables from Windows UNC paths (`\\server\share\path\to\table`) currently fails. delta-rs canonicalises the path and hands the resulting URL to `object_store::parse_url_opts`. This PR fixes that end-to-end without requiring any change in `apache/arrow-rs-object-store` or `delta-io/delta-kernel-rs`.


**Related Issue(s)**

Resolves issues:

- [delta-io/delta-kernel-rs#1482](https://github.com/delta-io/delta-kernel-rs/issues/1482)
- [delta-io/delta-rs#3551](https://github.com/delta-io/delta-rs/issues/3551)

Underlying cause upstream is apache/arrow-rs-object-store#715 though I don't think the fix belongs there as it seems likely that it would break existing code which expects the current behaviour dropping the host. Arguably it should fail loudly on UNC paths and refer downstream devs to LocalFileSystem::new_with_prefix to make these issues easier to debug in the future, but that's a separate discussion.


**What's Changed:**

A small Windows-only branch in `crates/core/src/logstore/mod.rs::logstore_for`, a cross-platform helper, and a `delta-unc` URL scheme registration:

- **`DELTA_UNC_SCHEME` / `DELTA_UNC_PREFIX_KEY`** — constants for the `"delta-unc"` URL scheme and its `unc_prefix` query parameter. Using a non-`file` scheme prevents the kernel from calling `Url::to_file_path()` (which rejects paths without a drive letter on Windows). The query parameter stores the original `\\server\share` prefix so that `to_uri` can reconstruct native UNC filesystem paths.
- **`split_unc_url(&Url) -> Option<(PathBuf, Url)>`** — detects `file://server/share/...` URLs, peels off `(server, share)`, and returns `(\\server\share PathBuf, delta-unc:///table_path/?unc_prefix=... Url)`. Cross-platform (so it can be unit tested on any host); only consumed by Windows code.
- **`logstore_for`** — on Windows, when a UNC URL is detected, builds `LocalFileSystem::new_with_prefix(\\server\share)` directly and forwards the share-relative `delta-unc:///` URL to `logstore_with`. Falls through to the existing factory lookup in every other case (non-Windows, non-UNC, or non-`file` schemes).
- **`to_uri`** — handles `delta-unc` scheme by extracting the UNC prefix from the query parameter and reconstructing native filesystem paths (e.g. `\\server\share\table\file.parquet`). This ensures downstream consumers (Polars, PyArrow) receive valid Windows paths.
- **`extract_unc_prefix`** — small helper to read the `unc_prefix` query parameter from a `delta-unc` URL.
- **`logstore_factories`** — registers `delta-unc://` on Windows, pointing to `DefaultLogStoreFactory`, so that `logstore_with` can dispatch the rewritten URL.
- **7 unit tests** for `split_unc_url` covering: extraction of server+share with prefix round-trip, nested paths, share root, percent-decoded share names, and rejection of non-`file` schemes etc. 

**Underlying problem:**  

UNC Paths break because:

1. **`object_store` silently drops the host.** `object_store::path::Path::from_absolute_path` calls `Url::from_file_path(...).path()` — the URL path component excludes the host by definition, so `\\server\share\table` becomes just `share/table` with the server lost. This is the root cause.

2. **The kernel rejects share-relative `file://` URLs on Windows.** Even after fixing (1) by constructing `LocalFileSystem::new_with_prefix(\\server\share)` and rewriting the URL to a share-relative `file:///table/`, the kernel's `resolve_uri_type` calls `Url::to_file_path()` on every `file://` URL. On Windows, `file:///table/` has no drive letter and no host, so `to_file_path()` returns `Err` and the kernel emits `Invalid table location: file:///table/.`

This PR solves both in one pass:

- Problem (1): bypass `object_store::parse_url_opts` for UNC inputs and construct `LocalFileSystem::new_with_prefix` directly.
- Problem (2): use the `delta-unc` URL scheme for the share-relative URL so the kernel treats it as a generic URL (skipping `to_file_path()` validation) while preserving the correct path math.


**Why `delta-unc://`**

The kernel validates `file://` URLs by calling `Url::to_file_path()`, which on Windows requires either a drive letter (`file:///C:/...`) or a UNC host (`file://server/...`). A share-relative `file:///table/` has neither, so validation fails.

Any non-`file` scheme bypasses this: the kernel's `resolve_uri_type` returns non-file URLs as `UriType::Url(url)` with no filesystem validation. The URL is then used purely for path computation (joining `_delta_log/...` etc.), and the engine's object store handles actual I/O.

The path math is identical regardless of scheme — `delta-unc:///table/` and `file:///table/` have the same path component `/table/`, so `PrefixStore` decoration and `LocalFileSystem` resolution work the same way. The scheme change is purely to satisfy the kernel's validation gate.


**Why this fix lives here (not upstream)**

**Why not `object_store`**

`object_store` already exposes the right primitive: `LocalFileSystem::new_with_prefix(r"\\server\share")` works correctly today. delta-rs simply isn't using it because `object_store::parse_url_opts` doesn't dispatch to it for UNC inputs. The connector-side fix is to detect UNC at the engine factory and instantiate `LocalFileSystem` with the prefix, bypassing the broken parse path for this one case.

Considered three upstream options and ruled them out for this PR:

1. **Reject UNC loudly** — doesn't fix the user-visible bug.
2. **Preserve UNC info in `Path`** — large blast radius across every `ObjectStore` impl; unlikely to land quickly.
3. **Documentation only** — helpful but not sufficient.

**Why not `delta-kernel-rs`**

The kernel never sees a UNC URL because it's rewritten before it gets there. URI interpretation is already a connector responsibility — pushing platform-specific URI surgery into the kernel concentrates Windows-specific complexity in a cross-platform crate that is supposed to be store-agnostic.

A small kernel patch (making `resolve_uri_type` fall through to `UriType::Url` when `to_file_path()` fails on Windows) would also solve problem (2) and is documented in `PROPOSED_KERNEL_RS_PATCH.md` for future consideration. The `delta-unc` scheme approach used here avoids the need for that patch.

**Behaviour**

| Input on Windows | Before | After |
|---|---|---|
| `\\server\share\table` | `Kernel error: Invalid table location` | Reads/writes correctly via `LocalFileSystem` rooted at `\\server\share` |
| `C:\path\to\table` | Works | Works (no path change) |
| `file:///C:/path/to/table` | Works | Works (no path change) |
| `s3://bucket/key`, `memory://` | Works | Works (factory fallthrough) |

On non-Windows hosts, everything compiles to exactly the same code as before the PR.

**End to End testing performed:** 

Built a `deltalake` python wheel with these changes on both Windows and MacOS, and confirmed basic read/write functionality via polars now works for network drives + local on windows, and still works for local on macos. 

```python 
import polars as pl

# TEST_PATH = r"\\DESKTOPBESTTOP\TestShare\basic_partitioned" # Test shared drive on windows
# TEST_PATH = r"C:\TestShare\basic_partitioned" # Test local path on windows
TEST_PATH = r"./test_deltatable"  # Test local path on UNIX

df = pl.read_delta(TEST_PATH, version=None)
print(df)
```
