### PR TITLE
feat(python): propagate read_version to write conflict checking

### DIFF
--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -213,6 +213,7 @@ class RawDeltaTable:
         writer_properties: WriterProperties | None,
         commit_properties: CommitProperties | None,
         post_commithook_properties: PostCommitHookProperties | None,
+        read_version: int | None = None,
     ) -> str: ...
     def repair(
         self,
@@ -228,6 +229,7 @@ class RawDeltaTable:
         safe_cast: bool,
         commit_properties: CommitProperties | None,
         post_commithook_properties: PostCommitHookProperties | None,
+        read_version: int | None = None,
     ) -> str: ...
     def create_merge_builder(
         self,
@@ -244,6 +246,7 @@ class RawDeltaTable:
         streamed_exec: bool,
         max_spill_size: int | None,
         max_temp_directory_size: int | None,
+        read_version: int | None = None,
     ) -> PyMergeBuilder: ...
     def merge_execute(self, merge_builder: PyMergeBuilder) -> str: ...
     def get_active_partitions(
@@ -295,6 +298,7 @@ class RawDeltaTable:
         writer_properties: WriterProperties | None,
         commit_properties: CommitProperties | None,
         post_commithook_properties: PostCommitHookProperties | None,
+        read_version: int | None = None,
     ) -> None: ...
 
 def rust_core_version() -> str: ...
@@ -329,6 +333,7 @@ def write_to_deltalake(
     writer_properties: WriterProperties | None,
     commit_properties: CommitProperties | None,
     post_commithook_properties: PostCommitHookProperties | None,
+    read_version: int | None = None,
 ) -> None: ...
 def convert_to_deltalake(
     uri: str,

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -707,6 +707,7 @@ class DeltaTable:
         *args: Any,
         commit_properties: CommitProperties | None = None,
         post_commithook_properties: PostCommitHookProperties | None = None,
+        read_version: int | None = None,
     ) -> dict[str, Any]:
         """`UPDATE` records in the Delta Table that matches an optional predicate. Either updates or new_values needs
         to be passed for it to execute.
@@ -719,6 +720,7 @@ class DeltaTable:
             error_on_type_mismatch: specify if update returns an error when update expressions fail to cast to target column types :default = True
             commit_properties: properties of the transaction commit. If None, default values are used.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            read_version: version of the table that was read to build the update. Will fail if the table has been updated since then in a way that conflicts with the update.
         Returns:
             the metrics from update
 
@@ -807,7 +809,10 @@ class DeltaTable:
             safe_cast=not error_on_type_mismatch,
             commit_properties=commit_properties,
             post_commithook_properties=post_commithook_properties,
+            read_version=read_version,
         )
+        if read_version is not None:
+            self.update_incremental()
         return json.loads(metrics)
 
     @property
@@ -847,6 +852,7 @@ class DeltaTable:
         *args: Any,
         commit_properties: CommitProperties | None = None,
         post_commithook_properties: PostCommitHookProperties | None = None,
+        read_version: int | None = None,
     ) -> TableMerger:
         """Pass the source data which you want to merge on the target delta table, providing a
         predicate in SQL query like format.
@@ -872,6 +878,7 @@ class DeltaTable:
             max_temp_directory_size: The maximum disk space for temporary spill files. If not specified, uses DataFusion's default.
             commit_properties: properties for the commit. If None, default values are used.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            read_version: version of the table that was read to build the merge. The commit fails with :class:`~deltalake.exceptions.CommitFailedError` if a concurrent writer committed a conflicting change after this version.
 
         Returns:
             TableMerger: TableMerger Object
@@ -903,8 +910,9 @@ class DeltaTable:
             writer_properties=writer_properties,
             commit_properties=commit_properties,
             post_commithook_properties=post_commithook_properties,
+            read_version=read_version,
         )
-        return TableMerger(py_merge_builder, self._table)
+        return TableMerger(py_merge_builder, self._table, read_version=read_version)
 
     def restore(
         self,
@@ -1239,6 +1247,7 @@ class DeltaTable:
         *args: Any,
         commit_properties: CommitProperties | None = None,
         post_commithook_properties: PostCommitHookProperties | None = None,
+        read_version: int | None = None,
     ) -> dict[str, Any]:
         """Delete records from a Delta Table that satisfy a predicate.
 
@@ -1252,6 +1261,7 @@ class DeltaTable:
             writer_properties: Pass writer properties to the Rust parquet writer.
             commit_properties: properties of the transaction commit. If None, default values are used.
             post_commithook_properties: properties for the post commit hook. If None, default values are used.
+            read_version: version of the table that was read to build the delete. The commit fails with :class:`~deltalake.exceptions.CommitFailedError` if a concurrent writer committed a conflicting change after this version.
 
         Returns:
             A metrics dict. The ``num_deleted_rows`` key is omitted when this library
@@ -1272,7 +1282,10 @@ class DeltaTable:
             writer_properties,
             commit_properties,
             post_commithook_properties,
+            read_version=read_version,
         )
+        if read_version is not None:
+            self.update_incremental()
         return json.loads(metrics)
 
     def repair(
@@ -1420,9 +1433,11 @@ class TableMerger:
         self,
         builder: PyMergeBuilder,
         table: RawDeltaTable,
+        read_version: int | None = None,
     ) -> None:
         self._builder = builder
         self._table = table
+        self._read_version = read_version
 
     def when_matched_update(
         self, updates: dict[str, str], predicate: str | None = None
@@ -1860,6 +1875,8 @@ class TableMerger:
             Dict: metrics
         """
         metrics = self._table.merge_execute(self._builder)
+        if self._read_version is not None:
+            self._table.update_incremental()
         return json.loads(metrics)
 
 

--- a/python/deltalake/writer/writer.py
+++ b/python/deltalake/writer/writer.py
@@ -39,6 +39,7 @@ def write_deltalake(
     writer_properties: WriterProperties = ...,
     commit_properties: CommitProperties | None = ...,
     post_commithook_properties: PostCommitHookProperties | None = ...,
+    read_version: int | None = ...,
 ) -> None: ...
 
 
@@ -59,6 +60,7 @@ def write_deltalake(
     writer_properties: WriterProperties = ...,
     commit_properties: CommitProperties | None = ...,
     post_commithook_properties: PostCommitHookProperties | None = ...,
+    read_version: int | None = ...,
 ) -> None: ...
 
 
@@ -78,6 +80,7 @@ def write_deltalake(
     writer_properties: WriterProperties | None = None,
     commit_properties: CommitProperties | None = None,
     post_commithook_properties: PostCommitHookProperties | None = None,
+    read_version: int | None = None,
 ) -> None:
     """Write to a Delta Lake table
 
@@ -104,6 +107,7 @@ def write_deltalake(
         writer_properties: Pass writer properties to the Rust parquet writer.
         commit_properties: properties of the transaction commit. If None, default values are used.
         post_commithook_properties: properties for the post commit hook. If None, default values are used.
+        read_version: version of the table that was read to build the write. The commit fails with :class:`~deltalake.exceptions.CommitFailedError` if a concurrent writer committed a conflicting change after this version.
     """
     table, table_uri = try_get_table_and_table_uri(table_or_uri, storage_options)
     if table is not None:
@@ -144,7 +148,10 @@ def write_deltalake(
             writer_properties=writer_properties,
             commit_properties=commit_properties,
             post_commithook_properties=post_commithook_properties,
+            read_version=read_version,
         )
+        if read_version is not None:
+            table.update_incremental()
     else:
         write_deltalake_rust(
             table_uri=table_uri,
@@ -162,4 +169,5 @@ def write_deltalake(
             writer_properties=writer_properties,
             commit_properties=commit_properties,
             post_commithook_properties=post_commithook_properties,
+            read_version=read_version,
         )

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -325,6 +325,16 @@ impl RawDeltaTable {
         original.state = state;
         Ok(())
     }
+
+    /// Clone the locked table and optionally rewind the clone to `read_version`.
+    ///
+    /// The caller's `RawDeltaTable` is never rewound; only the returned clone is pinned.
+    fn table_for_operation(&self, read_version: Option<Version>) -> PyResult<DeltaTable> {
+        let table = self._table.lock().map_err(to_rt_err)?.clone();
+        clone_table_at_read_version(table, read_version)
+            .map_err(PythonError::from)
+            .map_err(PyErr::from)
+    }
 }
 
 #[pymethods]
@@ -704,6 +714,7 @@ impl RawDeltaTable {
         safe_cast = false,
         commit_properties = None,
         post_commithook_properties=None,
+        read_version=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     pub fn update(
@@ -715,9 +726,11 @@ impl RawDeltaTable {
         safe_cast: bool,
         commit_properties: Option<PyCommitProperties>,
         post_commithook_properties: Option<PyPostCommitHookProperties>,
+        read_version: Option<Version>,
     ) -> PyResult<String> {
         let (table, metrics) = py.detach(|| {
-            let table = self._table.lock().map_err(to_rt_err)?.clone();
+            let table = self.table_for_operation(read_version)?;
+            let log_store = table.log_store().clone();
             let mut cmd = table.update().with_safe_cast(safe_cast);
 
             if let Some(writer_props) = writer_properties {
@@ -740,7 +753,7 @@ impl RawDeltaTable {
                 cmd = cmd.with_commit_properties(commit_properties);
             }
 
-            if self.log_store()?.name() == "LakeFSLogStore" {
+            if log_store.name() == "LakeFSLogStore" {
                 cmd = cmd.with_custom_execute_handler(Arc::new(LakeFSCustomExecuteHandler {}))
             }
 
@@ -1181,6 +1194,7 @@ impl RawDeltaTable {
         writer_properties = None,
         post_commithook_properties = None,
         commit_properties = None,
+        read_version=None,
     ))]
     pub fn create_merge_builder(
         &self,
@@ -1198,6 +1212,7 @@ impl RawDeltaTable {
         writer_properties: Option<PyWriterProperties>,
         post_commithook_properties: Option<PyPostCommitHookProperties>,
         commit_properties: Option<PyCommitProperties>,
+        read_version: Option<Version>,
     ) -> PyResult<PyMergeBuilder> {
         py.detach(|| {
             let handler: Option<Arc<dyn CustomExecuteHandler>> =
@@ -1207,9 +1222,13 @@ impl RawDeltaTable {
                     None
                 };
 
+            let table = self.table_for_operation(read_version)?;
+            let snapshot = snapshot_from_table(&table)?;
+            let log_store = table.log_store().clone();
+
             Ok(PyMergeBuilder::new(
-                self.log_store()?,
-                self.cloned_state()?,
+                log_store,
+                snapshot,
                 source,
                 batch_schema,
                 predicate,
@@ -1816,7 +1835,7 @@ impl RawDeltaTable {
 
     /// Run the delete command on the delta table: delete records following a predicate and return the delete metrics.
     #[pyo3(signature = (
-        predicate = None, writer_properties=None, commit_properties=None, post_commithook_properties=None
+        predicate = None, writer_properties=None, commit_properties=None, post_commithook_properties=None, read_version=None
     ))]
     pub fn delete(
         &self,
@@ -1825,9 +1844,11 @@ impl RawDeltaTable {
         writer_properties: Option<PyWriterProperties>,
         commit_properties: Option<PyCommitProperties>,
         post_commithook_properties: Option<PyPostCommitHookProperties>,
+        read_version: Option<Version>,
     ) -> PyResult<String> {
         let (table, metrics) = py.detach(|| {
-            let table = self._table.lock().map_err(to_rt_err)?.clone();
+            let table = self.table_for_operation(read_version)?;
+            let log_store = table.log_store().clone();
             let mut cmd = table.delete();
             if let Some(predicate) = predicate {
                 cmd = cmd.with_predicate(predicate);
@@ -1843,7 +1864,7 @@ impl RawDeltaTable {
                 cmd = cmd.with_commit_properties(commit_properties);
             }
 
-            if self.log_store()?.name() == "LakeFSLogStore" {
+            if log_store.name() == "LakeFSLogStore" {
                 cmd = cmd.with_custom_execute_handler(Arc::new(LakeFSCustomExecuteHandler {}))
             }
 
@@ -2056,7 +2077,8 @@ impl RawDeltaTable {
         configuration=None,
         writer_properties=None,
         commit_properties=None,
-        post_commithook_properties=None
+        post_commithook_properties=None,
+        read_version=None,
     ))]
     fn write(
         &self,
@@ -2074,17 +2096,26 @@ impl RawDeltaTable {
         writer_properties: Option<PyWriterProperties>,
         commit_properties: Option<PyCommitProperties>,
         post_commithook_properties: Option<PyPostCommitHookProperties>,
+        read_version: Option<Version>,
     ) -> PyResult<()> {
         let table = py.detach(|| {
             let save_mode = mode.parse().map_err(PythonError::from)?;
 
-            let mut builder = WriteBuilder::new(
-                self.log_store()?,
-                self.with_table(|t| Ok(t.state.as_ref().map(|s| s.snapshot().clone())))?,
-                // Take the Option<state> since it might be the first write,
-                // triggered through `write_to_deltalake`
-            )
-            .with_save_mode(save_mode);
+            let (log_store, snapshot) = if read_version.is_some() {
+                let table = self.table_for_operation(read_version)?;
+                (
+                    table.log_store().clone(),
+                    table.state.as_ref().map(|s| s.snapshot().clone()),
+                )
+            } else {
+                (
+                    self.log_store()?,
+                    self.with_table(|t| Ok(t.state.as_ref().map(|s| s.snapshot().clone())))?,
+                )
+            };
+
+            let mut builder =
+                WriteBuilder::new(log_store.clone(), snapshot).with_save_mode(save_mode);
 
             let table_provider = to_lazy_table(maybe_lazy_cast_reader(
                 data.into_reader()?,
@@ -2141,7 +2172,7 @@ impl RawDeltaTable {
                 builder = builder.with_commit_properties(commit_properties);
             };
 
-            if self.log_store()?.name() == "LakeFSLogStore" {
+            if log_store.name() == "LakeFSLogStore" {
                 builder =
                     builder.with_custom_execute_handler(Arc::new(LakeFSCustomExecuteHandler {}))
             }
@@ -2357,6 +2388,26 @@ fn convert_partition_filters(
             }
         })
         .collect()
+}
+
+fn clone_table_at_read_version(
+    table: DeltaTable,
+    read_version: Option<Version>,
+) -> DeltaResult<DeltaTable> {
+    let mut table = table;
+    if let Some(version) = read_version {
+        rt().block_on(table.load_version(version))?;
+    }
+    Ok(table)
+}
+
+fn snapshot_from_table(table: &DeltaTable) -> PyResult<EagerSnapshot> {
+    table
+        .snapshot()
+        .map(|snapshot| snapshot.snapshot())
+        .cloned()
+        .map_err(PythonError::from)
+        .map_err(PyErr::from)
 }
 
 fn maybe_create_commit_properties(
@@ -2862,6 +2913,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for PyCommitProperties {
     writer_properties=None,
     commit_properties=None,
     post_commithook_properties=None,
+    read_version=None,
 ))]
 fn write_to_deltalake(
     py: Python,
@@ -2880,26 +2932,41 @@ fn write_to_deltalake(
     writer_properties: Option<PyWriterProperties>,
     commit_properties: Option<PyCommitProperties>,
     post_commithook_properties: Option<PyPostCommitHookProperties>,
+    read_version: Option<Version>,
 ) -> PyResult<()> {
-    let raw_table: DeltaResult<RawDeltaTable> = py.detach(|| {
+    let raw_table: PyResult<RawDeltaTable> = py.detach(|| {
         let options = storage_options.clone().unwrap_or_default();
-        let table_url = deltalake::table::builder::ensure_table_uri(&table_uri)?;
-        let table = rt().block_on(DeltaTable::try_from_url_with_storage_options(
-            table_url.clone(),
-            options.clone(),
-        ))?;
+        let table_url =
+            deltalake::table::builder::ensure_table_uri(&table_uri).map_err(PythonError::from)?;
+        let table = if let Some(version) = read_version {
+            let table = rt()
+                .block_on(
+                    DeltaTableBuilder::from_url(table_url.clone())
+                        .map_err(PythonError::from)?
+                        .with_storage_options(options.clone())
+                        .with_version(version)
+                        .load(),
+                )
+                .map_err(PythonError::from)?;
+            table
+        } else {
+            rt().block_on(DeltaTable::try_from_url_with_storage_options(
+                table_url.clone(),
+                options.clone(),
+            ))
+            .map_err(PythonError::from)?
+        };
 
-        let raw_table = RawDeltaTable {
+        Ok(RawDeltaTable {
             _table: Arc::new(Mutex::new(table)),
             _config: FsConfig {
                 root_url: table_url,
                 options,
             },
-        };
-        Ok(raw_table)
+        })
     });
 
-    raw_table.map_err(PythonError::from)?.write(
+    raw_table?.write(
         py,
         data,
         batch_schema,
@@ -2914,6 +2981,7 @@ fn write_to_deltalake(
         writer_properties,
         commit_properties,
         post_commithook_properties,
+        read_version,
     )
 }
 


### PR DESCRIPTION
Closes #4417

Motivation

In cross-engine read-modify-write flows (for example: read in DuckDB/Polars/Spark, write in delta-rs), callers may want write-side conflict validation to operate against the snapshot originally used to build the change set.

While investigating #4417, I found that DeltaTable(version=N) already propagates pinned OCC semantics for operations like merge, update, and delete. So this PR is not introducing an entirely new transaction model or broad new OCC semantics.

Instead, this change focuses on:

exposing explicit read_version ergonomics consistently across the high-level Python write APIs
making snapshot-pinned behavior more explicit/documented at the API level
enabling pinned OCC validation for write_deltalake(uri, ...) flows where there is currently no explicit way to propagate the original read snapshot without reconstructing a pinned DeltaTable handle manually

The implementation intentionally reuses the existing delta-rs optimistic concurrency/conflict-checking behavior.

Approach

This PR adds optional read_version: int | None = None to:

DeltaTable.merge(...)
DeltaTable.update(...)
DeltaTable.delete(...)
write_deltalake(...)

read_version is threaded through the existing PyO3 bindings into the current Rust operation builders/conflict-checking paths.

Implementation details
operations clone the table and load the requested version on the clone before building the transaction
the original Python DeltaTable state is not mutated by snapshot pinning
log_store handling was adjusted to preserve pinned-table semantics in the write path
merge snapshots are pinned at builder creation time rather than execute() time

This change intentionally reuses existing delta-rs OCC semantics rather than introducing new conflict resolution behavior.

Tests

Validated with targeted repros and broader regression coverage:

stale read conflict scenarios
merge delayed execute / builder snapshot pinning
sequential read_version flows
invalid read_version handling
concurrent append conflict scenarios
metadata preservation
regression coverage for legacy behavior (read_version=None)

Additional verification included comparisons against upstream/main to validate existing OCC behavior for version-pinned DeltaTable handles.

cargo check -p deltalake-python passed.

The broader Python suite also passed aside from the existing Windows forkserver incompatibility in multiprocessing-related tests.