### PR TITLE
fix: reject cdf scans for column mapping tables

### DIFF
--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -14,6 +14,12 @@ pub(crate) fn unsupported_column_mapping_write(operation: &str) -> DeltaTableErr
     ))
 }
 
+pub(crate) fn unsupported_column_mapping_read(operation: &str) -> DeltaTableError {
+    DeltaTableError::Generic(format!(
+        "column mapping is not supported for {operation} yet"
+    ))
+}
+
 /// Delta Table specific error
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug)]

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -27,13 +27,14 @@ use datafusion::physical_expr::{PhysicalExpr, expressions};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::union::UnionExec;
+use delta_kernel::table_features::ColumnMappingMode;
 use tracing::log;
 
 use crate::DeltaTableError;
 use crate::delta_datafusion::{
     DataFusionMixins, DeltaSessionExt, extract_partition_only_predicate,
 };
-use crate::errors::DeltaResult;
+use crate::errors::{DeltaResult, unsupported_column_mapping_read};
 use crate::kernel::transaction::PROTOCOL;
 use crate::kernel::{
     Action, Add, AddCDCFile, CommitInfo, EagerSnapshot, Version, resolve_snapshot,
@@ -453,6 +454,9 @@ impl CdfLoadBuilder {
     ) -> DeltaResult<Arc<dyn ExecutionPlan>> {
         let snapshot = resolve_snapshot(&self.log_store, self.snapshot.clone(), true, None).await?;
         PROTOCOL.can_read_from(&snapshot)?;
+        if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+            return Err(unsupported_column_mapping_read("CHANGE DATA FEED scans"));
+        }
 
         let partition_values = snapshot.metadata().partition_columns();
         let schema = snapshot.input_schema();
@@ -708,6 +712,56 @@ pub(crate) mod tests {
         let table = DeltaTable::try_from_url(table_uri).await?;
         let provider = DeltaCdfTableProvider::try_new(table.scan_cdf().with_starting_version(0))?;
         ctx.register_table("cdf", Arc::new(provider))?;
+        Ok(())
+    }
+
+    async fn copied_column_mapping_cdf_table() -> Result<
+        (tempfile::TempDir, DeltaTable),
+        Box<dyn std::error::Error + 'static>,
+    > {
+        let fixture = Path::new("../test/tests/data/table_with_column_mapping");
+        let temp_dir = tempfile::tempdir()?;
+        fs_extra::dir::copy(fixture, temp_dir.path(), &Default::default())?;
+        let table_path = temp_dir.path().join("table_with_column_mapping");
+        let log_path = table_path.join("_delta_log/00000000000000000000.json");
+        let log = std::fs::read_to_string(&log_path)?;
+        let updated_log = log.replace(
+            "\"delta.columnMapping.mode\":\"name\"",
+            "\"delta.enableChangeDataFeed\":\"true\",\"delta.columnMapping.mode\":\"name\"",
+        );
+        assert_ne!(
+            log, updated_log,
+            "expected column mapping table fixture metadata to contain column mapping mode"
+        );
+        std::fs::write(log_path, updated_log)?;
+
+        let table_uri =
+            Url::from_directory_path(std::fs::canonicalize(table_path).unwrap()).unwrap();
+        let table = DeltaTable::try_from_url(table_uri).await?;
+        Ok((temp_dir, table))
+    }
+
+    #[tokio::test]
+    async fn cdf_scan_rejects_column_mapping_tables() -> TestResult {
+        let ctx: SessionContext = SessionContext::new();
+        let (_temp_dir, table) = copied_column_mapping_cdf_table().await?;
+
+        let err = table
+            .scan_cdf()
+            .with_starting_version(0)
+            .build(&ctx.state(), None)
+            .await
+            .expect_err("cdf scan should reject column-mapped tables before planning files");
+        let message = err.to_string();
+        assert!(
+            message.contains("column mapping"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("CHANGE DATA FEED"),
+            "expected CDF operation in error: {message}"
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
# Description
- Return an early error when a Change Data Feed scan is requested on a column mapping enabled table.
- Add a focused regression test that enables CDF on the existing column mapping fixture copy and verifies planning fails before scanning files.

# Related Issue(s)
Fixes #4474

# Documentation
No documentation changes; this is a guardrail for an unsupported CDF scan path.

# Verification
- `cargo +stable test -p deltalake-core --lib cdf_scan_rejects_column_mapping_tables --features datafusion`
- `cargo +stable test -p deltalake-core --lib operations::load_cdf::tests:: --features datafusion`

I also attempted the non-`--lib` focused Rust test, but this local checkout does not include the DAT acceptance fixtures under `dat/v0.0.3`, so unrelated integration test targets fail before running this change.

# AI assistance
I used AI assistance to inspect the code paths, draft the small patch, and prepare this PR text. I reviewed the resulting changes and tests, and I understand the behavior being changed.
