### PR TITLE
chore: clippy and dependency API fixes

### DIFF
--- a/crates/core/benches/json_parsing.rs
+++ b/crates/core/benches/json_parsing.rs
@@ -40,7 +40,7 @@ fn generate_commit_log_complex(
             add_json.push_str(r#","deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}"#);
         }
 
-        add_json.push_str("}");
+        add_json.push('}');
         log_lines.push(format!(r#"{{"add":{}}}"#, add_json));
     }
 

--- a/crates/core/src/delta_datafusion/data_validation.rs
+++ b/crates/core/src/delta_datafusion/data_validation.rs
@@ -77,6 +77,7 @@ impl PartialOrd for DataValidation {
 }
 
 impl DataValidation {
+    #[allow(dead_code)]
     pub(crate) fn try_new(
         input: LogicalPlan,
         validations: impl IntoIterator<Item = Expr>,
@@ -118,6 +119,7 @@ impl DataValidation {
 ///
 /// This is used to update the schema of the data after validation to
 /// reflect the non-nullability of these columns.
+#[allow(dead_code)]
 struct NotNullExtractor {
     non_nullable_columns: Vec<ColumnName>,
 }
@@ -722,6 +724,7 @@ fn collect_non_nullable_fields_recursive(
 /// ];
 /// let new_schema = make_fields_non_nullable(schema.as_ref(), &paths);
 /// ```
+#[allow(dead_code)]
 pub(crate) fn make_fields_non_nullable(schema: &Schema, paths: &[ColumnName]) -> Schema {
     // Convert ColumnName paths to Vec<String> for easier comparison
     let target_paths: HashSet<Vec<String>> = paths
@@ -743,6 +746,7 @@ pub(crate) fn make_fields_non_nullable(schema: &Schema, paths: &[ColumnName]) ->
 }
 
 /// Recursively make fields non-nullable based on target paths.
+#[allow(dead_code)]
 fn make_fields_non_nullable_recursive(
     field: &arrow_schema::Field,
     current_path: Vec<String>,

--- a/crates/core/src/delta_datafusion/logical.rs
+++ b/crates/core/src/delta_datafusion/logical.rs
@@ -17,6 +17,7 @@ pub(crate) trait LogicalPlanBuilderExt: Sized {
     fn with_column(self, name: &str, expr: Expr) -> Result<Self>;
     fn drop_columns(self, cols: impl IntoIterator<Item = impl ColumnReference>) -> Result<Self>;
     /// Validate all data produced by the plan coforms to the passed predicates.
+    #[allow(dead_code)]
     fn validate(self, validations: impl IntoIterator<Item = Expr>) -> Result<Self>;
 }
 

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -640,7 +640,7 @@ pub(crate) fn simplify_expr(
     let execution_props = session.execution_props();
     let context = SimplifyContext::default()
         .with_schema(df_schema.clone())
-        .with_query_execution_start_time(execution_props.query_execution_start_time.clone())
+        .with_query_execution_start_time(execution_props.query_execution_start_time)
         .with_config_options(
             execution_props
                 .config_options()

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
@@ -93,7 +93,7 @@ impl ProjectedScanContract {
         let query_projects_file_id = if let Some(file_id_idx) = file_id_idx {
             match projection {
                 None => true,
-                Some(projection) => projection.iter().any(|idx| *idx == file_id_idx),
+                Some(projection) => projection.contains(&file_id_idx),
             }
         } else {
             false
@@ -106,7 +106,7 @@ impl ProjectedScanContract {
         let query_projects_row_index = if let Some(row_index_idx) = row_index_idx {
             match projection {
                 None => true,
-                Some(projection) => projection.iter().any(|idx| *idx == row_index_idx),
+                Some(projection) => projection.contains(&row_index_idx),
             }
         } else {
             false
@@ -364,10 +364,7 @@ impl DeltaScanConfig {
             return Some(name);
         };
         let file_id_idx = result_schema.fields().len();
-        projection
-            .iter()
-            .any(|&idx| idx == file_id_idx)
-            .then_some(name)
+        projection.contains(&file_id_idx).then_some(name)
     }
 
     /// The physical arrow schema exposed by the table provider
@@ -769,7 +766,7 @@ mod tests {
         let scan_plan = KernelScanPlan::try_new(
             table.snapshot()?.snapshot().snapshot(),
             None,
-            &[expr.clone()],
+            std::slice::from_ref(&expr),
             &DeltaScanConfig::default(),
             None,
         )?;
@@ -781,7 +778,7 @@ mod tests {
         let scan_plan = KernelScanPlan::try_new(
             table.snapshot()?.snapshot().snapshot(),
             None,
-            &[expr.clone()],
+            std::slice::from_ref(&expr),
             &DeltaScanConfig::default(),
             None,
         )?;
@@ -791,7 +788,7 @@ mod tests {
         let scan_plan = KernelScanPlan::try_new(
             table.snapshot()?.snapshot().snapshot(),
             None,
-            &[expr.clone()],
+            std::slice::from_ref(&expr),
             &DeltaScanConfig::default(),
             None,
         )?;
@@ -860,7 +857,7 @@ mod tests {
         let filter =
             col(r#""Super Name""#).eq(lit(ScalarValue::Utf8View(Some("Timothy Lamb".to_string()))));
         let scan = provider
-            .scan(&ctx.state(), None, &[filter.clone()], None)
+            .scan(&ctx.state(), None, std::slice::from_ref(&filter), None)
             .await?;
         let batches = collect(scan, ctx.task_ctx()).await?;
         assert_batches_sorted_eq!(&expected, &batches);
@@ -918,8 +915,10 @@ mod tests {
             scan_plan.contract.result_schema.as_ref()
         ));
 
-        let mut config = DeltaScanConfig::default();
-        config.schema_force_view_types = true;
+        let config = DeltaScanConfig {
+            schema_force_view_types: true,
+            ..Default::default()
+        };
         let scan_plan = KernelScanPlan::try_new(snapshot, None, &[], &config, None)?;
         assert!(schema_has_view_types(
             scan_plan.contract.result_schema.as_ref()
@@ -979,8 +978,10 @@ mod tests {
             DataType::Utf8View | DataType::BinaryView
         ));
 
-        let mut config = DeltaScanConfig::default();
-        config.schema_force_view_types = false;
+        let config = DeltaScanConfig {
+            schema_force_view_types: false,
+            ..Default::default()
+        };
         let scan_plan = KernelScanPlan::try_new(snapshot, None, &[], &config, None)?;
         assert!(!schema_has_view_types(
             scan_plan.contract.result_schema.as_ref()
@@ -1363,7 +1364,7 @@ mod tests {
 
         let expected_schema = snapshot
             .schema()
-            .project(&vec!["cases", "county", "state"])
+            .project(&["cases", "county", "state"])
             .unwrap();
         // Assert string representation as the equality check is order-insensitive.
         assert_eq!(

--- a/crates/core/src/delta_datafusion/utils.rs
+++ b/crates/core/src/delta_datafusion/utils.rs
@@ -31,7 +31,7 @@ impl Expression {
         let execution_props = session.execution_props();
         let context = SimplifyContext::default()
             .with_schema(schema)
-            .with_query_execution_start_time(execution_props.query_execution_start_time.clone())
+            .with_query_execution_start_time(execution_props.query_execution_start_time)
             .with_config_options(
                 execution_props
                     .config_options()

--- a/crates/core/src/kernel/schema/mod.rs
+++ b/crates/core/src/kernel/schema/mod.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 
 pub mod cast;
 pub mod partitions;
+#[allow(clippy::module_inception)]
 mod schema;
 
 pub use cast::*;

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -642,14 +642,16 @@ impl Snapshot {
     ) -> DeltaResult<BoxStream<'_, DeltaResult<Option<CommitInfo>>>> {
         let store = log_store.root_object_store(None);
 
-        let log_root = self.table_root_path()?.child("_delta_log");
+        let log_root = self.table_root_path()?.join("_delta_log");
         let start_from = if let Some(limit) = limit {
             let v = self.version() as i64;
             std::cmp::max(v - limit as i64 + 1, 0)
         } else {
             0
         };
-        let start_from = log_root.child(format!("{:020}", start_from).as_str());
+        let start_from = log_root
+            .clone()
+            .join(format!("{:020}", start_from).as_str());
 
         let dummy_url = url::Url::parse("memory:///")
             .map_err(|e| DeltaTableError::InvalidTableLocation(format!("memory:///: {}", e)))?;
@@ -777,11 +779,7 @@ impl Snapshot {
                 .await
                 .map_err(|e| DeltaTableError::GenericError { source: e.into() })??;
         if let Some(version) = version {
-            return Ok(Some(version.try_into().map_err(|e| {
-                DeltaTableError::GenericError {
-                    source: Box::new(e),
-                }
-            })?));
+            return Ok(Some(version));
         }
         Ok(None)
     }
@@ -954,8 +952,10 @@ pub(crate) async fn resolve_snapshot(
             Ok(snapshot)
         }
     } else {
-        let mut config = DeltaTableConfig::default();
-        config.require_files = require_files;
+        let config = DeltaTableConfig {
+            require_files,
+            ..Default::default()
+        };
         EagerSnapshot::try_new(log_store, config, version).await
     }
 }
@@ -1532,8 +1532,10 @@ mod tests {
     #[tokio::test]
     async fn test_eager_snapshot_log_data_is_non_panicking_without_files() -> TestResult {
         let log_store = TestTables::Simple.table_builder()?.build_storage()?;
-        let mut config = DeltaTableConfig::default();
-        config.require_files = false;
+        let config = DeltaTableConfig {
+            require_files: false,
+            ..Default::default()
+        };
 
         let snapshot = EagerSnapshot::try_new(&log_store, config, None).await?;
 
@@ -1545,8 +1547,10 @@ mod tests {
     #[tokio::test]
     async fn test_eager_snapshot_try_log_data_is_non_panicking_without_files() -> TestResult {
         let log_store = TestTables::Simple.table_builder()?.build_storage()?;
-        let mut config = DeltaTableConfig::default();
-        config.require_files = false;
+        let config = DeltaTableConfig {
+            require_files: false,
+            ..Default::default()
+        };
 
         let snapshot = EagerSnapshot::try_new(&log_store, config, None).await?;
 
@@ -1683,8 +1687,10 @@ mod tests {
     #[tokio::test]
     async fn test_file_views_skip_stats_same_paths() -> TestResult {
         let base = TestTables::Checkpoints.table_builder()?.build_storage()?;
-        let mut skip_cfg = DeltaTableConfig::default();
-        skip_cfg.skip_stats = true;
+        let skip_cfg = DeltaTableConfig {
+            skip_stats: true,
+            ..Default::default()
+        };
         let with_skip = EagerSnapshot::try_new(base.as_ref(), skip_cfg, Some(12)).await?;
         let full = EagerSnapshot::try_new(base.as_ref(), Default::default(), Some(12)).await?;
         let mut paths_skip: Vec<String> = with_skip
@@ -1717,8 +1723,10 @@ mod tests {
         assert!(!default_stats.is_empty());
         assert!(default_stats.iter().any(|b| *b));
 
-        let mut skip_cfg = DeltaTableConfig::default();
-        skip_cfg.skip_stats = true;
+        let skip_cfg = DeltaTableConfig {
+            skip_stats: true,
+            ..Default::default()
+        };
         let skip_eager = EagerSnapshot::try_new(base.as_ref(), skip_cfg, Some(12)).await?;
         let skip_stats: Vec<Option<String>> = skip_eager
             .file_views(base.as_ref(), None)
@@ -1737,8 +1745,10 @@ mod tests {
 
         let base = TestTables::Checkpoints.table_builder()?.build_storage()?;
 
-        let mut skip_cfg = DeltaTableConfig::default();
-        skip_cfg.skip_stats = true;
+        let skip_cfg = DeltaTableConfig {
+            skip_stats: true,
+            ..Default::default()
+        };
         let snapshot = Snapshot::try_new(base.as_ref(), skip_cfg, Some(12)).await?;
 
         let predicate: PredicateRef =
@@ -1760,8 +1770,10 @@ mod tests {
     async fn test_eager_skip_stats_with_predicate_keeps_stats_omitted() -> TestResult {
         let base = TestTables::Checkpoints.table_builder()?.build_storage()?;
 
-        let mut skip_cfg = DeltaTableConfig::default();
-        skip_cfg.skip_stats = true;
+        let skip_cfg = DeltaTableConfig {
+            skip_stats: true,
+            ..Default::default()
+        };
         let snapshot = EagerSnapshot::try_new(base.as_ref(), skip_cfg, Some(12)).await?;
 
         let predicate: PredicateRef =
@@ -2021,8 +2033,10 @@ mod tests {
         let base = TestTables::Checkpoints.table_builder()?.build_storage()?;
         let (log_store, mut operations) = recording_log_store(base);
 
-        let mut config = DeltaTableConfig::default();
-        config.require_files = false;
+        let config = DeltaTableConfig {
+            require_files: false,
+            ..Default::default()
+        };
         let mut snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, Some(11)).await?;
 
         assert!(snapshot.snapshot().materialized_files().is_none());
@@ -2162,7 +2176,7 @@ mod tests {
         checkpoints::create_checkpoint(&table, None).await?;
 
         let updated = Arc::new(snapshot)
-            .update(log_store.engine(None), Some(version as u64))
+            .update(log_store.engine(None), Some(version))
             .await?;
         assert_eq!(updated.version(), version);
         assert_eq!(updated.checkpoint_version(), Some(version));
@@ -2201,9 +2215,7 @@ mod tests {
 
         checkpoints::create_checkpoint(&table, None).await?;
 
-        snapshot
-            .update(log_store.as_ref(), Some(version as u64))
-            .await?;
+        snapshot.update(log_store.as_ref(), Some(version)).await?;
         assert_eq!(snapshot.version(), version);
         assert_eq!(snapshot.snapshot.checkpoint_version(), Some(version));
         assert_eq!(
@@ -2269,9 +2281,7 @@ mod tests {
             EagerSnapshot::try_new(log_store.as_ref(), Default::default(), Some(version)).await?;
 
         checkpoints::create_checkpoint(&table, None).await?;
-        snapshot
-            .update(log_store.as_ref(), Some(version as u64))
-            .await?;
+        snapshot.update(log_store.as_ref(), Some(version)).await?;
         assert_eq!(snapshot.snapshot.checkpoint_version(), Some(version));
 
         let prior_snapshot = snapshot.snapshot.clone();
@@ -2282,9 +2292,7 @@ mod tests {
             .expect("expected materialized files");
         let prior_paths = eager_file_paths(&snapshot, log_store.as_ref()).await?;
 
-        snapshot
-            .update(log_store.as_ref(), Some(version as u64))
-            .await?;
+        snapshot.update(log_store.as_ref(), Some(version)).await?;
 
         assert!(Arc::ptr_eq(&snapshot.snapshot, &prior_snapshot));
         assert!(Arc::ptr_eq(
@@ -2321,7 +2329,7 @@ mod tests {
         }
 
         let err = Arc::new(snapshot)
-            .update(log_store.engine(None), Some(version as u64))
+            .update(log_store.engine(None), Some(version))
             .await
             .unwrap_err();
         assert!(

--- a/crates/core/src/kernel/snapshot/serde.rs
+++ b/crates/core/src/kernel/snapshot/serde.rs
@@ -5,7 +5,6 @@ use arrow_ipc::reader::FileReader;
 use arrow_ipc::writer::FileWriter;
 use delta_kernel::FileMeta;
 use delta_kernel::actions::{Metadata, Protocol};
-use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::log_segment::{LogSegment, LogSegmentFiles};
 use delta_kernel::path::ParsedLogPath;
 use delta_kernel::snapshot::Snapshot as KernelSnapshot;

--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -1002,7 +1002,7 @@ mod tests {
 
     use super::*;
     use crate::logstore::{LogStore, StorageConfig, default_logstore::DefaultLogStore};
-    use object_store::{ObjectStore, PutPayload, memory::InMemory};
+    use object_store::{PutPayload, memory::InMemory};
     use serde_json::json;
     use url::Url;
 

--- a/crates/core/src/logstore/storage/utils.rs
+++ b/crates/core/src/logstore/storage/utils.rs
@@ -19,7 +19,7 @@ use crate::kernel::Add;
 pub fn commit_uri_from_version(version: Option<Version>) -> Path {
     if let Some(version) = version {
         let version = format!("{version:020}.json");
-        super::DELTA_LOG_PATH.child(version.as_str())
+        super::DELTA_LOG_PATH.clone().join(version.as_str())
     } else {
         /*
          * Currently there are some situations where we're relying on negative versions for silly
@@ -27,7 +27,7 @@ pub fn commit_uri_from_version(version: Option<Version>) -> Path {
          */
         let version = -1;
         let version = format!("{version:020}.json");
-        super::DELTA_LOG_PATH.child(version.as_str())
+        super::DELTA_LOG_PATH.clone().join(version.as_str())
     }
 }
 

--- a/crates/core/src/operations/cdc.rs
+++ b/crates/core/src/operations/cdc.rs
@@ -321,8 +321,8 @@ mod tests {
             ],
         )
         .unwrap();
-        let _ = arrow::util::pretty::print_batches(&[batch.clone()]);
-        let _ = arrow::util::pretty::print_batches(&[updated_batch.clone()]);
+        let _ = arrow::util::pretty::print_batches(std::slice::from_ref(&batch));
+        let _ = arrow::util::pretty::print_batches(std::slice::from_ref(&updated_batch));
 
         let ctx = SessionContext::new();
         let before = ctx.read_batch(batch).expect("Failed to make DataFrame");

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -153,9 +153,7 @@ struct FullFileDeleteResult {
 }
 
 fn derive_live_row_count(view: &LogicalFileView) -> Option<usize> {
-    let Some(raw_rows) = view.num_records() else {
-        return None;
-    };
+    let raw_rows = view.num_records()?;
 
     let deleted = match view.deletion_vector_descriptor() {
         Some(dv) => match usize::try_from(dv.cardinality) {

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -353,7 +353,7 @@ impl CdfLoadBuilder {
         let (cdc, add, remove) = self.determine_files_to_read(&snapshot).await?;
         session.ensure_log_store_registered(self.log_store.as_ref())?;
 
-        let partition_values = snapshot.metadata().partition_columns().clone();
+        let partition_values = snapshot.metadata().partition_columns();
         let schema = snapshot.input_schema();
         let schema_fields: Vec<Arc<Field>> = schema
             .fields()
@@ -382,18 +382,17 @@ impl CdfLoadBuilder {
         add_remove_partition_cols.extend_from_slice(&this_partition_values);
 
         // Set up the partition to physical file mapping, this is a mostly unmodified version of what is done in load
-        let cdc_file_groups =
-            create_partition_values(schema.clone(), cdc, &partition_values, None)?;
+        let cdc_file_groups = create_partition_values(schema.clone(), cdc, partition_values, None)?;
         let add_file_groups = create_partition_values(
             schema.clone(),
             add,
-            &partition_values,
+            partition_values,
             Self::get_add_action_type(),
         )?;
         let remove_file_groups = create_partition_values(
             schema.clone(),
             remove,
-            &partition_values,
+            partition_values,
             Self::get_remove_action_type(),
         )?;
 

--- a/crates/core/src/operations/merge/barrier.rs
+++ b/crates/core/src/operations/merge/barrier.rs
@@ -471,6 +471,7 @@ mod tests {
     use datafusion::execution::TaskContext;
     use datafusion::physical_expr::expressions::Column;
     use datafusion::physical_plan::ExecutionPlan;
+    #[allow(deprecated)]
     use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
     use futures::StreamExt;
     use std::sync::Arc;
@@ -658,6 +659,7 @@ mod tests {
             MergeBarrierExec::new(exec, Arc::new("__delta_rs_path".to_string()), repartition);
 
         let survivors = merge.survivors();
+        #[allow(deprecated)]
         let coalescence = CoalesceBatchesExec::new(Arc::new(merge), 100);
         let mut stream = coalescence.execute(0, task_ctx).unwrap();
         (vec![stream.next().await.unwrap().unwrap()], survivors)

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -2457,7 +2457,7 @@ mod tests {
             .collect();
         assert_eq!(removed_paths, vec![original_path]);
 
-        let expected = vec![
+        let expected = [
             "+----+-------+------------+".to_string(),
             "| id | value | modified   |".to_string(),
             "+----+-------+------------+".to_string(),

--- a/crates/core/src/operations/merge/validation.rs
+++ b/crates/core/src/operations/merge/validation.rs
@@ -220,6 +220,7 @@ impl MergeValidationStream {
 
         let mut keep_mask = vec![true; batch.num_rows()];
 
+        #[allow(clippy::needless_range_loop)]
         for row in 0..batch.num_rows() {
             if cardinality_class_array.is_null(row) {
                 continue;

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -1195,12 +1195,11 @@ async fn build_compaction_plan(
     filters: &[PartitionFilter],
     target_size: NonZeroU64,
 ) -> Result<(OptimizeOperations, Metrics, PlannerStats), DeltaTableError> {
+    type PartitionFileEntry = (IndexMap<String, Scalar>, usize, Vec<OrderedFileCandidate>);
+
     let mut metrics = Metrics::default();
     let mut planner_stats = PlannerStats::preserve_locality();
-    let mut partition_files: HashMap<
-        String,
-        (IndexMap<String, Scalar>, usize, Vec<OrderedFileCandidate>),
-    > = HashMap::new();
+    let mut partition_files: HashMap<String, PartitionFileEntry> = HashMap::new();
 
     let predicate = if filters.is_empty() {
         None
@@ -1632,7 +1631,7 @@ pub(super) mod zorder {
             use arrow_ord::sort::sort_to_indices;
             use arrow_schema::Field;
             use arrow_select::take::take;
-            use rand::{Rng, RngExt};
+            use rand::RngExt;
 
             #[test]
             fn test_order() {

--- a/crates/core/src/operations/update/tests.rs
+++ b/crates/core/src/operations/update/tests.rs
@@ -729,7 +729,7 @@ async fn test_update_with_array_that_must_be_coerced() {
         ],
     )
     .expect("Failed to create record batch");
-    let _ = arrow::util::pretty::print_batches(&[batch.clone()]);
+    let _ = arrow::util::pretty::print_batches(std::slice::from_ref(&batch));
 
     let table = DeltaTable::new_in_memory()
         .create()

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -2507,15 +2507,14 @@ mod tests {
         assert_eq!(remove_actions.len(), 2);
         assert!(
             remove_actions.iter().any(|remove| {
-                remove.path == dv_source.path().to_string()
+                remove.path == dv_source.path()
                     && remove.deletion_vector == dv_source.deletion_vector_descriptor()
             }),
             "expected tombstone for DV-backed source file"
         );
         assert!(
             remove_actions.iter().any(|remove| {
-                remove.path == appended_source.path().to_string()
-                    && remove.deletion_vector.is_none()
+                remove.path == appended_source.path() && remove.deletion_vector.is_none()
             }),
             "expected tombstone for appended non-DV source file"
         );
@@ -3743,7 +3742,7 @@ mod tests {
                 true,
             ),
         ]));
-        let nanos = 1760961600_123456789i64;
+        let nanos = 1_760_961_600_123_456_789_i64;
         let batch = RecordBatch::try_new(
             schema,
             vec![

--- a/crates/core/src/operations/write/writer.rs
+++ b/crates/core/src/operations/write/writer.rs
@@ -686,7 +686,7 @@ mod tests {
             .unwrap()
             .object_store(None);
         let properties = WriterProperties::builder()
-            .set_max_row_group_size(1024)
+            .set_max_row_group_row_count(Some(1024))
             .build();
         // configure small target file size and and row group size so we can observe multiple files written
         let mut writer = get_partition_writer(

--- a/crates/core/src/protocol/checkpoints.rs
+++ b/crates/core/src/protocol/checkpoints.rs
@@ -243,7 +243,7 @@ mod tests {
         log_path: &Path,
     ) -> DeltaResult<Option<LastCheckpointHint>> {
         const LAST_CHECKPOINT_FILE_NAME: &str = "_last_checkpoint";
-        let file_path = log_path.child(LAST_CHECKPOINT_FILE_NAME);
+        let file_path = log_path.clone().join(LAST_CHECKPOINT_FILE_NAME);
         let maybe_data = storage.get(&file_path).await;
         let data = match maybe_data {
             Ok(data) => data.bytes().await?,
@@ -527,17 +527,24 @@ mod tests {
 
             let log_store = table.log_store();
 
-            let path = log_store.log_path().child("00000000000000000000.json");
+            let path = log_store
+                .log_path()
+                .clone()
+                .join("00000000000000000000.json");
             let res = table.log_store().object_store(None).get(&path).await;
             assert!(res.is_err());
 
             let path = log_store
                 .log_path()
-                .child("00000000000000000001.checkpoint.parquet");
+                .clone()
+                .join("00000000000000000001.checkpoint.parquet");
             let res = table.log_store().object_store(None).get(&path).await;
             assert!(res.is_ok());
 
-            let path = log_store.log_path().child("00000000000000000001.json");
+            let path = log_store
+                .log_path()
+                .clone()
+                .join("00000000000000000001.json");
             let res = table.log_store().object_store(None).get(&path).await;
             assert!(res.is_ok());
         }

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -568,8 +568,10 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await?;
 
-        let mut config = DeltaTableConfig::default();
-        config.skip_stats = true;
+        let config = DeltaTableConfig {
+            skip_stats: true,
+            ..Default::default()
+        };
         let log_store = table.log_store();
         let snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, None).await?;
         let batches = snapshot.snapshot().add_actions_batches(true)?;

--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -862,7 +862,7 @@ mod tests {
         writer = writer.with_writer_properties(
             WriterProperties::builder()
                 .set_compression(Compression::SNAPPY)
-                .set_max_row_group_size(128)
+                .set_max_row_group_row_count(Some(128))
                 .build(),
         );
 

--- a/crates/core/src/writer/utils.rs
+++ b/crates/core/src/writer/utils.rs
@@ -55,7 +55,7 @@ pub(crate) fn next_data_path(
         "part-{part}-{writer_id}-c000{}.parquet",
         compression_to_str(&compression)
     );
-    prefix.child(file_name)
+    prefix.clone().join(file_name)
 }
 
 /// Convert a vector of json values to a RecordBatch

--- a/crates/core/tests/command_optimize.rs
+++ b/crates/core/tests/command_optimize.rs
@@ -788,7 +788,7 @@ async fn test_optimize_compaction_tombstones_preserve_deletion_vector_metadata()
 
     let dv_remove = removes
         .iter()
-        .find(|remove| remove.path == dv_source.path().to_string())
+        .find(|remove| remove.path == dv_source.path())
         .ok_or_else(|| std::io::Error::other("expected tombstone for the DV-backed source add"))?;
     assert_eq!(
         dv_remove.deletion_vector,
@@ -1261,7 +1261,7 @@ async fn test_compact_rewrite_is_unbounded_and_idempotent() -> Result<(), Box<dy
     let make_uncompressed_writer_properties = || {
         WriterProperties::builder()
             .set_compression(parquet::basic::Compression::UNCOMPRESSED)
-            .set_max_row_group_size(64 * 1024)
+            .set_max_row_group_row_count(Some(64 * 1024))
             .build()
     };
 
@@ -1843,7 +1843,7 @@ async fn test_zorder_respects_target_size() -> Result<(), Box<dyn Error>> {
             WriterProperties::builder()
                 .set_compression(parquet::basic::Compression::UNCOMPRESSED)
                 // Easier to hit the target size with a smaller row group size
-                .set_max_row_group_size(64 * 1024)
+                .set_max_row_group_row_count(Some(64 * 1024))
                 .build(),
         )
         .with_type(OptimizeType::ZOrder(vec!["x".to_string(), "y".to_string()]))

--- a/crates/core/tests/command_restore.rs
+++ b/crates/core/tests/command_restore.rs
@@ -8,7 +8,7 @@ use deltalake_core::logstore::object_store::ObjectStoreExt as _;
 use deltalake_core::protocol::SaveMode;
 use deltalake_core::{DeltaTable, ensure_table_uri};
 use futures::TryStreamExt;
-use rand::{Rng, RngExt};
+use rand::RngExt;
 use std::error::Error;
 use std::fs;
 use std::sync::Arc;

--- a/crates/core/tests/integration_checkpoint.rs
+++ b/crates/core/tests/integration_checkpoint.rs
@@ -52,7 +52,12 @@ async fn cleanup_metadata_test(context: &IntegrationContext) -> TestResult {
         .build_storage()?;
     let object_store = log_store.object_store(None);
 
-    let log_path = |version| log_store.log_path().child(format!("{version:020}.json"));
+    let log_path = |version| {
+        log_store
+            .log_path()
+            .clone()
+            .join(format!("{version:020}.json"))
+    };
 
     // we don't need to actually populate files with content as cleanup works only with file's metadata
     object_store

--- a/crates/core/tests/integration_datafusion.rs
+++ b/crates/core/tests/integration_datafusion.rs
@@ -427,15 +427,17 @@ mod local {
 
         // Simple Equality test, we only exercise the limit in this test
         let e = col("value").eq(lit(2));
-        let metrics = get_scan_metrics(&table, &state, &[e.clone()]).await?;
+        let metrics = get_scan_metrics(&table, &state, std::slice::from_ref(&e)).await?;
         assert_eq!(metrics.num_scanned_files(), 2);
         assert_eq!(metrics.num_scanned_files(), metrics.keep_count);
 
-        let metrics = get_scan_metrics_with_limit(&table, &state, &[e.clone()], Some(1)).await?;
+        let metrics =
+            get_scan_metrics_with_limit(&table, &state, std::slice::from_ref(&e), Some(1)).await?;
         assert_eq!(metrics.num_scanned_files(), 1);
         assert_eq!(metrics.num_scanned_files(), metrics.keep_count);
 
-        let metrics = get_scan_metrics_with_limit(&table, &state, &[e.clone()], Some(3)).await?;
+        let metrics =
+            get_scan_metrics_with_limit(&table, &state, std::slice::from_ref(&e), Some(3)).await?;
         assert_eq!(metrics.num_scanned_files(), 2);
         assert_eq!(metrics.num_scanned_files(), metrics.keep_count);
 

--- a/crates/core/tests/read_delta_log_test.rs
+++ b/crates/core/tests/read_delta_log_test.rs
@@ -452,7 +452,7 @@ async fn test_read_table_features() -> DeltaResult<()> {
     let path = "../test/tests/data/simple_table_features";
     let table_uri =
         Url::from_directory_path(std::fs::canonicalize(path)?).expect("Failed to create Url path");
-    let mut table = deltalake_core::open_table(table_uri).await?;
+    let table = deltalake_core::open_table(table_uri).await?;
     let rf = table.snapshot()?.protocol().reader_features();
     let wf = table.snapshot()?.protocol().writer_features();
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1461,6 +1461,7 @@ impl RawDeltaTable {
         let log_store = self.log_store()?;
         let adds: Vec<_> = rt()
             .block_on(async {
+                #[allow(deprecated)]
                 state
                     .file_views_by_partitions(&log_store, &converted_filters)
                     .try_collect()
@@ -1541,6 +1542,7 @@ impl RawDeltaTable {
                     let log_store = self.log_store()?;
                     let add_actions: Vec<_> = rt()
                         .block_on(async {
+                            #[allow(deprecated)]
                             state
                                 .file_views_by_partitions(&log_store, &converted_filters)
                                 .try_collect()
@@ -2246,7 +2248,7 @@ fn set_writer_properties(writer_properties: PyWriterProperties) -> DeltaResult<W
         properties = properties.set_write_batch_size(batch_size);
     }
     if let Some(row_group_size) = max_row_group_size {
-        properties = properties.set_max_row_group_size(row_group_size);
+        properties = properties.set_max_row_group_row_count(Some(row_group_size));
     }
     properties = properties.set_statistics_truncate_length(statistics_truncate_length);
 


### PR DESCRIPTION
These clippy lints and warnings are getting in the way of spotting real
warnings when contributors are commiting.

Noted that this was slop generated.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Signed-off-by: R Tyler Croy <rtyler@scribd.com>
