### PR TITLE
feat: column mapping physical exec

### DIFF
--- a/crates/core/src/delta_datafusion/column_mapping.rs
+++ b/crates/core/src/delta_datafusion/column_mapping.rs
@@ -10,6 +10,7 @@
 //! survive), making the rewrite effectively zero-copy.
 
 use std::any::Any;
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -22,21 +23,98 @@ use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskCo
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::CardinalityEffect;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
-use delta_kernel::schema::{DataType as KernelDataType, StructField, StructType};
+use delta_kernel::schema::{
+    DataType as KernelDataType, SchemaRef as KernelSchemaRef, StructField, StructType,
+};
+use delta_kernel::table_configuration::TableConfiguration;
 use delta_kernel::table_features::ColumnMappingMode;
 use futures::{Stream, StreamExt};
 
-use crate::errors::DeltaResult;
+use crate::errors::{DeltaResult, DeltaTableError};
 
 /// Arrow field metadata key recognized by the Parquet writer to emit a `field_id`.
 const PARQUET_FIELD_ID_META_KEY: &str = "PARQUET:field_id";
+
+/// Length of the random data-file directory prefix on column-mapped tables (delta-spark default).
+const DEFAULT_RANDOM_PREFIX_LENGTH: usize = 2;
+
+/// Shared column-mapping write state, derived once from the table configuration and reused by
+/// every write entry point — the DataFusion plan path (via [`ColumnMappingState::wrap_plan`]) and
+/// the `DeltaDataSink` stream path (via [`ColumnMappingState::transform_batch`]) — so they all
+/// emit physical names/ids, physical partition keys, and random-prefixed paths consistently.
+#[derive(Clone)]
+pub(crate) struct ColumnMappingState {
+    mode: ColumnMappingMode,
+    /// Kernel table schema carrying the `delta.columnMapping.*` annotations.
+    logical_schema: KernelSchemaRef,
+}
+
+impl ColumnMappingState {
+    /// Build the state from a table configuration, returning `None` when column mapping is off.
+    pub(crate) fn from_table_config(table_config: &TableConfiguration) -> Option<Self> {
+        let mode = table_config.column_mapping_mode();
+        (mode != ColumnMappingMode::None).then(|| Self {
+            mode,
+            logical_schema: table_config.logical_schema(),
+        })
+    }
+
+    /// Physical Arrow schema for `input`: table columns renamed to physical names with `field_id`
+    /// metadata, non-table columns passed through.
+    pub(crate) fn physical_schema(&self, input: &SchemaRef) -> SchemaRef {
+        Arc::new(Schema::new(physical_fields(
+            input.fields(),
+            &self.logical_schema,
+            self.mode,
+        )))
+    }
+
+    /// Wrap a write plan so its output batches are emitted physically.
+    pub(crate) fn wrap_plan(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+    ) -> DeltaResult<Arc<dyn ExecutionPlan>> {
+        ColumnMappingExec::try_new(plan, self.logical_schema.as_ref(), self.mode)
+    }
+
+    /// Rewrite a single batch into its physical form (for stream-based writers like `DeltaDataSink`).
+    pub(crate) fn transform_batch(&self, batch: &RecordBatch) -> Result<RecordBatch> {
+        apply_column_mapping(batch, &self.physical_schema(&batch.schema()))
+    }
+
+    /// Translate logical partition column names to physical. Errors (rather than silently using
+    /// the logical name) if a partition column is missing from the table schema.
+    pub(crate) fn physical_partition_columns(
+        &self,
+        partition_columns: &[String],
+    ) -> DeltaResult<Vec<String>> {
+        partition_columns
+            .iter()
+            .map(|name| {
+                self.logical_schema
+                    .field(name)
+                    .map(|field| field.physical_name(self.mode).to_string())
+                    .ok_or_else(|| {
+                        DeltaTableError::Generic(format!(
+                            "partition column '{name}' not found in the table schema"
+                        ))
+                    })
+            })
+            .collect()
+    }
+
+    /// Directory-prefix length for data files on column-mapped tables.
+    pub(crate) fn random_prefix_length(&self) -> usize {
+        DEFAULT_RANDOM_PREFIX_LENGTH
+    }
+}
 
 /// Execution node that casts logical record batches to their physical, column-mapped form.
 ///
 /// See the [module docs](self) for details. Constructed via [`ColumnMappingExec::try_new`],
 /// which is a no-op (returns the input plan unchanged) when column mapping is disabled.
 #[derive(Debug)]
-pub(crate) struct ColumnMappingExec {
+struct ColumnMappingExec {
     input: Arc<dyn ExecutionPlan>,
     /// Output schema with physical column names and `field_id` metadata.
     physical_schema: SchemaRef,
@@ -49,7 +127,7 @@ impl ColumnMappingExec {
     /// Returns `input` unchanged when `mode` is [`ColumnMappingMode::None`], so callers can
     /// invoke this unconditionally. `logical_schema` is the kernel table schema carrying the
     /// `delta.columnMapping.*` annotations used to resolve physical names and field ids.
-    pub(crate) fn try_new(
+    fn try_new(
         input: Arc<dyn ExecutionPlan>,
         logical_schema: &StructType,
         mode: ColumnMappingMode,
@@ -204,11 +282,24 @@ fn physical_fields(
         .collect()
 }
 
+/// Clone a field's metadata, dropping any inherited `PARQUET:field_id`. Field ids are table-owned
+/// (the column-mapping id is written as the Parquet `field_id`, per PROTOCOL.md), so a stale id
+/// carried in on input batches must not survive into the written file. All other metadata is kept.
+fn metadata_without_field_id(field: &Field) -> HashMap<String, String> {
+    field
+        .metadata()
+        .iter()
+        .filter(|(key, _)| key.as_str() != PARQUET_FIELD_ID_META_KEY)
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
 /// Build the physical Arrow field for a single logical field: rename to the physical name,
-/// attach the `field_id` metadata, and recurse into nested types — all while preserving the
-/// input Arrow data type.
+/// attach the table-owned `field_id` metadata, and recurse into nested types — all while
+/// preserving the input Arrow data type.
 fn physical_field(field: &Field, kernel_field: &StructField, mode: ColumnMappingMode) -> Field {
-    let mut metadata = field.metadata().clone();
+    // Strip parquet field ids
+    let mut metadata = metadata_without_field_id(field);
     if let Some(id) = kernel_field.column_mapping_id() {
         metadata.insert(PARQUET_FIELD_ID_META_KEY.to_string(), id.to_string());
     }
@@ -267,8 +358,13 @@ fn physical_data_type(
             };
             // Map entries are a struct of [key, value]; recurse into both by position,
             // keeping the synthetic "key"/"value"/"entries" names as-is.
-            let mut new_fields: Vec<Field> =
-                entry_fields.iter().map(|f| f.as_ref().clone()).collect();
+            let mut new_fields: Vec<Field> = entry_fields
+                .iter()
+                .map(|f| {
+                    Field::new(f.name(), f.data_type().clone(), f.is_nullable())
+                        .with_metadata(metadata_without_field_id(f))
+                })
+                .collect();
             if let Some(key) = new_fields.get_mut(0) {
                 *key = key.clone().with_data_type(physical_data_type(
                     key.data_type(),
@@ -288,7 +384,7 @@ fn physical_data_type(
                 DataType::Struct(new_fields.into()),
                 entries.is_nullable(),
             )
-            .with_metadata(entries.metadata().clone());
+            .with_metadata(metadata_without_field_id(entries));
             DataType::Map(Arc::new(new_entries), *sorted)
         }
         KernelDataType::Primitive(_) | KernelDataType::Variant(_) => arrow_type.clone(),
@@ -305,7 +401,7 @@ fn rebuild_element(
     let data_type = physical_data_type(element.data_type(), element_kernel, mode);
     Arc::new(
         Field::new(element.name(), data_type, element.is_nullable())
-            .with_metadata(element.metadata().clone()),
+            .with_metadata(metadata_without_field_id(element)),
     )
 }
 
@@ -413,8 +509,13 @@ mod tests {
             vec![Arc::new(StringArray::from(vec!["a", "b", "c"])) as ArrayRef],
             None,
         );
+        // The list-element wrapper carries a stale field id on input; it must be stripped (the
+        // wrapper is not a column-mapped table field).
         let items = ListArray::new(
-            Arc::new(Field::new("item", item_struct.data_type().clone(), true)),
+            Arc::new(
+                Field::new("item", item_struct.data_type().clone(), true)
+                    .with_metadata(stale_field_id()),
+            ),
             OffsetBuffer::from_lengths([2usize, 1]),
             Arc::new(item_struct),
             None,
@@ -422,7 +523,8 @@ mod tests {
 
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int32, true),
-            Field::new("name", DataType::Utf8View, true),
+            // `name` carries a stale field id on input; the table-owned id (2) must win.
+            Field::new("name", DataType::Utf8View, true).with_metadata(stale_field_id()),
             Field::new("addr", addr.data_type().clone(), true),
             Field::new("items", items.data_type().clone(), true),
         ]));
@@ -443,6 +545,11 @@ mod tests {
             .metadata()
             .get(PARQUET_FIELD_ID_META_KEY)
             .map(String::as_str)
+    }
+
+    /// A stale, wrong field id as it might arrive on an input batch (e.g. read from another file).
+    fn stale_field_id() -> HashMap<String, String> {
+        HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), "999".to_string())])
     }
 
     /// Exercises the full nested rewrite: top-level + nested struct + struct-inside-list renames,
@@ -486,6 +593,9 @@ mod tests {
             let DataType::List(item_field) = fields.field(3).data_type() else {
                 panic!("items should be a list");
             };
+            // The synthetic element wrapper must not carry a field id (the stale input id is
+            // stripped and no table id applies to it).
+            assert_eq!(field_id(item_field), None, "{mode:?}");
             let DataType::Struct(item_fields) = item_field.data_type() else {
                 panic!("list element should be a struct");
             };
@@ -548,5 +658,33 @@ mod tests {
         assert_eq!(out.schema().field(0).name(), "col-id");
         assert_eq!(out.schema().field(1).name(), "_change_type");
         assert_eq!(field_id(out.schema().field(1)), None);
+    }
+
+    #[test]
+    fn physical_partition_columns_errors_on_unknown_column() {
+        let logical_schema =
+            Arc::new(StructType::try_new([column_mapping_test_field("p", "col-p", 1)]).unwrap());
+        let state = ColumnMappingState {
+            mode: ColumnMappingMode::Name,
+            logical_schema,
+        };
+        // Known columns translate to their physical names.
+        assert_eq!(
+            state
+                .physical_partition_columns(&["p".to_string()])
+                .unwrap(),
+            vec!["col-p".to_string()]
+        );
+        // An unknown partition column fails loudly instead of silently using the logical name.
+        let err = state
+            .physical_partition_columns(&["missing".to_string()])
+            .expect_err("unknown partition column should error");
+        match err {
+            DeltaTableError::Generic(message) => assert_eq!(
+                message,
+                "partition column 'missing' not found in the table schema"
+            ),
+            other => panic!("expected a Generic partition error, got: {other:?}"),
+        }
     }
 }

--- a/crates/core/src/delta_datafusion/column_mapping.rs
+++ b/crates/core/src/delta_datafusion/column_mapping.rs
@@ -1,0 +1,552 @@
+//! Execution node that rewrites logical record batches into their physical (column-mapped)
+//! form just before the write sink.
+//!
+//! Column mapping stores data in Parquet under *physical* column names (random `col-<uuid>` in
+//! `name` mode), each tagged with a Parquet `field_id`, while the rest of delta-rs works on the
+//! *logical* schema. This node renames each table column to its physical name and attaches the
+//! `field_id`, passing non-table columns (e.g. the CDC `_change_type` marker) through unchanged.
+//!
+//! Only names and metadata change — Arrow types and buffers are preserved (so Large/View types
+//! survive), making the rewrite effectively zero-copy.
+
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::array::{Array, ArrayData, ArrayRef, RecordBatch, make_array};
+use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
+use datafusion::common::Statistics;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::execution_plan::CardinalityEffect;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use delta_kernel::schema::{DataType as KernelDataType, StructField, StructType};
+use delta_kernel::table_features::ColumnMappingMode;
+use futures::{Stream, StreamExt};
+
+use crate::errors::DeltaResult;
+
+/// Arrow field metadata key recognized by the Parquet writer to emit a `field_id`.
+const PARQUET_FIELD_ID_META_KEY: &str = "PARQUET:field_id";
+
+/// Execution node that casts logical record batches to their physical, column-mapped form.
+///
+/// See the [module docs](self) for details. Constructed via [`ColumnMappingExec::try_new`],
+/// which is a no-op (returns the input plan unchanged) when column mapping is disabled.
+#[derive(Debug)]
+pub(crate) struct ColumnMappingExec {
+    input: Arc<dyn ExecutionPlan>,
+    /// Output schema with physical column names and `field_id` metadata.
+    physical_schema: SchemaRef,
+    properties: Arc<PlanProperties>,
+}
+
+impl ColumnMappingExec {
+    /// Wrap `input` so its output batches are rewritten to the physical schema.
+    ///
+    /// Returns `input` unchanged when `mode` is [`ColumnMappingMode::None`], so callers can
+    /// invoke this unconditionally. `logical_schema` is the kernel table schema carrying the
+    /// `delta.columnMapping.*` annotations used to resolve physical names and field ids.
+    pub(crate) fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        logical_schema: &StructType,
+        mode: ColumnMappingMode,
+    ) -> DeltaResult<Arc<dyn ExecutionPlan>> {
+        if mode == ColumnMappingMode::None {
+            return Ok(input);
+        }
+
+        let physical_fields = physical_fields(input.schema().fields(), logical_schema, mode);
+        let physical_schema = Arc::new(Schema::new(physical_fields));
+
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(physical_schema.clone()),
+            input.properties().partitioning.clone(),
+            input.properties().emission_type,
+            input.properties().boundedness,
+        );
+
+        Ok(Arc::new(Self {
+            input,
+            physical_schema,
+            properties: Arc::new(properties),
+        }))
+    }
+}
+
+impl DisplayAs for ColumnMappingExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default
+            | DisplayFormatType::TreeRender
+            | DisplayFormatType::Verbose => {
+                write!(f, "ColumnMappingExec")
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for ColumnMappingExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "ColumnMappingExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "ColumnMappingExec wrong number of children: expected 1, got {}",
+                children.len()
+            )));
+        }
+        Ok(Arc::new(Self {
+            input: children.remove(0),
+            physical_schema: self.physical_schema.clone(),
+            properties: self.properties.clone(),
+        }))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        Ok(Box::pin(ColumnMappingStream {
+            schema: self.physical_schema.clone(),
+            input: self.input.execute(partition, context)?,
+        }))
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        self.input.partition_statistics(partition)
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true; self.children().len()]
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Equal
+    }
+}
+
+/// Stream that rewrites each input batch into the physical schema.
+struct ColumnMappingStream {
+    schema: SchemaRef,
+    input: SendableRecordBatchStream,
+}
+
+impl Stream for ColumnMappingStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.input.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok(batch))) => {
+                Poll::Ready(Some(apply_column_mapping(&batch, &self.schema)))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl RecordBatchStream for ColumnMappingStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+/// Rebuild `batch` under `physical_schema`, reusing the underlying buffers and only changing
+/// (possibly nested) field names and metadata. Columns are matched positionally; name-checked
+/// adapters (`cast_record_batch`, `RecordBatch::with_schema`) reject the logical→physical rename.
+fn apply_column_mapping(batch: &RecordBatch, physical_schema: &SchemaRef) -> Result<RecordBatch> {
+    let columns = physical_schema
+        .fields()
+        .iter()
+        .zip(batch.columns())
+        .map(|(field, array)| retype_array(array, field.data_type()))
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(DataFusionError::from)?;
+    RecordBatch::try_new(physical_schema.clone(), columns).map_err(DataFusionError::from)
+}
+
+/// Compute the physical Arrow fields for `arrow_fields` against the column-mapping
+/// annotations in `logical_schema`. Fields not present in `logical_schema` (e.g. the CDC
+/// `_change_type` marker) are passed through unchanged.
+fn physical_fields(
+    arrow_fields: &Fields,
+    logical_schema: &StructType,
+    mode: ColumnMappingMode,
+) -> Vec<Field> {
+    arrow_fields
+        .iter()
+        .map(|field| match logical_schema.field(field.name()) {
+            Some(kernel_field) => physical_field(field, kernel_field, mode),
+            None => field.as_ref().clone(),
+        })
+        .collect()
+}
+
+/// Build the physical Arrow field for a single logical field: rename to the physical name,
+/// attach the `field_id` metadata, and recurse into nested types — all while preserving the
+/// input Arrow data type.
+fn physical_field(field: &Field, kernel_field: &StructField, mode: ColumnMappingMode) -> Field {
+    let mut metadata = field.metadata().clone();
+    if let Some(id) = kernel_field.column_mapping_id() {
+        metadata.insert(PARQUET_FIELD_ID_META_KEY.to_string(), id.to_string());
+    }
+    let data_type = physical_data_type(field.data_type(), kernel_field.data_type(), mode);
+    Field::new(
+        kernel_field.physical_name(mode),
+        data_type,
+        field.is_nullable(),
+    )
+    .with_metadata(metadata)
+}
+
+/// Recurse through nested Arrow types, renaming reachable struct fields to their physical names.
+/// Names come from `kernel_type`, but the representation stays `arrow_type`'s: converting the
+/// kernel type to Arrow (`make_physical().try_into_arrow()`) would canonicalize away the batch's
+/// View/Large types and force a copy.
+fn physical_data_type(
+    arrow_type: &DataType,
+    kernel_type: &KernelDataType,
+    mode: ColumnMappingMode,
+) -> DataType {
+    match kernel_type {
+        KernelDataType::Struct(kernel_struct) => {
+            let DataType::Struct(arrow_fields) = arrow_type else {
+                return arrow_type.clone();
+            };
+            DataType::Struct(physical_fields(arrow_fields, kernel_struct, mode).into())
+        }
+        KernelDataType::Array(kernel_array) => {
+            let element_kernel = kernel_array.element_type();
+            match arrow_type {
+                DataType::List(element) => {
+                    DataType::List(rebuild_element(element, element_kernel, mode))
+                }
+                DataType::LargeList(element) => {
+                    DataType::LargeList(rebuild_element(element, element_kernel, mode))
+                }
+                DataType::ListView(element) => {
+                    DataType::ListView(rebuild_element(element, element_kernel, mode))
+                }
+                DataType::LargeListView(element) => {
+                    DataType::LargeListView(rebuild_element(element, element_kernel, mode))
+                }
+                DataType::FixedSizeList(element, len) => {
+                    DataType::FixedSizeList(rebuild_element(element, element_kernel, mode), *len)
+                }
+                _ => arrow_type.clone(),
+            }
+        }
+        KernelDataType::Map(kernel_map) => {
+            let DataType::Map(entries, sorted) = arrow_type else {
+                return arrow_type.clone();
+            };
+            let DataType::Struct(entry_fields) = entries.data_type() else {
+                return arrow_type.clone();
+            };
+            // Map entries are a struct of [key, value]; recurse into both by position,
+            // keeping the synthetic "key"/"value"/"entries" names as-is.
+            let mut new_fields: Vec<Field> =
+                entry_fields.iter().map(|f| f.as_ref().clone()).collect();
+            if let Some(key) = new_fields.get_mut(0) {
+                *key = key.clone().with_data_type(physical_data_type(
+                    key.data_type(),
+                    kernel_map.key_type(),
+                    mode,
+                ));
+            }
+            if let Some(value) = new_fields.get_mut(1) {
+                *value = value.clone().with_data_type(physical_data_type(
+                    value.data_type(),
+                    kernel_map.value_type(),
+                    mode,
+                ));
+            }
+            let new_entries = Field::new(
+                entries.name(),
+                DataType::Struct(new_fields.into()),
+                entries.is_nullable(),
+            )
+            .with_metadata(entries.metadata().clone());
+            DataType::Map(Arc::new(new_entries), *sorted)
+        }
+        KernelDataType::Primitive(_) | KernelDataType::Variant(_) => arrow_type.clone(),
+    }
+}
+
+/// Rebuild a list/array element field, preserving its name and nullability while recursing
+/// into its (possibly nested) value type.
+fn rebuild_element(
+    element: &Arc<Field>,
+    element_kernel: &KernelDataType,
+    mode: ColumnMappingMode,
+) -> Arc<Field> {
+    let data_type = physical_data_type(element.data_type(), element_kernel, mode);
+    Arc::new(
+        Field::new(element.name(), data_type, element.is_nullable())
+            .with_metadata(element.metadata().clone()),
+    )
+}
+
+/// Reinterpret `array` under `target` data type, reusing all buffers and offsets and only
+/// fixing up nested field names. A fast path returns the input untouched when the types
+/// already match (the common case for primitive leaves and pass-through columns).
+fn retype_array(
+    array: &ArrayRef,
+    target: &DataType,
+) -> std::result::Result<ArrayRef, arrow_schema::ArrowError> {
+    if array.data_type() == target {
+        return Ok(array.clone());
+    }
+
+    let data = array.to_data();
+    let new_children: Vec<ArrayData> = match target {
+        DataType::Struct(fields) => data
+            .child_data()
+            .iter()
+            .zip(fields.iter())
+            .map(|(child, field)| {
+                retype_array(&make_array(child.clone()), field.data_type()).map(|a| a.to_data())
+            })
+            .collect::<std::result::Result<_, _>>()?,
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::ListView(field)
+        | DataType::LargeListView(field)
+        | DataType::FixedSizeList(field, _)
+        | DataType::Map(field, _) => {
+            vec![
+                retype_array(&make_array(data.child_data()[0].clone()), field.data_type())?
+                    .to_data(),
+            ]
+        }
+        _ => data.child_data().to_vec(),
+    };
+
+    let rebuilt = data
+        .into_builder()
+        .data_type(target.clone())
+        .child_data(new_children)
+        .build()?;
+    Ok(make_array(rebuilt))
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_array::cast::AsArray;
+    use arrow_array::types::Int32Type;
+    use arrow_array::{Int32Array, ListArray, StringArray, StringViewArray, StructArray};
+    use arrow_buffer::OffsetBuffer;
+    use delta_kernel::schema::ArrayType;
+
+    use super::*;
+    use crate::test_utils::{column_mapping_test_field, column_mapping_test_field_with_type};
+
+    /// Logical kernel schema carrying column-mapping annotations:
+    /// ```text
+    ///   id:    int                        -> col-id    (id 1)
+    ///   name:  string                     -> col-name  (id 2)
+    ///   addr:  struct<street:string>      -> col-addr  (id 3) { street -> col-street (id 4) }
+    ///   items: array<struct<sku:string>>  -> col-items (id 5) { ..struct { sku -> col-sku (id 6) } }
+    /// ```
+    fn logical_kernel_schema() -> StructType {
+        let addr = KernelDataType::Struct(Box::new(
+            StructType::try_new([column_mapping_test_field_with_type(
+                "street",
+                "col-street",
+                4,
+                KernelDataType::STRING,
+            )])
+            .unwrap(),
+        ));
+        let item_struct = KernelDataType::Struct(Box::new(
+            StructType::try_new([column_mapping_test_field_with_type(
+                "sku",
+                "col-sku",
+                6,
+                KernelDataType::STRING,
+            )])
+            .unwrap(),
+        ));
+        let items = KernelDataType::Array(Box::new(ArrayType::new(item_struct, true)));
+        StructType::try_new([
+            column_mapping_test_field("id", "col-id", 1),
+            column_mapping_test_field_with_type("name", "col-name", 2, KernelDataType::STRING),
+            column_mapping_test_field_with_type("addr", "col-addr", 3, addr),
+            column_mapping_test_field_with_type("items", "col-items", 5, items),
+        ])
+        .unwrap()
+    }
+
+    /// Logical Arrow batch. `name` deliberately uses `Utf8View` to prove the rewrite preserves the
+    /// input Arrow representation rather than canonicalizing it to `Utf8`.
+    fn logical_batch() -> RecordBatch {
+        let addr = StructArray::new(
+            Fields::from(vec![Field::new("street", DataType::Utf8, true)]),
+            vec![Arc::new(StringArray::from(vec!["s1", "s2"])) as ArrayRef],
+            None,
+        );
+        // items: [ [{sku:a},{sku:b}], [{sku:c}] ]
+        let item_struct = StructArray::new(
+            Fields::from(vec![Field::new("sku", DataType::Utf8, true)]),
+            vec![Arc::new(StringArray::from(vec!["a", "b", "c"])) as ArrayRef],
+            None,
+        );
+        let items = ListArray::new(
+            Arc::new(Field::new("item", item_struct.data_type().clone(), true)),
+            OffsetBuffer::from_lengths([2usize, 1]),
+            Arc::new(item_struct),
+            None,
+        );
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("name", DataType::Utf8View, true),
+            Field::new("addr", addr.data_type().clone(), true),
+            Field::new("items", items.data_type().clone(), true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringViewArray::from(vec!["n1", "n2"])),
+                Arc::new(addr),
+                Arc::new(items),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn field_id(field: &Field) -> Option<&str> {
+        field
+            .metadata()
+            .get(PARQUET_FIELD_ID_META_KEY)
+            .map(String::as_str)
+    }
+
+    /// Exercises the full nested rewrite: top-level + nested struct + struct-inside-list renames,
+    /// `field_id` assignment at every level, `Utf8View` preservation, and data integrity. Both
+    /// modes are asserted identical (physical name + id resolution is mode-independent), which is
+    /// the only thing the `id`-vs-`name` distinction changes on the write path.
+    #[test]
+    fn rewrites_nested_columns_to_physical_in_both_modes() {
+        let kernel_schema = logical_kernel_schema();
+        let batch = logical_batch();
+
+        for mode in [ColumnMappingMode::Name, ColumnMappingMode::Id] {
+            let physical_schema = Arc::new(Schema::new(physical_fields(
+                batch.schema().fields(),
+                &kernel_schema,
+                mode,
+            )));
+            let out = apply_column_mapping(&batch, &physical_schema).unwrap();
+            let fields = out.schema();
+
+            // Top-level physical names + field ids.
+            assert_eq!(fields.field(0).name(), "col-id");
+            assert_eq!(field_id(fields.field(0)), Some("1"), "{mode:?}");
+            assert_eq!(fields.field(1).name(), "col-name");
+            assert_eq!(field_id(fields.field(1)), Some("2"), "{mode:?}");
+            // Utf8View representation survives (not canonicalized to Utf8).
+            assert_eq!(fields.field(1).data_type(), &DataType::Utf8View, "{mode:?}");
+
+            // Nested struct field renamed + field id; child type preserved.
+            assert_eq!(fields.field(2).name(), "col-addr");
+            assert_eq!(field_id(fields.field(2)), Some("3"), "{mode:?}");
+            let DataType::Struct(addr_fields) = fields.field(2).data_type() else {
+                panic!("addr should be a struct");
+            };
+            assert_eq!(addr_fields[0].name(), "col-street");
+            assert_eq!(field_id(addr_fields[0].as_ref()), Some("4"), "{mode:?}");
+
+            // Struct nested INSIDE a list is renamed via the list/element path.
+            assert_eq!(fields.field(3).name(), "col-items");
+            assert_eq!(field_id(fields.field(3)), Some("5"), "{mode:?}");
+            let DataType::List(item_field) = fields.field(3).data_type() else {
+                panic!("items should be a list");
+            };
+            let DataType::Struct(item_fields) = item_field.data_type() else {
+                panic!("list element should be a struct");
+            };
+            assert_eq!(item_fields[0].name(), "col-sku");
+            assert_eq!(field_id(item_fields[0].as_ref()), Some("6"), "{mode:?}");
+
+            // Data is preserved through the buffer reinterpret.
+            assert_eq!(out.column(0).as_primitive::<Int32Type>().values(), &[1, 2]);
+            let names: Vec<&str> = out.column(1).as_string_view().iter().flatten().collect();
+            assert_eq!(names, vec!["n1", "n2"]);
+            let streets: Vec<&str> = out
+                .column(2)
+                .as_struct()
+                .column(0)
+                .as_string::<i32>()
+                .iter()
+                .flatten()
+                .collect();
+            assert_eq!(streets, vec!["s1", "s2"]);
+            let skus: Vec<&str> = out
+                .column(3)
+                .as_list::<i32>()
+                .values()
+                .as_struct()
+                .column(0)
+                .as_string::<i32>()
+                .iter()
+                .flatten()
+                .collect();
+            assert_eq!(skus, vec!["a", "b", "c"]);
+        }
+    }
+
+    /// Columns absent from the logical schema (e.g. the CDC `_change_type` marker) pass through
+    /// unchanged.
+    #[test]
+    fn passes_through_non_table_columns() {
+        let kernel_schema =
+            StructType::try_new([column_mapping_test_field("id", "col-id", 1)]).unwrap();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("_change_type", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(StringArray::from(vec!["insert"])),
+            ],
+        )
+        .unwrap();
+
+        let physical_schema = Arc::new(Schema::new(physical_fields(
+            batch.schema().fields(),
+            &kernel_schema,
+            ColumnMappingMode::Name,
+        )));
+        let out = apply_column_mapping(&batch, &physical_schema).unwrap();
+
+        assert_eq!(out.schema().field(0).name(), "col-id");
+        assert_eq!(out.schema().field(1).name(), "_change_type");
+        assert_eq!(field_id(out.schema().field(1)), None);
+    }
+}

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -69,6 +69,7 @@ pub use self::table_provider::next::{
 };
 pub(crate) use self::utils::*;
 pub use cdf::scan::DeltaCdfTableProvider;
+pub(crate) use column_mapping::ColumnMappingExec;
 pub(crate) use data_validation::{
     DataValidationExec, constraints_to_exprs, generated_columns_to_exprs, validation_predicates,
 };
@@ -86,6 +87,7 @@ pub(crate) const PATH_COLUMN: &str = "__delta_rs_path";
 #[doc(hidden)]
 pub mod bench_support;
 pub mod cdf;
+mod column_mapping;
 mod data_validation;
 pub mod engine;
 pub mod expr;

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -69,7 +69,7 @@ pub use self::table_provider::next::{
 };
 pub(crate) use self::utils::*;
 pub use cdf::scan::DeltaCdfTableProvider;
-pub(crate) use column_mapping::ColumnMappingExec;
+pub(crate) use column_mapping::ColumnMappingState;
 pub(crate) use data_validation::{
     DataValidationExec, constraints_to_exprs, generated_columns_to_exprs, validation_predicates,
 };

--- a/crates/core/src/delta_datafusion/table_provider/data_sink.rs
+++ b/crates/core/src/delta_datafusion/table_provider/data_sink.rs
@@ -17,10 +17,10 @@ use uuid::Uuid;
 
 use crate::{
     cast_record_batch,
-    delta_datafusion::DataFusionMixins as _,
+    delta_datafusion::{ColumnMappingState, DataFusionMixins as _},
     kernel::{Action, EagerSnapshot, transaction::CommitBuilder},
     logstore::LogStoreRef,
-    operations::write::{execution::write_streams, writer::WriterConfig},
+    operations::write::{WriterStatsConfig, execution::write_streams, writer::WriterConfig},
     protocol::{DeltaOperation, SaveMode},
     table::config::TablePropertiesExt as _,
 };
@@ -114,7 +114,7 @@ impl DataSink for DeltaDataSink {
 
         let operation_id = Uuid::new_v4();
         let stream = self.create_converted_stream(data, target_schema.clone());
-        let partition_columns = self.snapshot.metadata().partition_columns();
+        let logical_partition_columns = self.snapshot.metadata().partition_columns();
         let object_store = self.log_store.object_store(Some(operation_id));
         let total_rows_metric = MetricBuilder::new(&self.metrics).counter("total_rows", 0);
         let stream = {
@@ -129,18 +129,49 @@ impl DataSink for DeltaDataSink {
                 }),
             )) as SendableRecordBatchStream
         };
+        let column_mapping =
+            ColumnMappingState::from_table_config(self.snapshot.table_configuration());
+        let stats_config = WriterStatsConfig::from_config(self.snapshot.table_configuration());
+        let (stream, table_schema, physical_partition_columns, random_prefix_length) =
+            match &column_mapping {
+                None => (
+                    stream,
+                    self.snapshot.read_schema(),
+                    logical_partition_columns.to_vec(),
+                    None,
+                ),
+                Some(state) => {
+                    let physical_schema = state.physical_schema(&self.snapshot.read_schema());
+                    let physical_partition_columns = state
+                        .physical_partition_columns(logical_partition_columns)
+                        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                    let prefix_length = state.random_prefix_length();
+                    let state = state.clone();
+                    let stream: SendableRecordBatchStream =
+                        Box::pin(RecordBatchStreamAdapter::new(
+                            physical_schema.clone(),
+                            stream.map(move |batch| {
+                                batch.and_then(|batch| state.transform_batch(&batch))
+                            }),
+                        ));
+                    (
+                        stream,
+                        physical_schema,
+                        physical_partition_columns,
+                        Some(prefix_length),
+                    )
+                }
+            };
         let config = WriterConfig::new(
-            self.snapshot.read_schema(),
-            partition_columns.to_vec(),
+            table_schema,
+            physical_partition_columns,
             None,
             Some(table_props.target_file_size()),
             None,
-            table_props.num_indexed_cols(),
-            table_props
-                .data_skipping_stats_columns
-                .as_ref()
-                .map(|c| c.iter().map(|c| c.to_string()).collect_vec()),
-        );
+            stats_config.num_indexed_cols,
+            stats_config.stats_columns,
+        )
+        .with_random_prefix_length(random_prefix_length);
 
         let (adds, write_metrics) = write_streams(vec![stream], object_store, config)
             .await
@@ -162,10 +193,10 @@ impl DataSink for DeltaDataSink {
 
         let operation = DeltaOperation::Write {
             mode: self.save_mode,
-            partition_by: if partition_columns.is_empty() {
+            partition_by: if logical_partition_columns.is_empty() {
                 None
             } else {
-                Some(partition_columns.to_vec())
+                Some(logical_partition_columns.to_vec())
             },
             predicate: None,
         };

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -377,7 +377,17 @@ impl DeltaScanMetaStream {
             batch
         };
 
-        let result = if let Some(transform) = self.transforms.get(&file_id) {
+        let result = if self
+            .scan_plan
+            .scan
+            .logical_schema()
+            .fields()
+            .next()
+            .is_none()
+        {
+            // Empty projection: the kernel transform can't build a zero-field struct, keep as-is.
+            batch
+        } else if let Some(transform) = self.transforms.get(&file_id) {
             let evaluator = ARROW_HANDLER
                 .new_expression_evaluator(
                     EMPTY_KERNEL_SCHEMA.clone(),

--- a/crates/core/src/kernel/arrow/engine_ext.rs
+++ b/crates/core/src/kernel/arrow/engine_ext.rs
@@ -165,7 +165,7 @@ fn stats_source_schema(
 /// Translates `dataSkippingStatsColumns` from logical to physical names.
 ///
 /// Columns that cannot be resolved against `logical_schema` are dropped.
-fn stats_table_properties<'a>(
+pub(crate) fn stats_table_properties<'a>(
     logical_schema: &StructType,
     table_properties: &'a TableProperties,
     column_mapping_mode: ColumnMappingMode,

--- a/crates/core/src/kernel/transaction/protocol.rs
+++ b/crates/core/src/kernel/transaction/protocol.rs
@@ -319,9 +319,9 @@ pub static INSTANCE: LazyLock<ProtocolChecker> = LazyLock::new(|| {
         writer_features.insert(TableFeature::Invariants);
         writer_features.insert(TableFeature::CheckConstraints);
         writer_features.insert(TableFeature::GeneratedColumns);
+        writer_features.insert(TableFeature::ColumnMapping);
     }
     writer_features.insert(TableFeature::DeletionVectors);
-    // writer_features.insert(TableFeature::ColumnMapping);
     // writer_features.insert(TableFeature::IdentityColumns);
 
     ProtocolChecker::new(reader_features, writer_features)

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -51,7 +51,6 @@ use datafusion::optimizer::simplify_expressions::simplify_predicates;
 use datafusion::physical_plan::{ExecutionPlan, metrics::MetricBuilder};
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 use datafusion::prelude::Expr;
-use delta_kernel::table_features::ColumnMappingMode;
 use futures::future::BoxFuture;
 use futures::{StreamExt as _, TryStreamExt, stream};
 use parquet::file::properties::WriterProperties;
@@ -74,7 +73,7 @@ use crate::delta_datafusion::{
     Expression, add_actions_partition_mem_table, create_session, resolve_session_state,
     scan_files_where_matches, update_datafusion_session,
 };
-use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
+use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
 use crate::kernel::{Action, EagerSnapshot, LogicalFileView, resolve_snapshot};
 use crate::logstore::{LogStore, LogStoreRef};
@@ -294,9 +293,6 @@ impl std::future::IntoFuture for DeleteBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
-            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
-                return Err(unsupported_column_mapping_write("DELETE"));
-            }
             PROTOCOL.check_append_only(&snapshot)?;
             PROTOCOL.can_write_to(&snapshot)?;
 

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -99,6 +99,7 @@ use crate::protocol::{DeltaOperation, MergePredicate};
 use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 use crate::{DeltaResult, DeltaTable, DeltaTableError};
+use delta_kernel::table_features::ColumnMappingMode;
 
 mod barrier;
 mod filter;
@@ -1826,6 +1827,14 @@ impl std::future::IntoFuture for MergeBuilder {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
             PROTOCOL.can_write_to(&snapshot)?;
+
+            if this.merge_schema
+                && snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None
+            {
+                return Err(DeltaTableError::Generic(
+                    "Schema evolution on column-mapped tables is not yet supported".to_string(),
+                ));
+            }
 
             let operation_id = this.get_operation_id();
             this.pre_execute(operation_id).await?;

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -61,7 +61,6 @@ use datafusion::{
 
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow as _, TryIntoKernel as _};
 use delta_kernel::schema::{ColumnMetadataKey, StructType};
-use delta_kernel::table_features::ColumnMappingMode;
 use filter::try_construct_early_filter;
 use futures::future::BoxFuture;
 use parquet::file::properties::WriterProperties;
@@ -85,7 +84,6 @@ use crate::delta_datafusion::{
     resolve_session_state, update_datafusion_session,
 };
 use crate::delta_datafusion::{Expression, into_expr, maybe_into_expr};
-use crate::errors::unsupported_column_mapping_write;
 use crate::kernel::schema::cast::{merge_arrow_field, merge_arrow_schema};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
 use crate::kernel::{Action, EagerSnapshot, StructTypeExt, new_metadata, resolve_snapshot};
@@ -1827,10 +1825,6 @@ impl std::future::IntoFuture for MergeBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
-            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
-                return Err(unsupported_column_mapping_write("MERGE"));
-            }
-
             PROTOCOL.can_write_to(&snapshot)?;
 
             let operation_id = this.get_operation_id();

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -699,6 +699,7 @@ impl MergePlan {
             },
             None,
             None,
+            None,
         )?;
         let mut writer = PartitionWriter::try_with_config(
             object_store,

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -35,7 +35,6 @@ use datafusion::{
     physical_planner::{ExtensionPlanner, PhysicalPlanner},
     prelude::Expr,
 };
-use delta_kernel::table_features::ColumnMappingMode;
 use futures::{StreamExt as _, TryStreamExt as _, future::BoxFuture, stream};
 use itertools::Itertools as _;
 use parquet::file::properties::WriterProperties;
@@ -51,7 +50,6 @@ use super::{
 use crate::delta_datafusion::{
     DeltaScanConfig, Expression, scan_files_where_matches, update_datafusion_session,
 };
-use crate::errors::unsupported_column_mapping_write;
 use crate::kernel::resolve_snapshot;
 use crate::logstore::LogStoreRef;
 use crate::operations::cdc::*;
@@ -459,9 +457,6 @@ impl std::future::IntoFuture for UpdateBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
-            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
-                return Err(unsupported_column_mapping_write("UPDATE"));
-            }
             PROTOCOL.check_append_only(&snapshot)?;
             PROTOCOL.can_write_to(&snapshot)?;
 

--- a/crates/core/src/operations/write/configs.rs
+++ b/crates/core/src/operations/write/configs.rs
@@ -2,6 +2,7 @@ use delta_kernel::{
     table_configuration::TableConfiguration, table_properties::DataSkippingNumIndexedCols,
 };
 
+use crate::kernel::arrow::engine_ext::stats_table_properties;
 use crate::table::config::TablePropertiesExt as _;
 
 /// Configuration for the writer on how to collect stats
@@ -26,13 +27,77 @@ impl WriterStatsConfig {
     }
 
     pub fn from_config(config: &TableConfiguration) -> Self {
+        let properties = stats_table_properties(
+            config.logical_schema().as_ref(),
+            config.table_properties(),
+            config.column_mapping_mode(),
+        );
         Self {
-            num_indexed_cols: config.table_properties().num_indexed_cols(),
-            stats_columns: config
-                .table_properties()
+            num_indexed_cols: properties.num_indexed_cols(),
+            stats_columns: properties
                 .data_skipping_stats_columns
                 .as_ref()
-                .map(|v| v.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
+                .map(|columns| columns.iter().map(|c| c.to_string()).collect()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use delta_kernel::schema::{DataType, StructField, StructType};
+
+    use super::*;
+    use crate::test_utils::{build_test_table_configuration, column_mapping_test_field};
+
+    #[test]
+    fn from_config_translates_stats_columns_to_physical_names() {
+        // `physical_name` resolves to the `physicalName` annotation under both name and id modes.
+        for mode in ["name", "id"] {
+            let logical_schema = StructType::try_new([
+                column_mapping_test_field("p", "col_p", 1),
+                column_mapping_test_field("a", "col_a", 2),
+            ])
+            .unwrap();
+            let table_config = build_test_table_configuration(
+                logical_schema,
+                vec!["p".to_string()],
+                HashMap::from([
+                    ("delta.columnMapping.mode".to_string(), mode.to_string()),
+                    (
+                        "delta.dataSkippingStatsColumns".to_string(),
+                        "a".to_string(),
+                    ),
+                ]),
+            );
+
+            let config = WriterStatsConfig::from_config(&table_config);
+            assert_eq!(
+                config.stats_columns,
+                Some(vec!["col_a".to_string()]),
+                "stats columns should be physical names in {mode} mode"
+            );
+        }
+    }
+
+    #[test]
+    fn from_config_keeps_logical_names_without_column_mapping() {
+        let logical_schema = StructType::try_new([
+            StructField::nullable("a", DataType::STRING),
+            StructField::nullable("b", DataType::STRING),
+        ])
+        .unwrap();
+        let table_config = build_test_table_configuration(
+            logical_schema,
+            vec![],
+            HashMap::from([(
+                "delta.dataSkippingStatsColumns".to_string(),
+                "a".to_string(),
+            )]),
+        );
+
+        let config = WriterStatsConfig::from_config(&table_config);
+        assert_eq!(config.stats_columns, Some(vec!["a".to_string()]));
     }
 }

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -16,7 +16,9 @@ use datafusion::physical_plan::{
     execute_stream_partitioned,
 };
 use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
+use delta_kernel::schema::SchemaRef as KernelSchemaRef;
 use delta_kernel::table_configuration::TableConfiguration;
+use delta_kernel::table_features::ColumnMappingMode;
 use futures::{StreamExt as _, TryStreamExt as _};
 use object_store::prefix::PrefixStore;
 use parquet::file::properties::WriterProperties;
@@ -28,7 +30,7 @@ use uuid::Uuid;
 use super::writer::{DeltaWriter, WriterConfig};
 use crate::DeltaTableError;
 use crate::delta_datafusion::{
-    DataValidationExec, generated_columns_to_exprs, validation_predicates,
+    ColumnMappingExec, DataValidationExec, generated_columns_to_exprs, validation_predicates,
 };
 use crate::errors::DeltaResult;
 use crate::kernel::{Action, Add, AddCDCFile, EagerSnapshot, StructType, StructTypeExt};
@@ -277,6 +279,62 @@ struct WriteSinkConfig {
     write_batch_size: Option<usize>,
     writer_properties: Option<WriterProperties>,
     writer_stats_config: WriterStatsConfig,
+    column_mapping: Option<ColumnMappingState>,
+}
+
+/// Random data-file directory prefix length on column-mapped tables (delta-spark default).
+const DEFAULT_RANDOM_PREFIX_LENGTH: usize = 2;
+
+/// State needed to rewrite logical data into its physical (column-mapped) form at write time.
+struct ColumnMappingState {
+    mode: ColumnMappingMode,
+    /// Kernel table schema carrying the `delta.columnMapping.*` annotations.
+    logical_schema: KernelSchemaRef,
+}
+
+impl ColumnMappingState {
+    /// Build the state from a table configuration, returning `None` when column mapping is off.
+    fn from_table_config(table_config: &TableConfiguration) -> Option<Self> {
+        let mode = table_config.column_mapping_mode();
+        (mode != ColumnMappingMode::None).then(|| Self {
+            mode,
+            logical_schema: table_config.logical_schema(),
+        })
+    }
+
+    /// Translate logical partition column names to their physical names.
+    fn physical_partition_columns(&self, partition_columns: &[String]) -> Vec<String> {
+        partition_columns
+            .iter()
+            .map(|name| {
+                self.logical_schema
+                    .field(name)
+                    .map(|field| field.physical_name(self.mode).to_string())
+                    .unwrap_or_else(|| name.clone())
+            })
+            .collect()
+    }
+}
+
+/// Wrap the plan in a [`ColumnMappingExec`], translate partition columns to physical names, and
+/// request a random file prefix. No-op (returns its inputs) when `column_mapping` is `None`.
+fn apply_column_mapping_to_plan(
+    plan: Arc<dyn ExecutionPlan>,
+    partition_columns: Vec<String>,
+    column_mapping: &Option<ColumnMappingState>,
+) -> DeltaResult<(Arc<dyn ExecutionPlan>, Vec<String>, Option<usize>)> {
+    match column_mapping {
+        None => Ok((plan, partition_columns, None)),
+        Some(state) => {
+            let plan = ColumnMappingExec::try_new(plan, state.logical_schema.as_ref(), state.mode)?;
+            let physical_partition_columns = state.physical_partition_columns(&partition_columns);
+            Ok((
+                plan,
+                physical_partition_columns,
+                Some(DEFAULT_RANDOM_PREFIX_LENGTH),
+            ))
+        }
+    }
 }
 
 /// Metrics captured from draining streams through a writer.
@@ -419,6 +477,8 @@ pub(crate) async fn write_execution_plan_v2(
         write_batch_size,
         writer_properties,
         writer_stats_config,
+        column_mapping: snapshot
+            .and_then(|s| ColumnMappingState::from_table_config(s.table_configuration())),
     };
 
     if !contains_cdc {
@@ -475,6 +535,7 @@ pub(crate) async fn write_exec_plan(
         write_batch_size: None,
         writer_properties: Some(writer_properties),
         writer_stats_config: stats_config,
+        column_mapping: ColumnMappingState::from_table_config(table_config),
     };
 
     if write_as_cdc {
@@ -664,7 +725,10 @@ async fn write_data_plan(
         write_batch_size,
         writer_properties,
         writer_stats_config,
+        column_mapping,
     } = sink_config;
+    let (plan, partition_columns, random_prefix_length) =
+        apply_column_mapping_to_plan(plan, partition_columns, &column_mapping)?;
     let config = WriterConfig::new(
         plan.schema().clone(),
         partition_columns.clone(),
@@ -673,7 +737,8 @@ async fn write_data_plan(
         write_batch_size,
         writer_stats_config.num_indexed_cols,
         writer_stats_config.stats_columns.clone(),
-    );
+    )
+    .with_random_prefix_length(random_prefix_length);
 
     // For unpartitioned writes, centralize writer behavior through write_streams.
     if partition_columns.is_empty() {
@@ -759,7 +824,10 @@ async fn write_cdc_plan(
         write_batch_size,
         writer_properties,
         writer_stats_config,
+        column_mapping,
     } = sink_config;
+    let (plan, partition_columns, random_prefix_length) =
+        apply_column_mapping_to_plan(plan, partition_columns, &column_mapping)?;
     let cdf_store = Arc::new(PrefixStore::new(object_store.clone(), "_change_data"));
 
     let write_schema = Arc::new(Schema::new(
@@ -786,7 +854,8 @@ async fn write_cdc_plan(
         write_batch_size,
         writer_stats_config.num_indexed_cols,
         writer_stats_config.stats_columns.clone(),
-    );
+    )
+    .with_random_prefix_length(random_prefix_length);
 
     let cdf_config = WriterConfig::new(
         cdf_schema.clone(),
@@ -796,7 +865,8 @@ async fn write_cdc_plan(
         write_batch_size,
         writer_stats_config.num_indexed_cols,
         writer_stats_config.stats_columns.clone(),
-    );
+    )
+    .with_random_prefix_length(random_prefix_length);
 
     // Keep the previous single-writer fan-in path for unpartitioned tables.
     if partition_columns.is_empty() {

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -16,9 +16,7 @@ use datafusion::physical_plan::{
     execute_stream_partitioned,
 };
 use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
-use delta_kernel::schema::SchemaRef as KernelSchemaRef;
 use delta_kernel::table_configuration::TableConfiguration;
-use delta_kernel::table_features::ColumnMappingMode;
 use futures::{StreamExt as _, TryStreamExt as _};
 use object_store::prefix::PrefixStore;
 use parquet::file::properties::WriterProperties;
@@ -30,7 +28,7 @@ use uuid::Uuid;
 use super::writer::{DeltaWriter, WriterConfig};
 use crate::DeltaTableError;
 use crate::delta_datafusion::{
-    ColumnMappingExec, DataValidationExec, generated_columns_to_exprs, validation_predicates,
+    ColumnMappingState, DataValidationExec, generated_columns_to_exprs, validation_predicates,
 };
 use crate::errors::DeltaResult;
 use crate::kernel::{Action, Add, AddCDCFile, EagerSnapshot, StructType, StructTypeExt};
@@ -282,42 +280,9 @@ struct WriteSinkConfig {
     column_mapping: Option<ColumnMappingState>,
 }
 
-/// Random data-file directory prefix length on column-mapped tables (delta-spark default).
-const DEFAULT_RANDOM_PREFIX_LENGTH: usize = 2;
-
-/// State needed to rewrite logical data into its physical (column-mapped) form at write time.
-struct ColumnMappingState {
-    mode: ColumnMappingMode,
-    /// Kernel table schema carrying the `delta.columnMapping.*` annotations.
-    logical_schema: KernelSchemaRef,
-}
-
-impl ColumnMappingState {
-    /// Build the state from a table configuration, returning `None` when column mapping is off.
-    fn from_table_config(table_config: &TableConfiguration) -> Option<Self> {
-        let mode = table_config.column_mapping_mode();
-        (mode != ColumnMappingMode::None).then(|| Self {
-            mode,
-            logical_schema: table_config.logical_schema(),
-        })
-    }
-
-    /// Translate logical partition column names to their physical names.
-    fn physical_partition_columns(&self, partition_columns: &[String]) -> Vec<String> {
-        partition_columns
-            .iter()
-            .map(|name| {
-                self.logical_schema
-                    .field(name)
-                    .map(|field| field.physical_name(self.mode).to_string())
-                    .unwrap_or_else(|| name.clone())
-            })
-            .collect()
-    }
-}
-
-/// Wrap the plan in a [`ColumnMappingExec`], translate partition columns to physical names, and
-/// request a random file prefix. No-op (returns its inputs) when `column_mapping` is `None`.
+/// Apply column mapping to a write plan: wrap it so its batches are emitted physically, translate
+/// partition columns to physical names, and request a random file prefix. No-op (returns its
+/// inputs) when `column_mapping` is `None`.
 fn apply_column_mapping_to_plan(
     plan: Arc<dyn ExecutionPlan>,
     partition_columns: Vec<String>,
@@ -326,12 +291,13 @@ fn apply_column_mapping_to_plan(
     match column_mapping {
         None => Ok((plan, partition_columns, None)),
         Some(state) => {
-            let plan = ColumnMappingExec::try_new(plan, state.logical_schema.as_ref(), state.mode)?;
-            let physical_partition_columns = state.physical_partition_columns(&partition_columns);
+            let plan = state.wrap_plan(plan)?;
+            let physical_partition_columns =
+                state.physical_partition_columns(&partition_columns)?;
             Ok((
                 plan,
                 physical_partition_columns,
-                Some(DEFAULT_RANDOM_PREFIX_LENGTH),
+                Some(state.random_prefix_length()),
             ))
         }
     }

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -57,7 +57,7 @@ use crate::delta_datafusion::{
     DeltaSessionExt, SessionFallbackPolicy, SessionResolveContext, create_session,
     resolve_session_state, update_datafusion_session,
 };
-use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
+use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::schema::cast::normalize_for_delta;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL, TableReference};
 use crate::kernel::{Action, EagerSnapshot, StructType};
@@ -406,8 +406,12 @@ impl WriteBuilder {
 
         match &self.snapshot {
             Some(snapshot) => {
-                if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
-                    return Err(unsupported_column_mapping_write("WRITE"));
+                if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None
+                    && self.schema_mode.is_some()
+                {
+                    return Err(DeltaTableError::Generic(
+                        "Schema evolution on column-mapped tables is not yet supported".to_string(),
+                    ));
                 }
 
                 if self.mode == SaveMode::Overwrite {

--- a/crates/core/src/operations/write/writer.rs
+++ b/crates/core/src/operations/write/writer.rs
@@ -143,6 +143,9 @@ pub struct WriterConfig {
     num_indexed_cols: DataSkippingNumIndexedCols,
     /// Stats columns, specific columns to collect stats from, takes precedence over num_indexed_cols
     stats_columns: Option<Vec<String>>,
+    /// When set, write data files under a random prefix directory of this length instead of
+    /// Hive-style partition dirs — keeps physical (UUID) column names out of paths under CM.
+    random_prefix_length: Option<usize>,
 }
 
 impl WriterConfig {
@@ -168,7 +171,15 @@ impl WriterConfig {
             write_batch_size,
             num_indexed_cols,
             stats_columns,
+            random_prefix_length: None,
         }
+    }
+
+    /// Write data files under a random prefix of `length` chars instead of Hive-style dirs
+    /// (column-mapped tables); `None` keeps the Hive layout.
+    pub fn with_random_prefix_length(mut self, length: Option<usize>) -> Self {
+        self.random_prefix_length = length;
+        self
     }
 
     /// Schema of files written to disk
@@ -233,6 +244,10 @@ impl DeltaWriter {
                 writer.write(&record_batch).await?;
             }
             None => {
+                let prefix_override = match self.config.random_prefix_length {
+                    Some(length) => Some(Path::parse(random_prefix(length))?),
+                    None => None,
+                };
                 let config = PartitionWriterConfig::try_new(
                     self.config.file_schema(),
                     partition_values.clone(),
@@ -240,6 +255,7 @@ impl DeltaWriter {
                     self.config.target_file_size,
                     Some(self.config.write_batch_size),
                     None,
+                    prefix_override,
                 )?;
                 let mut writer = PartitionWriter::try_with_config(
                     self.object_store.clone(),
@@ -289,6 +305,13 @@ impl DeltaWriter {
     }
 }
 
+/// Random hex (URI-safe) directory prefix of `length` chars, used to keep physical column
+/// names out of data-file paths on column-mapped tables.
+fn random_prefix(length: usize) -> String {
+    let uuid = uuid::Uuid::new_v4().simple().to_string();
+    uuid[..length.min(uuid.len())].to_string()
+}
+
 /// Write configuration for partition writers
 #[derive(Debug, Clone)]
 pub struct PartitionWriterConfig {
@@ -319,9 +342,12 @@ impl PartitionWriterConfig {
         target_file_size: Option<NonZeroU64>,
         write_batch_size: Option<usize>,
         max_concurrency_tasks: Option<usize>,
+        prefix_override: Option<Path>,
     ) -> DeltaResult<Self> {
-        let part_path = partition_values.hive_partition_path();
-        let prefix = Path::parse(part_path)?;
+        let prefix = match prefix_override {
+            Some(prefix) => prefix,
+            None => Path::parse(partition_values.hive_partition_path())?,
+        };
         let writer_properties =
             writer_properties.unwrap_or_else(|| default_writer_properties(Compression::SNAPPY));
         let write_batch_size = write_batch_size.unwrap_or(DEFAULT_WRITE_BATCH_SIZE);
@@ -581,6 +607,7 @@ mod tests {
             target_file_size,
             write_batch_size,
             None,
+            None,
         )
         .unwrap();
         PartitionWriter::try_with_config(
@@ -633,7 +660,7 @@ mod tests {
             true,
         )]));
         let config =
-            PartitionWriterConfig::try_new(schema, IndexMap::new(), None, None, None, None)
+            PartitionWriterConfig::try_new(schema, IndexMap::new(), None, None, None, None, None)
                 .unwrap();
 
         assert_default_created_by(&config.writer_properties);

--- a/crates/core/tests/it/column_mapping_guardrails.rs
+++ b/crates/core/tests/it/column_mapping_guardrails.rs
@@ -90,28 +90,80 @@ fn collect_data_files(root: &Path) -> TestResult<BTreeSet<PathBuf>> {
     Ok(files)
 }
 
+/// Physical partition column name baked into the fixture's `_delta_log` metadata.
+const PHYSICAL_PARTITION_NAME: &str = "col-173b4db9-b5ad-427f-9e75-516aae37fbbb";
+
+/// Reads the entire table back via DataFusion, returning all row batches.
+#[cfg(feature = "datafusion")]
+async fn read_all(table: &DeltaTable) -> TestResult<Vec<arrow_array::RecordBatch>> {
+    use datafusion::prelude::SessionContext;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("t", table.table_provider().await?)?;
+    Ok(ctx.sql("SELECT * FROM t").await?.collect().await?)
+}
+
+#[cfg(feature = "datafusion")]
+fn count_rows(batches: &[arrow_array::RecordBatch]) -> usize {
+    batches.iter().map(|b| b.num_rows()).sum()
+}
+
+/// Appending to a column-mapped table writes physical column names, keeps physical partition
+/// keys in `partitionValues`, uses random-prefixed (non-Hive) paths, and round-trips the data
+/// back under the logical schema.
 #[cfg(feature = "datafusion")]
 #[tokio::test]
-async fn column_mapping_guardrails_write_builder_rejects_before_files() -> TestResult {
-    use deltalake_core::protocol::SaveMode;
+async fn column_mapping_append_roundtrip() -> TestResult {
+    let (_temp_dir, table_path, table) = copied_column_mapping_table().await?;
+    let before = collect_data_files(&table_path)?;
+
+    let table = table.write(vec![column_mapping_batch()]).await?;
+
+    // A new data file was written...
+    let after = collect_data_files(&table_path)?;
+    let new_files: Vec<_> = after.difference(&before).collect();
+    assert_eq!(new_files.len(), 1, "exactly one new data file expected");
+    // ...under a random prefix, not a Hive-style `col=value/` directory.
+    let new_file = new_files[0].to_string_lossy();
+    assert!(
+        !new_file.contains('='),
+        "column-mapped writes must not use Hive-style paths, got: {new_file}"
+    );
+
+    // The new commit records partition values under the physical column name (the logical name
+    // still legitimately appears in commitInfo's operationParameters).
+    let commit = std::fs::read_to_string(table_path.join("_delta_log/00000000000000000001.json"))?;
+    assert!(
+        commit.contains(PHYSICAL_PARTITION_NAME),
+        "partitionValues should use the physical column name, commit: {commit}"
+    );
+
+    // Data reads back under the logical schema, including the appended row.
+    let batches = read_all(&table).await?;
+    assert_eq!(count_rows(&batches), 6, "5 fixture rows + 1 appended");
+
+    Ok(())
+}
+
+/// Schema evolution on a column-mapped table is rejected for now (handled in a follow-up).
+#[cfg(feature = "datafusion")]
+#[tokio::test]
+async fn column_mapping_schema_evolution_rejected() -> TestResult {
+    use deltalake_core::operations::write::SchemaMode;
 
     let (_temp_dir, table_path, table) = copied_column_mapping_table().await?;
     let before = collect_data_files(&table_path)?;
 
     let err = table
-        .clone()
         .write(vec![column_mapping_batch()])
+        .with_schema_mode(SchemaMode::Merge)
         .await
-        .expect_err("append should reject column-mapped tables");
-    assert_unsupported_column_mapping_write(&err, "WRITE");
-    assert_eq!(before, collect_data_files(&table_path)?);
-
-    let err = table
-        .write(vec![column_mapping_batch()])
-        .with_save_mode(SaveMode::Overwrite)
-        .await
-        .expect_err("overwrite should reject column-mapped tables");
-    assert_unsupported_column_mapping_write(&err, "WRITE");
+        .expect_err("schema evolution should be rejected on column-mapped tables");
+    assert!(
+        err.to_string()
+            .contains("Schema evolution on column-mapped tables"),
+        "unexpected error: {err}"
+    );
     assert_eq!(before, collect_data_files(&table_path)?);
 
     Ok(())
@@ -145,46 +197,95 @@ async fn column_mapping_guardrails_legacy_writers_reject() -> TestResult {
     Ok(())
 }
 
+/// UPDATE rewrites a column-mapped table and the change reads back under the logical schema.
 #[cfg(feature = "datafusion")]
 #[tokio::test]
-async fn column_mapping_guardrails_dml_rejects_before_files() -> TestResult {
+async fn column_mapping_update_roundtrip() -> TestResult {
     use datafusion::prelude::{SessionContext, lit};
 
+    let (_temp_dir, _table_path, table) = copied_column_mapping_table().await?;
+    let (table, _metrics) = table
+        .update()
+        .with_update("Super Name", lit("Updated"))
+        .await?;
+
+    let ctx = SessionContext::new();
+    ctx.register_table("t", table.table_provider().await?)?;
+    let updated = ctx
+        .sql("SELECT * FROM t WHERE \"Super Name\" = 'Updated'")
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(count_rows(&updated), 5, "every row should be updated");
+
+    Ok(())
+}
+
+/// DELETE removes matching rows from a column-mapped table.
+#[cfg(feature = "datafusion")]
+#[tokio::test]
+async fn column_mapping_delete_roundtrip() -> TestResult {
+    use datafusion::prelude::{col, lit};
+
+    let (_temp_dir, _table_path, table) = copied_column_mapping_table().await?;
+    let (table, _metrics) = table
+        .delete()
+        .with_predicate(col("Super Name").eq(lit("Timothy Lamb")))
+        .await?;
+
+    let batches = read_all(&table).await?;
+    assert_eq!(count_rows(&batches), 4, "one of five rows deleted");
+
+    Ok(())
+}
+
+/// MERGE inserts a not-matched row into a column-mapped table.
+#[cfg(feature = "datafusion")]
+#[tokio::test]
+async fn column_mapping_merge_roundtrip() -> TestResult {
+    use datafusion::common::Column;
+    use datafusion::logical_expr::Expr;
+    use datafusion::prelude::SessionContext;
+
+    // Build qualified column refs explicitly so the spaces in the column names don't trip up
+    // identifier parsing.
+    let target_name = Expr::Column(Column::new(Some("target"), "Super Name"));
+    let source_name = Expr::Column(Column::new(Some("source"), "Super Name"));
+    let source_company = Expr::Column(Column::new(Some("source"), "Company Very Short"));
+    let source_super = Expr::Column(Column::new(Some("source"), "Super Name"));
+
+    let (_temp_dir, _table_path, table) = copied_column_mapping_table().await?;
+    let ctx = SessionContext::new();
+    let source = ctx.read_batch(column_mapping_batch())?;
+
+    let (table, _metrics) = table
+        .merge(source, target_name.eq(source_name))
+        .with_source_alias("source")
+        .with_target_alias("target")
+        .when_not_matched_insert(|insert| {
+            insert
+                .set("Company Very Short", source_company)
+                .set("Super Name", source_super)
+        })?
+        .await?;
+
+    let batches = read_all(&table).await?;
+    assert_eq!(count_rows(&batches), 6, "one row inserted via merge");
+
+    Ok(())
+}
+
+/// OPTIMIZE is still rejected on column-mapped tables (handled in a follow-up).
+#[cfg(feature = "datafusion")]
+#[tokio::test]
+async fn column_mapping_optimize_still_rejected() -> TestResult {
     let (_temp_dir, table_path, table) = copied_column_mapping_table().await?;
     let before = collect_data_files(&table_path)?;
 
     let err = table
-        .clone()
-        .update()
-        .with_update("Super Name", lit("Updated"))
-        .await
-        .expect_err("update should reject column-mapped tables");
-    assert_unsupported_column_mapping_write(&err, "UPDATE");
-    assert_eq!(before, collect_data_files(&table_path)?);
-
-    let err = table
-        .clone()
-        .delete()
-        .with_predicate(lit(true))
-        .await
-        .expect_err("delete should reject column-mapped tables");
-    assert_unsupported_column_mapping_write(&err, "DELETE");
-    assert_eq!(before, collect_data_files(&table_path)?);
-
-    let ctx = SessionContext::new();
-    let source = ctx.read_batch(column_mapping_batch())?;
-    let err = table
-        .clone()
-        .merge(source, lit(true))
-        .await
-        .expect_err("merge should reject column-mapped tables");
-    assert_unsupported_column_mapping_write(&err, "MERGE");
-    assert_eq!(before, collect_data_files(&table_path)?);
-
-    let err = table
         .optimize()
         .await
-        .expect_err("optimize should reject column-mapped tables");
+        .expect_err("optimize should still reject column-mapped tables");
     assert_unsupported_column_mapping_write(&err, "OPTIMIZE");
     assert_eq!(before, collect_data_files(&table_path)?);
 
@@ -257,6 +358,109 @@ async fn column_mapping_guardrails_add_feature_still_allows_column_mapping() -> 
         .with_feature(TableFeatures::ColumnMapping)
         .with_allow_protocol_versions_increase(true)
         .await?;
+
+    Ok(())
+}
+
+/// Writing change data to a column-mapped table is correct: the `_change_data` files use physical
+/// column names, and a column-mapping-aware reader (here kernel's `TableChanges`) resolves them
+/// back to the logical schema. This is the round-trip delta-rs's own (CM-unaware) `load_cdf`
+/// cannot yet do — proving the write side is spec-correct independent of that reader gap.
+#[cfg(feature = "datafusion")]
+#[tokio::test(flavor = "multi_thread")]
+async fn column_mapping_cdf_write_is_kernel_readable() -> TestResult {
+    use std::sync::Arc;
+
+    use arrow_array::cast::AsArray;
+    use arrow_array::{Int32Array, RecordBatch, StringArray};
+    use arrow_schema::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
+    use datafusion::prelude::{col, lit};
+    use delta_kernel::committer::FileSystemCommitter;
+    use delta_kernel::engine::arrow_data::ArrowEngineData;
+    use delta_kernel::engine::default::DefaultEngineBuilder;
+    use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
+    use delta_kernel::object_store::DynObjectStore;
+    use delta_kernel::object_store::local::LocalFileSystem;
+    use delta_kernel::schema::{DataType as KernelDataType, StructField, StructType};
+    use delta_kernel::table_changes::TableChanges;
+    use delta_kernel::transaction::create_table::create_table;
+
+    // 1. Create a name-mode column-mapped table with CDF enabled (via kernel, which assigns the
+    //    physical names/ids; delta-rs can't create CM tables yet).
+    let tmp = tempfile::tempdir()?;
+    let table_url = Url::from_directory_path(tmp.path()).unwrap();
+    let store: Arc<DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let engine = Arc::new(
+        DefaultEngineBuilder::new(store)
+            .with_task_executor(Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )))
+            .build(),
+    );
+    let schema = Arc::new(StructType::try_new([
+        StructField::nullable("id", KernelDataType::INTEGER),
+        StructField::nullable("value", KernelDataType::STRING),
+    ])?);
+    let _ = create_table(table_url.as_str(), schema, "delta-rs-test/1.0")
+        .with_table_properties([
+            ("delta.columnMapping.mode", "name"),
+            ("delta.enableChangeDataFeed", "true"),
+        ])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    // 2. Append two rows, then delete one — through delta-rs's column-mapping write path.
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("id", ArrowDataType::Int32, true),
+        Field::new("value", ArrowDataType::Utf8, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2])),
+            Arc::new(StringArray::from(vec!["a", "b"])),
+        ],
+    )?;
+    let table = open_table(table_url.clone()).await?;
+    let table = table.write(vec![batch]).await?;
+    let (_table, _metrics) = table.delete().with_predicate(col("id").eq(lit(2))).await?;
+
+    // 3. Read the change feed back via kernel (column-mapping aware) and assert the delete event
+    //    surfaces under the LOGICAL schema with the correct value — proving physical->logical
+    //    resolution of the physically-named _change_data file.
+    let table_changes = TableChanges::try_new(table_url, engine.as_ref(), 0, None)?;
+    let scan = table_changes.into_scan_builder().build()?;
+
+    let mut delete_values = Vec::new();
+    for result in scan.execute(engine.clone())? {
+        let batch: RecordBatch = ArrowEngineData::try_from_engine_data(result?)?.into();
+        // Logical column names are present (not the physical col-<uuid> names on disk).
+        assert!(
+            batch.schema().column_with_name("id").is_some()
+                && batch.schema().column_with_name("value").is_some(),
+            "change feed should expose logical columns, got {:?}",
+            batch.schema()
+        );
+        let change_type = arrow::compute::cast(
+            batch.column_by_name("_change_type").unwrap(),
+            &ArrowDataType::Utf8,
+        )?;
+        let change_type = change_type.as_string::<i32>();
+        let values =
+            arrow::compute::cast(batch.column_by_name("value").unwrap(), &ArrowDataType::Utf8)?;
+        let values = values.as_string::<i32>();
+        for i in 0..batch.num_rows() {
+            if change_type.value(i) == "delete" {
+                delete_values.push(values.value(i).to_string());
+            }
+        }
+    }
+
+    assert_eq!(
+        delete_values,
+        vec!["b".to_string()],
+        "expected exactly one delete change event for the row id=2 (value 'b')"
+    );
 
     Ok(())
 }

--- a/crates/core/tests/it/column_mapping_guardrails.rs
+++ b/crates/core/tests/it/column_mapping_guardrails.rs
@@ -9,18 +9,17 @@ use deltalake_core::{DeltaTable, DeltaTableError, open_table};
 use tempfile::TempDir;
 use url::Url;
 
+#[cfg(feature = "datafusion")]
+use datafusion::common::assert_batches_sorted_eq;
+
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 fn assert_unsupported_column_mapping_write(err: &DeltaTableError, operation: &str) {
-    let message = err.to_string();
-    assert!(
-        message.contains("column mapping writes are not supported"),
-        "unexpected error: {message}"
-    );
-    assert!(
-        message.contains(operation),
-        "expected operation `{operation}` in error: {message}"
-    );
+    let expected = format!("column mapping writes are not supported for {operation} yet");
+    match err {
+        DeltaTableError::Generic(message) => assert_eq!(message, &expected),
+        other => panic!("expected a Generic column-mapping error, got: {other:?}"),
+    }
 }
 
 #[cfg(feature = "datafusion")]
@@ -103,11 +102,6 @@ async fn read_all(table: &DeltaTable) -> TestResult<Vec<arrow_array::RecordBatch
     Ok(ctx.sql("SELECT * FROM t").await?.collect().await?)
 }
 
-#[cfg(feature = "datafusion")]
-fn count_rows(batches: &[arrow_array::RecordBatch]) -> usize {
-    batches.iter().map(|b| b.num_rows()).sum()
-}
-
 /// Appending to a column-mapped table writes physical column names, keeps physical partition
 /// keys in `partitionValues`, uses random-prefixed (non-Hive) paths, and round-trips the data
 /// back under the logical schema.
@@ -140,7 +134,21 @@ async fn column_mapping_append_roundtrip() -> TestResult {
 
     // Data reads back under the logical schema, including the appended row.
     let batches = read_all(&table).await?;
-    assert_eq!(count_rows(&batches), 6, "5 fixture rows + 1 appended");
+    assert_batches_sorted_eq! {
+        [
+            "+--------------------+------------------------+",
+            "| Company Very Short | Super Name             |",
+            "+--------------------+------------------------+",
+            "| BME                | Timothy Lamb           |",
+            "| BMS                | Anthony Johnson        |",
+            "| BMS                | Mr. Daniel Ferguson MD |",
+            "| BMS                | Nathan Bennett         |",
+            "| BMS                | New Customer           |",
+            "| BMS                | Stephanie Mcgrath      |",
+            "+--------------------+------------------------+",
+        ],
+        &batches
+    };
 
     Ok(())
 }
@@ -159,11 +167,13 @@ async fn column_mapping_schema_evolution_rejected() -> TestResult {
         .with_schema_mode(SchemaMode::Merge)
         .await
         .expect_err("schema evolution should be rejected on column-mapped tables");
-    assert!(
-        err.to_string()
-            .contains("Schema evolution on column-mapped tables"),
-        "unexpected error: {err}"
-    );
+    match err {
+        DeltaTableError::Generic(message) => assert_eq!(
+            message,
+            "Schema evolution on column-mapped tables is not yet supported"
+        ),
+        other => panic!("expected a Generic schema-evolution error, got: {other:?}"),
+    }
     assert_eq!(before, collect_data_files(&table_path)?);
 
     Ok(())
@@ -201,7 +211,7 @@ async fn column_mapping_guardrails_legacy_writers_reject() -> TestResult {
 #[cfg(feature = "datafusion")]
 #[tokio::test]
 async fn column_mapping_update_roundtrip() -> TestResult {
-    use datafusion::prelude::{SessionContext, lit};
+    use datafusion::prelude::lit;
 
     let (_temp_dir, _table_path, table) = copied_column_mapping_table().await?;
     let (table, _metrics) = table
@@ -209,14 +219,21 @@ async fn column_mapping_update_roundtrip() -> TestResult {
         .with_update("Super Name", lit("Updated"))
         .await?;
 
-    let ctx = SessionContext::new();
-    ctx.register_table("t", table.table_provider().await?)?;
-    let updated = ctx
-        .sql("SELECT * FROM t WHERE \"Super Name\" = 'Updated'")
-        .await?
-        .collect()
-        .await?;
-    assert_eq!(count_rows(&updated), 5, "every row should be updated");
+    let batches = read_all(&table).await?;
+    assert_batches_sorted_eq! {
+        [
+            "+--------------------+------------+",
+            "| Company Very Short | Super Name |",
+            "+--------------------+------------+",
+            "| BME                | Updated    |",
+            "| BMS                | Updated    |",
+            "| BMS                | Updated    |",
+            "| BMS                | Updated    |",
+            "| BMS                | Updated    |",
+            "+--------------------+------------+",
+        ],
+        &batches
+    };
 
     Ok(())
 }
@@ -234,7 +251,19 @@ async fn column_mapping_delete_roundtrip() -> TestResult {
         .await?;
 
     let batches = read_all(&table).await?;
-    assert_eq!(count_rows(&batches), 4, "one of five rows deleted");
+    assert_batches_sorted_eq! {
+        [
+            "+--------------------+------------------------+",
+            "| Company Very Short | Super Name             |",
+            "+--------------------+------------------------+",
+            "| BMS                | Anthony Johnson        |",
+            "| BMS                | Mr. Daniel Ferguson MD |",
+            "| BMS                | Nathan Bennett         |",
+            "| BMS                | Stephanie Mcgrath      |",
+            "+--------------------+------------------------+",
+        ],
+        &batches
+    };
 
     Ok(())
 }
@@ -270,7 +299,21 @@ async fn column_mapping_merge_roundtrip() -> TestResult {
         .await?;
 
     let batches = read_all(&table).await?;
-    assert_eq!(count_rows(&batches), 6, "one row inserted via merge");
+    assert_batches_sorted_eq! {
+        [
+            "+--------------------+------------------------+",
+            "| Company Very Short | Super Name             |",
+            "+--------------------+------------------------+",
+            "| BME                | Timothy Lamb           |",
+            "| BMS                | Anthony Johnson        |",
+            "| BMS                | Mr. Daniel Ferguson MD |",
+            "| BMS                | Nathan Bennett         |",
+            "| BMS                | New Customer           |",
+            "| BMS                | Stephanie Mcgrath      |",
+            "+--------------------+------------------------+",
+        ],
+        &batches
+    };
 
     Ok(())
 }
@@ -314,7 +357,7 @@ async fn column_mapping_guardrails_metadata_operations() -> TestResult {
         )]))
         .await
         .expect_err("setting column mapping mode should be rejected");
-    assert_unsupported_column_mapping_write(&err, "SET TBLPROPERTIES");
+    assert_unsupported_column_mapping_write(&err, "SET TBLPROPERTIES delta.columnMapping.mode");
 
     Ok(())
 }
@@ -327,7 +370,7 @@ async fn column_mapping_guardrails_create_rejects_activation_and_reserved_metada
         .with_configuration([("delta.columnMapping.mode", Some("name"))])
         .await
         .expect_err("create should reject column mapping mode");
-    assert_unsupported_column_mapping_write(&err, "CREATE TABLE");
+    assert_unsupported_column_mapping_write(&err, "CREATE TABLE with delta.columnMapping.mode");
 
     let mapped_field = StructField::nullable("id", DataType::INTEGER).with_metadata([
         (
@@ -345,7 +388,7 @@ async fn column_mapping_guardrails_create_rejects_activation_and_reserved_metada
         .with_columns([mapped_field])
         .await
         .expect_err("create should reject column mapping metadata");
-    assert_unsupported_column_mapping_write(&err, "CREATE TABLE");
+    assert_unsupported_column_mapping_write(&err, "CREATE TABLE with column mapping metadata");
 
     Ok(())
 }
@@ -372,6 +415,7 @@ async fn column_mapping_cdf_write_is_kernel_readable() -> TestResult {
     use std::sync::Arc;
 
     use arrow_array::cast::AsArray;
+    use arrow_array::types::Int32Type;
     use arrow_array::{Int32Array, RecordBatch, StringArray};
     use arrow_schema::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
     use datafusion::prelude::{col, lit};
@@ -431,36 +475,209 @@ async fn column_mapping_cdf_write_is_kernel_readable() -> TestResult {
     let table_changes = TableChanges::try_new(table_url, engine.as_ref(), 0, None)?;
     let scan = table_changes.into_scan_builder().build()?;
 
-    let mut delete_values = Vec::new();
+    // Collect the deterministic change-feed columns (the feed also carries a non-deterministic
+    // `_commit_timestamp`). Reading `id`/`value` by their LOGICAL names proves physical->logical
+    // resolution of the physically-named files.
+    let mut changes: Vec<(String, i32, String)> = Vec::new();
     for result in scan.execute(engine.clone())? {
         let batch: RecordBatch = ArrowEngineData::try_from_engine_data(result?)?.into();
-        // Logical column names are present (not the physical col-<uuid> names on disk).
-        assert!(
-            batch.schema().column_with_name("id").is_some()
-                && batch.schema().column_with_name("value").is_some(),
-            "change feed should expose logical columns, got {:?}",
-            batch.schema()
-        );
         let change_type = arrow::compute::cast(
             batch.column_by_name("_change_type").unwrap(),
             &ArrowDataType::Utf8,
         )?;
         let change_type = change_type.as_string::<i32>();
+        let ids = arrow::compute::cast(batch.column_by_name("id").unwrap(), &ArrowDataType::Int32)?;
+        let ids = ids.as_primitive::<Int32Type>();
         let values =
             arrow::compute::cast(batch.column_by_name("value").unwrap(), &ArrowDataType::Utf8)?;
         let values = values.as_string::<i32>();
         for i in 0..batch.num_rows() {
-            if change_type.value(i) == "delete" {
-                delete_values.push(values.value(i).to_string());
-            }
+            changes.push((
+                change_type.value(i).to_string(),
+                ids.value(i),
+                values.value(i).to_string(),
+            ));
         }
     }
+    changes.sort();
 
+    // The original insert of (1,'a'),(2,'b') and the delete of (2,'b').
     assert_eq!(
-        delete_values,
-        vec!["b".to_string()],
-        "expected exactly one delete change event for the row id=2 (value 'b')"
+        changes,
+        vec![
+            ("delete".to_string(), 2, "b".to_string()),
+            ("insert".to_string(), 1, "a".to_string()),
+            ("insert".to_string(), 2, "b".to_string()),
+        ]
     );
+
+    Ok(())
+}
+
+/// Create an empty column-mapped table (schema: `id INT, value STRING`) via kernel `create_table`,
+/// applying `properties` (which must include `delta.columnMapping.mode`). delta-rs can't create CM
+/// tables yet, so this is how the round-trip tests obtain one to write against.
+#[cfg(feature = "datafusion")]
+async fn create_kernel_cm_table(properties: &[(&str, &str)]) -> TestResult<(TempDir, Url)> {
+    use std::sync::Arc;
+
+    use delta_kernel::committer::FileSystemCommitter;
+    use delta_kernel::engine::default::DefaultEngineBuilder;
+    use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
+    use delta_kernel::object_store::DynObjectStore;
+    use delta_kernel::object_store::local::LocalFileSystem;
+    use delta_kernel::schema::{DataType as KernelDataType, StructField, StructType};
+    use delta_kernel::transaction::create_table::create_table;
+
+    let tmp = tempfile::tempdir()?;
+    let url = Url::from_directory_path(tmp.path()).unwrap();
+    let store: Arc<DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let engine = DefaultEngineBuilder::new(store)
+        .with_task_executor(Arc::new(TokioMultiThreadExecutor::new(
+            tokio::runtime::Handle::current(),
+        )))
+        .build();
+    let schema = Arc::new(StructType::try_new([
+        StructField::nullable("id", KernelDataType::INTEGER),
+        StructField::nullable("value", KernelDataType::STRING),
+    ])?);
+    let _ = create_table(url.as_str(), schema, "delta-rs-test/1.0")
+        .with_table_properties(properties.iter().copied())
+        .build(&engine, Box::new(FileSystemCommitter::new()))?
+        .commit(&engine)?;
+    Ok((tmp, url))
+}
+
+/// A DataFusion `INSERT INTO` (the `DeltaDataSink` write path) must write physical column names on
+/// a column-mapped table, so the inserted rows round-trip. Currently FAILS: `DeltaDataSink` builds
+/// its `WriterConfig` from the logical schema and never applies the column-mapping rewrite, so the
+/// rows are written under logical names and a column-mapping-aware scan reads them back as nulls.
+#[cfg(feature = "datafusion")]
+#[tokio::test(flavor = "multi_thread")]
+async fn column_mapping_datafusion_insert_roundtrips() -> TestResult {
+    use datafusion::prelude::SessionContext;
+
+    let (_tmp, url) = create_kernel_cm_table(&[("delta.columnMapping.mode", "name")]).await?;
+
+    let table = open_table(url.clone()).await?;
+    let ctx = SessionContext::new();
+    ctx.register_table("t", table.table_provider().await?)?;
+    ctx.sql("INSERT INTO t VALUES (1, 'x'), (2, 'y')")
+        .await?
+        .collect()
+        .await?;
+
+    // Reopen so the scan sees the committed insert, then read it back through the CM-aware path.
+    let table = open_table(url).await?;
+    let batches = read_all(&table).await?;
+    assert_batches_sorted_eq! {
+        [
+            "+----+-------+",
+            "| id | value |",
+            "+----+-------+",
+            "| 1  | x     |",
+            "| 2  | y     |",
+            "+----+-------+",
+        ],
+        &batches
+    };
+
+    Ok(())
+}
+
+/// `MERGE ... with_merge_schema(true)` on a column-mapped table must be rejected: that path builds
+/// replacement metadata without assigning column-mapping ids / physical names / maxColumnId.
+/// Currently FAILS: the merge schema-evolution path is not guarded (the WriteBuilder guard does
+/// not cover it), so it does not produce the expected error.
+#[cfg(feature = "datafusion")]
+#[tokio::test(flavor = "multi_thread")]
+async fn column_mapping_merge_schema_evolution_rejected() -> TestResult {
+    use std::sync::Arc;
+
+    use arrow_array::{Int32Array, RecordBatch, StringArray};
+    use arrow_schema::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
+    use datafusion::prelude::{SessionContext, col};
+
+    let (_tmp, url) = create_kernel_cm_table(&[("delta.columnMapping.mode", "name")]).await?;
+    let table = open_table(url).await?;
+
+    // Source carries an extra column, so with_merge_schema(true) attempts to evolve the schema.
+    let source_schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("id", ArrowDataType::Int32, true),
+        Field::new("value", ArrowDataType::Utf8, true),
+        Field::new("extra", ArrowDataType::Utf8, true),
+    ]));
+    let source_batch = RecordBatch::try_new(
+        source_schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1])),
+            Arc::new(StringArray::from(vec!["x"])),
+            Arc::new(StringArray::from(vec!["new"])),
+        ],
+    )?;
+    let ctx = SessionContext::new();
+    let source = ctx.read_batch(source_batch)?;
+
+    let result = table
+        .merge(source, col("target.id").eq(col("source.id")))
+        .with_source_alias("source")
+        .with_target_alias("target")
+        .with_merge_schema(true)
+        .when_not_matched_insert(|insert| {
+            insert
+                .set("id", col("source.id"))
+                .set("value", col("source.value"))
+                .set("extra", col("source.extra"))
+        })?
+        .await;
+
+    let err =
+        result.expect_err("merge schema evolution should be rejected on column-mapped tables");
+    match err {
+        DeltaTableError::Generic(message) => assert_eq!(
+            message,
+            "Schema evolution on column-mapped tables is not yet supported"
+        ),
+        other => panic!("expected a Generic schema-evolution error, got: {other:?}"),
+    }
+
+    Ok(())
+}
+
+/// DataFusion `INSERT INTO` a *string-partitioned* column-mapped table (the fixture is partitioned
+/// by a String column under `name` mapping). Exercises the DataSink path where `read_schema()`
+/// dict-encodes string partition columns while the stream is native — must still round-trip.
+#[cfg(feature = "datafusion")]
+#[tokio::test]
+async fn column_mapping_datafusion_insert_into_partitioned() -> TestResult {
+    use datafusion::prelude::SessionContext;
+
+    let (_temp_dir, table_path, table) = copied_column_mapping_table().await?;
+    let ctx = SessionContext::new();
+    ctx.register_table("t", table.table_provider().await?)?;
+    ctx.sql("INSERT INTO t VALUES ('BMS', 'Inserted Row')")
+        .await?
+        .collect()
+        .await?;
+
+    let table_url = Url::from_directory_path(table_path.canonicalize()?).unwrap();
+    let table = open_table(table_url).await?;
+    let batches = read_all(&table).await?;
+    assert_batches_sorted_eq! {
+        [
+            "+--------------------+------------------------+",
+            "| Company Very Short | Super Name             |",
+            "+--------------------+------------------------+",
+            "| BME                | Timothy Lamb           |",
+            "| BMS                | Anthony Johnson        |",
+            "| BMS                | Inserted Row           |",
+            "| BMS                | Mr. Daniel Ferguson MD |",
+            "| BMS                | Nathan Bennett         |",
+            "| BMS                | Stephanie Mcgrath      |",
+            "+--------------------+------------------------+",
+        ],
+        &batches
+    };
 
     Ok(())
 }

--- a/python/tests/test_column_mapping.py
+++ b/python/tests/test_column_mapping.py
@@ -1,0 +1,184 @@
+"""Write-path tests against an existing column-mapped Delta table.
+
+delta-rs cannot create/enable column mapping yet, so these round-trips run against the
+Spark-written, name-mode, string-partitioned fixture copied into a temp dir. They cover
+append/overwrite/delete/merge under the logical schema (the data is stored under physical
+``col-<uuid>`` names on disk) and assert that schema evolution is rejected.
+"""
+
+import pathlib
+
+import pytest
+from arro3.core import Array, DataType, Table
+from arro3.core import Field as ArrowField
+
+from deltalake import DeltaTable, write_deltalake
+from deltalake.exceptions import DeltaError
+from deltalake.query import QueryBuilder
+
+
+def _column_mapping_table(tmp_path: pathlib.Path) -> str:
+    """Copy the Spark-written, name-mode, string-partitioned column-mapped fixture to a writable
+    temp dir. delta-rs cannot create column-mapped tables yet, so the write round-trips below run
+    against an existing one."""
+    import shutil
+
+    dst = tmp_path / "table_with_column_mapping"
+    shutil.copytree("../crates/test/tests/data/table_with_column_mapping", dst)
+    return str(dst)
+
+
+def _cm_data(companies: list[str], names: list[str]) -> Table:
+    """Build a logical-schema arro3 table matching the fixture's two string columns."""
+    return Table(
+        {
+            "Company Very Short": Array(
+                companies,
+                ArrowField("Company Very Short", type=DataType.string(), nullable=True),
+            ),
+            "Super Name": Array(
+                names, ArrowField("Super Name", type=DataType.string(), nullable=True)
+            ),
+        }
+    )
+
+
+def _cm_read(table_uri: str, order_by: str) -> list[dict]:
+    """Read the fixture's two logical columns back via QueryBuilder as a list of row dicts."""
+    result = (
+        QueryBuilder()
+        .register("tbl", DeltaTable(table_uri))
+        .execute(
+            f'select "Company Very Short", "Super Name" from tbl order by {order_by}'
+        )
+        .read_all()
+    )
+    return result.to_struct_array().to_pylist()
+
+
+def test_column_mapping_append_roundtrip(tmp_path: pathlib.Path):
+    """Append to an existing column-mapped table and read it back via QueryBuilder under the
+    logical schema (the data is written under physical names on disk)."""
+    table_uri = _column_mapping_table(tmp_path)
+    write_deltalake(table_uri, _cm_data(["BMS"], ["New Customer"]), mode="append")
+
+    assert _cm_read(table_uri, '"Company Very Short", "Super Name"') == [
+        {"Company Very Short": "BME", "Super Name": "Timothy Lamb"},
+        {"Company Very Short": "BMS", "Super Name": "Anthony Johnson"},
+        {"Company Very Short": "BMS", "Super Name": "Mr. Daniel Ferguson MD"},
+        {"Company Very Short": "BMS", "Super Name": "Nathan Bennett"},
+        {"Company Very Short": "BMS", "Super Name": "New Customer"},
+        {"Company Very Short": "BMS", "Super Name": "Stephanie Mcgrath"},
+    ]
+
+
+def test_column_mapping_overwrite_roundtrip(tmp_path: pathlib.Path):
+    """Overwrite a column-mapped table and read the replacement data back via QueryBuilder."""
+    table_uri = _column_mapping_table(tmp_path)
+    write_deltalake(
+        table_uri, _cm_data(["BMS", "BME"], ["Solo", "Duo"]), mode="overwrite"
+    )
+
+    assert _cm_read(table_uri, '"Company Very Short"') == [
+        {"Company Very Short": "BME", "Super Name": "Duo"},
+        {"Company Very Short": "BMS", "Super Name": "Solo"},
+    ]
+
+
+def test_column_mapping_delete_roundtrip(tmp_path: pathlib.Path):
+    """Delete from a column-mapped table and read the survivors back via QueryBuilder."""
+    table_uri = _column_mapping_table(tmp_path)
+    DeltaTable(table_uri).delete("\"Super Name\" = 'Timothy Lamb'")
+
+    assert _cm_read(table_uri, '"Super Name"') == [
+        {"Company Very Short": "BMS", "Super Name": "Anthony Johnson"},
+        {"Company Very Short": "BMS", "Super Name": "Mr. Daniel Ferguson MD"},
+        {"Company Very Short": "BMS", "Super Name": "Nathan Bennett"},
+        {"Company Very Short": "BMS", "Super Name": "Stephanie Mcgrath"},
+    ]
+
+
+def test_column_mapping_merge_roundtrip(tmp_path: pathlib.Path):
+    """Merge a not-matched row into a column-mapped table and read it back via QueryBuilder."""
+    table_uri = _column_mapping_table(tmp_path)
+    (
+        DeltaTable(table_uri)
+        .merge(
+            source=_cm_data(["BMS"], ["Merged Row"]),
+            predicate='t."Super Name" = s."Super Name"',
+            source_alias="s",
+            target_alias="t",
+        )
+        .when_not_matched_insert_all()
+        .execute()
+    )
+
+    assert _cm_read(table_uri, '"Company Very Short", "Super Name"') == [
+        {"Company Very Short": "BME", "Super Name": "Timothy Lamb"},
+        {"Company Very Short": "BMS", "Super Name": "Anthony Johnson"},
+        {"Company Very Short": "BMS", "Super Name": "Merged Row"},
+        {"Company Very Short": "BMS", "Super Name": "Mr. Daniel Ferguson MD"},
+        {"Company Very Short": "BMS", "Super Name": "Nathan Bennett"},
+        {"Company Very Short": "BMS", "Super Name": "Stephanie Mcgrath"},
+    ]
+
+
+def test_column_mapping_write_schema_evolution_rejected(tmp_path: pathlib.Path):
+    """Schema evolution via write (schema_mode='merge') is rejected on column-mapped tables."""
+    table_uri = _column_mapping_table(tmp_path)
+    evolving = Table(
+        {
+            "Company Very Short": Array(
+                ["BMS"],
+                ArrowField("Company Very Short", type=DataType.string(), nullable=True),
+            ),
+            "Super Name": Array(
+                ["New Customer"],
+                ArrowField("Super Name", type=DataType.string(), nullable=True),
+            ),
+            "extra": Array(
+                [1], ArrowField("extra", type=DataType.int32(), nullable=True)
+            ),
+        }
+    )
+    with pytest.raises(
+        DeltaError,
+        match="Schema evolution on column-mapped tables is not yet supported",
+    ):
+        write_deltalake(table_uri, evolving, mode="append", schema_mode="merge")
+
+
+def test_column_mapping_merge_schema_evolution_rejected(tmp_path: pathlib.Path):
+    """Schema-evolving merge (merge_schema=True) is rejected on column-mapped tables."""
+    table_uri = _column_mapping_table(tmp_path)
+    source = Table(
+        {
+            "Company Very Short": Array(
+                ["BMS"],
+                ArrowField("Company Very Short", type=DataType.string(), nullable=True),
+            ),
+            "Super Name": Array(
+                ["Merged Row"],
+                ArrowField("Super Name", type=DataType.string(), nullable=True),
+            ),
+            "extra": Array(
+                [1], ArrowField("extra", type=DataType.int32(), nullable=True)
+            ),
+        }
+    )
+    with pytest.raises(
+        DeltaError,
+        match="Schema evolution on column-mapped tables is not yet supported",
+    ):
+        (
+            DeltaTable(table_uri)
+            .merge(
+                source=source,
+                predicate='t."Super Name" = s."Super Name"',
+                source_alias="s",
+                target_alias="t",
+                merge_schema=True,
+            )
+            .when_not_matched_insert_all()
+            .execute()
+        )


### PR DESCRIPTION
# Description
Add column mapping write support through datafusion physical execution node that rewrites columns and nested column names and attaches the metadata from te physical kernel schema.

Schema evolution, and optimize is not supported yet. Will do that in followups