### PR TITLE
fix: preserve merge row ordinals across scan planning

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -21,8 +21,8 @@ use datafusion::common::{
     ColumnStatistics, HashMap, internal_datafusion_err, internal_err, plan_err,
 };
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_expr::utils::collect_columns;
+use datafusion::physical_expr::{Distribution, EquivalenceProperties};
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, PlanProperties};
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
@@ -272,6 +272,15 @@ impl ExecutionPlan for DeltaScanExec {
         vec![&self.input]
     }
 
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        if self.scan_plan.contract.retained_row_index_field().is_some() {
+            // Retained row indexes depend on one stream seeing each file's rows.
+            vec![Distribution::SinglePartition]
+        } else {
+            vec![Distribution::UnspecifiedDistribution]
+        }
+    }
+
     // TODO: setting this will fail certain tests, but why
     // fn maintains_input_order(&self) -> Vec<bool> {
     //     vec![true]
@@ -300,8 +309,8 @@ impl ExecutionPlan for DeltaScanExec {
         config: &ConfigOptions,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
         if self.scan_plan.contract.retained_row_index_field().is_some() {
-            // DeltaScanStream stores row ordinal counters per execution partition. Repartitioning
-            // can split a file's rows across streams and break ordinal contiguity.
+            // Each DeltaScanStream keeps row ordinal counters for one execution partition.
+            // Repartitioning can split one file across streams and break ordinal contiguity.
             return Ok(None);
         }
 
@@ -320,6 +329,17 @@ impl ExecutionPlan for DeltaScanExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        // Normal planning enforces this through EnforceDistribution. Keep this check for
+        // callers that build DeltaScanExec directly or replace its child plan.
+        if self.scan_plan.contract.retained_row_index_field().is_some() {
+            let input_partition_count = self.input.properties().partitioning.partition_count();
+            if input_partition_count > 1 {
+                return plan_err!(
+                    "DeltaScanExec retained row indexes require a single input partition, got {input_partition_count}"
+                );
+            }
+        }
+
         Ok(Box::pin(DeltaScanStream {
             scan_plan: Arc::clone(&self.scan_plan),
             kernel_type: Arc::clone(self.scan_plan.scan.logical_schema()).into(),
@@ -747,9 +767,11 @@ mod tests {
         physical_expr::expressions::{
             BinaryExpr, Column, DynamicFilterPhysicalExpr, lit as physical_lit,
         },
+        physical_expr::{Distribution, Partitioning},
         physical_plan::{
             PhysicalExpr, collect, collect_partitioned,
             filter_pushdown::{FilterPushdownPhase, PushedDown},
+            repartition::RepartitionExec,
         },
         prelude::{col, lit},
         scalar::ScalarValue,
@@ -1638,6 +1660,85 @@ mod tests {
             .as_primitive::<UInt64Type>()
             .values()
             .to_vec()
+    }
+
+    #[tokio::test]
+    async fn test_required_input_distribution_tracks_retained_row_index_contract() -> TestResult {
+        let (_kernel_type, scan_plan) = int32_scan_plan().await?;
+        let table = TestTables::Simple.table_builder()?.load().await?;
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .as_any()
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        let distribution = exec.required_input_distribution();
+        assert!(
+            matches!(
+                distribution.as_slice(),
+                [Distribution::UnspecifiedDistribution]
+            ),
+            "unexpected distribution: {distribution:?}"
+        );
+
+        let retained_exec = DeltaScanExec::new(
+            retain_row_index(scan_plan, "row_ordinal"),
+            Arc::clone(&exec.input),
+            Arc::clone(&exec.transforms),
+            Arc::clone(&exec.selection_vectors),
+            exec.partition_stats.clone(),
+            exec.metrics.clone(),
+        );
+
+        let distribution = retained_exec.required_input_distribution();
+        assert!(
+            matches!(distribution.as_slice(), [Distribution::SinglePartition]),
+            "unexpected distribution: {distribution:?}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_retained_row_index_execute_rejects_multi_partition_child() -> TestResult {
+        let (_kernel_type, scan_plan) = int32_scan_plan().await?;
+        let table = TestTables::Simple.table_builder()?.load().await?;
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .as_any()
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        let repartitioned_input = Arc::new(RepartitionExec::try_new(
+            Arc::clone(&exec.input),
+            Partitioning::RoundRobinBatch(2),
+        )?);
+
+        let retained_exec = DeltaScanExec::new(
+            retain_row_index(scan_plan, "row_ordinal"),
+            repartitioned_input,
+            Arc::clone(&exec.transforms),
+            Arc::clone(&exec.selection_vectors),
+            exec.partition_stats.clone(),
+            exec.metrics.clone(),
+        );
+
+        let err = match retained_exec.execute(0, session.task_ctx()) {
+            Ok(_) => panic!("retained row-index scans must reject multi-partition children"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string()
+                .contains("retained row indexes require a single input partition"),
+            "unexpected error: {err}"
+        );
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1907,6 +1907,7 @@ mod tests {
     use datafusion::logical_expr::expr::Placeholder;
     use datafusion::logical_expr::lit;
     use datafusion::logical_expr::{Extension, LogicalPlan, LogicalPlanBuilder};
+    use datafusion::physical_plan::ExecutionPlan;
     use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
     use datafusion::physical_plan::metrics::MetricBuilder;
     use datafusion::physical_plan::{collect, displayable};
@@ -2242,9 +2243,43 @@ mod tests {
             .await
             .expect("physical plan builds");
         let plan = displayable(physical.as_ref()).indent(true).to_string();
-        assert!(plan.contains("DeltaScanExec"));
+        assert_retained_row_index_scan_has_single_partition_child(&physical);
         assert!(!plan.contains("BoundedWindowAggExec"));
         assert!(!plan.contains("SortExec"));
+    }
+
+    #[tokio::test]
+    async fn test_target_row_ordinal_scan_plan_coalesces_repartitioned_input() {
+        let schema = get_arrow_schema(&None);
+        let table = setup_table(None).await;
+        let table = write_data(table, &schema).await;
+        let config = SessionConfig::new()
+            .with_batch_size(2)
+            .with_target_partitions(4)
+            .with_repartition_file_min_size(0);
+        let state = SessionContext::new_with_config(config).state();
+
+        let target_provider = provider_as_source(
+            DeltaScanNext::builder()
+                .with_eager_snapshot(table.snapshot().unwrap().snapshot().clone())
+                .with_log_store(table.log_store.clone())
+                .with_session(state.clone().into())
+                .with_file_column(PATH_COLUMN)
+                .with_row_index_column(TARGET_ROW_ORDINAL_IN_FILE_COLUMN)
+                .await
+                .expect("target provider builds"),
+        );
+        let target =
+            LogicalPlanBuilder::scan(TableReference::bare("target"), target_provider, None)
+                .expect("scan builds")
+                .build()
+                .expect("scan plan builds");
+
+        let physical = state
+            .create_physical_plan(&target)
+            .await
+            .expect("physical plan builds");
+        assert_retained_row_index_scan_coalesces_partitioned_child(&physical, 4);
     }
 
     #[tokio::test]
@@ -2363,6 +2398,78 @@ mod tests {
     fn count_unions(plan: &LogicalPlan) -> usize {
         let current = usize::from(matches!(plan, LogicalPlan::Union(_)));
         current + plan.inputs().into_iter().map(count_unions).sum::<usize>()
+    }
+
+    fn collect_retained_row_index_scan_inputs<'a>(
+        plan: &'a Arc<dyn ExecutionPlan>,
+        scan_children: &mut Vec<&'a Arc<dyn ExecutionPlan>>,
+    ) {
+        if plan.name() == "DeltaScanExec"
+            && format!("{}", displayable(plan.as_ref()).indent(false)).contains("row_index_column=")
+        {
+            let children = plan.children();
+            assert_eq!(children.len(), 1, "DeltaScanExec should have one child");
+            scan_children.push(children[0]);
+        }
+
+        for child in plan.children() {
+            collect_retained_row_index_scan_inputs(child, scan_children);
+        }
+    }
+
+    fn assert_retained_row_index_scan_has_single_partition_child(plan: &Arc<dyn ExecutionPlan>) {
+        let child = retained_row_index_delta_scan_child(plan);
+        assert_eq!(
+            child.properties().partitioning.partition_count(),
+            1,
+            "retained row-index DeltaScanExec must receive a single-partition child: {}",
+            displayable(plan.as_ref()).indent(true)
+        );
+    }
+
+    fn assert_retained_row_index_scan_coalesces_partitioned_child(
+        plan: &Arc<dyn ExecutionPlan>,
+        expected_partition_count: usize,
+    ) {
+        let child = retained_row_index_delta_scan_child(plan);
+        assert_eq!(
+            child.name(),
+            "CoalescePartitionsExec",
+            "retained row-index DeltaScanExec should coalesce partitioned input: {}",
+            displayable(plan.as_ref()).indent(true)
+        );
+
+        let coalesce_children = child.children();
+        assert_eq!(
+            coalesce_children.len(),
+            1,
+            "CoalescePartitionsExec should have one child"
+        );
+        assert_eq!(
+            coalesce_children[0]
+                .properties()
+                .partitioning
+                .partition_count(),
+            expected_partition_count,
+            "expected retained row-index scan to coalesce a partitioned child: {}",
+            displayable(plan.as_ref()).indent(true)
+        );
+    }
+
+    fn retained_row_index_delta_scan_child<'a>(
+        plan: &'a Arc<dyn ExecutionPlan>,
+    ) -> &'a Arc<dyn ExecutionPlan> {
+        let mut scan_children = Vec::new();
+        collect_retained_row_index_scan_inputs(plan, &mut scan_children);
+
+        assert_eq!(
+            scan_children.len(),
+            1,
+            "expected exactly one retained-row-index DeltaScanExec in plan: {}",
+            displayable(plan.as_ref()).indent(true)
+        );
+
+        scan_children[0]
     }
 
     async fn assert_merge_encoded_partition_value_removes_original_file(

--- a/crates/core/tests/it_datafusion/command_merge.rs
+++ b/crates/core/tests/it_datafusion/command_merge.rs
@@ -3,9 +3,10 @@
 #[allow(unused_imports)]
 use crate::fs_common;
 
-use arrow_array::RecordBatch;
-use arrow_schema::{DataType, Field, Schema as ArrowSchema};
-use datafusion::common::Column;
+use arrow::array::{Float64Array, Int64Array, StringArray, TimestampMicrosecondArray};
+use arrow_array::{RecordBatch, StringViewArray};
+use arrow_schema::{DataType, Field, Schema as ArrowSchema, TimeUnit};
+use datafusion::common::{Column, ScalarValue, TableReference};
 use datafusion::dataframe::DataFrame;
 use datafusion::logical_expr::{Expr, col, lit};
 use datafusion::prelude::{SessionConfig, SessionContext};
@@ -14,8 +15,12 @@ use deltalake_core::kernel::{DataType as DeltaDataType, PrimitiveType, StructFie
 use deltalake_core::operations::merge::MergeMetrics;
 use deltalake_core::protocol::SaveMode;
 use deltalake_core::{DeltaResult, DeltaTable, DeltaTableError, open_table};
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 use url::Url;
+
+const SCD_TS_V1_US: i64 = 1_747_133_263_000_000;
+const SCD_TS_V2_US: i64 = 1_747_133_498_000_000;
+const SCD_OPEN_END_US: i64 = 9_214_646_399_000_000;
 
 async fn create_table(table_uri: &str, partition: Option<Vec<&str>>) -> DeltaTable {
     let table_schema = get_delta_schema();
@@ -114,6 +119,483 @@ fn create_test_data() -> (DataFrame, DataFrame) {
     .unwrap();
     let df2 = ctx.read_batch(batch).unwrap();
     (df1, df2)
+}
+
+fn id_value_schema() -> Arc<ArrowSchema> {
+    Arc::new(ArrowSchema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]))
+}
+
+fn id_value_delta_schema() -> StructType {
+    StructType::try_new(vec![
+        StructField::new(
+            "id".to_string(),
+            DeltaDataType::Primitive(PrimitiveType::Long),
+            false,
+        ),
+        StructField::new(
+            "value".to_string(),
+            DeltaDataType::Primitive(PrimitiveType::Long),
+            false,
+        ),
+    ])
+    .unwrap()
+}
+
+fn id_value_batch(ids: Vec<i64>, values: Vec<i64>) -> RecordBatch {
+    RecordBatch::try_new(
+        id_value_schema(),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(values)),
+        ],
+    )
+    .unwrap()
+}
+
+fn int64_value(batch: &RecordBatch, column: usize, row: usize) -> i64 {
+    batch
+        .column(column)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(row)
+}
+
+fn scd_arrow_schema() -> Arc<ArrowSchema> {
+    Arc::new(ArrowSchema::new(vec![
+        Field::new("customer_id", DataType::Utf8, false),
+        Field::new("metric_value", DataType::Float64, false),
+        Field::new(
+            "ingestion_datetime",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        ),
+        Field::new(
+            "valid_from_dt",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        ),
+        Field::new(
+            "valid_to_dt",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        ),
+    ]))
+}
+
+fn scd_delta_schema() -> StructType {
+    StructType::try_new(vec![
+        StructField::new(
+            "customer_id".to_string(),
+            DeltaDataType::Primitive(PrimitiveType::String),
+            false,
+        ),
+        StructField::new(
+            "metric_value".to_string(),
+            DeltaDataType::Primitive(PrimitiveType::Double),
+            false,
+        ),
+        StructField::new(
+            "ingestion_datetime".to_string(),
+            DeltaDataType::Primitive(PrimitiveType::TimestampNtz),
+            false,
+        ),
+        StructField::new(
+            "valid_from_dt".to_string(),
+            DeltaDataType::Primitive(PrimitiveType::TimestampNtz),
+            false,
+        ),
+        StructField::new(
+            "valid_to_dt".to_string(),
+            DeltaDataType::Primitive(PrimitiveType::TimestampNtz),
+            false,
+        ),
+    ])
+    .unwrap()
+}
+
+fn scd_batch(
+    row_count: i64,
+    metric_values: Vec<f64>,
+    ingestion_datetime: i64,
+    valid_from_dt: i64,
+    valid_to_dt: i64,
+) -> RecordBatch {
+    let row_count = usize::try_from(row_count).unwrap();
+    assert_eq!(metric_values.len(), row_count);
+    let customer_ids = (0..row_count)
+        .map(|idx| format!("C-{idx}"))
+        .collect::<Vec<_>>();
+
+    RecordBatch::try_new(
+        scd_arrow_schema(),
+        vec![
+            Arc::new(StringArray::from(customer_ids)),
+            Arc::new(Float64Array::from(metric_values)),
+            Arc::new(TimestampMicrosecondArray::from_iter(
+                (0..row_count).map(|_| Some(ingestion_datetime)),
+            )),
+            Arc::new(TimestampMicrosecondArray::from_iter(
+                (0..row_count).map(|_| Some(valid_from_dt)),
+            )),
+            Arc::new(TimestampMicrosecondArray::from_iter(
+                (0..row_count).map(|_| Some(valid_to_dt)),
+            )),
+        ],
+    )
+    .unwrap()
+}
+
+fn qualified_col(relation: &str, name: &str) -> Expr {
+    col(Column::new(Some(TableReference::bare(relation)), name))
+}
+
+enum TestStringArray<'a> {
+    Utf8(&'a StringArray),
+    Utf8View(&'a StringViewArray),
+}
+
+impl TestStringArray<'_> {
+    fn value(&self, row: usize) -> &str {
+        match self {
+            Self::Utf8(array) => array.value(row),
+            Self::Utf8View(array) => array.value(row),
+        }
+    }
+}
+
+fn string_column<'a>(batch: &'a RecordBatch, column: &str) -> TestStringArray<'a> {
+    let array = batch.column_by_name(column).unwrap();
+    if let Some(array) = array.as_any().downcast_ref::<StringArray>() {
+        TestStringArray::Utf8(array)
+    } else if let Some(array) = array.as_any().downcast_ref::<StringViewArray>() {
+        TestStringArray::Utf8View(array)
+    } else {
+        panic!("unexpected {column} type: {:?}", array.data_type());
+    }
+}
+
+async fn single_file_id_value_table(row_count: i64) -> DeltaTable {
+    let table = DeltaTable::new_in_memory()
+        .create()
+        .with_columns(id_value_delta_schema().fields().cloned())
+        .await
+        .unwrap();
+
+    let ids = (0..row_count).collect::<Vec<_>>();
+    let values = vec![1_i64; row_count as usize];
+    let table = table
+        .write(vec![id_value_batch(ids, values)])
+        .with_save_mode(SaveMode::Append)
+        .await
+        .unwrap();
+
+    assert_eq!(table.snapshot().unwrap().log_data().num_files(), 1);
+    table
+}
+
+async fn multi_file_id_value_table(file_count: usize, rows_per_file: i64) -> DeltaTable {
+    let mut table = DeltaTable::new_in_memory()
+        .create()
+        .with_columns(id_value_delta_schema().fields().cloned())
+        .await
+        .unwrap();
+
+    for file_idx in 0..file_count {
+        let start = i64::try_from(file_idx).unwrap() * rows_per_file;
+        let end = start + rows_per_file;
+        table = table
+            .write(vec![id_value_batch(
+                (start..end).collect::<Vec<_>>(),
+                vec![1_i64; rows_per_file as usize],
+            )])
+            .with_save_mode(SaveMode::Append)
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(table.snapshot().unwrap().log_data().num_files(), file_count);
+    table
+}
+
+async fn single_file_scd_table(row_count: i64) -> DeltaTable {
+    let table = DeltaTable::new_in_memory()
+        .create()
+        .with_columns(scd_delta_schema().fields().cloned())
+        .await
+        .unwrap();
+
+    let table = table
+        .write(vec![scd_batch(
+            row_count,
+            vec![100.0; row_count as usize],
+            SCD_TS_V1_US,
+            SCD_TS_V1_US,
+            SCD_OPEN_END_US,
+        )])
+        .with_save_mode(SaveMode::Append)
+        .await
+        .unwrap();
+
+    assert_eq!(table.snapshot().unwrap().log_data().num_files(), 1);
+    table
+}
+
+async fn assert_id_value_table_complete(
+    table: &DeltaTable,
+    row_count: i64,
+    updated_id: Option<i64>,
+    expected_updated_rows: i64,
+) -> DeltaResult<()> {
+    let ctx = SessionContext::new();
+    table.update_datafusion_session(&ctx.state()).unwrap();
+    let provider = table.table_provider().await.unwrap();
+    ctx.register_table("target", provider).unwrap();
+
+    let summary = ctx
+        .sql(
+            "SELECT COUNT(*) AS row_count, COUNT(DISTINCT id) AS distinct_ids, MIN(id) AS min_id, MAX(id) AS max_id, \
+                    SUM(CASE WHEN value = 2 THEN 1 ELSE 0 END) AS updated_rows, \
+                    SUM(CASE WHEN value = 1 THEN 1 ELSE 0 END) AS unchanged_rows \
+             FROM target",
+        )
+        .await?
+        .collect()
+        .await?;
+    let batch = &summary[0];
+    assert_eq!(int64_value(batch, 0, 0), row_count);
+    assert_eq!(int64_value(batch, 1, 0), row_count);
+    assert_eq!(int64_value(batch, 2, 0), 0);
+    assert_eq!(int64_value(batch, 3, 0), row_count - 1);
+    assert_eq!(int64_value(batch, 4, 0), expected_updated_rows);
+    assert_eq!(int64_value(batch, 5, 0), row_count - expected_updated_rows);
+
+    if let Some(updated_id) = updated_id {
+        let updated = ctx
+            .sql(&format!("SELECT value FROM target WHERE id = {updated_id}"))
+            .await?
+            .collect()
+            .await?;
+        assert_eq!(int64_value(&updated[0], 0, 0), 2);
+    }
+
+    Ok(())
+}
+
+async fn assert_scd_table_complete(
+    table: &DeltaTable,
+    row_count: i64,
+    expected_expired_rows: usize,
+) -> DeltaResult<()> {
+    let ctx = SessionContext::new();
+    table.update_datafusion_session(&ctx.state()).unwrap();
+    let provider = table.table_provider().await.unwrap();
+    ctx.register_table("target", provider).unwrap();
+
+    let batches = ctx
+        .sql("SELECT customer_id, metric_value, valid_to_dt FROM target")
+        .await?
+        .collect()
+        .await?;
+
+    let mut customer_ids = HashSet::new();
+    let mut row_total = 0usize;
+    let mut expired_rows = 0usize;
+    let mut current_rows = 0usize;
+    let mut unchanged_metric_rows = 0usize;
+
+    for batch in batches {
+        row_total += batch.num_rows();
+        let customer_id = string_column(&batch, "customer_id");
+        let metric_value = batch
+            .column_by_name("metric_value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        let valid_to = batch
+            .column_by_name("valid_to_dt")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+
+        for row in 0..batch.num_rows() {
+            customer_ids.insert(customer_id.value(row).to_string());
+            assert_eq!(metric_value.value(row), 100.0);
+            unchanged_metric_rows += 1;
+            match valid_to.value(row) {
+                SCD_TS_V2_US => expired_rows += 1,
+                SCD_OPEN_END_US => current_rows += 1,
+                other => panic!("unexpected valid_to_dt value: {other}"),
+            }
+        }
+    }
+
+    assert_eq!(row_total, row_count as usize);
+    assert_eq!(customer_ids.len(), row_count as usize);
+    assert_eq!(expired_rows, expected_expired_rows);
+    assert_eq!(current_rows, row_count as usize - expected_expired_rows);
+    assert_eq!(unchanged_metric_rows, row_count as usize);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_merge_large_single_file_unique_source_does_not_report_duplicate_match()
+-> DeltaResult<()> {
+    let table = single_file_id_value_table(25_000).await;
+
+    let config = SessionConfig::new().with_target_partitions(4);
+    let ctx = SessionContext::new_with_config(config);
+    let source = ctx
+        .read_batch(id_value_batch(
+            (0..25_000).collect::<Vec<_>>(),
+            vec![2_i64; 25_000],
+        ))
+        .unwrap();
+
+    let (table, metrics) = table
+        .merge(source, col("target.id").eq(col("source.id")))
+        .with_source_alias("source")
+        .with_target_alias("target")
+        .with_session_state(Arc::new(ctx.state()))
+        .when_matched_update(|update| update.update("value", col("source.value")))?
+        .await?;
+
+    assert_eq!(metrics.num_source_rows, 25_000);
+    assert_eq!(metrics.num_target_rows_updated, 25_000);
+    assert_eq!(metrics.num_target_rows_inserted, 0);
+    assert_eq!(metrics.num_output_rows, 25_000);
+    assert_eq!(metrics.num_target_files_scanned, 1);
+
+    assert_id_value_table_complete(&table, 25_000, Some(0), 25_000).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_merge_batch_boundary_update_does_not_drop_target_rows() -> DeltaResult<()> {
+    let table = single_file_id_value_table(8_193).await;
+
+    let config = SessionConfig::new().with_target_partitions(4);
+    let ctx = SessionContext::new_with_config(config);
+    let source = ctx
+        .read_batch(id_value_batch(vec![8_192], vec![2]))
+        .unwrap();
+
+    let (table, metrics) = table
+        .merge(source, col("target.id").eq(col("source.id")))
+        .with_source_alias("source")
+        .with_target_alias("target")
+        .with_session_state(Arc::new(ctx.state()))
+        .when_matched_update(|update| update.update("value", col("source.value")))?
+        .await?;
+
+    assert_eq!(metrics.num_source_rows, 1);
+    assert_eq!(metrics.num_target_rows_updated, 1);
+    assert_eq!(metrics.num_target_rows_inserted, 0);
+    assert_eq!(metrics.num_output_rows, 8_193);
+    assert_eq!(metrics.num_target_files_scanned, 1);
+
+    assert_id_value_table_complete(&table, 8_193, Some(8_192), 1).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_merge_multi_file_batch_boundary_unique_source_preserves_target_rows()
+-> DeltaResult<()> {
+    let file_count = 4;
+    let rows_per_file = 8_193;
+    let row_count = i64::try_from(file_count).unwrap() * rows_per_file;
+    let table = multi_file_id_value_table(file_count, rows_per_file).await;
+
+    let config = SessionConfig::new().with_target_partitions(4);
+    let ctx = SessionContext::new_with_config(config);
+    let source = ctx
+        .read_batch(id_value_batch(
+            (0..row_count).collect::<Vec<_>>(),
+            vec![2_i64; row_count as usize],
+        ))
+        .unwrap();
+
+    let (table, metrics) = table
+        .merge(source, col("target.id").eq(col("source.id")))
+        .with_source_alias("source")
+        .with_target_alias("target")
+        .with_session_state(Arc::new(ctx.state()))
+        .when_matched_update(|update| update.update("value", col("source.value")))?
+        .await?;
+
+    assert_eq!(metrics.num_source_rows, row_count as usize);
+    assert_eq!(metrics.num_target_rows_updated, row_count as usize);
+    assert_eq!(metrics.num_target_rows_inserted, 0);
+    assert_eq!(metrics.num_output_rows, row_count as usize);
+    assert_eq!(metrics.num_target_files_scanned, file_count);
+
+    assert_id_value_table_complete(&table, row_count, Some(0), row_count).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_merge_scd2_conditional_update_unique_source_does_not_report_duplicate_match()
+-> DeltaResult<()> {
+    let row_count = 25_000;
+    let table = single_file_scd_table(row_count).await;
+
+    let config = SessionConfig::new().with_target_partitions(4);
+    let ctx = SessionContext::new_with_config(config);
+    let source_metric_values = (0..row_count)
+        .map(|idx| if idx % 2 == 0 { 200.0 } else { 100.0 })
+        .collect::<Vec<_>>();
+    let source = ctx
+        .read_batch(scd_batch(
+            row_count,
+            source_metric_values,
+            SCD_TS_V2_US,
+            SCD_TS_V2_US,
+            SCD_OPEN_END_US,
+        ))
+        .unwrap();
+
+    let (table, metrics) = table
+        .merge(
+            source,
+            qualified_col("target", "customer_id")
+                .eq(qualified_col("source", "customer_id"))
+                .and(qualified_col("target", "valid_to_dt").eq(lit(
+                    ScalarValue::TimestampMicrosecond(Some(SCD_OPEN_END_US), None),
+                )))
+                .and(qualified_col("target", "ingestion_datetime").lt(lit(
+                    ScalarValue::TimestampMicrosecond(Some(SCD_TS_V2_US), None),
+                ))),
+        )
+        .with_source_alias("source")
+        .with_target_alias("target")
+        .with_session_state(Arc::new(ctx.state()))
+        .when_matched_update(|update| {
+            update
+                .update(
+                    "valid_to_dt",
+                    lit(ScalarValue::TimestampMicrosecond(Some(SCD_TS_V2_US), None)),
+                )
+                .predicate(
+                    qualified_col("target", "metric_value")
+                        .not_eq(qualified_col("source", "metric_value")),
+                )
+        })?
+        .await?;
+
+    assert_eq!(metrics.num_source_rows, 25_000);
+    assert_eq!(metrics.num_target_rows_updated, 12_500);
+    assert_eq!(metrics.num_target_rows_inserted, 0);
+    assert_eq!(metrics.num_output_rows, 25_000);
+    assert_eq!(metrics.num_target_files_scanned, 1);
+
+    assert_scd_table_complete(&table, row_count, 12_500).await?;
+    Ok(())
 }
 
 async fn merge(


### PR DESCRIPTION
Fixes #4471.

Retained row index scans synthesize row ordinals with per stream counters, which only works if all rows for a file flow through one stream. DataFusion can insert a repartition below `DeltaScanExec`
and split a file across partitions, causing colliding ordinals and duplicate match errors or dropped target rows.

To fix this we retain row index `DeltaScanExec` plans and declare `SinglePartition` input distribution which blocks DataFusion from repartition underneath them. Also adds a runtime guard for directly constructed plans that bypass the optimizer.

we can rework this once we have physical row identities from the source