### PR TITLE
refactor: deprecate legacy DeltaScan codec surface

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -436,10 +436,17 @@ pub(crate) fn to_correct_scalar_value(
     }
 }
 
-/// A codec for deltalake physical plans
+/// Legacy codec for serialized plans that still contain the retired physical
+/// [`DeltaScan`] wrapper.
+#[deprecated(
+    note = "DeltaPhysicalCodec only supports the retired physical DeltaScan wrapper. \
+            Use DeltaLogicalCodec for table-provider serialization until a DeltaScanExec \
+            physical codec is available."
+)]
 #[derive(Debug)]
 pub struct DeltaPhysicalCodec {}
 
+#[allow(deprecated)]
 impl PhysicalExtensionCodec for DeltaPhysicalCodec {
     fn try_decode(
         &self,
@@ -449,12 +456,7 @@ impl PhysicalExtensionCodec for DeltaPhysicalCodec {
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let wire: DeltaScanWire = serde_json::from_reader(buf)
             .map_err(|_| DataFusionError::Internal("Unable to decode DeltaScan".to_string()))?;
-        let delta_scan = DeltaScan::new(
-            &wire.table_url,
-            wire.config,
-            (*inputs)[0].clone(),
-            wire.logical_schema,
-        );
+        let delta_scan = wire.into_delta_scan((*inputs)[0].clone());
         Ok(Arc::new(delta_scan))
     }
 
@@ -466,11 +468,12 @@ impl PhysicalExtensionCodec for DeltaPhysicalCodec {
         let delta_scan = node
             .as_any()
             .downcast_ref::<DeltaScan>()
-            .ok_or_else(|| DataFusionError::Internal("Not a delta scan!".to_string()))?;
+            .ok_or_else(|| DataFusionError::Internal("Not a legacy delta scan!".to_string()))?;
 
         let wire = DeltaScanWire::from(delta_scan);
-        serde_json::to_writer(buf, &wire)
-            .map_err(|_| DataFusionError::Internal("Unable to encode delta scan!".to_string()))?;
+        serde_json::to_writer(buf, &wire).map_err(|_| {
+            DataFusionError::Internal("Unable to encode legacy delta scan!".to_string())
+        })?;
         Ok(())
     }
 }
@@ -707,6 +710,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn roundtrip_test_delta_exec_plan() {
         let ctx = SessionContext::new();
         let codec = DeltaPhysicalCodec {};

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -497,11 +497,11 @@ pub(super) struct DeltaScan {
     /// The normalized [Url] of the ObjectStore root
     table_url: Url,
     /// Column that contains an index that maps to the original metadata Add
-    pub(crate) config: DeltaScanConfig,
+    config: DeltaScanConfig,
     /// The parquet scan to wrap
-    pub(crate) parquet_scan: Arc<dyn ExecutionPlan>,
+    parquet_scan: Arc<dyn ExecutionPlan>,
     /// The schema of the table to be used when evaluating expressions
-    pub(crate) logical_schema: Arc<Schema>,
+    logical_schema: Arc<Schema>,
     /// Metrics for scan reported via DataFusion
     metrics: ExecutionPlanMetricsSet,
 }
@@ -527,9 +527,9 @@ impl DeltaScan {
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct DeltaScanWire {
     /// This [Url] should have already been passed through [normalize_table_url]
-    pub(crate) table_url: Url,
-    pub(crate) config: DeltaScanConfig,
-    pub(crate) logical_schema: Arc<Schema>,
+    table_url: Url,
+    config: DeltaScanConfig,
+    logical_schema: Arc<Schema>,
 }
 
 impl From<&DeltaScan> for DeltaScanWire {
@@ -539,6 +539,17 @@ impl From<&DeltaScan> for DeltaScanWire {
             config: scan.config.clone(),
             logical_schema: scan.logical_schema.clone(),
         }
+    }
+}
+
+impl DeltaScanWire {
+    pub(super) fn into_delta_scan(self, parquet_scan: Arc<dyn ExecutionPlan>) -> DeltaScan {
+        DeltaScan::new(
+            &self.table_url,
+            self.config,
+            parquet_scan,
+            self.logical_schema,
+        )
     }
 }
 


### PR DESCRIPTION
Deprecates `DeltaPhysicalCodec` while keeping the compat path for plans that still contain the retired physical DeltaScan wrapper.

I have some follow ups planned to remove the legacy path once a replacement `DeltaScanExec` codec lands (#4171). Part of the DeltaTableProvider removal epic #4239