### PR TITLE
fix(python): gate jemallocator off on FreeBSD (fall back to system allocator)

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -72,8 +72,13 @@ tracing-subscriber = { workspace = true }
 [target.'cfg(any(not(target_family = "unix"), target_os = "emscripten"))'.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 
-# Unix (excluding macOS & emscripten) → jemalloc
-[target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten")))'.dependencies]
+# Unix (excluding macOS, emscripten & FreeBSD) → jemalloc
+# FreeBSD's system malloc is already jemalloc-derived, and the bundled
+# jemallocator's `dlsym(RTLD_NEXT, "pthread_create")` initialization fails on
+# FreeBSD (jemalloc aborts during DSO init). Fall back to the system allocator
+# on FreeBSD instead — no performance regression since the system allocator
+# is the same family.
+[target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten"), not(target_os = "freebsd")))'.dependencies]
 jemallocator = { version = "0.5", features = [
     "disable_initial_exec_tls",
     "background_threads",

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -89,12 +89,22 @@ use crate::utils::rt;
 use crate::writer::to_lazy_table;
 
 #[global_allocator]
-#[cfg(all(target_family = "unix", not(target_os = "emscripten")))]
+#[cfg(all(
+    target_family = "unix",
+    not(target_os = "emscripten"),
+    not(target_os = "freebsd")
+))]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[global_allocator]
 #[cfg(any(not(target_family = "unix"), target_os = "emscripten"))]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+// On FreeBSD, neither jemallocator nor mimalloc is set as global allocator.
+// jemallocator fails its dlsym(RTLD_NEXT, "pthread_create") init under
+// FreeBSD's threading model (see python/Cargo.toml comment). The Rust
+// system allocator is used by default; FreeBSD's libc malloc is
+// jemalloc-derived already, so there is no performance regression.
 
 #[derive(FromPyObject)]
 enum PartitionFilterValue {


### PR DESCRIPTION
# python: gate jemallocator off on FreeBSD (fall back to system allocator)

## Summary

The `deltalake` Python package fails to import on FreeBSD with:

```
<jemalloc>: Error in dlsym(RTLD_NEXT, "pthread_create")
```

(SIGABRT, exit 134.) This patch gates `jemallocator` off on FreeBSD targets and lets the Rust standard system allocator handle allocations — FreeBSD's libc malloc is jemalloc-derived already, so there is no measurable performance impact.

## Reproduction (pre-patch)

```sh
# FreeBSD 15.0-RELEASE-p5, x86_64, Python 3.12
pip install deltalake
python -c "import deltalake; print(deltalake.__version__)"
# <jemalloc>: Error in dlsym(RTLD_NEXT, "pthread_create")
# (process aborts before deltalake's __version__ can print)
```

## Root cause

The bundled `jemallocator` Rust crate calls `dlsym(RTLD_NEXT, "pthread_create")` during DSO init to wrap `pthread_create`. On Linux/glibc, `libpthread` is reliably loaded before jemalloc in the dynamic-linker symbol-search order, so the `dlsym` succeeds. On FreeBSD, the threading library is `libthr.so.3` and the search-order dynamics differ — `pthread_create` isn't visible to `dlsym(RTLD_NEXT, ...)` at the moment jemalloc tries to wrap it. jemalloc aborts during init before the Python interpreter has a chance to import the module.

Standard workarounds (`LD_PRELOAD=/usr/lib/libthr.so`, `MALLOC_CONF=...`) don't help — the abort happens too early in the load order for preloaded library symbols to be visible.

## Changes

Two minimal `cfg`-gate additions, both adding `not(target_os = "freebsd")`:

- `python/Cargo.toml` — exclude FreeBSD from the unix-non-macOS `jemallocator` dependency target.
- `python/src/lib.rs` — exclude FreeBSD from the unix `#[global_allocator]` cfg.

On FreeBSD, neither `jemallocator` nor `mimalloc` is declared as global allocator, so the Rust standard `System` allocator is used. FreeBSD's `System` allocator (libc malloc) has been a fork of jemalloc since the early 2000s, so the performance profile is essentially the same allocator family — no regression.

Linux and macOS code paths are byte-identical post-patch: the `cfg` only adds an OS-specific exclusion, no other arms changed.

## Previous attempt

PR #3624 (closed July 2025) attempted FreeBSD compatibility but commented out the `jemallocator` deps entirely — disabling them for *all* platforms — and bundled in unrelated changes to `catalog-unity` feature flags. This PR is a more targeted approach that only affects FreeBSD builds and changes nothing else.

## Test plan

- [x] **Pre-patch on FreeBSD:** `import deltalake` aborts with SIGABRT and the jemalloc dlsym error
- [x] **Post-patch on FreeBSD:** `import deltalake` succeeds; `deltalake.__version__` prints; basic `DeltaTable` instantiation works
- [x] **Linux:** no behavioral change — `target_os = "freebsd"` is false on Linux, all `cfg`s evaluate the same way as pre-patch
- [x] **macOS:** no behavioral change — `cfg(target_family = "unix", target_os = "macos")` arm in Cargo.toml is unchanged; the lib.rs `#[global_allocator]` arm matches macOS the same way it did before
- [ ] **Upstream CI:** existing test suite should pass on Linux and macOS (would appreciate maintainer-side CI to confirm)

## Risk

Low. The change is purely additive (one OS exclusion in each cfg) and only affects builds where `target_os = "freebsd"`. No platform that currently works is touched.
