### PR TITLE
docs: update dynamodb locking setup

### DIFF
--- a/docs/usage/writing/writing-to-s3-with-locking-provider.md
+++ b/docs/usage/writing/writing-to-s3-with-locking-provider.md
@@ -68,10 +68,14 @@ The following code allows creating the necessary DynamoDB table from the AWS cli
 
 ```sh
 aws dynamodb create-table \
---table-name delta_log \
---attribute-definitions AttributeName=tablePath,AttributeType=S AttributeName=fileName,AttributeType=S \
---key-schema AttributeName=tablePath,KeyType=HASH AttributeName=fileName,KeyType=RANGE \
---provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
+  --table-name delta_log \
+  --attribute-definitions AttributeName=tablePath,AttributeType=S AttributeName=fileName,AttributeType=S \
+  --key-schema AttributeName=tablePath,KeyType=HASH AttributeName=fileName,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST
+
+aws dynamodb update-time-to-live \
+  --table-name delta_log \
+  --time-to-live-specification Enabled=true,AttributeName=expireTime
 ```
 
 You can find additional information in the [Delta Lake documentation](https://docs.delta.io/latest/delta-storage.html#multi-cluster-setup), which also includes recommendations on configuring a time-to-live (TTL) for the table to avoid growing the table indefinitely.

--- a/python/docs/source/usage.rst
+++ b/python/docs/source/usage.rst
@@ -622,10 +622,14 @@ The following code allows creating the necessary table from the AWS cli:
 .. code-block:: sh
 
         aws dynamodb create-table \
-        --table-name delta_log \
-        --attribute-definitions AttributeName=tablePath,AttributeType=S AttributeName=fileName,AttributeType=S \
-        --key-schema AttributeName=tablePath,KeyType=HASH AttributeName=fileName,KeyType=RANGE \
-        --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
+          --table-name delta_log \
+          --attribute-definitions AttributeName=tablePath,AttributeType=S AttributeName=fileName,AttributeType=S \
+          --key-schema AttributeName=tablePath,KeyType=HASH AttributeName=fileName,KeyType=RANGE \
+          --billing-mode PAY_PER_REQUEST
+
+        aws dynamodb update-time-to-live \
+          --table-name delta_log \
+          --time-to-live-specification Enabled=true,AttributeName=expireTime
 
 You can find additional information in the `delta-rs-documentation
 https://docs.delta.io/latest/delta-storage.html#multi-cluster-setup`_, which


### PR DESCRIPTION
fixes #4452

summary:
- update the dynamodb locking setup commands to use `--billing-mode PAY_PER_REQUEST`
- add the `update-time-to-live` command for the `expireTime` attribute
- keep the mkdocs and python docs examples aligned

validation:
- checked the updated commands against the aws cli dynamodb `create-table` and `update-time-to-live` command references
- ran `rg "provisioned-throughput|PAY_PER_REQUEST|update-time-to-live|expireTime" docs/usage/writing/writing-to-s3-with-locking-provider.md python/docs/source/usage.rst`