### PR TITLE
fix: restore merge safe cast behavior

### DIFF
--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -47,7 +47,7 @@ use datafusion::logical_expr::build_join_schema;
 use datafusion::logical_expr::simplify::SimplifyContext;
 use datafusion::logical_expr::utils::split_conjunction_owned;
 use datafusion::logical_expr::{
-    Expr, JoinType, col, conditional_expressions::CaseBuilder, lit, when,
+    Expr, JoinType, cast, col, conditional_expressions::CaseBuilder, lit, try_cast, when,
 };
 use datafusion::logical_expr::{
     Extension, LogicalPlan, LogicalPlanBuilder, UNNAMED_TABLE, UserDefinedLogicalNode,
@@ -56,9 +56,7 @@ use datafusion::optimizer::simplify_expressions::ExprSimplifier;
 use datafusion::physical_plan::metrics::{MetricBuilder, MetricsSet};
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 use datafusion::{
-    execution::context::SessionState,
-    physical_plan::ExecutionPlan,
-    prelude::{DataFrame, cast},
+    execution::context::SessionState, physical_plan::ExecutionPlan, prelude::DataFrame,
 };
 
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow as _, TryIntoKernel as _};
@@ -137,6 +135,14 @@ const TARGET_FILES_PRUNED_METRIC_LEGACY: &str = "files_pruned";
 const SOURCE_COUNT_ID: &str = "merge_source_count";
 const TARGET_COUNT_ID: &str = "merge_target_count";
 const OUTPUT_COUNT_ID: &str = "merge_output_count";
+
+fn merge_cast(expr: Expr, data_type: DataType, safe_cast: bool) -> Expr {
+    if safe_cast {
+        try_cast(expr, data_type)
+    } else {
+        cast(expr, data_type)
+    }
+}
 
 /// Merge records into a Delta Table.
 pub struct MergeBuilder {
@@ -438,10 +444,11 @@ impl MergeBuilder {
         self
     }
 
-    /// Specify the cast options to use when casting columns that do not match
-    /// the table's schema.  When `cast_options.safe` is set true then any
-    /// failures to cast a datatype will use null instead of returning an error
-    /// to the user.
+    /// Specify whether MERGE uses safe casts when casting update and insert
+    /// expressions to the table's schema. When enabled, failed casts yield null
+    /// for target columns that allow null values. When disabled, failed casts
+    /// return an error. A failed safe cast into a column that does not allow
+    /// null values still fails the write constraint check.
     ///
     /// Example (column's type is int):
     /// Input               Output
@@ -824,7 +831,7 @@ async fn execute(
     state: SessionState,
     writer_properties: Option<WriterProperties>,
     mut commit_properties: CommitProperties,
-    _safe_cast: bool,
+    safe_cast: bool,
     streaming: bool,
     source_alias: Option<String>,
     target_alias: Option<String>,
@@ -1257,7 +1264,11 @@ async fn execute(
                 col_ref
             }
         } else {
-            null_target_column = Some(cast(lit(ScalarValue::Null).alias(name), cast_type.clone()));
+            null_target_column = Some(merge_cast(
+                lit(ScalarValue::Null).alias(name),
+                cast_type.clone(),
+                safe_cast,
+            ));
             Column::new(source_qualifier.clone(), name)
         };
 
@@ -1282,16 +1293,18 @@ async fn execute(
         let name = "__delta_rs_c_".to_owned() + delta_field.name();
         merge_value_column_names.push(name.clone());
 
-        write_projection.push(cast(
+        write_projection.push(merge_cast(
             Expr::Column(Column::from_name(name.clone())).alias(delta_field.name()),
             cast_type.clone(),
+            safe_cast,
         ));
 
         let cdc_target_preimage_name = "__delta_rs_target_c_".to_owned() + delta_field.name();
         let cdc_target_preimage = null_target_column.clone().unwrap_or_else(|| {
-            cast(
+            merge_cast(
                 Expr::Column(Column::new(qualifier.clone(), delta_field.name())),
                 cast_type.clone(),
+                safe_cast,
             )
         });
         if should_cdc {
@@ -1302,14 +1315,16 @@ async fn execute(
         write_projection_with_cdf.push(
             when(
                 col(CDC_COLUMN_NAME).not_eq(lit("update_preimage")),
-                cast(
+                merge_cast(
                     Expr::Column(Column::from_name(name.clone())),
                     cast_type.clone(),
+                    safe_cast,
                 ),
             )
-            .otherwise(cast(
+            .otherwise(merge_cast(
                 Expr::Column(Column::from_name(cdc_target_preimage_name)),
                 cast_type,
+                safe_cast,
             ))?
             .alias(delta_field.name()),
         );
@@ -2560,6 +2575,24 @@ mod tests {
             .unwrap()
     }
 
+    fn invalid_int_source(ctx: &SessionContext) -> DataFrame {
+        let source_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", ArrowDataType::Utf8, true),
+            Field::new("value", ArrowDataType::Utf8, true),
+            Field::new("modified", ArrowDataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            source_schema,
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["B"])),
+                Arc::new(arrow::array::StringArray::from(vec!["not an integer"])),
+                Arc::new(arrow::array::StringArray::from(vec!["2023-07-04"])),
+            ],
+        )
+        .unwrap();
+        ctx.read_batch(batch).unwrap()
+    }
+
     fn merge_source(schema: Arc<ArrowSchema>) -> DataFrame {
         let ctx = SessionContext::new();
         let batch = RecordBatch::try_new(
@@ -2942,6 +2975,67 @@ mod tests {
 
         assert_merge(table, metrics).await;
     }
+
+    #[tokio::test]
+    async fn test_merge_strict_cast_errors_on_invalid_update_value() {
+        let schema = get_arrow_schema(&None);
+        let table = setup_table(None).await;
+        let table = write_data(table, &schema).await;
+
+        let ctx = SessionContext::new();
+        let source = invalid_int_source(&ctx);
+
+        let err = table
+            .merge(source, col("target.id").eq(col("source.id")))
+            .with_source_alias("source")
+            .with_target_alias("target")
+            .when_matched_update(|update| update.update("value", col("source.value")))
+            .unwrap()
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Cannot cast")
+                && err.to_string().contains("not an integer")
+                && err.to_string().contains("Int32"),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_safe_cast_converts_invalid_update_value_to_null() {
+        let schema = get_arrow_schema(&None);
+        let table = setup_table(None).await;
+        let table = write_data(table, &schema).await;
+
+        let ctx = SessionContext::new();
+        let source = invalid_int_source(&ctx);
+
+        let (table, metrics) = table
+            .merge(source, col("target.id").eq(col("source.id")))
+            .with_source_alias("source")
+            .with_target_alias("target")
+            .with_safe_cast(true)
+            .when_matched_update(|update| update.update("value", col("source.value")))
+            .unwrap()
+            .await
+            .unwrap();
+
+        assert_eq!(metrics.num_target_rows_updated, 1);
+        let expected = vec![
+            "+----+-------+------------+",
+            "| id | value | modified   |",
+            "+----+-------+------------+",
+            "| A  | 1     | 2021-02-01 |",
+            "| B  |       | 2021-02-01 |",
+            "| C  | 10    | 2021-02-02 |",
+            "| D  | 100   | 2021-02-02 |",
+            "+----+-------+------------+",
+        ];
+        let actual = get_data(&table).await;
+        assert_batches_sorted_eq!(&expected, &actual);
+    }
+
     #[tokio::test]
     async fn test_merge_preserves_nullability_without_schema_merge() {
         // Test that nullability constraints are preserved when merge_schema is false (default)

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -708,7 +708,7 @@ class DeltaTable:
             new_values: a mapping of column name to python datatype.
             predicate: a logical expression.
             writer_properties: Pass writer properties to the Rust parquet writer.
-            error_on_type_mismatch: specify if update will return error if data types are mismatching :default = True
+            error_on_type_mismatch: specify if update returns an error when update expressions fail to cast to target column types :default = True
             commit_properties: properties of the transaction commit. If None, default values are used.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
         Returns:
@@ -841,8 +841,12 @@ class DeltaTable:
         post_commithook_properties: PostCommitHookProperties | None = None,
     ) -> TableMerger:
         """Pass the source data which you want to merge on the target delta table, providing a
-        predicate in SQL query like format. You can also specify on what to do when the underlying data types do not
-        match the underlying table.
+        predicate in SQL query like format.
+
+        MERGE casts update and insert expressions to the target column types. If
+        ``error_on_type_mismatch`` is True, failed casts raise an error. If
+        ``error_on_type_mismatch`` is False, failed casts become null for target columns that allow
+        null values. Target columns that do not allow null values still fail the write constraint check.
 
         Args:
             source: source data
@@ -850,7 +854,7 @@ class DeltaTable:
             source_alias: Alias for the source table
             target_alias: Alias for the target table
             merge_schema: Enable merge schema evolution for mismatch schema between source and target tables
-            error_on_type_mismatch: specify if merge will return error if data types are mismatching :default = True
+            error_on_type_mismatch: specify if merge returns an error when update or insert expressions fail to cast to target column types :default = True
             writer_properties: Pass writer properties to the Rust parquet writer
             streamed_exec: Will execute MERGE using a LazyMemoryExec plan, this improves memory pressure for large source tables. Enabling streamed_exec
                 implicitly disables source table stats to derive an early_pruning_predicate

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -2847,6 +2847,367 @@ def test_merge_when_wrong_but_castable_type_passed_while_merge(
     assert table_schema.field("price").type == sample_table["price"].type
 
 
+def _merge_with_type_mismatch_actions(merger, action_style: str):
+    if action_style == "all":
+        return merger.when_matched_update_all().when_not_matched_insert_all()
+
+    return merger.when_matched_update(
+        {"value": "source.value"}
+    ).when_not_matched_insert({"id": "source.id", "value": "source.value"})
+
+
+@pytest.mark.pyarrow
+@pytest.mark.parametrize("action_style", ("all", "explicit"))
+def test_merge_type_mismatch_default_castable_value_succeeds(
+    tmp_path: pathlib.Path, action_style: str
+):
+    import pyarrow as pa
+
+    target = pa.table(
+        {
+            "id": pa.array([1], type=pa.int64()),
+            "value": pa.array(["old"], type=pa.string()),
+        }
+    )
+    source = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "value": pa.array([99, 100], type=pa.int64()),
+        }
+    )
+    write_deltalake(tmp_path, target)
+
+    dt = DeltaTable(tmp_path)
+    merger = dt.merge(
+        source=source,
+        predicate="target.id = source.id",
+        source_alias="source",
+        target_alias="target",
+    )
+
+    _merge_with_type_mismatch_actions(merger, action_style).execute()
+
+    result = dt.to_pyarrow_table().sort_by([("id", "ascending")]).to_pydict()
+    assert result == {"id": [1, 2], "value": ["99", "100"]}
+
+
+@pytest.mark.pyarrow
+@pytest.mark.parametrize("action_style", ("all", "explicit"))
+def test_merge_type_mismatch_default_uncastable_value_errors(
+    tmp_path: pathlib.Path, action_style: str
+):
+    import pyarrow as pa
+
+    target = pa.table(
+        {
+            "id": pa.array([1], type=pa.int64()),
+            "value": pa.array([10], type=pa.int64()),
+        }
+    )
+    source = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "value": pa.array(["abc", "def"], type=pa.string()),
+        }
+    )
+    write_deltalake(tmp_path, target)
+
+    dt = DeltaTable(tmp_path)
+    merger = dt.merge(
+        source=source,
+        predicate="target.id = source.id",
+        source_alias="source",
+        target_alias="target",
+    )
+
+    with pytest.raises(
+        Exception,
+        match="Cannot cast string '.+' to value of Int64 type",
+    ):
+        _merge_with_type_mismatch_actions(merger, action_style).execute()
+
+
+@pytest.mark.pyarrow
+@pytest.mark.parametrize("action_style", ("all", "explicit"))
+def test_merge_safe_cast_uncastable_value_becomes_null_for_nullable_target(
+    tmp_path: pathlib.Path, action_style: str
+):
+    import pyarrow as pa
+
+    target = pa.table(
+        {
+            "id": pa.array([1], type=pa.int64()),
+            "value": pa.array([10], type=pa.int64()),
+        }
+    )
+    source = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "value": pa.array(["abc", "def"], type=pa.string()),
+        }
+    )
+    write_deltalake(tmp_path, target)
+
+    dt = DeltaTable(tmp_path)
+    merger = dt.merge(
+        source=source,
+        predicate="target.id = source.id",
+        source_alias="source",
+        target_alias="target",
+        error_on_type_mismatch=False,
+    )
+
+    _merge_with_type_mismatch_actions(merger, action_style).execute()
+
+    result = dt.to_pyarrow_table().sort_by([("id", "ascending")]).to_pydict()
+    assert result == {"id": [1, 2], "value": [None, None]}
+
+
+@pytest.mark.pyarrow
+def test_merge_safe_cast_numeric_overflow_becomes_null_for_nullable_target(
+    tmp_path: pathlib.Path,
+):
+    import pyarrow as pa
+
+    target = pa.table(
+        {
+            "id": pa.array([1], type=pa.int64()),
+            "value": pa.array([10], type=pa.int32()),
+        }
+    )
+    source = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "value": pa.array([2**31, -(2**31) - 1], type=pa.int64()),
+        }
+    )
+    write_deltalake(tmp_path, target)
+
+    dt = DeltaTable(tmp_path)
+    (
+        dt.merge(
+            source=source,
+            predicate="target.id = source.id",
+            source_alias="source",
+            target_alias="target",
+            error_on_type_mismatch=False,
+        )
+        .when_matched_update({"value": "source.value"})
+        .when_not_matched_insert({"id": "source.id", "value": "source.value"})
+        .execute()
+    )
+
+    result = dt.to_pyarrow_table().sort_by([("id", "ascending")]).to_pydict()
+    assert result == {"id": [1, 2], "value": [None, None]}
+
+
+@pytest.mark.pyarrow
+def test_merge_safe_cast_not_matched_by_source_update_failed_cast_becomes_null(
+    tmp_path: pathlib.Path,
+):
+    import pyarrow as pa
+
+    target = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "value": pa.array([10, 20], type=pa.int64()),
+        }
+    )
+    source = pa.table({"id": pa.array([1], type=pa.int64())})
+    write_deltalake(tmp_path, target)
+
+    dt = DeltaTable(tmp_path)
+    (
+        dt.merge(
+            source=source,
+            predicate="target.id = source.id",
+            source_alias="source",
+            target_alias="target",
+            error_on_type_mismatch=False,
+        )
+        .when_not_matched_by_source_update({"value": "'abc'"})
+        .execute()
+    )
+
+    result = dt.to_pyarrow_table().sort_by([("id", "ascending")]).to_pydict()
+    assert result == {"id": [1, 2], "value": [10, None]}
+
+
+@pytest.mark.pyarrow
+@pytest.mark.parametrize("action_style", ("all", "explicit"))
+def test_merge_safe_cast_uncastable_value_still_fails_for_non_nullable_target(
+    tmp_path: pathlib.Path, action_style: str
+):
+    import pyarrow as pa
+
+    target_schema = pa.schema(
+        [
+            pa.field("id", pa.int64(), nullable=False),
+            pa.field("value", pa.int64(), nullable=False),
+        ]
+    )
+    target = pa.Table.from_arrays(
+        [pa.array([1], type=pa.int64()), pa.array([10], type=pa.int64())],
+        schema=target_schema,
+    )
+    source = pa.table(
+        {
+            "id": pa.array([1], type=pa.int64()),
+            "value": pa.array(["abc"], type=pa.string()),
+        }
+    )
+    write_deltalake(tmp_path, target)
+
+    dt = DeltaTable(tmp_path)
+    merger = dt.merge(
+        source=source,
+        predicate="target.id = source.id",
+        source_alias="source",
+        target_alias="target",
+        error_on_type_mismatch=False,
+    )
+
+    with pytest.raises(Exception, match="Invalid data found:"):
+        _merge_with_type_mismatch_actions(merger, action_style).execute()
+
+
+@pytest.mark.pyarrow
+def test_merge_safe_cast_cdf_projection_uses_null_on_failed_cast(
+    tmp_path: pathlib.Path,
+):
+    import pyarrow as pa
+
+    target = pa.table(
+        {
+            "id": pa.array([1], type=pa.int64()),
+            "value": pa.array([10], type=pa.int64()),
+        }
+    )
+    source = pa.table(
+        {
+            "id": pa.array([1], type=pa.int64()),
+            "value": pa.array(["abc"], type=pa.string()),
+        }
+    )
+    write_deltalake(
+        tmp_path,
+        target,
+        configuration={"delta.enableChangeDataFeed": "true"},
+    )
+
+    dt = DeltaTable(tmp_path)
+    (
+        dt.merge(
+            source=source,
+            predicate="target.id = source.id",
+            source_alias="source",
+            target_alias="target",
+            error_on_type_mismatch=False,
+        )
+        .when_matched_update({"value": "source.value"})
+        .execute()
+    )
+
+    result = dt.to_pyarrow_table().to_pydict()
+    assert result == {"id": [1], "value": [None]}
+
+    cdf = pa.table(dt.load_cdf(1, 1).read_all()).select(["id", "value", "_change_type"])
+    values_by_change_type = {
+        row["_change_type"]: row["value"] for row in cdf.to_pylist()
+    }
+    assert values_by_change_type == {
+        "update_preimage": 10,
+        "update_postimage": None,
+    }
+
+
+@pytest.mark.pyarrow
+def test_merge_schema_type_mismatch_existing_column_still_errors_by_default(
+    tmp_path: pathlib.Path,
+):
+    import pyarrow as pa
+
+    target = pa.table(
+        {
+            "id": pa.array([1], type=pa.int64()),
+            "value": pa.array([10], type=pa.int64()),
+        }
+    )
+    source = pa.table(
+        {
+            "id": pa.array([1], type=pa.int64()),
+            "value": pa.array(["abc"], type=pa.string()),
+            "extra": pa.array(["new"], type=pa.string()),
+        }
+    )
+    write_deltalake(tmp_path, target)
+
+    dt = DeltaTable(tmp_path)
+    merger = dt.merge(
+        source=source,
+        predicate="target.id = source.id",
+        source_alias="source",
+        target_alias="target",
+        merge_schema=True,
+    ).when_matched_update({"value": "source.value", "extra": "source.extra"})
+
+    with pytest.raises(
+        Exception,
+        match="Cannot cast string 'abc' to value of Int64 type",
+    ):
+        merger.execute()
+
+
+@pytest.mark.pyarrow
+def test_merge_schema_safe_cast_existing_column_failed_cast_becomes_null(
+    tmp_path: pathlib.Path,
+):
+    import pyarrow as pa
+
+    target = pa.table(
+        {
+            "id": pa.array([1], type=pa.int64()),
+            "value": pa.array([10], type=pa.int64()),
+        }
+    )
+    source = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "value": pa.array(["abc", "def"], type=pa.string()),
+            "extra": pa.array(["matched", "inserted"], type=pa.string()),
+        }
+    )
+    write_deltalake(tmp_path, target)
+
+    dt = DeltaTable(tmp_path)
+    (
+        dt.merge(
+            source=source,
+            predicate="target.id = source.id",
+            source_alias="source",
+            target_alias="target",
+            merge_schema=True,
+            error_on_type_mismatch=False,
+        )
+        .when_matched_update({"value": "source.value", "extra": "source.extra"})
+        .when_not_matched_insert(
+            {
+                "id": "source.id",
+                "value": "source.value",
+                "extra": "source.extra",
+            }
+        )
+        .execute()
+    )
+
+    result = dt.to_pyarrow_table().sort_by([("id", "ascending")]).to_pydict()
+    assert result == {
+        "id": [1, 2],
+        "value": [None, None],
+        "extra": ["matched", "inserted"],
+    }
+
+
 @pytest.mark.pyarrow
 def test_merge_on_decimal_3033(tmp_path):
     import pyarrow as pa


### PR DESCRIPTION
The merge `safe_cast` flag was being threaded into planning but ignored during execution, which caused `error_on_type_mismatch=False` to quietly behave like the strict path. This wires the flag through allowing merge write projections and CDF projections to actually use safe casts when the caller asks for them  and keeps strict casts as the default.

The behavior lines up with what the docs describe for merge and update. I also cleaned up the type mismatch docs in both places since they were a little ambiguous about which knob controls what. Added rust and python regression coverage for strict casts, safe casts, CDF output, schema merge interactions, overflow, and NOT NULL handling so this path doesn't silently regress again.

part of #4448
