### PR TITLE
fix: keep delta materialized filters above parquet

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -22,6 +22,7 @@ use datafusion::common::{
 };
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_expr::utils::collect_columns;
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, PlanProperties};
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
@@ -235,6 +236,23 @@ impl DeltaScanExec {
         stats.column_statistics = new_stats;
         Ok(stats)
     }
+
+    /// The default physical expr adapter rewrites missing nullable columns to null literals.
+    /// That rewrite supports schema evolution. Delta materialized columns live above the
+    /// Parquet child, including partition values, file id, and row index. Dynamic filters
+    /// on those columns must stay bound to this exec's output schema; rewriting them
+    /// against the Parquet child can turn them into null literals and drop rows.
+    fn references_delta_materialized_column(&self, filter: &Arc<dyn PhysicalExpr>) -> bool {
+        let input_schema = self.input.schema();
+        collect_columns(filter).iter().any(|column| {
+            self.scan_plan
+                .contract
+                .result_schema
+                .field_with_name(column.name())
+                .is_ok()
+                && input_schema.field_with_name(column.name()).is_err()
+        })
+    }
 }
 
 impl ExecutionPlan for DeltaScanExec {
@@ -379,7 +397,16 @@ impl ExecutionPlan for DeltaScanExec {
             .and_then(|adapter| {
                 parent_filters
                     .iter()
-                    .map(|filter| adapter.rewrite(Arc::clone(filter)))
+                    .map(|filter| {
+                        if self.references_delta_materialized_column(filter) {
+                            // Leave filters that reference Delta materialized columns in the parent
+                            // schema. `FilterDescription::from_children` marks them unsupported for
+                            // the Parquet child because those columns are absent from the child schema.
+                            Ok(Arc::clone(filter))
+                        } else {
+                            adapter.rewrite(Arc::clone(filter))
+                        }
+                    })
                     .collect::<Result<Vec<_>>>()
             });
 
@@ -716,8 +743,12 @@ mod tests {
     use datafusion::{
         common::{ToDFSchema, stats::Precision},
         datasource::TableProvider,
+        logical_expr::Operator,
+        physical_expr::expressions::{
+            BinaryExpr, Column, DynamicFilterPhysicalExpr, lit as physical_lit,
+        },
         physical_plan::{
-            collect, collect_partitioned,
+            PhysicalExpr, collect, collect_partitioned,
             filter_pushdown::{FilterPushdownPhase, PushedDown},
         },
         prelude::{col, lit},
@@ -903,6 +934,119 @@ mod tests {
         let input_batches = collect(Arc::clone(&exec.input), session.task_ctx()).await?;
         assert!(!input_batches.is_empty());
         child_filters[0][0].predicate.evaluate(&input_batches[0])?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_gather_filters_for_pushdown_rejects_delta_materialized_dynamic_filters()
+    -> TestResult {
+        let table = open_fs_path("../../dat/v0.0.3/reader_tests/generated/multi_partitioned/delta");
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .as_any()
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        let letter_idx = exec.schema().index_of("letter")?;
+        assert!(exec.schema().field_with_name("letter").is_ok());
+        assert!(exec.input.schema().field_with_name("letter").is_err());
+
+        let letter: Arc<dyn PhysicalExpr> = Arc::new(Column::new("letter", letter_idx));
+        let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::clone(&letter),
+            Operator::Eq,
+            physical_lit("a"),
+        ));
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(vec![letter], predicate));
+
+        let description = exec.gather_filters_for_pushdown(
+            FilterPushdownPhase::Post,
+            vec![filter],
+            session.state().config().options(),
+        )?;
+
+        let child_filters = description.parent_filters();
+        assert_eq!(child_filters.len(), 1);
+        assert_eq!(child_filters[0].len(), 1);
+        assert!(matches!(child_filters[0][0].discriminant, PushedDown::No));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_gather_filters_for_pushdown_rejects_mixed_delta_materialized_dynamic_filters()
+    -> TestResult {
+        let table = open_fs_path("../../dat/v0.0.3/reader_tests/generated/multi_partitioned/delta");
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .as_any()
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        let letter_idx = exec.schema().index_of("letter")?;
+        let number_idx = exec.schema().index_of("number")?;
+        assert!(exec.schema().field_with_name("letter").is_ok());
+        assert!(exec.schema().field_with_name("number").is_ok());
+        assert!(exec.input.schema().field_with_name("letter").is_err());
+        assert!(exec.input.schema().field_with_name("number").is_ok());
+
+        let letter: Arc<dyn PhysicalExpr> = Arc::new(Column::new("letter", letter_idx));
+        let number: Arc<dyn PhysicalExpr> = Arc::new(Column::new("number", number_idx));
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![letter, number],
+            physical_lit(true),
+        ));
+
+        let description = exec.gather_filters_for_pushdown(
+            FilterPushdownPhase::Post,
+            vec![filter],
+            session.state().config().options(),
+        )?;
+
+        let child_filters = description.parent_filters();
+        assert_eq!(child_filters.len(), 1);
+        assert_eq!(child_filters[0].len(), 1);
+        assert!(matches!(child_filters[0][0].discriminant, PushedDown::No));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_gather_filters_for_pushdown_keeps_parquet_dynamic_filters() -> TestResult {
+        let table = TestTables::Simple.table_builder()?.load().await?;
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .as_any()
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        let id_idx = exec.schema().index_of("id")?;
+        assert!(exec.schema().field_with_name("id").is_ok());
+        assert!(exec.input.schema().field_with_name("id").is_ok());
+
+        let data: Arc<dyn PhysicalExpr> = Arc::new(Column::new("id", id_idx));
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![data],
+            physical_lit(true),
+        ));
+
+        let description = exec.gather_filters_for_pushdown(
+            FilterPushdownPhase::Post,
+            vec![filter],
+            session.state().config().options(),
+        )?;
+
+        let child_filters = description.parent_filters();
+        assert_eq!(child_filters.len(), 1);
+        assert_eq!(child_filters[0].len(), 1);
+        assert!(matches!(child_filters[0][0].discriminant, PushedDown::Yes));
 
         Ok(())
     }

--- a/crates/core/tests/it_datafusion/integration_datafusion.rs
+++ b/crates/core/tests/it_datafusion/integration_datafusion.rs
@@ -417,19 +417,25 @@ mod local {
         Ok(())
     }
 
-    const ISSUE_4467_SCENARIO_COUNT: usize = 3;
-    const ISSUE_4467_ZONE_COUNT: usize = 2;
+    const ISSUE_4467_SCENARIOS: &[&str] = &["s0", "s1", "s2"];
+    const ISSUE_4467_ZONES: &[&str] = &["z0", "z1"];
     const ISSUE_4467_ROWS_PER_ZONE: usize = 5;
-    const ISSUE_4467_FILTERED_SCENARIO_COUNT: usize = 2;
-    const ISSUE_4467_FILTERED_ZONE_COUNT: usize = 1;
-    const ISSUE_4467_FILTERED_IDX_COUNT: usize = 3;
-    const ISSUE_4467_FILTERED_EXPECTED_ROWS: i64 = (ISSUE_4467_FILTERED_SCENARIO_COUNT
-        * ISSUE_4467_FILTERED_ZONE_COUNT
-        * ISSUE_4467_ROWS_PER_ZONE) as i64;
+    const ISSUE_4467_FILTERED_SCENARIOS: &[&str] = &["s0", "s1"];
+    const ISSUE_4467_FILTERED_ZONES: &[&str] = &["z0"];
+    const ISSUE_4467_FILTERED_IDXS: &[i64] = &[0, 1, 2];
 
-    fn issue_4467_quoted_values(prefix: &str, count: usize) -> String {
-        (0..count)
-            .map(|value| format!("'{prefix}{value}'"))
+    fn issue_4467_quoted_values(values: &[&str]) -> String {
+        values
+            .iter()
+            .map(|value| format!("'{value}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    fn issue_4467_int_values(values: &[i64]) -> String {
+        values
+            .iter()
+            .map(|value| value.to_string())
             .collect::<Vec<_>>()
             .join(", ")
     }
@@ -440,11 +446,11 @@ mod local {
         let mut idx = vec![];
         let mut values = vec![];
 
-        for scenario in 0..ISSUE_4467_SCENARIO_COUNT {
-            for zone in 0..ISSUE_4467_ZONE_COUNT {
+        for scenario in ISSUE_4467_SCENARIOS {
+            for zone in ISSUE_4467_ZONES {
                 for row_idx in 0..ISSUE_4467_ROWS_PER_ZONE {
-                    scenarios.push(format!("s{scenario}"));
-                    zones.push(format!("z{zone}"));
+                    scenarios.push((*scenario).to_string());
+                    zones.push((*zone).to_string());
                     idx.push(row_idx as i64);
                     values.push(offset + values.len() as i64);
                 }
@@ -505,8 +511,8 @@ mod local {
         let ctx = SessionContext::new();
         let (_left_dir, _right_dir) = issue_4467_register_tables(&ctx).await?;
 
-        let scenario_in = issue_4467_quoted_values("s", ISSUE_4467_FILTERED_SCENARIO_COUNT);
-        let zone_in = issue_4467_quoted_values("z", ISSUE_4467_FILTERED_ZONE_COUNT);
+        let scenario_in = issue_4467_quoted_values(ISSUE_4467_FILTERED_SCENARIOS);
+        let zone_in = issue_4467_quoted_values(ISSUE_4467_FILTERED_ZONES);
         let count = issue_4467_count(
             &ctx,
             &format!(
@@ -524,7 +530,10 @@ mod local {
         )
         .await?;
 
-        assert_eq!(count, ISSUE_4467_FILTERED_EXPECTED_ROWS);
+        let expected_rows = (ISSUE_4467_FILTERED_SCENARIOS.len()
+            * ISSUE_4467_FILTERED_ZONES.len()
+            * ISSUE_4467_ROWS_PER_ZONE) as i64;
+        assert_eq!(count, expected_rows);
         Ok(())
     }
 
@@ -533,10 +542,7 @@ mod local {
         let ctx = SessionContext::new();
         let (_left_dir, _right_dir) = issue_4467_register_tables(&ctx).await?;
 
-        let idx_in = (0..ISSUE_4467_FILTERED_IDX_COUNT)
-            .map(|idx| idx.to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
+        let idx_in = issue_4467_int_values(ISSUE_4467_FILTERED_IDXS);
         let count = issue_4467_count(
             &ctx,
             &format!(
@@ -554,9 +560,9 @@ mod local {
 
         // `price_zone` is absent from the join keys. Each matching scenario and idx row
         // joins every left zone to every right zone.
-        let expected_fanout = ISSUE_4467_SCENARIO_COUNT
-            * ISSUE_4467_FILTERED_IDX_COUNT
-            * ISSUE_4467_ZONE_COUNT.pow(2);
+        let expected_fanout = ISSUE_4467_SCENARIOS.len()
+            * ISSUE_4467_FILTERED_IDXS.len()
+            * ISSUE_4467_ZONES.len().pow(2);
         assert_eq!(count, expected_fanout as i64);
         Ok(())
     }

--- a/crates/core/tests/it_datafusion/integration_datafusion.rs
+++ b/crates/core/tests/it_datafusion/integration_datafusion.rs
@@ -417,6 +417,150 @@ mod local {
         Ok(())
     }
 
+    const ISSUE_4467_SCENARIO_COUNT: usize = 3;
+    const ISSUE_4467_ZONE_COUNT: usize = 2;
+    const ISSUE_4467_ROWS_PER_ZONE: usize = 5;
+    const ISSUE_4467_FILTERED_SCENARIO_COUNT: usize = 2;
+    const ISSUE_4467_FILTERED_ZONE_COUNT: usize = 1;
+    const ISSUE_4467_FILTERED_IDX_COUNT: usize = 3;
+    const ISSUE_4467_FILTERED_EXPECTED_ROWS: i64 = (ISSUE_4467_FILTERED_SCENARIO_COUNT
+        * ISSUE_4467_FILTERED_ZONE_COUNT
+        * ISSUE_4467_ROWS_PER_ZONE) as i64;
+
+    fn issue_4467_quoted_values(prefix: &str, count: usize) -> String {
+        (0..count)
+            .map(|value| format!("'{prefix}{value}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    async fn issue_4467_prepare_table(offset: i64) -> (tempfile::TempDir, DeltaTable) {
+        let mut scenarios = vec![];
+        let mut zones = vec![];
+        let mut idx = vec![];
+        let mut values = vec![];
+
+        for scenario in 0..ISSUE_4467_SCENARIO_COUNT {
+            for zone in 0..ISSUE_4467_ZONE_COUNT {
+                for row_idx in 0..ISSUE_4467_ROWS_PER_ZONE {
+                    scenarios.push(format!("s{scenario}"));
+                    zones.push(format!("z{zone}"));
+                    idx.push(row_idx as i64);
+                    values.push(offset + values.len() as i64);
+                }
+            }
+        }
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("scenario", ArrowDataType::Utf8, false),
+            ArrowField::new("price_zone", ArrowDataType::Utf8, false),
+            ArrowField::new("idx", ArrowDataType::Int64, false),
+            ArrowField::new("val", ArrowDataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(scenarios)),
+                Arc::new(StringArray::from(zones)),
+                Arc::new(Int64Array::from(idx)),
+                Arc::new(Int64Array::from(values)),
+            ],
+        )
+        .expect("issue 4467 fixture batch should be valid");
+
+        prepare_table(
+            vec![batch],
+            SaveMode::Overwrite,
+            vec!["scenario".to_string()],
+        )
+        .await
+    }
+
+    async fn issue_4467_register_tables(
+        ctx: &SessionContext,
+    ) -> Result<(tempfile::TempDir, tempfile::TempDir)> {
+        let (left_dir, left_table) = issue_4467_prepare_table(0).await;
+        let (right_dir, right_table) = issue_4467_prepare_table(1_000_000).await;
+
+        ctx.register_table("issue_4467_left", left_table.table_provider().await?)?;
+        ctx.register_table("issue_4467_right", right_table.table_provider().await?)?;
+
+        Ok((left_dir, right_dir))
+    }
+
+    async fn issue_4467_count(ctx: &SessionContext, sql: &str) -> Result<i64> {
+        let batches = ctx.sql(sql).await?.collect().await?;
+        let schema = batches[0].schema();
+        let batch = arrow::compute::concat_batches(&schema, &batches)?;
+        Ok(batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("count column should be Int64")
+            .value(0))
+    }
+
+    #[tokio::test]
+    async fn issue_4467_join_dynamic_filter_partition_key_keeps_expected_rows() -> Result<()> {
+        let ctx = SessionContext::new();
+        let (_left_dir, _right_dir) = issue_4467_register_tables(&ctx).await?;
+
+        let scenario_in = issue_4467_quoted_values("s", ISSUE_4467_FILTERED_SCENARIO_COUNT);
+        let zone_in = issue_4467_quoted_values("z", ISSUE_4467_FILTERED_ZONE_COUNT);
+        let count = issue_4467_count(
+            &ctx,
+            &format!(
+                "
+            SELECT COUNT(*) AS count
+            FROM issue_4467_left l
+            INNER JOIN issue_4467_right r
+              ON l.scenario = r.scenario
+             AND l.price_zone = r.price_zone
+             AND l.idx = r.idx
+            WHERE l.scenario IN ({scenario_in})
+              AND l.price_zone IN ({zone_in})
+            "
+            ),
+        )
+        .await?;
+
+        assert_eq!(count, ISSUE_4467_FILTERED_EXPECTED_ROWS);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn issue_4467_join_dynamic_filter_idx_only_keeps_expected_rows() -> Result<()> {
+        let ctx = SessionContext::new();
+        let (_left_dir, _right_dir) = issue_4467_register_tables(&ctx).await?;
+
+        let idx_in = (0..ISSUE_4467_FILTERED_IDX_COUNT)
+            .map(|idx| idx.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let count = issue_4467_count(
+            &ctx,
+            &format!(
+                "
+            SELECT COUNT(*) AS count
+            FROM issue_4467_left l
+            INNER JOIN issue_4467_right r
+              ON l.scenario = r.scenario
+             AND l.idx = r.idx
+            WHERE l.idx IN ({idx_in})
+            "
+            ),
+        )
+        .await?;
+
+        // `price_zone` is absent from the join keys. Each matching scenario and idx row
+        // joins every left zone to every right zone.
+        let expected_fanout = ISSUE_4467_SCENARIO_COUNT
+            * ISSUE_4467_FILTERED_IDX_COUNT
+            * ISSUE_4467_ZONE_COUNT.pow(2);
+        assert_eq!(count, expected_fanout as i64);
+        Ok(())
+    }
+
     #[ignore]
     #[tokio::test]
     async fn test_files_scanned_pushdown_limit() -> Result<()> {

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1185,6 +1185,64 @@ def test_read_query_builder_join_multiple_tables(tmp_path):
     assert expected == actual
 
 
+@pytest.mark.pyarrow
+def test_querybuilder_partition_join_issue_4467_dynamic_filter(tmp_path):
+    import pyarrow as pa
+
+    scenarios = [f"s{i}" for i in range(3)]
+    zones = [f"z{i}" for i in range(2)]
+    rows_per_zone = 5
+    scenario_values = []
+    zone_values = []
+    idx_values = []
+    for scenario in scenarios:
+        for zone in zones:
+            scenario_values.extend([scenario] * rows_per_zone)
+            zone_values.extend([zone] * rows_per_zone)
+            idx_values.extend(range(rows_per_zone))
+
+    data = pa.table(
+        {
+            "scenario": pa.array(scenario_values, type=pa.string()),
+            "price_zone": pa.array(zone_values, type=pa.string()),
+            "idx": pa.array(idx_values, type=pa.int64()),
+            "val": pa.array(range(len(idx_values)), type=pa.int64()),
+        }
+    )
+
+    left_path = tmp_path / "left"
+    right_path = tmp_path / "right"
+    write_deltalake(left_path, data, partition_by="scenario")
+    write_deltalake(right_path, data, partition_by="scenario")
+
+    filtered_scenarios = scenarios[:2]
+    filtered_zones = zones[:1]
+    scenario_in = ", ".join(repr(scenario) for scenario in filtered_scenarios)
+    zone_in = ", ".join(repr(zone) for zone in filtered_zones)
+    actual = (
+        QueryBuilder()
+        .register("left_tbl", DeltaTable(left_path))
+        .register("right_tbl", DeltaTable(right_path))
+        .execute(
+            f"""
+            SELECT COUNT(*) AS count
+            FROM left_tbl l
+            INNER JOIN right_tbl r
+              ON l.scenario = r.scenario
+             AND l.price_zone = r.price_zone
+             AND l.idx = r.idx
+            WHERE l.scenario IN ({scenario_in})
+              AND l.price_zone IN ({zone_in})
+            """
+        )
+        .read_all()
+    )
+
+    assert actual["count"].to_pylist() == [
+        len(filtered_scenarios) * len(filtered_zones) * rows_per_zone
+    ]
+
+
 def test_deletion_vectors_api_smoke():
     table_path = "../crates/test/tests/data/table-with-dv-small"
     dt = DeltaTable(table_path)

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1187,28 +1187,10 @@ def test_read_query_builder_join_multiple_tables(tmp_path):
 
 @pytest.mark.pyarrow
 def test_querybuilder_partition_join_issue_4467_dynamic_filter(tmp_path):
-    import pyarrow as pa
-
     scenarios = [f"s{i}" for i in range(3)]
     zones = [f"z{i}" for i in range(2)]
     rows_per_zone = 5
-    scenario_values = []
-    zone_values = []
-    idx_values = []
-    for scenario in scenarios:
-        for zone in zones:
-            scenario_values.extend([scenario] * rows_per_zone)
-            zone_values.extend([zone] * rows_per_zone)
-            idx_values.extend(range(rows_per_zone))
-
-    data = pa.table(
-        {
-            "scenario": pa.array(scenario_values, type=pa.string()),
-            "price_zone": pa.array(zone_values, type=pa.string()),
-            "idx": pa.array(idx_values, type=pa.int64()),
-            "val": pa.array(range(len(idx_values)), type=pa.int64()),
-        }
-    )
+    data = _issue_4467_table(scenarios, zones, rows_per_zone)
 
     left_path = tmp_path / "left"
     right_path = tmp_path / "right"
@@ -1241,6 +1223,92 @@ def test_querybuilder_partition_join_issue_4467_dynamic_filter(tmp_path):
     assert actual["count"].to_pylist() == [
         len(filtered_scenarios) * len(filtered_zones) * rows_per_zone
     ]
+
+
+def _issue_4467_table(scenarios, zones, rows_per_zone, *, with_period_type=False):
+    import pyarrow as pa
+
+    scenario_values = []
+    zone_values = []
+    idx_values = []
+    for scenario in scenarios:
+        for zone in zones:
+            scenario_values.extend([scenario] * rows_per_zone)
+            zone_values.extend([zone] * rows_per_zone)
+            idx_values.extend(range(rows_per_zone))
+
+    columns = {
+        "scenario": pa.array(scenario_values, type=pa.string()),
+        "price_zone": pa.array(zone_values, type=pa.string()),
+        "idx": pa.array(idx_values, type=pa.int64()),
+        "val": pa.array(range(len(idx_values)), type=pa.int64()),
+    }
+    if with_period_type:
+        columns["period_type"] = pa.array(["hour"] * len(idx_values), type=pa.string())
+
+    return pa.table(columns)
+
+
+@pytest.mark.parametrize(
+    "join_predicate",
+    [
+        pytest.param(
+            """
+              ON l.scenario = r.scenario
+             AND l.price_zone = r.price_zone
+             AND l.idx = r.idx
+            """,
+            id="case_5_right_filter",
+        ),
+        pytest.param(
+            """
+              ON CAST(l.scenario AS VARCHAR) = CAST(r.scenario AS VARCHAR)
+             AND CAST(l.price_zone AS VARCHAR) = CAST(r.price_zone AS VARCHAR)
+             AND l.idx = r.idx
+            """,
+            id="case_6_cast_right_filter",
+        ),
+    ],
+)
+@pytest.mark.pyarrow
+def test_querybuilder_partition_join_issue_4467_right_filter_cases_5_and_6(
+    tmp_path, join_predicate
+):
+    scenarios = [f"s{i}" for i in range(5)]
+    zones = [f"z{i}" for i in range(3)]
+    rows_per_zone = 100
+    left_path = tmp_path / "left"
+    right_path = tmp_path / "right"
+    write_deltalake(
+        left_path,
+        _issue_4467_table(scenarios, zones, rows_per_zone),
+        partition_by="scenario",
+    )
+    write_deltalake(
+        right_path,
+        _issue_4467_table(scenarios, zones, rows_per_zone, with_period_type=True),
+        partition_by="scenario",
+    )
+
+    zone_in = ", ".join(repr(zone) for zone in zones)
+    actual = (
+        QueryBuilder()
+        .register("left_tbl", DeltaTable(left_path))
+        .register("right_tbl", DeltaTable(right_path))
+        .execute(
+            f"""
+            SELECT COUNT(*) AS count
+            FROM left_tbl l
+            INNER JOIN right_tbl r
+            {join_predicate}
+            WHERE l.price_zone IN ({zone_in})
+              AND r.period_type = 'hour'
+            """
+        )
+        .read_all()
+    )
+
+    assert actual["count"].to_pylist() == [len(scenarios) * len(zones) * rows_per_zone]
 
 
 def test_deletion_vectors_api_smoke():


### PR DESCRIPTION
Fixes #4467.

`DefaultPhysicalExprAdapterFactory` rewrites nullable columns missing from the child schema to null literals. This is correct behavior for schema evolution but wrong for Delta materialized columns (partition values, file id, row index). Those columns are injected above the parquet child. Under join dynamic filters, rewriting a partition column filter against the parquet child and turns it into a null predicate and drops valid rows.

The fix here is to skip parquet child filter adaptation when a parent filter references a delta materialized column. Keep those filters bound to `DeltaScanExec` output.