### PR TITLE
chore: upgrade to the buoyant_kernel 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ repository = "https://github.com/delta-io/delta.rs"
 
 [workspace.dependencies]
 #delta_kernel = { package = "buoyant_kernel", path = "../delta-kernel-rs/kernel", features = [
-delta_kernel = { package = "buoyant_kernel", version = "0.21.200, <0.21.300", features = [
+delta_kernel = { package = "buoyant_kernel", git = "https://github.com/buoyant-data/delta-kernel-rs", branch = "buoyant/main", features = [
+#delta_kernel = { package = "buoyant_kernel", version = "0.22.0, <0.22.100", features = [
     "arrow-58",
     "internal-api",
 ] }

--- a/crates/core/src/kernel/arrow/engine_ext.rs
+++ b/crates/core/src/kernel/arrow/engine_ext.rs
@@ -20,7 +20,7 @@ use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_configuration::TableConfiguration;
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::table_properties::{DataSkippingNumIndexedCols, TableProperties};
-use delta_kernel::transforms::SchemaTransform;
+use delta_kernel::transforms::{SchemaTransform, transform_output_type};
 use delta_kernel::{DeltaResult, ExpressionEvaluator};
 
 use crate::errors::{DeltaResult as DeltaResultLocal, DeltaTableError};
@@ -277,6 +277,8 @@ pub(crate) fn stats_schema(
 // Convert a min/max stats schema into a nullcount schema (all leaf fields are LONG)
 pub(crate) struct NullCountStatsTransform;
 impl<'a> SchemaTransform<'a> for NullCountStatsTransform {
+    transform_output_type!(|'a, T| Option<Cow<'a, T>>);
+
     fn transform_primitive(&mut self, _ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
         Some(Cow::Owned(PrimitiveType::Long))
     }
@@ -354,6 +356,8 @@ impl BaseStatsTransform {
 }
 
 impl<'a> SchemaTransform<'a> for BaseStatsTransform {
+    transform_output_type!(|'a, T| Option<Cow<'a, T>>);
+
     fn transform_struct_field(&mut self, field: &'a StructField) -> Option<Cow<'a, StructField>> {
         use Cow::*;
 
@@ -416,6 +420,8 @@ impl<'a> SchemaTransform<'a> for BaseStatsTransform {
 struct MinMaxStatsTransform;
 
 impl<'a> SchemaTransform<'a> for MinMaxStatsTransform {
+    transform_output_type!(|'a, T| Option<Cow<'a, T>>);
+
     // array and map fields are not eligible for data skipping, so filter them out.
     fn transform_array(&mut self, _: &'a ArrayType) -> Option<Cow<'a, ArrayType>> {
         None

--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -769,6 +769,9 @@ impl TableFeatures {
 
                     // Unknown features
                     TableFeature::Unknown(_) => (None, None),
+                    others => {
+                        panic!("This table has unsupported table features: {others:?}");
+                    }
                 }
             }
             None => (None, None),

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -40,7 +40,7 @@ pub(crate) async fn create_checkpoint_for(
     .await
     .map_err(|e| DeltaTableError::Generic(e.to_string()))??;
 
-    snapshot.checkpoint(engine.as_ref())?;
+    snapshot.checkpoint(engine.as_ref(), None)?;
     Ok(())
 }
 


### PR DESCRIPTION
This is pointing to the git branch for now since I haven't released
buoyant_kernel 0.22.0 which tracks delta_kernel 0.22.0 with our
additional patches incorporated.

Signed-off-by: R. Tyler Croy <rtyler@brokenco.de>
