### PR TITLE
fix: simplify expressions when conflict checking

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -266,9 +266,12 @@ pub(crate) fn files_matching_predicate<'a>(
     if let Some(Some(predicate)) =
         (!filters.is_empty()).then_some(conjunction(filters.iter().cloned()))
     {
-        let expr = SessionContext::new()
-            .create_physical_expr(predicate, &log_data.read_schema().to_dfschema()?)?;
-        let pruning_predicate = PruningPredicate::try_new(expr, log_data.read_schema())?;
+        let session: SessionContext = create_session().into();
+        let schema = log_data.read_schema();
+        let df_schema = Arc::new(schema.clone().to_dfschema()?);
+        let resolved = Expression::from(predicate).resolve(&session.state(), df_schema.clone())?;
+        let expr = session.create_physical_expr(resolved, &df_schema)?;
+        let pruning_predicate = PruningPredicate::try_new(expr, schema)?;
         let mask = pruning_predicate.prune(&log_data)?;
 
         Ok(Either::Left(log_data.into_iter().zip(mask).filter_map(

--- a/crates/core/src/kernel/transaction/state.rs
+++ b/crates/core/src/kernel/transaction/state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use arrow_array::{ArrayRef, BooleanArray};
 use arrow_schema::{DataType as ArrowDataType, SchemaRef as ArrowSchemaRef};
@@ -8,7 +9,9 @@ use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::Expr;
 use datafusion::physical_optimizer::pruning::{PruningPredicate, PruningStatistics};
 
-use crate::delta_datafusion::{get_null_of_arrow_type, to_correct_scalar_value};
+use crate::delta_datafusion::{
+    Expression, create_session, get_null_of_arrow_type, to_correct_scalar_value,
+};
 use crate::errors::DeltaResult;
 use crate::kernel::{Add, EagerSnapshot};
 
@@ -85,9 +88,10 @@ impl<'a> AddContainer<'a> {
     /// so evaluating expressions is inexact. However, excluded files are guaranteed (for a correct log)
     /// to not contain matches by the predicate expression.
     pub fn predicate_matches(&self, predicate: Expr) -> DeltaResult<impl Iterator<Item = &Add>> {
-        //let expr = logical_expr_to_physical_expr(predicate, &self.schema);
-        let expr = SessionContext::new()
-            .create_physical_expr(predicate, &self.schema.clone().to_dfschema()?)?;
+        let session: SessionContext = create_session().into();
+        let df_schema = Arc::new(self.schema.clone().to_dfschema()?);
+        let resolved = Expression::from(predicate).resolve(&session.state(), df_schema.clone())?;
+        let expr = session.create_physical_expr(resolved, df_schema.as_ref())?;
         let pruning_predicate = PruningPredicate::try_new(expr, self.schema.clone())?;
         Ok(self
             .inner

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -2641,4 +2641,122 @@ mod tests {
         assert_eq!(table.version(), Some(2), "The delete failed to execute");
         Ok(())
     }
+
+    const START_TIMESTAMP_US: i64 = 1_704_067_200 * 1_000_000; // 2024-01-01 00:00:00 UTC
+    const DAY_US: i64 = 60 * 60 * 24 * 1_000_000;
+
+    async fn setup_timestamp_table() -> DeltaResult<(DeltaTable, Arc<Schema>)> {
+        use arrow::array::TimestampMicrosecondArray;
+
+        let table: DeltaTable = DeltaTable::new_in_memory()
+            .create()
+            .with_column(
+                "timestamp",
+                DeltaDataType::Primitive(PrimitiveType::Timestamp),
+                true,
+                None,
+            )
+            .await?;
+
+        let arrow_schema = Arc::new(Schema::new(vec![Field::new(
+            "timestamp",
+            DataType::Timestamp(arrow_schema::TimeUnit::Microsecond, Some("UTC".into())),
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(
+                TimestampMicrosecondArray::from(vec![
+                    START_TIMESTAMP_US,
+                    START_TIMESTAMP_US + DAY_US,
+                    START_TIMESTAMP_US + 2 * DAY_US,
+                ])
+                .with_timezone("UTC"),
+            )],
+        )?;
+        let table = table.write(vec![batch]).await?;
+
+        Ok((table, arrow_schema))
+    }
+
+    /// Ensure conflict checking works when a delete operation with a timestamp predicate follows
+    /// a concurrent write operation. This requires arrow_cast expressions to be simplified.
+    #[tokio::test]
+    async fn test_concurrent_delete_with_timestamp_predicate_after_write() -> DeltaResult<()> {
+        use arrow::array::TimestampMicrosecondArray;
+        let (table, arrow_schema) = setup_timestamp_table().await?;
+
+        // Clone the table to make two concurrent operations
+        let table_for_op1 = table.clone();
+        let table_for_op2 = table;
+
+        // Successful commit: adds new data
+        let new_batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(
+                TimestampMicrosecondArray::from(vec![
+                    START_TIMESTAMP_US + 3 * DAY_US,
+                    START_TIMESTAMP_US + 4 * DAY_US,
+                ])
+                .with_timezone("UTC"),
+            )],
+        )?;
+        let table_after_append = table_for_op1
+            .write(vec![new_batch])
+            .await
+            .expect("Failed to append new data");
+        assert_eq!(table_after_append.version(), Some(2));
+
+        // Concurrent commit that deletes a range of data.
+        let result = table_for_op2
+            .delete()
+            .with_predicate("timestamp >= '2024-01-02T00:00:00Z'")
+            .await;
+
+        let err = result.expect_err(
+            "expected concurrent delete with a timestamp predicate to fail conflict checking",
+        );
+        assert!(
+            err.to_string()
+                .contains("concurrent transactions added new data"),
+            "unexpected error: {err}",
+        );
+        Ok(())
+    }
+
+    /// Ensure conflict checking works with two concurrent delete operations with timestamp
+    /// predicates. This requires arrow_cast expressions to be simplified.
+    #[tokio::test]
+    async fn test_concurrent_deletes_with_timestamp_predicates() -> DeltaResult<()> {
+        let (table, _) = setup_timestamp_table().await?;
+
+        // Clone the table to make two concurrent operations
+        let table_for_op1 = table.clone();
+        let table_for_op2 = table;
+
+        // Successful commit: delete with timestamp predicate
+        let (table_after_delete, _) = table_for_op1
+            .delete()
+            .with_predicate("timestamp >= '2024-01-02T00:00:00Z'")
+            .await
+            .expect("Failed to delete data");
+        assert_eq!(table_after_delete.version(), Some(2));
+
+        // Concurrent other delete with a different predicate
+        let result = table_for_op2
+            .delete()
+            .with_predicate("timestamp >= '2024-01-03T00:00:00Z'")
+            .await;
+
+        let err = result.expect_err(
+            "expected concurrent delete with a timestamp predicate to fail conflict checking",
+        );
+        assert!(
+            err.to_string()
+                .contains("concurrent transaction deleted data this operation read"),
+            "unexpected error: {err}",
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
# Description

Uses `Expression::resolve` when evaluating predicates during conflict resolution to fix `arrow_cast should have been simplified to cast` errors.

Both `files_matching_predicate` and `predicate_matches` needed to be updated to handle different code paths for the current operation and for previous operations (via `check_for_added_files_that_should_have_been_read_by_current_txn` and `check_for_deleted_files_against_current_txn_read_files`).

# Related Issue(s)

- closes #4478