### PR TITLE
fix: allow partition column changes on schema overwrite

### DIFF
--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -7,8 +7,10 @@
 //!  - The save mode will control how existing data is handled (i.e. overwrite, append, etc)
 //!  - Conflicting columns (i.e. a INT, and a STRING)
 //!    will result in an exception.
-//!  - The partition columns, if present, are validated against the existing metadata. If not
-//!    present, then the partitioning of the table is respected.
+//!    Partition columns, if present, are validated against the existing metadata.
+//!    When omitted, the table partitioning is respected.
+//!    Full table overwrite with `SchemaMode::Overwrite` and no replaceWhere predicate may
+//!    replace the partition columns.
 //!
 //! In combination with `Overwrite`, a `replaceWhere` option can be used to transactionally
 //! replace data that matches a predicate.
@@ -79,12 +81,15 @@ pub(crate) enum WriteError {
     AlreadyExists(Url),
 
     #[error(
-        "Specified table partitioning does not match table partitioning: expected: {expected:?}, got: {got:?}"
+        "Specified table partitioning does not match table partitioning: expected: {expected:?}, got: {got:?}. To change partition columns, use full table overwrite with schema overwrite and no replaceWhere predicate."
     )]
     PartitionColumnMismatch {
         expected: Vec<String>,
         got: Vec<String>,
     },
+
+    #[error("Partition column(s) not found in write schema: {}", columns.join(", "))]
+    MissingPartitionColumns { columns: Vec<String> },
 }
 
 impl From<WriteError> for DeltaTableError {
@@ -224,8 +229,10 @@ impl WriteBuilder {
         self
     }
 
-    /// (Optional) Specify table partitioning. If specified, the partitioning is validated,
-    /// if the table already exists. In case a new table is created, the partitioning is applied.
+    /// (Optional) Specify table partitioning. For existing tables this must match the
+    /// current partitioning, except full table overwrite with schema overwrite and
+    /// no replaceWhere predicate may replace the partitioning. For new tables, the
+    /// partitioning is applied.
     pub fn with_partition_columns(
         mut self,
         partition_columns: impl IntoIterator<Item = impl Into<String>>,
@@ -346,6 +353,14 @@ impl WriteBuilder {
         self
     }
 
+    /// Partition layout changes require a full table rewrite. Predicate overwrites
+    /// replace only a table subset and must keep the existing layout.
+    fn can_overwrite_partition_columns(&self) -> bool {
+        self.mode == SaveMode::Overwrite
+            && self.schema_mode == Some(SchemaMode::Overwrite)
+            && self.predicate.is_none()
+    }
+
     fn get_partition_columns(&self) -> Result<Vec<String>, WriteError> {
         // validate partition columns
         let active_partitions = self
@@ -356,10 +371,14 @@ impl WriteBuilder {
         if let Some(active_part) = active_partitions {
             if let Some(ref partition_columns) = self.partition_columns {
                 if &active_part != partition_columns {
-                    Err(WriteError::PartitionColumnMismatch {
-                        expected: active_part,
-                        got: partition_columns.to_vec(),
-                    })
+                    if self.can_overwrite_partition_columns() {
+                        Ok(partition_columns.clone())
+                    } else {
+                        Err(WriteError::PartitionColumnMismatch {
+                            expected: active_part,
+                            got: partition_columns.to_vec(),
+                        })
+                    }
                 } else {
                     Ok(partition_columns.clone())
                 }
@@ -734,6 +753,22 @@ mod tests {
                 _ => None,
             })
             .collect())
+    }
+
+    async fn modified_partitioned_table(batch: &RecordBatch) -> TestResult<DeltaTable> {
+        Ok(DeltaTable::new_in_memory()
+            .write(vec![batch.clone()])
+            .with_partition_columns(["modified"])
+            .await?)
+    }
+
+    fn expect_write_error(err: &DeltaTableError) -> &WriteError {
+        let DeltaTableError::GenericError { source } = err else {
+            panic!("expected WriteError, got {err:?}");
+        };
+        source
+            .downcast_ref::<WriteError>()
+            .expect("expected WriteError source")
     }
 
     fn assert_common_write_metrics(write_metrics: WriteMetrics) {
@@ -1277,6 +1312,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_merge_schema_with_partitions_allows_source_missing_partition_column() -> TestResult
+    {
+        let batch = get_record_batch(None, false);
+        let table = modified_partitioned_table(&batch).await?;
+
+        let evolved_schema = Arc::new(ArrowSchema::new(vec![
+            batch.schema().field(0).as_ref().clone(),
+            batch.schema().field(1).as_ref().clone(),
+            Field::new("inserted_by", DataType::Utf8, true),
+        ]));
+        let evolved_batch = RecordBatch::try_new(
+            evolved_schema,
+            vec![
+                batch.column(0).clone(),
+                batch.column(1).clone(),
+                Arc::new(StringArray::from(vec![
+                    Some("A1"),
+                    Some("B1"),
+                    None,
+                    Some("B2"),
+                    Some("A3"),
+                    Some("A4"),
+                    None,
+                    None,
+                    Some("B4"),
+                    Some("A5"),
+                    Some("A7"),
+                ])),
+            ],
+        )?;
+
+        let table = table
+            .write(vec![evolved_batch])
+            .with_save_mode(SaveMode::Append)
+            .with_schema_mode(SchemaMode::Merge)
+            .await?;
+
+        assert_eq!(table.version(), Some(1));
+        let schema = table.snapshot().unwrap().metadata().parse_schema()?;
+        let names = schema
+            .fields()
+            .map(|field| field.name())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["id", "value", "modified", "inserted_by"]);
+        assert_eq!(
+            table.snapshot().unwrap().metadata().partition_columns(),
+            &vec!["modified".to_string()]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_merge_schema_preserves_existing_field_metadata() {
         let schema: StructType = serde_json::from_value(json!({
             "type": "struct",
@@ -1403,6 +1491,285 @@ mod tests {
             .with_schema_mode(SchemaMode::Overwrite)
             .await;
         assert!(table.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_schema_can_change_partition_columns_without_schema_change() -> TestResult
+    {
+        let batch = get_record_batch(None, false);
+
+        let table = modified_partitioned_table(&batch).await?;
+
+        assert_eq!(
+            table.snapshot().unwrap().metadata().partition_columns(),
+            &vec!["modified".to_string()]
+        );
+        let initial_num_files = table.snapshot().unwrap().log_data().num_files();
+
+        let table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_schema_mode(SchemaMode::Overwrite)
+            .with_partition_columns(["id"])
+            .await?;
+
+        assert_eq!(table.version(), Some(1));
+        assert_eq!(
+            table.snapshot().unwrap().metadata().partition_columns(),
+            &vec!["id".to_string()]
+        );
+
+        let add_paths = table
+            .snapshot()
+            .unwrap()
+            .log_data()
+            .iter()
+            .map(|add| add.path().into_owned())
+            .collect::<Vec<_>>();
+        assert!(!add_paths.is_empty());
+        assert!(add_paths.iter().all(|path| path.contains("id=")));
+
+        let remove_actions = latest_remove_actions(&table).await?;
+        assert_eq!(remove_actions.len(), initial_num_files);
+        assert!(
+            remove_actions
+                .iter()
+                .all(|remove| remove.deletion_timestamp.is_some())
+        );
+
+        let commit_info: Vec<_> = table.history(Some(1)).await?.collect();
+        let operation_parameters = commit_info[0].operation_parameters.as_ref().unwrap();
+        assert_eq!(operation_parameters["partitionBy"], json!("[\"id\"]"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_schema_can_change_schema_and_partition_columns() -> TestResult {
+        let batch = get_record_batch(None, false);
+        let table = modified_partitioned_table(&batch).await?;
+
+        let mut new_schema_builder = arrow_schema::SchemaBuilder::new();
+        for field in batch.schema().fields() {
+            if field.name() != "modified" {
+                new_schema_builder.push(field.clone());
+            }
+        }
+        new_schema_builder.push(Field::new("inserted_by", DataType::Utf8, true));
+        let new_schema = new_schema_builder.finish();
+        let inserted_by = StringArray::from(vec![
+            Some("A1"),
+            Some("B1"),
+            None,
+            Some("B2"),
+            Some("A3"),
+            Some("A4"),
+            None,
+            None,
+            Some("B4"),
+            Some("A5"),
+            Some("A7"),
+        ]);
+        let new_batch = RecordBatch::try_new(
+            Arc::new(new_schema),
+            vec![
+                Arc::new(batch.column_by_name("id").unwrap().clone()),
+                Arc::new(batch.column_by_name("value").unwrap().clone()),
+                Arc::new(inserted_by),
+            ],
+        )?;
+
+        let table = table
+            .write(vec![new_batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_schema_mode(SchemaMode::Overwrite)
+            .with_partition_columns(["inserted_by"])
+            .await?;
+
+        let schema = table.snapshot().unwrap().metadata().parse_schema()?;
+        let names = schema
+            .fields()
+            .map(|field| field.name())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["id", "value", "inserted_by"]);
+        assert_eq!(
+            table.snapshot().unwrap().metadata().partition_columns(),
+            &vec!["inserted_by".to_string()]
+        );
+
+        let add_paths = table
+            .snapshot()
+            .unwrap()
+            .log_data()
+            .iter()
+            .map(|add| add.path().into_owned())
+            .collect::<Vec<_>>();
+        assert!(!add_paths.is_empty());
+        assert!(add_paths.iter().all(|path| path.contains("inserted_by=")));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_schema_partition_change_preserves_table_metadata() -> TestResult {
+        let batch = get_record_batch(None, false);
+        let table = DeltaTable::new_in_memory()
+            .write(vec![batch.clone()])
+            .with_partition_columns(["modified"])
+            .with_table_name("preserve_name")
+            .with_description("preserve_description")
+            .await?;
+
+        let initial_metadata = table.snapshot().unwrap().metadata().clone();
+        let initial_created_time = initial_metadata.created_time();
+
+        let table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_schema_mode(SchemaMode::Overwrite)
+            .with_partition_columns(["id"])
+            .await?;
+
+        let metadata = table.snapshot().unwrap().metadata();
+        assert_eq!(metadata.id(), initial_metadata.id());
+        assert_eq!(metadata.name(), Some("preserve_name"));
+        assert_eq!(metadata.description(), Some("preserve_description"));
+        assert_eq!(metadata.created_time(), initial_created_time);
+        assert_eq!(metadata.partition_columns(), &vec!["id".to_string()]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_schema_can_remove_partition_columns() -> TestResult {
+        let batch = get_record_batch(None, false);
+        let table = modified_partitioned_table(&batch).await?;
+
+        let table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_schema_mode(SchemaMode::Overwrite)
+            .with_partition_columns(std::iter::empty::<&str>())
+            .await?;
+
+        assert_eq!(table.version(), Some(1));
+        assert!(
+            table
+                .snapshot()
+                .unwrap()
+                .metadata()
+                .partition_columns()
+                .is_empty()
+        );
+
+        let add_paths = table
+            .snapshot()
+            .unwrap()
+            .log_data()
+            .iter()
+            .map(|add| add.path().into_owned())
+            .collect::<Vec<_>>();
+        assert!(!add_paths.is_empty());
+        assert!(add_paths.iter().all(|path| !path.contains('/')));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_append_rejects_partition_column_change() -> TestResult {
+        let batch = get_record_batch(None, false);
+        let table = modified_partitioned_table(&batch).await?;
+
+        let result = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .with_partition_columns(["id"])
+            .await;
+
+        let err = result.expect_err("append should reject partition column change");
+        match expect_write_error(&err) {
+            WriteError::PartitionColumnMismatch { expected, got } => {
+                assert_eq!(expected, &vec!["modified".to_string()]);
+                assert_eq!(got, &vec!["id".to_string()]);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_without_schema_overwrite_rejects_partition_column_change() -> TestResult
+    {
+        let batch = get_record_batch(None, false);
+        let table = modified_partitioned_table(&batch).await?;
+
+        let result = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_partition_columns(["id"])
+            .await;
+
+        assert!(matches!(result, Err(DeltaTableError::GenericError { .. })));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_replace_where_rejects_partition_column_change() -> TestResult {
+        let batch = get_record_batch(None, false);
+        let table = modified_partitioned_table(&batch).await?;
+
+        let result = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_schema_mode(SchemaMode::Overwrite)
+            .with_partition_columns(["id"])
+            .with_replace_where(col("id").eq(lit("A")))
+            .await;
+
+        assert!(matches!(result, Err(DeltaTableError::GenericError { .. })));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_schema_preserves_partition_columns_when_omitted() -> TestResult {
+        let batch = get_record_batch(None, false);
+        let table = modified_partitioned_table(&batch).await?;
+
+        let table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_schema_mode(SchemaMode::Overwrite)
+            .await?;
+
+        assert_eq!(
+            table.snapshot().unwrap().metadata().partition_columns(),
+            &vec!["modified".to_string()]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_schema_rejects_missing_new_partition_column() -> TestResult {
+        let batch = get_record_batch(None, false);
+        let table = modified_partitioned_table(&batch).await?;
+
+        let result = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Overwrite)
+            .with_schema_mode(SchemaMode::Overwrite)
+            .with_partition_columns(["missing_partition"])
+            .await;
+
+        let err = result.expect_err("missing partition column should fail");
+        match expect_write_error(&err) {
+            WriteError::MissingPartitionColumns { columns } => {
+                assert_eq!(columns, &vec!["missing_partition".to_string()]);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -22,11 +22,11 @@ use itertools::Itertools as _;
 use parquet::file::properties::WriterProperties;
 use uuid::Uuid;
 
-use super::SchemaMode;
 use super::configs::WriterStatsConfig;
 use super::generated_columns::{gc_is_enabled, with_generated_columns};
 use super::metrics::SOURCE_COUNT_ID;
 use super::schema_evolution::try_cast_schema;
+use super::{SchemaMode, WriteError};
 use crate::delta_datafusion::logical::{LogicalPlanBuilderExt as _, MetricObserver};
 use crate::delta_datafusion::{
     DataFusionMixins, Expression, analyze_predicate_for_find_files, scan_files_where_matches,
@@ -34,8 +34,8 @@ use crate::delta_datafusion::{
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::schema::cast::{merge_arrow_schema, normalize_for_delta};
 use crate::kernel::{
-    Action, Add, DeletionVectorDescriptor, EagerSnapshot, MetadataExt as _, ProtocolExt as _,
-    Remove, StructType, StructTypeExt, new_metadata,
+    Action, Add, DeletionVectorDescriptor, EagerSnapshot, Metadata, ProtocolExt as _, Remove,
+    StructType, StructTypeExt,
 };
 use crate::logstore::LogStoreRef;
 use crate::operations::cdc::{CDC_COLUMN_NAME, should_write_cdc};
@@ -378,6 +378,10 @@ pub(super) fn prepare_write(input: WritePreparationInput<'_>) -> DeltaResult<Pre
             .build()?;
     }
 
+    // Validate the effective partition columns against the prepared writer input.
+    // Schema merge projects missing table columns before partition values are derived.
+    validate_partition_columns_in_schema(&partition_columns, source.schema().inner().as_ref())?;
+
     let insert_plan = LogicalPlan::Extension(Extension {
         node: Arc::new(MetricObserver {
             id: SOURCE_COUNT_ID.into(),
@@ -708,6 +712,39 @@ fn resolve_exact_validation(
         .transpose()?)
 }
 
+fn validate_partition_columns_in_schema(
+    partition_columns: &[String],
+    schema: &Schema,
+) -> DeltaResult<()> {
+    let missing = partition_columns
+        .iter()
+        .filter(|column| schema.index_of(column.as_str()).is_err())
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(WriteError::MissingPartitionColumns { columns: missing }.into())
+    }
+}
+
+fn metadata_with_schema_and_partition_columns(
+    metadata: &Metadata,
+    schema: &StructType,
+    partition_columns: &[String],
+) -> DeltaResult<Metadata> {
+    let mut value = serde_json::to_value(metadata)?;
+    value["schemaString"] = serde_json::Value::String(serde_json::to_string(schema)?);
+    value["partitionColumns"] = serde_json::Value::Array(
+        partition_columns
+            .iter()
+            .map(|column| serde_json::Value::String(column.clone()))
+            .collect(),
+    );
+    Ok(serde_json::from_value(value)?)
+}
+
 fn schema_delta_for_prepared_source(
     snapshot: Option<&EagerSnapshot>,
     insert_plan: &LogicalPlan,
@@ -721,16 +758,17 @@ fn schema_delta_for_prepared_source(
         return Ok(SchemaDelta::default());
     };
 
-    let should_update_schema = match schema_mode {
+    let partition_columns_changed = snapshot.metadata().partition_columns() != partition_columns;
+    let should_update_metadata = match schema_mode {
         Some(SchemaMode::Merge) if schema_drift => true,
         Some(SchemaMode::Overwrite) if mode == SaveMode::Overwrite => {
             let delta_schema: StructType = insert_plan.schema().as_arrow().try_into_kernel()?;
-            &delta_schema != snapshot.schema().as_ref()
+            &delta_schema != snapshot.schema().as_ref() || partition_columns_changed
         }
         _ => false,
     };
 
-    if !should_update_schema {
+    if !should_update_metadata {
         return Ok(SchemaDelta::default());
     }
 
@@ -739,8 +777,16 @@ fn schema_delta_for_prepared_source(
         _ => insert_plan.schema().as_arrow().try_into_kernel()?,
     };
 
-    if &schema_struct == snapshot.schema().as_ref() {
+    if &schema_struct == snapshot.schema().as_ref() && !partition_columns_changed {
         return Ok(SchemaDelta::default());
+    }
+
+    if partition_columns_changed {
+        tracing::info!(
+            previous_partition_columns = ?snapshot.metadata().partition_columns(),
+            new_partition_columns = ?partition_columns,
+            "replacing table partition columns during schema overwrite"
+        );
     }
 
     let current_protocol = snapshot.protocol();
@@ -750,11 +796,11 @@ fn schema_delta_for_prepared_source(
         .apply_column_metadata_to_protocol(&schema_struct)?
         .move_table_properties_into_features(&configuration);
 
-    let mut metadata = new_metadata(&schema_struct, partition_columns, configuration)?;
-    let existing_metadata_id = snapshot.metadata().id().to_string();
-    if !existing_metadata_id.is_empty() {
-        metadata = metadata.with_table_id(existing_metadata_id)?;
-    }
+    let metadata = metadata_with_schema_and_partition_columns(
+        snapshot.metadata(),
+        &schema_struct,
+        partition_columns,
+    )?;
 
     Ok(SchemaDelta {
         metadata: Some(metadata.into()),

--- a/docs/usage/working-with-partitions.md
+++ b/docs/usage/working-with-partitions.md
@@ -135,6 +135,34 @@ print(pdf)
 5     2      b      US
 ```
 
+### Replacing Partition Columns
+
+To change a table's partition columns, rewrite the full table with
+`mode="overwrite"` and `schema_mode="overwrite"`, and pass the new
+`partition_by` value. The new partition columns must be present in the data being
+written. This rewrites the table metadata and data files in one transaction.
+
+```python
+df_repartitioned = pd.DataFrame({
+    "num": [1, 2, 3],
+    "letter": ["a", "b", "c"],
+    "continent": ["NA", "NA", "NA"]
+})
+
+dt = DeltaTable("tmp/partitioned-table")
+write_deltalake(
+    dt,
+    df_repartitioned,
+    mode="overwrite",
+    schema_mode="overwrite",
+    partition_by=["continent"],
+)
+```
+
+Partition columns cannot be changed when using a `predicate` overwrite because a
+predicate overwrite replaces only part of the table and must preserve the
+existing partition layout.
+
 ## Updating Partitioned Tables with Merge
 
 You can perform merge operations on partitioned tables in the same way you do on non-partitioned ones. If only a subset of existing partitions are present in the source (i.e. new) data then `deltalake` can skip reading the partitions not present in the source data. You can do this by providing a predicate that specifies which partition values are in the source data.

--- a/docs/usage/writing/index.md
+++ b/docs/usage/writing/index.md
@@ -28,6 +28,12 @@ alter the schema as part of an overwrite pass in `schema_mode="overwrite"` or `s
 `schema_mode="overwrite"` will completely overwrite the schema, even if columns are dropped; merge will append the new columns
 and fill missing columns with `null`. `schema_mode="merge"` is also supported on append operations.
 
+When replacing the entire table with `mode="overwrite"` and `schema_mode="overwrite"`,
+you may also provide a different `partition_by` value to replace the table's
+partition columns. This is only supported for full table overwrites. Overwrites
+that use a `predicate` (also known as `replaceWhere`) must keep the existing
+partition columns because they replace only a subset of the table.
+
 ## Overwriting part of the table data using a predicate
 
 !!! note

--- a/python/deltalake/writer/writer.py
+++ b/python/deltalake/writer/writer.py
@@ -87,7 +87,9 @@ def write_deltalake(
         table_or_uri: URI of a table or a DeltaTable object.
         data: Data to write. If passing iterable, the schema must also be given.
         partition_by: List of columns to partition the table by. Only required
-            when creating a new table.
+            when creating a new table, or when replacing partition columns during a
+            full table ``mode="overwrite"`` with ``schema_mode="overwrite"`` and no
+            ``predicate``.
         mode: How to handle existing data. Default is to error if table already exists.
             If 'append', will add new data.
             If 'overwrite', will replace table with new data.

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -145,6 +145,122 @@ def test_update_schema(existing_sample_table: DeltaTable):
 
 
 @pytest.mark.pyarrow
+def test_overwrite_schema_can_change_partition_by(tmp_path: pathlib.Path):
+    data = Table(
+        {
+            "some_int": Array(
+                [1],
+                ArrowField("some_int", type=DataType.int32(), nullable=True),
+            ),
+            "some_str": Array(
+                ["foo"],
+                ArrowField("some_str", type=DataType.string(), nullable=True),
+            ),
+        }
+    )
+
+    write_deltalake(
+        tmp_path,
+        data,
+        partition_by=["some_str"],
+        name="preserve_name",
+        description="preserve_description",
+    )
+    table = DeltaTable(tmp_path)
+    assert table.metadata().partition_columns == ["some_str"]
+
+    write_deltalake(
+        table,
+        data,
+        mode="overwrite",
+        schema_mode="overwrite",
+        partition_by=["some_int"],
+    )
+
+    table.update_incremental()
+    assert table.version() == 1
+    assert table.metadata().partition_columns == ["some_int"]
+    assert table.metadata().name == "preserve_name"
+    assert table.metadata().description == "preserve_description"
+    assert table.to_pyarrow_table().to_pydict() == {
+        "some_int": [1],
+        "some_str": ["foo"],
+    }
+
+    version_actions = get_version_actions(table, 1)
+    add_actions = [entry["add"] for entry in version_actions if "add" in entry]
+    remove_actions = [entry["remove"] for entry in version_actions if "remove" in entry]
+    assert add_actions
+    assert all("some_int=" in add["path"] for add in add_actions)
+    assert len(remove_actions) == 1
+
+
+@pytest.mark.pyarrow
+def test_overwrite_schema_can_remove_partition_by(tmp_path: pathlib.Path):
+    data = Table(
+        {
+            "some_int": Array(
+                [1],
+                ArrowField("some_int", type=DataType.int32(), nullable=True),
+            ),
+            "some_str": Array(
+                ["foo"],
+                ArrowField("some_str", type=DataType.string(), nullable=True),
+            ),
+        }
+    )
+
+    write_deltalake(tmp_path, data, partition_by=["some_str"])
+    table = DeltaTable(tmp_path)
+
+    write_deltalake(
+        table,
+        data,
+        mode="overwrite",
+        schema_mode="overwrite",
+        partition_by=[],
+    )
+
+    table.update_incremental()
+    assert table.version() == 1
+    assert table.metadata().partition_columns == []
+    version_actions = get_version_actions(table, 1)
+    add_actions = [entry["add"] for entry in version_actions if "add" in entry]
+    assert add_actions
+    assert all("/" not in add["path"] for add in add_actions)
+
+
+def test_replace_where_rejects_partition_by_change(tmp_path: pathlib.Path):
+    data = Table(
+        {
+            "some_int": Array(
+                [1, 2],
+                ArrowField("some_int", type=DataType.int32(), nullable=True),
+            ),
+            "some_str": Array(
+                ["foo", "bar"],
+                ArrowField("some_str", type=DataType.string(), nullable=True),
+            ),
+        }
+    )
+
+    write_deltalake(tmp_path, data, partition_by=["some_str"])
+
+    with pytest.raises(
+        DeltaError,
+        match="Specified table partitioning does not match table partitioning",
+    ):
+        write_deltalake(
+            tmp_path,
+            data,
+            mode="overwrite",
+            schema_mode="overwrite",
+            partition_by=["some_int"],
+            predicate="some_int = 1",
+        )
+
+
+@pytest.mark.pyarrow
 def test_merge_schema(existing_table: DeltaTable):
     import pyarrow as pa
 
@@ -844,6 +960,11 @@ def test_writer_partitioning(tmp_path: pathlib.Path):
 def get_log_path(table: DeltaTable) -> str:
     """Returns _delta_log path for this delta table."""
     return table._table.table_uri() + "/_delta_log/" + ("0" * 20 + ".json")
+
+
+def get_version_actions(table: DeltaTable, version: int) -> list[dict]:
+    log_path = table._table.table_uri() + "/_delta_log/" + f"{version:020}.json"
+    return [json.loads(line) for line in urlopen(log_path).readlines()]
 
 
 def get_add_actions(table: DeltaTable) -> list[dict]:


### PR DESCRIPTION
Allows partition columns to change when writing with `mode="overwrite"` and `schema_mode="overwrite"`, as long as there's no `replaceWhere` predicate. Previously you had to drop and recreate the table to reshape the partition layout, which is annoying when the schema overwrite is already replacing everything anyway.

The table metadata identity is preserved across the change and only the schema and partition columns get swapped in the metadata action. If `partition_by` is omitted, the existing partition columns are kept rather than silently cleared. Partition changes are still rejected on appends, on overwrites without schema overwrite, and on predicate overwrite paths.

Partition columns are validated against the prepared writer input after schema evolution, and missing partition columns surface as structured write errors instead of generic failures.

closes of #4434