### PR TITLE
fix: add TimestampNanos to supported reader features

### DIFF
--- a/crates/core/src/kernel/transaction/protocol.rs
+++ b/crates/core/src/kernel/transaction/protocol.rs
@@ -299,6 +299,8 @@ pub static INSTANCE: LazyLock<ProtocolChecker> = LazyLock::new(|| {
     reader_features.insert(TableFeature::DeletionVectors);
     reader_features.insert(TableFeature::VariantType);
     reader_features.insert(TableFeature::VariantTypePreview);
+    #[cfg(feature = "nanosecond-timestamps")]
+    reader_features.insert(TableFeature::TimestampNanos);
     #[cfg(feature = "datafusion")]
     {
         reader_features.insert(TableFeature::ColumnMapping);

--- a/crates/core/tests/it_datafusion/main.rs
+++ b/crates/core/tests/it_datafusion/main.rs
@@ -15,5 +15,7 @@ mod file_selection_bench_bridge;
 mod integration;
 mod integration_checkpoint;
 mod integration_datafusion;
+#[cfg(feature = "nanosecond-timestamps")]
+mod nanosecond_timestamps;
 mod read_delta_log_test;
 mod read_delta_partitions_test;

--- a/crates/core/tests/it_datafusion/nanosecond_timestamps.rs
+++ b/crates/core/tests/it_datafusion/nanosecond_timestamps.rs
@@ -1,0 +1,211 @@
+// Test basic operations on a table that uses the nanosecond-timestamps feature
+
+use arrow_array::cast::AsArray;
+use arrow_array::types::TimestampNanosecondType;
+use arrow_array::{RecordBatch, TimestampNanosecondArray};
+use arrow_schema::{DataType, Field, Schema, TimeUnit};
+use datafusion::prelude::SessionContext;
+use deltalake_core::delta_datafusion::create_session;
+use deltalake_core::{DeltaResult, DeltaTable};
+use std::sync::Arc;
+
+const START_TIMESTAMP_NS: i64 = 1_704_067_200 * 1_000_000_000; // 2024-01-01 00:00:00 UTC
+const DAY_NS: i64 = 60 * 60 * 24 * 1_000_000_000;
+
+async fn setup_timestamp_nanos_table() -> DeltaResult<(DeltaTable, Arc<Schema>)> {
+    let arrow_schema = Arc::new(Schema::new(vec![Field::new(
+        "timestamp",
+        DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+        true,
+    )]));
+
+    let batch = RecordBatch::try_new(
+        arrow_schema.clone(),
+        vec![Arc::new(
+            TimestampNanosecondArray::from(vec![
+                START_TIMESTAMP_NS,
+                START_TIMESTAMP_NS + DAY_NS,
+                START_TIMESTAMP_NS + 2 * DAY_NS,
+            ])
+            .with_timezone("UTC"),
+        )],
+    )?;
+
+    let table: DeltaTable = DeltaTable::new_in_memory().write(vec![batch]).await?;
+
+    Ok((table, arrow_schema))
+}
+
+async fn get_data(table: DeltaTable) -> Vec<RecordBatch> {
+    let ctx: SessionContext = create_session().into();
+    table.update_datafusion_session(&ctx.state()).unwrap();
+    ctx.register_table("test", table.table_provider().await.unwrap())
+        .unwrap();
+    ctx.sql("select * from test")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn read_timestamp_nanos_table() -> DeltaResult<()> {
+    let (table, _) = setup_timestamp_nanos_table().await?;
+    let batches = get_data(table).await;
+
+    let schema = batches[0].schema();
+    let timestamp_field = schema.field_with_name("timestamp")?;
+    assert_eq!(
+        timestamp_field.data_type(),
+        &DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+    );
+
+    let mut values: Vec<i64> = Vec::new();
+    for batch in batches {
+        let nanos_column = batch.column(0).as_primitive::<TimestampNanosecondType>();
+        for i in 0..batch.num_rows() {
+            values.push(nanos_column.value(i));
+        }
+    }
+    values.sort();
+    assert_eq!(
+        values,
+        vec![
+            START_TIMESTAMP_NS,
+            START_TIMESTAMP_NS + DAY_NS,
+            START_TIMESTAMP_NS + 2 * DAY_NS,
+        ]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn append_timestamp_nanos() -> DeltaResult<()> {
+    let (table, arrow_schema) = setup_timestamp_nanos_table().await?;
+
+    let new_batch = RecordBatch::try_new(
+        arrow_schema.clone(),
+        vec![Arc::new(
+            TimestampNanosecondArray::from(vec![
+                START_TIMESTAMP_NS + 3 * DAY_NS,
+                START_TIMESTAMP_NS + 4 * DAY_NS,
+            ])
+            .with_timezone("UTC"),
+        )],
+    )?;
+    let table = table.write(vec![new_batch]).await?;
+    assert_eq!(table.version(), Some(1));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_with_timestamp_nanos_predicate() -> DeltaResult<()> {
+    let (table, _) = setup_timestamp_nanos_table().await?;
+
+    let (table, metrics) = table
+        .delete()
+        .with_predicate("timestamp >= '2024-01-02T00:00:00Z'")
+        .await?;
+    assert_eq!(table.version(), Some(1));
+    assert!(metrics.num_deleted_rows.is_some_and(|r| r == 2));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_with_timestamp_nanos() -> DeltaResult<()> {
+    let (table, _) = setup_timestamp_nanos_table().await?;
+
+    let new_timestamp_ns: i64 = START_TIMESTAMP_NS + 10 * DAY_NS + 123_456_789;
+
+    let (table, metrics) = table
+        .update()
+        .with_predicate("timestamp >= '2024-01-02T00:00:00Z'")
+        .with_update("timestamp", "'2024-01-11T00:00:00.123456789Z'")
+        .await?;
+    assert_eq!(table.version(), Some(1));
+    assert_eq!(metrics.num_updated_rows, 2);
+
+    let batches = get_data(table).await;
+    let mut values: Vec<i64> = Vec::new();
+    for batch in batches {
+        let nanos_column = batch.column(0).as_primitive::<TimestampNanosecondType>();
+        for i in 0..batch.num_rows() {
+            values.push(nanos_column.value(i));
+        }
+    }
+    values.sort();
+    assert_eq!(
+        values,
+        vec![START_TIMESTAMP_NS, new_timestamp_ns, new_timestamp_ns]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn merge_with_timestamp_nanos() -> DeltaResult<()> {
+    use datafusion::common::ScalarValue;
+    use datafusion::logical_expr::{col, lit};
+
+    let (table, arrow_schema) = setup_timestamp_nanos_table().await?;
+
+    let matched_update_ns: i64 = START_TIMESTAMP_NS + 14 * DAY_NS + 987_654_321;
+    let inserted_ns: i64 = START_TIMESTAMP_NS + 4 * DAY_NS + 123_456_789;
+
+    // Source row 1 matches a target row, row 2 does not.
+    let source_batch = RecordBatch::try_new(
+        arrow_schema.clone(),
+        vec![Arc::new(
+            TimestampNanosecondArray::from(vec![START_TIMESTAMP_NS + DAY_NS, inserted_ns])
+                .with_timezone("UTC"),
+        )],
+    )?;
+
+    let ctx: SessionContext = create_session().into();
+    let source = ctx.read_batch(source_batch)?;
+
+    let (table, metrics) = table
+        .merge(source, col("target.timestamp").eq(col("source.timestamp")))
+        .with_source_alias("source")
+        .with_target_alias("target")
+        .when_matched_update(|update| {
+            update.update(
+                "timestamp",
+                lit(ScalarValue::TimestampNanosecond(
+                    Some(matched_update_ns),
+                    Some("UTC".into()),
+                )),
+            )
+        })?
+        .when_not_matched_insert(|insert| insert.set("timestamp", col("source.timestamp")))?
+        .await?;
+
+    assert_eq!(table.version(), Some(1));
+    assert_eq!(metrics.num_target_rows_updated, 1);
+    assert_eq!(metrics.num_target_rows_inserted, 1);
+
+    let batches = get_data(table).await;
+    let mut values: Vec<i64> = Vec::new();
+    for batch in batches {
+        let nanos_column = batch.column(0).as_primitive::<TimestampNanosecondType>();
+        for i in 0..batch.num_rows() {
+            values.push(nanos_column.value(i));
+        }
+    }
+    values.sort();
+    assert_eq!(
+        values,
+        vec![
+            START_TIMESTAMP_NS,
+            START_TIMESTAMP_NS + 2 * DAY_NS,
+            inserted_ns,
+            matched_update_ns,
+        ]
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

* Adds unit tests to cover various operations involving nanosecond timestamp data
* Adds `TimestampNanos` as a supported reader feature in the protocol checker. Without this, operations fail with a `UnsupportedTableFeatures([TimestampNanos])` error, including write operations as those also check the reader features first:
https://github.com/delta-io/delta-rs/blob/b8768628fcfc5dbf22314172cd029a8fd2ed3b13/crates/core/src/kernel/transaction/protocol.rs#L219-L221

# Related Issue(s)

* Follow up to #4370
* Related to #4420

cc @itamarst
