### PR TITLE
fix: support Windows UNC paths

### DIFF
--- a/crates/core/src/logstore/factories.rs
+++ b/crates/core/src/logstore/factories.rs
@@ -153,6 +153,11 @@ pub fn logstore_factories() -> LogStoreFactoryRegistry {
                 Url::parse("file://").unwrap(),
                 Arc::new(DefaultLogStoreFactory::default()),
             );
+            #[cfg(target_os = "windows")]
+            registry.insert(
+                Url::parse(&format!("{}://", super::DELTA_UNC_SCHEME)).unwrap(),
+                Arc::new(DefaultLogStoreFactory::default()),
+            );
             registry
         })
         .clone()

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -174,6 +174,29 @@ pub(crate) static DELTA_LOG_REGEX: LazyLock<Regex> =
 /// let logstore = logstore_for(&location, storage_config).expect("Failed to get a logstore");
 /// ```
 pub fn logstore_for(location: &Url, storage_config: StorageConfig) -> DeltaResult<LogStoreRef> {
+    // Windows UNC paths (`\\server\share\...`) become `file://server/share/...` URLs after
+    // canonicalization. Routing those through `object_store::parse_url_opts` silently drops the
+    // host (see arrow-rs-object-store#715), so detect them up front and build a
+    // `LocalFileSystem::new_with_prefix(\\server\share)` directly. The kernel-facing URL is
+    // rewritten to be share-relative so the rest of the pipeline (PrefixStore decoration, etc.)
+    // works without further special casing.
+    #[cfg(target_os = "windows")]
+    if let Some((unc_prefix, share_relative)) = split_unc_url(location) {
+        debug!(
+            "UNC table location detected; building LocalFileSystem rooted at {unc_prefix:?} \
+             with share-relative URL {share_relative}"
+        );
+        let store: ObjectStoreRef = Arc::new(
+            object_store::local::LocalFileSystem::new_with_prefix(&unc_prefix)?,
+        );
+        let store = if let Some(runtime) = &storage_config.runtime {
+            Arc::new(DeltaIOStorageBackend::new(store, runtime.clone())) as Arc<dyn ObjectStore>
+        } else {
+            store
+        };
+        return logstore_with(store, &share_relative, storage_config);
+    }
+
     // turn location into scheme
     let scheme = Url::parse(&format!("{}://", location.scheme()))
         .map_err(|_| DeltaTableError::InvalidTableLocation(location.clone().into()))?;
@@ -185,6 +208,79 @@ pub fn logstore_for(location: &Url, storage_config: StorageConfig) -> DeltaResul
     }
 
     Err(DeltaTableError::InvalidTableLocation(location.to_string()))
+}
+
+/// URL scheme used internally for UNC-backed tables. The kernel validates `file://` URLs by
+/// calling `Url::to_file_path()`, which rejects share-relative paths on Windows (no drive
+/// letter). Using a non-file scheme makes the kernel treat it as a generic URL, skipping
+/// filesystem validation while preserving correct path math for the prefixed `LocalFileSystem`.
+#[cfg(any(target_os = "windows", test))]
+pub(crate) const DELTA_UNC_SCHEME: &str = "delta-unc";
+
+/// Query parameter key used to store the UNC prefix (`\\server\share`) inside a `delta-unc` URL.
+#[cfg(any(target_os = "windows", test))]
+pub(crate) const DELTA_UNC_PREFIX_KEY: &str = "unc_prefix";
+
+/// Split a `file://server/share/...` URL produced from a Windows UNC path into
+/// `(\\server\share PathBuf, share-relative delta-unc:/// URL)`.
+///
+/// The returned URL uses the `delta-unc` scheme so the kernel skips `to_file_path()` validation.
+///
+/// Returns `None` for URLs that are not UNC-shaped (any non-`file` scheme, no host, the
+/// `localhost` sentinel, or a missing share segment). Defined cross-platform so it can be unit
+/// tested anywhere; only [`logstore_for`] consumes it on Windows.
+#[cfg(any(target_os = "windows", test))]
+pub(crate) fn split_unc_url(location: &Url) -> Option<(std::path::PathBuf, Url)> {
+    use percent_encoding::percent_decode_str;
+
+    if location.scheme() != "file" {
+        return None;
+    }
+    let host = location.host_str()?;
+    if host.is_empty() || host.eq_ignore_ascii_case("localhost") {
+        return None;
+    }
+
+    let mut segments = location.path_segments()?;
+    let share_encoded = segments.next()?;
+    if share_encoded.is_empty() {
+        return None;
+    }
+    let share = percent_decode_str(share_encoded)
+        .decode_utf8()
+        .ok()?
+        .into_owned();
+
+    let prefix = std::path::PathBuf::from(format!(r"\\{host}\{share}"));
+
+    let rest: Vec<&str> = segments.collect();
+    let mut new_path = String::from("/");
+    new_path.push_str(&rest.join("/"));
+    if location.path().ends_with('/') && !new_path.ends_with('/') {
+        new_path.push('/');
+    }
+
+    // `file:` is a "special" scheme in the URL spec — set_scheme() cannot change it to a
+    // non-special scheme. Construct the delta-unc URL from scratch instead.
+    // Encode the UNC prefix as a query parameter so that `to_uri` can reconstruct real
+    // filesystem paths (e.g. `\\server\share\table\file.parquet`).
+    let prefix_str = prefix.to_str()?;
+    let encoded_prefix =
+        percent_encoding::utf8_percent_encode(prefix_str, percent_encoding::NON_ALPHANUMERIC);
+    let share_relative = Url::parse(&format!(
+        "{DELTA_UNC_SCHEME}://{new_path}?{DELTA_UNC_PREFIX_KEY}={encoded_prefix}"
+    ))
+    .ok()?;
+
+    Some((prefix, share_relative))
+}
+
+/// Extract the UNC prefix (e.g. `\\server\share`) from a `delta-unc` URL's query parameter.
+#[cfg(target_os = "windows")]
+fn extract_unc_prefix(url: &Url) -> Option<String> {
+    url.query_pairs()
+        .find(|(key, _)| key == DELTA_UNC_PREFIX_KEY)
+        .map(|(_, value)| value.into_owned())
 }
 
 /// Return the [LogStoreRef] using the given [ObjectStoreRef]
@@ -550,6 +646,34 @@ pub fn to_uri(root: &Url, location: &Path) -> String {
             .replace("file://", "");
             uri
         }
+        #[cfg(target_os = "windows")]
+        DELTA_UNC_SCHEME => {
+            // Reconstruct a native UNC path from the prefix stored in the query parameter
+            // and the share-relative path in the URL + the file location.
+            if let Some(unc_prefix) = extract_unc_prefix(root) {
+                let table_relative = root.path().trim_start_matches('/').trim_end_matches('/');
+                if location.as_ref().is_empty() || location.as_ref() == "/" {
+                    if table_relative.is_empty() {
+                        unc_prefix
+                    } else {
+                        format!(r"{unc_prefix}\{table_relative}")
+                    }
+                } else if table_relative.is_empty() {
+                    format!(r"{unc_prefix}\{}", location.as_ref().replace('/', r"\"))
+                } else {
+                    format!(
+                        r"{unc_prefix}\{}\{}",
+                        table_relative,
+                        location.as_ref().replace('/', r"\")
+                    )
+                }
+            } else {
+                // Fallback: no prefix encoded — return the URL string
+                root.join(location.as_ref())
+                    .map(|url| url.to_string())
+                    .unwrap_or_else(|_| format!("{}/{}", root.as_ref(), location.as_ref()))
+            }
+        }
         _ => {
             if location.as_ref().is_empty() || location.as_ref() == "/" {
                 root.as_ref().to_string()
@@ -765,6 +889,72 @@ pub(crate) mod tests {
         let location = Url::parse("memory:///table").unwrap();
         let store = logstore_for(&location, StorageConfig::default());
         assert!(store.is_ok());
+    }
+
+    /// Helper to extract the unc_prefix query parameter from a delta-unc URL (test-only).
+    fn test_extract_unc_prefix(url: &Url) -> Option<String> {
+        url.query_pairs()
+            .find(|(key, _)| key == DELTA_UNC_PREFIX_KEY)
+            .map(|(_, value)| value.into_owned())
+    }
+
+    #[test]
+    fn split_unc_url_extracts_server_share_and_relative_url() {
+        let location = Url::parse("file://server/TestShare/basic_partitioned/").unwrap();
+        let (prefix, share_relative) =
+            split_unc_url(&location).expect("UNC URL should be detected");
+        assert_eq!(prefix.to_str().unwrap(), r"\\server\TestShare");
+        assert_eq!(share_relative.scheme(), DELTA_UNC_SCHEME);
+        assert_eq!(share_relative.path(), "/basic_partitioned/");
+        assert_eq!(
+            test_extract_unc_prefix(&share_relative).as_deref(),
+            Some(r"\\server\TestShare")
+        );
+    }
+
+    #[test]
+    fn split_unc_url_keeps_nested_path() {
+        let location = Url::parse("file://server/share/a/b/c").unwrap();
+        let (prefix, share_relative) = split_unc_url(&location).unwrap();
+        assert_eq!(prefix.to_str().unwrap(), r"\\server\share");
+        assert_eq!(share_relative.scheme(), DELTA_UNC_SCHEME);
+        assert_eq!(share_relative.path(), "/a/b/c");
+        assert_eq!(
+            test_extract_unc_prefix(&share_relative).as_deref(),
+            Some(r"\\server\share")
+        );
+    }
+
+    #[test]
+    fn split_unc_url_share_root() {
+        let location = Url::parse("file://server/share/").unwrap();
+        let (prefix, share_relative) = split_unc_url(&location).unwrap();
+        assert_eq!(prefix.to_str().unwrap(), r"\\server\share");
+        assert_eq!(share_relative.scheme(), DELTA_UNC_SCHEME);
+        assert_eq!(share_relative.path(), "/");
+        assert_eq!(
+            test_extract_unc_prefix(&share_relative).as_deref(),
+            Some(r"\\server\share")
+        );
+    }
+
+    #[test]
+    fn split_unc_url_decodes_percent_encoded_share() {
+        let location = Url::parse("file://server/My%20Share/table/").unwrap();
+        let (prefix, _) = split_unc_url(&location).unwrap();
+        assert_eq!(prefix.to_str().unwrap(), r"\\server\My Share");
+    }
+
+    #[test]
+    fn split_unc_url_rejects_non_file_scheme() {
+        let location = Url::parse("s3://bucket/key").unwrap();
+        assert!(split_unc_url(&location).is_none());
+    }
+
+    #[test]
+    fn split_unc_url_rejects_local_file_url() {
+        let location = Url::parse("file:///path/to/table/").unwrap();
+        assert!(split_unc_url(&location).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Reading and writing Delta tables from Windows UNC paths
(\\server\share\path\to\table) currently fails. delta-rs canonicalises
the path and hands the resulting URL to object_store::parse_url_opts.

Signed-off-by: Lachlan Cahill <lachlan.cahill@gmail.com>
