### PR TITLE
fix: normalize commit metadata handling

### DIFF
--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -74,6 +74,7 @@
 //!       └───────────────────────────────┘
 //!</pre>
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -93,11 +94,13 @@ use serde::{Deserialize, Serialize};
 
 use self::conflict_checker::{TransactionInfo, WinningCommitSummary};
 use crate::errors::DeltaTableError;
-use crate::kernel::{Action, CommitInfo, EagerSnapshot, Metadata, Protocol, Transaction, Version};
+use crate::kernel::{
+    Action, CommitInfo, EagerSnapshot, IsolationLevel, Metadata, Protocol, Transaction, Version,
+};
 use crate::logstore::ObjectStoreRef;
 use crate::logstore::{CommitOrBytes, LogStoreRef};
 use crate::operations::CustomExecuteHandler;
-use crate::protocol::DeltaOperation;
+use crate::protocol::{DeltaOperation, operation_parameter_value};
 use crate::protocol::{cleanup_expired_logs_for, create_checkpoint_for};
 use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
@@ -115,6 +118,21 @@ mod state;
 
 const DELTA_LOG_FOLDER: &str = "_delta_log";
 pub(crate) const DEFAULT_RETRIES: usize = 15;
+// These keys map to typed CommitInfo fields used by common Spark compatible writers. They are not
+// required by the protocol, but leaving them in flattened metadata can produce duplicate JSON keys.
+// Keep this list aligned with validate_reserved_commit_metadata in python/src/lib.rs.
+const RESERVED_COMMIT_INFO_KEYS: &[&str] = &[
+    "timestamp",
+    "userId",
+    "userName",
+    "operation",
+    "operationParameters",
+    "readVersion",
+    "isolationLevel",
+    "isBlindAppend",
+    "engineInfo",
+    "userMetadata",
+];
 
 #[derive(Default, Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -290,6 +308,142 @@ pub struct CommitData {
     pub app_transactions: Vec<Transaction>,
 }
 
+/// Moves reserved commit metadata into typed CommitInfo fields.
+///
+/// This prevents serde flatten from serializing duplicate commitInfo keys when callers pass fields
+/// such as readVersion or operationParameters through custom metadata. Rust callers keep the
+/// existing tolerant behavior: invalid reserved metadata is logged and dropped. Python validates
+/// the same key set early in validate_reserved_commit_metadata and raises ValueError instead.
+/// See issue 4443 for the Python custom metadata request that introduced this normalization path.
+fn normalize_reserved_commit_metadata(
+    commit_info: &mut CommitInfo,
+    app_metadata: &mut HashMap<String, Value>,
+) {
+    match app_metadata.remove("operationParameters") {
+        Some(Value::Object(operation_parameters)) => {
+            let generated_parameters = commit_info
+                .operation_parameters
+                .get_or_insert_with(HashMap::new);
+            for (key, value) in operation_parameters {
+                generated_parameters
+                    .entry(key)
+                    .or_insert_with(|| operation_parameter_value(value));
+            }
+        }
+        Some(value) => log_unexpected_reserved_metadata_type(
+            "operationParameters",
+            &value,
+            "object with string-compatible values",
+        ),
+        None => {}
+    }
+
+    if let Some(value) = app_metadata.remove("readVersion") {
+        if let Some(value) = value.as_u64() {
+            if commit_info.read_version.is_none() {
+                commit_info.read_version = Some(value);
+            }
+        } else {
+            log_unexpected_reserved_metadata_type("readVersion", &value, "non-negative integer");
+        }
+    }
+
+    promote_string_reserved_metadata(app_metadata, "userId", &mut commit_info.user_id);
+    promote_string_reserved_metadata(app_metadata, "userName", &mut commit_info.user_name);
+    promote_string_reserved_metadata(app_metadata, "userMetadata", &mut commit_info.user_metadata);
+
+    if let Some(value) = app_metadata.remove("isolationLevel") {
+        if let Some(value) = value
+            .as_str()
+            .and_then(|value| IsolationLevel::from_str(value).ok())
+        {
+            if commit_info.isolation_level.is_none() {
+                commit_info.isolation_level = Some(value);
+            }
+        } else {
+            log_unexpected_reserved_metadata_type(
+                "isolationLevel",
+                &value,
+                "valid IsolationLevel string",
+            );
+        }
+    }
+
+    if let Some(value) = app_metadata.remove("isBlindAppend") {
+        if let Some(value) = value.as_bool() {
+            if commit_info.is_blind_append.is_none() {
+                commit_info.is_blind_append = Some(value);
+            }
+        } else {
+            log_unexpected_reserved_metadata_type("isBlindAppend", &value, "boolean");
+        }
+    }
+
+    for key in RESERVED_COMMIT_INFO_KEYS {
+        app_metadata.remove(*key);
+    }
+}
+
+fn promote_string_reserved_metadata(
+    metadata: &mut HashMap<String, Value>,
+    key: &'static str,
+    target: &mut Option<String>,
+) {
+    let Some(value) = metadata.remove(key) else {
+        return;
+    };
+
+    if let Value::String(value) = value {
+        if target.is_none() {
+            *target = Some(value);
+        }
+    } else {
+        log_unexpected_reserved_metadata_type(key, &value, "string");
+    }
+}
+
+fn log_unexpected_reserved_metadata_type(key: &str, value: &Value, expected: &str) {
+    debug!(
+        key,
+        expected,
+        actual = json_value_kind(value),
+        "Ignoring reserved commit metadata key with unexpected type"
+    );
+}
+
+fn json_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn assign_commit_info_metadata(
+    commit_info: &mut CommitInfo,
+    app_metadata: &mut HashMap<String, Value>,
+) {
+    normalize_reserved_commit_metadata(commit_info, app_metadata);
+
+    let mut existing_info = std::mem::take(&mut commit_info.info);
+    normalize_reserved_commit_metadata(commit_info, &mut existing_info);
+    // app_metadata is the override layer for flattened commit info. It fills missing typed fields
+    // above, and wins over provided CommitInfo.info keys for custom fields.
+    for (key, value) in existing_info {
+        app_metadata.entry(key).or_insert(value);
+    }
+    debug_assert!(
+        RESERVED_COMMIT_INFO_KEYS
+            .iter()
+            .all(|key| !app_metadata.contains_key(*key))
+    );
+
+    commit_info.info = app_metadata.clone();
+}
+
 impl CommitData {
     /// Create new data to be committed
     pub fn new(
@@ -298,14 +452,23 @@ impl CommitData {
         mut app_metadata: HashMap<String, Value>,
         app_transactions: Vec<Transaction>,
     ) -> Self {
-        if !actions.iter().any(|a| matches!(a, Action::CommitInfo(..))) {
+        if let Some(Action::CommitInfo(commit_info)) = actions
+            .iter_mut()
+            .find(|action| matches!(action, Action::CommitInfo(..)))
+        {
+            // Callers that provide a CommitInfo action own generated typed fields such as
+            // timestamp and engineInfo. Flattened app metadata overrides custom keys, and callers
+            // may provide clientVersion for compatibility.
+            assign_commit_info_metadata(commit_info, &mut app_metadata);
+        } else {
             let mut commit_info = operation.get_commit_info();
             commit_info.timestamp = Some(Utc::now().timestamp_millis());
+            // clientVersion is provenance metadata, but it is not reserved. Callers can override it
+            // while engineInfo remains a generated typed CommitInfo field.
             app_metadata
                 .entry("clientVersion".to_string())
                 .or_insert(Value::String(format!("delta-rs.{}", crate_version())));
-            app_metadata.extend(commit_info.info);
-            commit_info.info = app_metadata.clone();
+            assign_commit_info_metadata(&mut commit_info, &mut app_metadata);
             // commit info should be the first action to support in-commit timestamps.
             actions.insert(0, Action::CommitInfo(commit_info));
         }
@@ -1001,7 +1164,9 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::kernel::IsolationLevel;
     use crate::logstore::{LogStore, StorageConfig, default_logstore::DefaultLogStore};
+    use crate::protocol::SaveMode;
     use object_store::{PutPayload, memory::InMemory};
     use serde_json::json;
     use url::Url;
@@ -1099,5 +1264,195 @@ mod tests {
             *with_metadata.app_metadata.get("clientVersion").unwrap(),
             json!("test-client.0.0.1")
         );
+    }
+
+    fn commit_info(data: &CommitData) -> &CommitInfo {
+        match &data.actions[0] {
+            Action::CommitInfo(info) => info,
+            action => panic!("expected first action to be commitInfo, got {action:?}"),
+        }
+    }
+
+    #[test]
+    fn test_commit_data_strips_and_promotes_reserved_metadata() {
+        let data = CommitData::new(
+            vec![],
+            DeltaOperation::FileSystemCheck {},
+            HashMap::from([
+                ("readVersion".to_owned(), json!(7)),
+                ("userId".to_owned(), json!("user-1")),
+                ("userName".to_owned(), json!("Jane Doe")),
+                ("userMetadata".to_owned(), json!("metadata")),
+                ("isolationLevel".to_owned(), json!("SnapshotIsolation")),
+                ("isBlindAppend".to_owned(), json!(true)),
+                ("timestamp".to_owned(), json!(1)),
+                ("operation".to_owned(), json!("CUSTOM OPERATION")),
+                ("engineInfo".to_owned(), json!("custom-engine")),
+                ("custom".to_owned(), json!({"kept": true})),
+            ]),
+            vec![],
+        );
+
+        let info = commit_info(&data);
+        assert_eq!(info.read_version, Some(7));
+        assert_eq!(info.user_id.as_deref(), Some("user-1"));
+        assert_eq!(info.user_name.as_deref(), Some("Jane Doe"));
+        assert_eq!(info.user_metadata.as_deref(), Some("metadata"));
+        assert_eq!(
+            info.isolation_level,
+            Some(IsolationLevel::SnapshotIsolation)
+        );
+        assert_eq!(info.is_blind_append, Some(true));
+        assert_eq!(info.operation.as_deref(), Some("FSCK"));
+        assert_ne!(info.engine_info.as_deref(), Some("custom-engine"));
+        assert_eq!(info.info.get("custom"), Some(&json!({"kept": true})));
+
+        for key in [
+            "timestamp",
+            "userId",
+            "userName",
+            "operation",
+            "operationParameters",
+            "readVersion",
+            "isolationLevel",
+            "isBlindAppend",
+            "engineInfo",
+            "userMetadata",
+        ] {
+            assert!(
+                !info.info.contains_key(key),
+                "reserved key {key} must not remain in flattened commit info"
+            );
+        }
+    }
+
+    #[test]
+    fn test_commit_data_merges_operation_parameters_generated_keys_win() {
+        let data = CommitData::new(
+            vec![],
+            DeltaOperation::Write {
+                mode: SaveMode::Overwrite,
+                partition_by: Some(vec!["id".to_owned()]),
+                predicate: None,
+            },
+            HashMap::from([(
+                "operationParameters".to_owned(),
+                json!({
+                    "mode": "custom-mode",
+                    "partitionBy": "custom-partitioning",
+                    "customParameter": {"kept": true},
+                    "customBoolean": true,
+                    "customNumber": 7,
+                }),
+            )]),
+            vec![],
+        );
+
+        let info = commit_info(&data);
+        let operation_parameters = info
+            .operation_parameters
+            .as_ref()
+            .expect("operation parameters should be present");
+        assert_eq!(operation_parameters.get("mode"), Some(&json!("Overwrite")));
+        assert_eq!(
+            operation_parameters.get("partitionBy"),
+            Some(&json!("[\"id\"]"))
+        );
+        assert_eq!(
+            operation_parameters.get("customParameter"),
+            Some(&json!("{\"kept\":true}"))
+        );
+        assert_eq!(
+            operation_parameters.get("customBoolean"),
+            Some(&json!("true"))
+        );
+        assert_eq!(operation_parameters.get("customNumber"), Some(&json!("7")));
+        assert!(!info.info.contains_key("operationParameters"));
+    }
+
+    #[test]
+    fn test_commit_data_normalizes_reserved_keys_from_existing_commit_info_info() {
+        let data = CommitData::new(
+            vec![Action::CommitInfo(CommitInfo {
+                info: HashMap::from([
+                    ("userName".to_owned(), json!("shadow-user")),
+                    (
+                        "operationParameters".to_owned(),
+                        json!({"custom": {"kept": true}}),
+                    ),
+                    ("custom".to_owned(), json!("kept")),
+                ]),
+                ..Default::default()
+            })],
+            DeltaOperation::FileSystemCheck {},
+            HashMap::from([("custom".to_owned(), json!("metadata-wins"))]),
+            vec![],
+        );
+
+        let info = commit_info(&data);
+        assert_eq!(info.user_name.as_deref(), Some("shadow-user"));
+        let operation_parameters = info
+            .operation_parameters
+            .as_ref()
+            .expect("operation parameters should be promoted");
+        assert_eq!(
+            operation_parameters.get("custom"),
+            Some(&json!("{\"kept\":true}"))
+        );
+        assert_eq!(info.info.get("custom"), Some(&json!("metadata-wins")));
+        assert!(!info.info.contains_key("userName"));
+        assert!(!info.info.contains_key("operationParameters"));
+    }
+
+    #[test]
+    fn test_commit_data_does_not_promote_reserved_metadata_over_typed_fields() {
+        let data = CommitData::new(
+            vec![Action::CommitInfo(CommitInfo {
+                user_name: Some("typed-user".to_owned()),
+                read_version: Some(10),
+                ..Default::default()
+            })],
+            DeltaOperation::FileSystemCheck {},
+            HashMap::from([
+                ("userName".to_owned(), json!("metadata-user")),
+                ("readVersion".to_owned(), json!(11)),
+                ("custom".to_owned(), json!("kept")),
+            ]),
+            vec![],
+        );
+
+        let info = commit_info(&data);
+        assert_eq!(info.user_name.as_deref(), Some("typed-user"));
+        assert_eq!(info.read_version, Some(10));
+        assert!(!info.info.contains_key("userName"));
+        assert!(!info.info.contains_key("readVersion"));
+        assert_eq!(info.info.get("custom"), Some(&json!("kept")));
+    }
+
+    #[test]
+    fn test_commit_data_strips_wrong_typed_reserved_metadata_without_clobbering_typed_fields() {
+        let data = CommitData::new(
+            vec![Action::CommitInfo(CommitInfo {
+                user_name: Some("typed-user".to_owned()),
+                read_version: Some(10),
+                ..Default::default()
+            })],
+            DeltaOperation::FileSystemCheck {},
+            HashMap::from([
+                ("userName".to_owned(), json!(123)),
+                ("readVersion".to_owned(), json!("abc")),
+                ("isBlindAppend".to_owned(), json!("not-a-bool")),
+                ("custom".to_owned(), json!("kept")),
+            ]),
+            vec![],
+        );
+
+        let info = commit_info(&data);
+        assert_eq!(info.user_name.as_deref(), Some("typed-user"));
+        assert_eq!(info.read_version, Some(10));
+        assert_eq!(info.info.get("custom"), Some(&json!("kept")));
+        assert!(!info.info.contains_key("userName"));
+        assert!(!info.info.contains_key("readVersion"));
+        assert!(!info.info.contains_key("isBlindAppend"));
     }
 }

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -412,29 +412,20 @@ impl DeltaOperation {
 
     /// Parameters configured for operation.
     pub fn operation_parameters(&self) -> DeltaResult<HashMap<String, Value>> {
-        if let Some(Some(Some(map))) = serde_json::to_value(self)?
-            .as_object()
-            .map(|p| p.values().next().map(|q| q.as_object()))
-        {
-            Ok(map
-                .iter()
-                .filter(|item| !item.1.is_null())
-                .map(|(k, v)| {
-                    (
-                        k.to_owned(),
-                        serde_json::Value::String(if v.is_string() {
-                            String::from(v.as_str().unwrap())
-                        } else {
-                            v.to_string()
-                        }),
-                    )
-                })
-                .collect())
-        } else {
-            Err(DeltaTableError::Generic(
-                "Operation parameters serialized into unexpected shape".into(),
-            ))
+        let value = serde_json::to_value(self)?;
+        if let Value::Object(mut operation) = value {
+            if let Some(Value::Object(parameters)) = operation.values_mut().next() {
+                return Ok(take(parameters)
+                    .into_iter()
+                    .filter(|item| !item.1.is_null())
+                    .map(|(key, value)| (key, operation_parameter_value(value)))
+                    .collect());
+            }
         }
+
+        Err(DeltaTableError::Generic(
+            "Operation parameters serialized into unexpected shape".into(),
+        ))
     }
 
     /// Denotes if the operation changes the data contained in the table
@@ -492,6 +483,13 @@ impl DeltaOperation {
             _ => false,
         }
     }
+}
+
+pub(crate) fn operation_parameter_value(value: Value) -> Value {
+    Value::String(match value {
+        Value::String(value) => value,
+        value => value.to_string(),
+    })
 }
 
 /// The SaveMode used when performing a DeltaOperation

--- a/python/deltalake/transaction.py
+++ b/python/deltalake/transaction.py
@@ -50,14 +50,25 @@ class CommitProperties:
 
     def __init__(
         self,
-        custom_metadata: dict[str, str] | None = None,
+        custom_metadata: dict[str, Any] | None = None,
         max_commit_retries: int | None = None,
         app_transactions: list[Transaction] | None = None,
     ) -> None:
         """Custom metadata to be stored in the commit. Controls the number of retries for the commit.
 
         Args:
-            custom_metadata: custom metadata that will be added to the transaction commit.
+            custom_metadata: custom metadata that will be added to the transaction
+                commit. Top level keys must be strings and values must be JSON
+                serializable. Values such as NaN and Infinity are rejected.
+                Reserved commit info keys have stricter requirements:
+                "operationParameters" must be a JSON object; "readVersion" must
+                be an integer greater than or equal to zero, not a float;
+                "userId", "userName", and "userMetadata" must be strings;
+                "isolationLevel" must be one of "Serializable",
+                "WriteSerializable", or "SnapshotIsolation"; "isBlindAppend"
+                must be a boolean. The generated keys "timestamp", "operation",
+                and "engineInfo" cannot be set through custom metadata. Callers
+                may set "clientVersion", and it is preserved when provided.
             max_commit_retries: maximum number of times to retry the transaction commit.
         """
         self.custom_metadata = custom_metadata

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -36,7 +36,8 @@ use deltalake::errors::DeltaTableError;
 use deltalake::kernel::scalars::ScalarExt;
 use deltalake::kernel::transaction::{CommitBuilder, CommitProperties, TableReference};
 use deltalake::kernel::{
-    Action, Add, EagerSnapshot, LogicalFileView, MetadataExt as _, Transaction, Version,
+    Action, Add, EagerSnapshot, IsolationLevel, LogicalFileView, MetadataExt as _, Transaction,
+    Version,
 };
 use deltalake::lakefs::LakeFSCustomExecuteHandler;
 use deltalake::logstore::LogStoreRef;
@@ -59,8 +60,10 @@ use deltalake::{DeltaResult, DeltaTable, DeltaTableBuilder, init_client_version}
 use futures::TryStreamExt;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::pybacked::PyBackedStr;
-use pyo3::types::{PyCapsule, PyDict, PyFrozenSet, PyModule};
-use pyo3::{IntoPyObjectExt, prelude::*};
+use pyo3::types::{
+    IntoPyDict, PyCapsule, PyDict, PyFrozenSet, PyMapping, PyMappingMethods, PyModule, PyTuple,
+};
+use pyo3::{Borrowed, IntoPyObjectExt, prelude::*};
 use pyo3_arrow::export::{Arro3RecordBatchReader, Arro3Table};
 use pyo3_arrow::{PyRecordBatchReader, PySchema as PyArrowSchema, PyTable};
 use schema::PySchema;
@@ -1585,22 +1588,9 @@ impl RawDeltaTable {
                 predicate: None,
             };
 
-            let mut properties = CommitProperties::default();
-            if let Some(props) = commit_properties {
-                if let Some(metadata) = props.custom_metadata {
-                    let json_metadata: Map<String, Value> =
-                        metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-                    properties = properties.with_metadata(json_metadata);
-                };
-
-                if let Some(max_retries) = props.max_commit_retries {
-                    properties = properties.with_max_retries(max_retries);
-                };
-            }
-
-            if let Some(post_commit_hook_props) = post_commithook_properties {
-                properties = set_post_commithook_properties(properties, post_commit_hook_props)
-            }
+            let properties =
+                maybe_create_commit_properties(commit_properties, post_commithook_properties)
+                    .unwrap_or_default();
 
             rt().block_on(
                 CommitBuilder::from(properties)
@@ -2370,9 +2360,7 @@ fn maybe_create_commit_properties(
 
     if let Some(commit_props) = maybe_commit_properties {
         if let Some(metadata) = commit_props.custom_metadata {
-            let json_metadata: Map<String, Value> =
-                metadata.into_iter().map(|(k, v)| (k, v.into())).collect();
-            commit_properties = commit_properties.with_metadata(json_metadata);
+            commit_properties = commit_properties.with_metadata(metadata.into_inner());
         };
 
         if let Some(max_retries) = commit_props.max_commit_retries {
@@ -2733,11 +2721,117 @@ impl From<&PyTransaction> for Transaction {
     }
 }
 
-#[derive(FromPyObject)]
+#[derive(Debug)]
+struct PyCustomMetadata(Map<String, Value>);
+
+impl PyCustomMetadata {
+    fn into_inner(self) -> Map<String, Value> {
+        self.0
+    }
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for PyCustomMetadata {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        let py = obj.py();
+        let mapping = obj.cast::<PyMapping>().map_err(|_| {
+            PyValueError::new_err("CommitProperties.custom_metadata must be a mapping")
+        })?;
+        let json_dumps = PyModule::import(py, "json")?.getattr("dumps")?;
+        let kwargs = [("allow_nan", false)].into_py_dict(py)?;
+        let mut metadata = Map::new();
+
+        for item in mapping.items()? {
+            let item = item.cast::<PyTuple>()?;
+            let key = item.get_item(0)?;
+            let value = item.get_item(1)?;
+            let key = key.extract::<String>().map_err(|_| {
+                PyValueError::new_err("CommitProperties.custom_metadata keys must be strings")
+            })?;
+            let value = py_to_json_metadata_value(&json_dumps, &kwargs, &value, &key)?;
+            validate_reserved_commit_metadata(&key, &value)?;
+            metadata.insert(key, value);
+        }
+
+        Ok(Self(metadata))
+    }
+}
+
+fn py_to_json_metadata_value(
+    json_dumps: &Bound<'_, PyAny>,
+    kwargs: &Bound<'_, PyDict>,
+    value: &Bound<'_, PyAny>,
+    key: &str,
+) -> PyResult<Value> {
+    let value_json: String = json_dumps
+        .call((value,), Some(kwargs))
+        .and_then(|json| json.extract())
+        .map_err(|err| {
+            PyValueError::new_err(format!(
+                "CommitProperties.custom_metadata value for '{key}' must be JSON-serializable: {err}"
+            ))
+        })?;
+
+    serde_json::from_str(&value_json).map_err(|err| {
+        PyValueError::new_err(format!(
+            "CommitProperties.custom_metadata value for '{key}' must be valid JSON: {err}"
+        ))
+    })
+}
+
+fn validate_reserved_commit_metadata(key: &str, value: &Value) -> PyResult<()> {
+    // Keep this match aligned with RESERVED_COMMIT_INFO_KEYS in core transaction metadata
+    // normalization. Python raises ValueError before commit construction, while core
+    // normalization keeps Rust callers compatible by logging and dropping invalid reserved data.
+    match key {
+        "timestamp" | "operation" | "engineInfo" => Err(PyValueError::new_err(format!(
+            "CommitProperties.custom_metadata key '{key}' is generated by delta-rs and cannot be set"
+        ))),
+        "operationParameters" if !value.is_object() => Err(PyValueError::new_err(
+            "CommitProperties.custom_metadata['operationParameters'] must be a JSON object",
+        )),
+        "readVersion" if value.as_u64().is_none() => Err(PyValueError::new_err(
+            "CommitProperties.custom_metadata['readVersion'] must be a non-negative integer",
+        )),
+        "userId" | "userName" | "userMetadata" if !value.is_string() => Err(PyValueError::new_err(
+            format!("CommitProperties.custom_metadata['{key}'] must be a string"),
+        )),
+        "isolationLevel" => {
+            let valid = value
+                .as_str()
+                .is_some_and(|value| value.parse::<IsolationLevel>().is_ok());
+            if valid {
+                Ok(())
+            } else {
+                Err(PyValueError::new_err(
+                    "CommitProperties.custom_metadata['isolationLevel'] must be a valid IsolationLevel string",
+                ))
+            }
+        }
+        "isBlindAppend" if !value.is_boolean() => Err(PyValueError::new_err(
+            "CommitProperties.custom_metadata['isBlindAppend'] must be a boolean",
+        )),
+        _ => Ok(()),
+    }
+}
+
 pub struct PyCommitProperties {
-    custom_metadata: Option<HashMap<String, String>>,
+    custom_metadata: Option<PyCustomMetadata>,
     max_commit_retries: Option<usize>,
     app_transactions: Option<Vec<PyTransaction>>,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for PyCommitProperties {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            custom_metadata: obj.getattr("custom_metadata")?.extract()?,
+            max_commit_retries: obj.getattr("max_commit_retries")?.extract()?,
+            app_transactions: obj.getattr("app_transactions")?.extract()?,
+        })
+    }
 }
 
 #[pyfunction]

--- a/python/tests/test_commit_properties.py
+++ b/python/tests/test_commit_properties.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import json
+import math
+import pathlib
+from collections.abc import Iterable
+from typing import Any
+
+import pytest
+from arro3.core import Array, DataType, Table
+from arro3.core import Field as ArrowField
+
+from deltalake import (
+    CommitProperties,
+    DeltaTable,
+    Field,
+    Schema,
+    Transaction,
+    write_deltalake,
+)
+from deltalake.schema import PrimitiveType
+from deltalake.transaction import AddAction
+
+
+def _reject_duplicate_object_pairs(pairs: Iterable[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        assert key not in result, f"duplicate JSON key found: {key}"
+        result[key] = value
+    return result
+
+
+def _commit_info_from_log(table_path: pathlib.Path, version: int = 0) -> dict[str, Any]:
+    log_path = table_path / "_delta_log" / f"{version:020}.json"
+    for line in log_path.read_text().splitlines():
+        action = json.loads(line, object_pairs_hook=_reject_duplicate_object_pairs)
+        if "commitInfo" in action:
+            return action["commitInfo"]
+    raise AssertionError(f"No commitInfo action found in {log_path}")
+
+
+def _schema() -> Schema:
+    return Schema(
+        fields=[
+            Field("id", type=PrimitiveType("string"), nullable=True),
+            Field("price", type=PrimitiveType("long"), nullable=True),
+        ]
+    )
+
+
+def _table() -> Table:
+    return Table(
+        {
+            "id": Array(
+                ["1"], ArrowField("id", type=DataType.string_view(), nullable=True)
+            ),
+            "price": Array(
+                [10], ArrowField("price", type=DataType.int64(), nullable=True)
+            ),
+        }
+    )
+
+
+def _manual_write_transaction_parts(
+    table_path: pathlib.Path,
+) -> tuple[DeltaTable, Schema, AddAction]:
+    from arro3.io import write_parquet
+
+    schema = _schema()
+    table = _table()
+    DeltaTable.create(table_path, schema)
+
+    data_file = table_path / "manual.parquet"
+    write_parquet(table, data_file)
+
+    action = AddAction(
+        "manual.parquet",
+        data_file.stat().st_size,
+        {},
+        0,
+        True,
+        "{}",
+    )
+    return DeltaTable(table_path), schema, action
+
+
+def test_custom_metadata_json_values_round_trip(tmp_path: pathlib.Path) -> None:
+    custom_metadata = {
+        "intValue": 7,
+        "nested": {"flag": True, "items": [1, None, {"name": "value"}]},
+        "boolValue": False,
+        "nullValue": None,
+    }
+
+    write_deltalake(
+        tmp_path,
+        _table(),
+        commit_properties=CommitProperties(custom_metadata=custom_metadata),
+    )
+
+    history = DeltaTable(tmp_path).history(1)[0]
+    assert history["intValue"] == 7
+    assert history["nested"] == {"flag": True, "items": [1, None, {"name": "value"}]}
+    assert history["boolValue"] is False
+    assert history["nullValue"] is None
+
+    raw_commit_info = _commit_info_from_log(tmp_path)
+    assert raw_commit_info["intValue"] == 7
+
+
+def test_create_write_transaction_accepts_json_custom_metadata(
+    tmp_path: pathlib.Path,
+) -> None:
+    dt, schema, action = _manual_write_transaction_parts(tmp_path)
+    dt.create_write_transaction(
+        actions=[action],
+        mode="append",
+        schema=schema,
+        commit_properties=CommitProperties(
+            custom_metadata={"attempt": 1, "details": {"manual": True}}
+        ),
+    )
+
+    history = DeltaTable(tmp_path).history(1)[0]
+    assert history["attempt"] == 1
+    assert history["details"] == {"manual": True}
+
+
+def test_operation_parameters_merge_without_duplicate_json_keys(
+    tmp_path: pathlib.Path,
+) -> None:
+    write_deltalake(
+        tmp_path,
+        _table(),
+        mode="overwrite",
+        partition_by=["id"],
+        commit_properties=CommitProperties(
+            custom_metadata={
+                "operationParameters": {
+                    "mode": "custom-mode",
+                    "partitionBy": "custom-partitioning",
+                    "customParameter": {"from": "metadata"},
+                    "customBoolean": True,
+                    "customNumber": 7,
+                }
+            }
+        ),
+    )
+
+    history = DeltaTable(tmp_path).history(1)[0]
+    assert history["operationParameters"]["mode"] == "Overwrite"
+    assert history["operationParameters"]["partitionBy"] == '["id"]'
+    assert history["operationParameters"]["customParameter"] == '{"from":"metadata"}'
+    assert history["operationParameters"]["customBoolean"] == "true"
+    assert history["operationParameters"]["customNumber"] == "7"
+
+    raw_commit_info = _commit_info_from_log(tmp_path)
+    assert raw_commit_info["operationParameters"]["mode"] == "Overwrite"
+    assert raw_commit_info["operationParameters"]["partitionBy"] == '["id"]'
+    assert (
+        raw_commit_info["operationParameters"]["customParameter"]
+        == '{"from":"metadata"}'
+    )
+
+
+@pytest.mark.parametrize(
+    ("custom_metadata", "match"),
+    [
+        ({"operationParameters": "not-an-object"}, "operationParameters"),
+        ({"readVersion": -1}, "readVersion"),
+        ({"readVersion": 1.0}, "readVersion"),
+        ({"readVersion": 1.5}, "readVersion"),
+        ({"readVersion": "1"}, "readVersion"),
+        ({"isolationLevel": "NotAnIsolationLevel"}, "isolationLevel"),
+        ({"userName": 123}, "userName"),
+        ({"timestamp": 123}, "timestamp"),
+        ({"operation": "WRITE"}, "operation"),
+        ({"engineInfo": "custom-engine"}, "engineInfo"),
+    ],
+)
+def test_invalid_reserved_custom_metadata_values_raise(
+    tmp_path: pathlib.Path, custom_metadata: dict[str, Any], match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        write_deltalake(
+            tmp_path,
+            _table(),
+            commit_properties=CommitProperties(custom_metadata=custom_metadata),
+        )
+
+
+@pytest.mark.parametrize(
+    ("custom_metadata", "match"),
+    [
+        ([("key", "value")], "mapping"),
+        ({1: "value"}, "keys must be strings"),
+        ({"score": math.nan}, "JSON"),
+        ({"payload": object()}, "JSON"),
+    ],
+)
+def test_invalid_custom_metadata_json_values_raise(
+    tmp_path: pathlib.Path, custom_metadata: Any, match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        write_deltalake(
+            tmp_path,
+            _table(),
+            commit_properties=CommitProperties(custom_metadata=custom_metadata),
+        )
+
+
+def test_valid_reserved_user_fields_are_visible_in_history(
+    tmp_path: pathlib.Path,
+) -> None:
+    write_deltalake(
+        tmp_path,
+        _table(),
+        commit_properties=CommitProperties(
+            custom_metadata={"userName": "Jane Doe", "userId": "jane"}
+        ),
+    )
+
+    history = DeltaTable(tmp_path).history(1)[0]
+    assert history["userName"] == "Jane Doe"
+    assert history["userId"] == "jane"
+
+    raw_commit_info = _commit_info_from_log(tmp_path)
+    assert raw_commit_info["userName"] == "Jane Doe"
+    assert raw_commit_info["userId"] == "jane"
+
+
+def test_reserved_read_version_is_visible_in_history(
+    tmp_path: pathlib.Path,
+) -> None:
+    write_deltalake(
+        tmp_path,
+        _table(),
+        commit_properties=CommitProperties(custom_metadata={"readVersion": 15}),
+    )
+
+    history = DeltaTable(tmp_path).history(1)[0]
+    assert history["readVersion"] == 15
+
+    raw_commit_info = _commit_info_from_log(tmp_path)
+    assert raw_commit_info["readVersion"] == 15
+
+
+def test_custom_client_version_is_preserved(tmp_path: pathlib.Path) -> None:
+    write_deltalake(
+        tmp_path,
+        _table(),
+        commit_properties=CommitProperties(
+            custom_metadata={"clientVersion": "test-client.1.2.3"}
+        ),
+    )
+
+    history = DeltaTable(tmp_path).history(1)[0]
+    assert history["clientVersion"] == "test-client.1.2.3"
+
+    raw_commit_info = _commit_info_from_log(tmp_path)
+    assert raw_commit_info["clientVersion"] == "test-client.1.2.3"
+
+
+def test_create_write_transaction_forwards_app_transactions(
+    tmp_path: pathlib.Path,
+) -> None:
+    dt, schema, action = _manual_write_transaction_parts(tmp_path)
+    dt.create_write_transaction(
+        actions=[action],
+        mode="append",
+        schema=schema,
+        commit_properties=CommitProperties(
+            app_transactions=[Transaction(app_id="manual-writer", version=42)]
+        ),
+    )
+
+    assert DeltaTable(tmp_path).transaction_version("manual-writer") == 42


### PR DESCRIPTION
Cleans up a few rough edges in how python commit metadata flows through to the commit info action. This fix makes `CommitProperties.custom_metadata` accept arbitrary json typed values instead of being restricted to strings, which matches what the protocol allows and what users were already trying to pass in.

Reserved commit info keys are promoted into their typed fields on `CommitInfo` rather than being left in the custom metadata bag, this makes sure we don't end up emitting duplicate json keys when a user passes one through. Generated commit fields are preserved on the way out, but `clientVersion` stays user overridable since there are legitimate reasons to want to set it explicitly. Also threads `app_transactions` through `create_write_transaction`, which was being dropped on that path.

Closes #4443