### PR TITLE
fix: skip boolean min max stats during scans

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -848,7 +848,10 @@ pub(crate) fn test_multi_partitioned_override_schema() -> SchemaRef {
 #[cfg(test)]
 mod tests {
     use arrow::{
-        array::{Date32Array, Int32Array, Int64Array, StringArray, TimestampMillisecondArray},
+        array::{
+            BooleanArray, Date32Array, Int32Array, Int64Array, StringArray,
+            TimestampMillisecondArray,
+        },
         datatypes::{
             DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema, TimeUnit,
         },
@@ -1650,6 +1653,59 @@ mod tests {
                 "expected pruning predicate to reference {expected}, got {pruning_predicate}",
             );
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_boolean_predicate_does_not_require_minmax_stats() -> TestResult {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int64, true),
+            ArrowField::new("active", ArrowDataType::Boolean, true),
+            ArrowField::new("value", ArrowDataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2])),
+                Arc::new(BooleanArray::from(vec![true, false])),
+                Arc::new(StringArray::from(vec!["old-1", "old-2"])),
+            ],
+        )?;
+        let table = crate::DeltaTable::new_in_memory()
+            .write(vec![batch])
+            .with_save_mode(crate::protocol::SaveMode::Append)
+            .await?;
+        let provider = DeltaScan::new(
+            table.snapshot()?.snapshot().snapshot().clone(),
+            DeltaScanConfig::default(),
+        )?
+        .with_log_store(table.log_store());
+
+        let session = Arc::new(create_session().into_inner());
+        session.register_table("delta_table", Arc::new(provider))?;
+
+        let expected = vec![
+            "+----+--------+-------+",
+            "| id | active | value |",
+            "+----+--------+-------+",
+            "| 1  | true   | old-1 |",
+            "+----+--------+-------+",
+        ];
+
+        let batches = session
+            .sql("SELECT id, active, value FROM delta_table WHERE active = true")
+            .await?
+            .collect()
+            .await?;
+        assert_batches_sorted_eq!(&expected, &batches);
+
+        let batches = session
+            .sql("SELECT id, active, value FROM delta_table WHERE id = 1 AND active = true")
+            .await?
+            .collect()
+            .await?;
+        assert_batches_sorted_eq!(&expected, &batches);
 
         Ok(())
     }

--- a/crates/core/src/kernel/arrow/engine_ext.rs
+++ b/crates/core/src/kernel/arrow/engine_ext.rs
@@ -229,8 +229,9 @@ fn physical_column_name(
 /// For the `nullCount` schema, we consider the whole base schema and convert all leaf fields
 /// to data type LONG. Maps, arrays, and variant are considered leaf fields in this case.
 ///
-/// For the min / max schemas, we non-eligible leaf fields from the base schema.
-/// Field eligibility is determined by the fields data type via [`is_skipping_eligeble_datatype`].
+/// For the min / max schemas, remove ineligible leaf fields from the base schema.
+/// The field data type determines eligibility via
+/// [`is_public_min_max_stats_eligible_primitive`].
 ///
 /// The overall schema is then:
 /// ```ignored
@@ -430,9 +431,9 @@ impl<'a> SchemaTransform<'a> for BaseStatsTransform {
     }
 }
 
-// removes all fields with non eligible data types
+// Remove fields with data types that cannot provide min/max stats.
 //
-// should only be applied to schema oricessed via `BaseStatsTransform`.
+// Apply this only to schemas processed by `BaseStatsTransform`.
 struct MinMaxStatsTransform;
 
 impl<'a> SchemaTransform<'a> for MinMaxStatsTransform {
@@ -450,7 +451,7 @@ impl<'a> SchemaTransform<'a> for MinMaxStatsTransform {
     }
 
     fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
-        if is_skipping_eligeble_datatype(ptype) {
+        if is_public_min_max_stats_eligible_primitive(ptype) {
             Some(Cow::Borrowed(ptype))
         } else {
             None
@@ -469,9 +470,14 @@ fn should_include_column(column_name: &ColumnName, column_names: &[ColumnName]) 
     })
 }
 
-/// Checks if a data type is eligible for min/max file skipping.
+/// Returns true when a primitive belongs in the public min/max stats schema.
+///
+/// The public `Add.stats` min/max schema includes booleans. [`StatsProjection`]
+/// applies a stricter scan projection before asking Delta Kernel to parse stats.
 /// https://github.com/delta-io/delta/blob/143ab3337121248d2ca6a7d5bc31deae7c8fe4be/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java#L61
-fn is_skipping_eligeble_datatype(data_type: &PrimitiveType) -> bool {
+///
+/// [`StatsProjection`]: crate::kernel::snapshot::StatsProjection
+pub(crate) fn is_public_min_max_stats_eligible_primitive(data_type: &PrimitiveType) -> bool {
     let matches_nanos = false;
     #[cfg(feature = "nanosecond-timestamps")]
     let matches_nanos = matches!(data_type, &PrimitiveType::TimestampNanos);
@@ -488,7 +494,6 @@ fn is_skipping_eligeble_datatype(data_type: &PrimitiveType) -> bool {
             | &PrimitiveType::Timestamp
             | &PrimitiveType::TimestampNtz
             | &PrimitiveType::String
-            // | &PrimitiveType::Boolean
             | PrimitiveType::Decimal(_)
     ) || matches_nanos
 }
@@ -504,7 +509,7 @@ pub(crate) fn rb_from_scan_meta(metadata: ScanMetadata) -> DeltaResult<RecordBat
 
 /// Internal extension trait for expression evaluators.
 ///
-/// This just abstracts the conversion between Arrow [`RecoedBatch`]es and
+/// Provides conversion between Arrow [`RecordBatch`]es and
 /// Kernel's [`ArrowEngineData`].
 pub(crate) trait ExpressionEvaluatorExt {
     fn evaluate_arrow(&self, batch: RecordBatch) -> DeltaResult<RecordBatch>;
@@ -986,7 +991,7 @@ mod tests {
         ])
         .unwrap();
 
-        // Expected minValues/maxValues schema: only eligible fields (no boolean, no binary)
+        // Expected minValues/maxValues schema: only eligible fields (no binary)
         let expected_min_max = StructType::try_new([
             StructField::nullable("id", DataType::LONG),
             StructField::nullable("is_active", DataType::BOOLEAN),

--- a/crates/core/src/kernel/snapshot/stats_projection.rs
+++ b/crates/core/src/kernel/snapshot/stats_projection.rs
@@ -10,16 +10,18 @@ use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::ColumnName;
 #[cfg(feature = "datafusion")]
 use delta_kernel::scan::Scan as KernelScan;
-use delta_kernel::schema::{DataType, SchemaRef as KernelSchemaRef, StructField, StructType};
+use delta_kernel::schema::{
+    DataType, PrimitiveType, SchemaRef as KernelSchemaRef, StructField, StructType,
+};
 use delta_kernel::snapshot::Snapshot as KernelSnapshot;
 use delta_kernel::table_features::ColumnMappingMode;
-use tracing::debug;
+use tracing::{debug, warn};
 
 #[cfg(test)]
 use super::Snapshot;
 use crate::DeltaResult;
 use crate::kernel::SCAN_ROW_ARROW_SCHEMA;
-use crate::kernel::arrow::engine_ext::SnapshotExt;
+use crate::kernel::arrow::engine_ext::{SnapshotExt, is_public_min_max_stats_eligible_primitive};
 
 pub(crate) const FIELD_MAX_VALUES: &str = "maxValues";
 pub(crate) const FIELD_MIN_VALUES: &str = "minValues";
@@ -165,9 +167,14 @@ impl StatsProjection {
         let columns = requested_columns
             .iter()
             .filter_map(|column| {
-                physicalize_column_path(logical_schema, column, column_mapping_mode)
+                if !schema_contains_min_max_data_path(logical_schema, column) {
+                    return None;
+                }
+                let physical =
+                    physicalize_column_path(logical_schema, column, column_mapping_mode)?;
+                stats_schema_contains_data_column(stats_schema.as_ref(), &physical)
+                    .then_some(physical)
             })
-            .filter(|column| stats_schema_contains_data_column(stats_schema.as_ref(), column))
             .collect::<BTreeSet<_>>();
 
         if columns.is_empty() {
@@ -213,6 +220,7 @@ impl StatsProjection {
         };
 
         let physical_schema = scan.physical_schema();
+        let stats_schema = scan.snapshot().table_configuration().stats_schema()?;
         let requested_columns = predicate
             .references()
             .into_iter()
@@ -221,8 +229,13 @@ impl StatsProjection {
 
         let columns = requested_columns
             .iter()
-            .filter(|column| schema_contains_path(physical_schema.as_ref(), column))
-            .cloned()
+            .filter_map(|column| {
+                if !schema_contains_min_max_data_path(physical_schema.as_ref(), column) {
+                    return None;
+                }
+                stats_schema_contains_data_column(stats_schema.as_ref(), column)
+                    .then(|| column.clone())
+            })
             .collect::<BTreeSet<_>>();
 
         if columns.is_empty() {
@@ -335,6 +348,55 @@ fn schema_contains_path(schema: &StructType, column: &ColumnName) -> bool {
     current.field(last).is_some()
 }
 
+/// Returns whether `schema` contains `column` with at least one min/max eligible leaf.
+fn schema_contains_min_max_data_path(schema: &StructType, column: &ColumnName) -> bool {
+    let Some((last, parents)) = column.path().split_last() else {
+        return false;
+    };
+
+    let mut current = schema;
+    for segment in parents {
+        let Some(field) = find_field_case_insensitive(current, segment) else {
+            return false;
+        };
+        let DataType::Struct(inner) = field.data_type() else {
+            return false;
+        };
+        current = inner;
+    }
+
+    current
+        .fields()
+        .find(|field| field.name().eq_ignore_ascii_case(last.as_str()))
+        .is_some_and(|field| data_type_has_min_max_stats_leaf(field.data_type()))
+}
+
+/// Returns whether `data_type` has at least one leaf that scan min/max stats can parse.
+fn data_type_has_min_max_stats_leaf(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Struct(inner) => inner
+            .fields()
+            .any(|field| data_type_has_min_max_stats_leaf(field.data_type())),
+        DataType::Primitive(primitive) => is_min_max_stats_eligible_primitive(primitive),
+        _ => false,
+    }
+}
+
+/// Scan min/max stats parsing requests a primitive when this returns true.
+///
+/// The public `Add` action stats schema keeps boolean min/max for compatibility. Scan
+/// projection excludes boolean for kernel parity.
+fn is_min_max_stats_eligible_primitive(data_type: &PrimitiveType) -> bool {
+    !matches!(data_type, &PrimitiveType::Boolean)
+        && is_public_min_max_stats_eligible_primitive(data_type)
+}
+
+fn find_field_case_insensitive<'a>(schema: &'a StructType, name: &str) -> Option<&'a StructField> {
+    schema
+        .fields()
+        .find(|field| field.name().eq_ignore_ascii_case(name))
+}
+
 fn physicalize_column_path(
     schema: &StructType,
     column: &ColumnName,
@@ -362,19 +424,48 @@ fn physicalize_column_path(
 }
 
 fn stats_schema_contains_data_column(stats_schema: &StructType, column: &ColumnName) -> bool {
-    let min_max_fields = [FIELD_MIN_VALUES, FIELD_MAX_VALUES]
-        .into_iter()
-        .filter_map(|field_name| stats_schema.field(field_name))
-        .filter_map(|field| match field.data_type() {
-            DataType::Struct(inner) => Some(inner.as_ref()),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
+    let Some(min_max_fields) = min_max_stats_schemas(stats_schema, column) else {
+        return false;
+    };
 
-    min_max_fields.len() == 2
-        && min_max_fields
-            .iter()
-            .all(|schema| schema_contains_path(schema, column))
+    min_max_fields
+        .iter()
+        .all(|schema| schema_contains_path(schema, column))
+}
+
+/// Returns the min/max stats schemas when both sides are present as structs.
+///
+/// The stats builder emits minValues and maxValues as a pair. Require both sides; callers then
+/// use conservative scanning, and the log records the mismatch.
+fn min_max_stats_schemas<'a>(
+    stats_schema: &'a StructType,
+    column: &ColumnName,
+) -> Option<[&'a StructType; 2]> {
+    let min_values = stats_struct_schema(stats_schema, FIELD_MIN_VALUES);
+    let max_values = stats_struct_schema(stats_schema, FIELD_MAX_VALUES);
+
+    match (min_values, max_values) {
+        (Some(min_values), Some(max_values)) => Some([min_values, max_values]),
+        (min_values, max_values) => {
+            warn!(
+                column = %column,
+                has_min_values_schema = min_values.is_some(),
+                has_max_values_schema = max_values.is_some(),
+                "stats schema lacks a complete min/max field pair; using conservative scan"
+            );
+            None
+        }
+    }
+}
+
+fn stats_struct_schema<'a>(
+    stats_schema: &'a StructType,
+    field_name: &str,
+) -> Option<&'a StructType> {
+    match stats_schema.field(field_name)?.data_type() {
+        DataType::Struct(inner) => Some(inner.as_ref()),
+        _ => None,
+    }
 }
 
 fn display_columns(columns: &BTreeSet<ColumnName>) -> String {
@@ -406,6 +497,13 @@ fn filter_stats_schema(
             continue;
         };
         let Some(filtered) = filter_schema_by_paths(inner, paths)? else {
+            continue;
+        };
+        let filtered = match stats_field_name {
+            FIELD_MIN_VALUES | FIELD_MAX_VALUES => filter_min_max_schema(&filtered)?,
+            _ => Some(filtered),
+        };
+        let Some(filtered) = filtered else {
             continue;
         };
 
@@ -468,6 +566,38 @@ fn filter_schema_by_paths(
                 }
             }
             _ => fields.push(field.clone()),
+        }
+    }
+
+    if fields.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(StructType::try_new(fields)?))
+    }
+}
+
+/// Removes leaves unsupported by scan min/max stats parsing.
+fn filter_min_max_schema(schema: &StructType) -> DeltaResult<Option<StructType>> {
+    let mut fields = Vec::new();
+    for field in schema.fields() {
+        match field.data_type() {
+            DataType::Struct(inner) => {
+                let Some(filtered) = filter_min_max_schema(inner)? else {
+                    continue;
+                };
+                fields.push(
+                    StructField::new(
+                        field.name().clone(),
+                        DataType::Struct(Box::new(filtered)),
+                        field.is_nullable(),
+                    )
+                    .with_metadata(field.metadata().clone()),
+                );
+            }
+            DataType::Primitive(primitive) if is_min_max_stats_eligible_primitive(primitive) => {
+                fields.push(field.clone());
+            }
+            _ => {}
         }
     }
 
@@ -591,6 +721,34 @@ mod tests {
         Snapshot::try_new(table.log_store().as_ref(), Default::default(), None).await
     }
 
+    async fn boolean_snapshot() -> DeltaResult<Snapshot> {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([
+                StructField::nullable("id", DataType::LONG),
+                StructField::nullable("active", DataType::BOOLEAN),
+                StructField::nullable("value", DataType::STRING),
+            ])
+            .await?;
+        Snapshot::try_new(table.log_store().as_ref(), Default::default(), None).await
+    }
+
+    async fn nested_boolean_snapshot() -> DeltaResult<Snapshot> {
+        let user = StructType::try_new([
+            StructField::nullable("name", DataType::STRING),
+            StructField::nullable("is_admin", DataType::BOOLEAN),
+            StructField::nullable("age", DataType::INTEGER),
+        ])?;
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([
+                StructField::nullable("id", DataType::LONG),
+                StructField::nullable("user", DataType::Struct(Box::new(user))),
+            ])
+            .await?;
+        Snapshot::try_new(table.log_store().as_ref(), Default::default(), None).await
+    }
+
     async fn column_mapping_snapshot() -> DeltaResult<Snapshot> {
         let log_store = column_mapping_builder()?.build_storage()?;
         Snapshot::try_new(log_store.as_ref(), Default::default(), None).await
@@ -641,6 +799,36 @@ mod tests {
         assert_eq!(materialization.stats_projection(), &StatsProjection::none());
     }
 
+    #[test]
+    fn min_max_stats_schemas_requires_complete_pair() -> TestResult {
+        let value_stats = StructType::try_new([StructField::nullable("value", DataType::INTEGER)])?;
+        let partial = StructType::try_new([
+            StructField::nullable(FIELD_NUM_RECORDS, DataType::LONG),
+            StructField::nullable(FIELD_MIN_VALUES, value_stats.clone()),
+        ])?;
+
+        assert!(min_max_stats_schemas(&partial, &ColumnName::new(["value"])).is_none());
+
+        let complete = StructType::try_new([
+            StructField::nullable(FIELD_NUM_RECORDS, DataType::LONG),
+            StructField::nullable(FIELD_MIN_VALUES, value_stats.clone()),
+            StructField::nullable(FIELD_MAX_VALUES, value_stats),
+        ])?;
+        let schemas =
+            min_max_stats_schemas(&complete, &ColumnName::new(["value"])).expect("complete pair");
+
+        assert!(schema_contains_path(
+            schemas[0],
+            &ColumnName::new(["value"])
+        ));
+        assert!(schema_contains_path(
+            schemas[1],
+            &ColumnName::new(["value"])
+        ));
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn stats_projection_full_matches_snapshot_stats_schema() -> TestResult {
         let snapshot = synthetic_snapshot().await?;
@@ -665,13 +853,29 @@ mod tests {
         for field_name in ["minValues", "maxValues", "nullCount"] {
             let field = stats_schema
                 .field(field_name)
-                .unwrap_or_else(|| panic!("{field_name} should be projected"));
+                .unwrap_or_else(|| panic!("missing {field_name} projection"));
             let DataType::Struct(inner) = field.data_type() else {
-                panic!("{field_name} should be a struct");
+                panic!("expected {field_name} stats struct");
             };
             assert!(inner.field("value").is_some());
             assert!(inner.field("unreferenced_col").is_none());
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stats_projection_predicate_matching_is_case_insensitive() -> TestResult {
+        let snapshot = synthetic_snapshot().await?;
+        let predicate: PredicateRef =
+            Arc::new(Expression::column(["VALUE"]).gt(Scalar::Integer(10)));
+
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
+
+        assert_eq!(
+            projection,
+            StatsProjection::PredicateColumns(BTreeSet::from([ColumnName::new(["value"])]))
+        );
 
         Ok(())
     }
@@ -685,6 +889,109 @@ mod tests {
         let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
 
         assert_eq!(projection, StatsProjection::NumRecordsOnly);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stats_projection_boolean_predicate_uses_num_records_only() -> TestResult {
+        let snapshot = boolean_snapshot().await?;
+        let predicate: PredicateRef =
+            Arc::new(Expression::column(["active"]).eq(Scalar::Boolean(true)));
+
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
+
+        assert_eq!(projection, StatsProjection::NumRecordsOnly);
+
+        let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
+        assert!(stats_schema.field(FIELD_NUM_RECORDS).is_some());
+        assert!(stats_schema.field(FIELD_NULL_COUNT).is_none());
+        assert!(stats_schema.field(FIELD_MIN_VALUES).is_none());
+        assert!(stats_schema.field(FIELD_MAX_VALUES).is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stats_projection_mixed_boolean_and_indexed_predicate_drops_boolean() -> TestResult {
+        let snapshot = boolean_snapshot().await?;
+        let predicate: PredicateRef = Arc::new(delta_kernel::Predicate::and(
+            Expression::column(["id"]).eq(Scalar::Long(2)),
+            Expression::column(["active"]).eq(Scalar::Boolean(true)),
+        ));
+
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
+
+        assert_eq!(
+            projection,
+            StatsProjection::PredicateColumns(BTreeSet::from([ColumnName::new(["id"])]))
+        );
+
+        let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
+        for field_name in [FIELD_MIN_VALUES, FIELD_MAX_VALUES, FIELD_NULL_COUNT] {
+            let field = stats_schema
+                .field(field_name)
+                .unwrap_or_else(|| panic!("missing {field_name} projection"));
+            let DataType::Struct(inner) = field.data_type() else {
+                panic!("expected {field_name} stats struct");
+            };
+            assert!(inner.field("id").is_some());
+            assert!(inner.field("active").is_none());
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stats_projection_nested_boolean_predicate_uses_num_records_only() -> TestResult {
+        let snapshot = nested_boolean_snapshot().await?;
+        let predicate: PredicateRef =
+            Arc::new(Expression::column(["user", "is_admin"]).eq(Scalar::Boolean(true)));
+
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
+
+        assert_eq!(projection, StatsProjection::NumRecordsOnly);
+
+        let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
+        assert!(stats_schema.field(FIELD_NUM_RECORDS).is_some());
+        assert!(stats_schema.field(FIELD_NULL_COUNT).is_none());
+        assert!(stats_schema.field(FIELD_MIN_VALUES).is_none());
+        assert!(stats_schema.field(FIELD_MAX_VALUES).is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stats_projection_mixed_nested_boolean_and_indexed_predicate_drops_boolean()
+    -> TestResult {
+        let snapshot = nested_boolean_snapshot().await?;
+        let predicate: PredicateRef = Arc::new(delta_kernel::Predicate::and(
+            Expression::column(["user", "age"]).gt(Scalar::Integer(21)),
+            Expression::column(["user", "is_admin"]).eq(Scalar::Boolean(true)),
+        ));
+
+        let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
+
+        assert_eq!(
+            projection,
+            StatsProjection::PredicateColumns(BTreeSet::from([ColumnName::new(["user", "age"])]))
+        );
+
+        let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
+        for field_name in [FIELD_MIN_VALUES, FIELD_MAX_VALUES, FIELD_NULL_COUNT] {
+            let field = stats_schema
+                .field(field_name)
+                .unwrap_or_else(|| panic!("missing {field_name} projection"));
+            let DataType::Struct(inner) = field.data_type() else {
+                panic!("expected {field_name} stats struct");
+            };
+            let user = inner.field("user").expect("missing user projection");
+            let DataType::Struct(user_inner) = user.data_type() else {
+                panic!("expected user stats struct");
+            };
+            assert!(user_inner.field("age").is_some());
+            assert!(user_inner.field("is_admin").is_none());
+        }
 
         Ok(())
     }

--- a/crates/core/src/kernel/snapshot/stats_projection.rs
+++ b/crates/core/src/kernel/snapshot/stats_projection.rs
@@ -167,9 +167,6 @@ impl StatsProjection {
         let columns = requested_columns
             .iter()
             .filter_map(|column| {
-                if !schema_contains_min_max_data_path(logical_schema, column) {
-                    return None;
-                }
                 let physical =
                     physicalize_column_path(logical_schema, column, column_mapping_mode)?;
                 stats_schema_contains_data_column(stats_schema.as_ref(), &physical)
@@ -219,7 +216,6 @@ impl StatsProjection {
             return Ok(Self::NumRecordsOnly);
         };
 
-        let physical_schema = scan.physical_schema();
         let stats_schema = scan.snapshot().table_configuration().stats_schema()?;
         let requested_columns = predicate
             .references()
@@ -230,9 +226,6 @@ impl StatsProjection {
         let columns = requested_columns
             .iter()
             .filter_map(|column| {
-                if !schema_contains_min_max_data_path(physical_schema.as_ref(), column) {
-                    return None;
-                }
                 stats_schema_contains_data_column(stats_schema.as_ref(), column)
                     .then(|| column.clone())
             })
@@ -348,40 +341,6 @@ fn schema_contains_path(schema: &StructType, column: &ColumnName) -> bool {
     current.field(last).is_some()
 }
 
-/// Returns whether `schema` contains `column` with at least one min/max eligible leaf.
-fn schema_contains_min_max_data_path(schema: &StructType, column: &ColumnName) -> bool {
-    let Some((last, parents)) = column.path().split_last() else {
-        return false;
-    };
-
-    let mut current = schema;
-    for segment in parents {
-        let Some(field) = find_field_case_insensitive(current, segment) else {
-            return false;
-        };
-        let DataType::Struct(inner) = field.data_type() else {
-            return false;
-        };
-        current = inner;
-    }
-
-    current
-        .fields()
-        .find(|field| field.name().eq_ignore_ascii_case(last.as_str()))
-        .is_some_and(|field| data_type_has_min_max_stats_leaf(field.data_type()))
-}
-
-/// Returns whether `data_type` has at least one leaf that scan min/max stats can parse.
-fn data_type_has_min_max_stats_leaf(data_type: &DataType) -> bool {
-    match data_type {
-        DataType::Struct(inner) => inner
-            .fields()
-            .any(|field| data_type_has_min_max_stats_leaf(field.data_type())),
-        DataType::Primitive(primitive) => is_min_max_stats_eligible_primitive(primitive),
-        _ => false,
-    }
-}
-
 /// Scan min/max stats parsing requests a primitive when this returns true.
 ///
 /// The public `Add` action stats schema keeps boolean min/max for compatibility. Scan
@@ -389,12 +348,6 @@ fn data_type_has_min_max_stats_leaf(data_type: &DataType) -> bool {
 fn is_min_max_stats_eligible_primitive(data_type: &PrimitiveType) -> bool {
     !matches!(data_type, &PrimitiveType::Boolean)
         && is_public_min_max_stats_eligible_primitive(data_type)
-}
-
-fn find_field_case_insensitive<'a>(schema: &'a StructType, name: &str) -> Option<&'a StructField> {
-    schema
-        .fields()
-        .find(|field| field.name().eq_ignore_ascii_case(name))
 }
 
 fn physicalize_column_path(
@@ -424,13 +377,15 @@ fn physicalize_column_path(
 }
 
 fn stats_schema_contains_data_column(stats_schema: &StructType, column: &ColumnName) -> bool {
-    let Some(min_max_fields) = min_max_stats_schemas(stats_schema, column) else {
-        return false;
-    };
+    let has_null_count = stats_struct_schema(stats_schema, FIELD_NULL_COUNT)
+        .is_some_and(|schema| schema_contains_path(schema, column));
+    let has_min_max = min_max_stats_schemas(stats_schema, column).is_some_and(|min_max_fields| {
+        min_max_fields
+            .iter()
+            .all(|schema| schema_contains_path(schema, column))
+    });
 
-    min_max_fields
-        .iter()
-        .all(|schema| schema_contains_path(schema, column))
+    has_null_count || has_min_max
 }
 
 /// Returns the min/max stats schemas when both sides are present as structs.
@@ -881,31 +836,50 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stats_projection_binary_predicate_uses_num_records_only() -> TestResult {
+    async fn stats_projection_binary_predicate_uses_null_count_only() -> TestResult {
         let snapshot = binary_snapshot().await?;
         let predicate: PredicateRef =
             Arc::new(Expression::column(["data"]).eq(Scalar::Binary(b"bbb".to_vec())));
 
         let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
 
-        assert_eq!(projection, StatsProjection::NumRecordsOnly);
+        assert_eq!(
+            projection,
+            StatsProjection::PredicateColumns(BTreeSet::from([ColumnName::new(["data"])]))
+        );
+
+        let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
+        let null_count = stats_schema.field(FIELD_NULL_COUNT).unwrap();
+        let DataType::Struct(inner) = null_count.data_type() else {
+            panic!("expected nullCount stats struct");
+        };
+        assert!(inner.field("data").is_some());
+        assert!(stats_schema.field(FIELD_MIN_VALUES).is_none());
+        assert!(stats_schema.field(FIELD_MAX_VALUES).is_none());
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn stats_projection_boolean_predicate_uses_num_records_only() -> TestResult {
+    async fn stats_projection_boolean_predicate_uses_null_count_only() -> TestResult {
         let snapshot = boolean_snapshot().await?;
         let predicate: PredicateRef =
             Arc::new(Expression::column(["active"]).eq(Scalar::Boolean(true)));
 
         let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
 
-        assert_eq!(projection, StatsProjection::NumRecordsOnly);
+        assert_eq!(
+            projection,
+            StatsProjection::PredicateColumns(BTreeSet::from([ColumnName::new(["active"])]))
+        );
 
         let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
         assert!(stats_schema.field(FIELD_NUM_RECORDS).is_some());
-        assert!(stats_schema.field(FIELD_NULL_COUNT).is_none());
+        let null_count = stats_schema.field(FIELD_NULL_COUNT).unwrap();
+        let DataType::Struct(inner) = null_count.data_type() else {
+            panic!("expected nullCount stats struct");
+        };
+        assert!(inner.field("active").is_some());
         assert!(stats_schema.field(FIELD_MIN_VALUES).is_none());
         assert!(stats_schema.field(FIELD_MAX_VALUES).is_none());
 
@@ -924,11 +898,14 @@ mod tests {
 
         assert_eq!(
             projection,
-            StatsProjection::PredicateColumns(BTreeSet::from([ColumnName::new(["id"])]))
+            StatsProjection::PredicateColumns(BTreeSet::from([
+                ColumnName::new(["active"]),
+                ColumnName::new(["id"])
+            ]))
         );
 
         let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
-        for field_name in [FIELD_MIN_VALUES, FIELD_MAX_VALUES, FIELD_NULL_COUNT] {
+        for field_name in [FIELD_MIN_VALUES, FIELD_MAX_VALUES] {
             let field = stats_schema
                 .field(field_name)
                 .unwrap_or_else(|| panic!("missing {field_name} projection"));
@@ -938,23 +915,42 @@ mod tests {
             assert!(inner.field("id").is_some());
             assert!(inner.field("active").is_none());
         }
+        let null_count = stats_schema.field(FIELD_NULL_COUNT).unwrap();
+        let DataType::Struct(inner) = null_count.data_type() else {
+            panic!("expected nullCount stats struct");
+        };
+        assert!(inner.field("id").is_some());
+        assert!(inner.field("active").is_some());
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn stats_projection_nested_boolean_predicate_uses_num_records_only() -> TestResult {
+    async fn stats_projection_nested_boolean_predicate_uses_null_count_only() -> TestResult {
         let snapshot = nested_boolean_snapshot().await?;
         let predicate: PredicateRef =
             Arc::new(Expression::column(["user", "is_admin"]).eq(Scalar::Boolean(true)));
 
         let projection = projection_for_predicate(&snapshot, Some(&predicate))?;
 
-        assert_eq!(projection, StatsProjection::NumRecordsOnly);
+        assert_eq!(
+            projection,
+            StatsProjection::PredicateColumns(BTreeSet::from([ColumnName::new([
+                "user", "is_admin"
+            ])]))
+        );
 
         let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
         assert!(stats_schema.field(FIELD_NUM_RECORDS).is_some());
-        assert!(stats_schema.field(FIELD_NULL_COUNT).is_none());
+        let null_count = stats_schema.field(FIELD_NULL_COUNT).unwrap();
+        let DataType::Struct(inner) = null_count.data_type() else {
+            panic!("expected nullCount stats struct");
+        };
+        let user = inner.field("user").expect("missing user projection");
+        let DataType::Struct(user_inner) = user.data_type() else {
+            panic!("expected user stats struct");
+        };
+        assert!(user_inner.field("is_admin").is_some());
         assert!(stats_schema.field(FIELD_MIN_VALUES).is_none());
         assert!(stats_schema.field(FIELD_MAX_VALUES).is_none());
 
@@ -974,11 +970,14 @@ mod tests {
 
         assert_eq!(
             projection,
-            StatsProjection::PredicateColumns(BTreeSet::from([ColumnName::new(["user", "age"])]))
+            StatsProjection::PredicateColumns(BTreeSet::from([
+                ColumnName::new(["user", "age"]),
+                ColumnName::new(["user", "is_admin"])
+            ]))
         );
 
         let stats_schema = projection.stats_schema(snapshot.inner.as_ref())?;
-        for field_name in [FIELD_MIN_VALUES, FIELD_MAX_VALUES, FIELD_NULL_COUNT] {
+        for field_name in [FIELD_MIN_VALUES, FIELD_MAX_VALUES] {
             let field = stats_schema
                 .field(field_name)
                 .unwrap_or_else(|| panic!("missing {field_name} projection"));
@@ -992,6 +991,16 @@ mod tests {
             assert!(user_inner.field("age").is_some());
             assert!(user_inner.field("is_admin").is_none());
         }
+        let null_count = stats_schema.field(FIELD_NULL_COUNT).unwrap();
+        let DataType::Struct(inner) = null_count.data_type() else {
+            panic!("expected nullCount stats struct");
+        };
+        let user = inner.field("user").expect("missing user projection");
+        let DataType::Struct(user_inner) = user.data_type() else {
+            panic!("expected user stats struct");
+        };
+        assert!(user_inner.field("age").is_some());
+        assert!(user_inner.field("is_admin").is_some());
 
         Ok(())
     }

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -2273,6 +2273,62 @@ def test_merge_partitioned_schema_evolution_with_existing_string_partition_4292(
 
 
 @pytest.mark.parametrize("streaming", (True, False))
+def test_merge_boolean_target_predicate_4490(tmp_path: pathlib.Path, streaming: bool):
+    data = Table(
+        {
+            "id": Array([1, 2], ArrowField("id", type=DataType.int64(), nullable=True)),
+            "active": Array(
+                [True, False], ArrowField("active", type=DataType.bool(), nullable=True)
+            ),
+            "value": Array(
+                ["old-1", "old-2"],
+                ArrowField("value", type=DataType.string_view(), nullable=True),
+            ),
+        }
+    )
+    write_deltalake(tmp_path, data, mode="append")
+
+    dt = DeltaTable(tmp_path)
+    source = Table(
+        {
+            "id": Array([1, 2], ArrowField("id", type=DataType.int64(), nullable=True)),
+            "value": Array(
+                ["new-1", "new-2"],
+                ArrowField("value", type=DataType.string_view(), nullable=True),
+            ),
+        }
+    )
+
+    dt.merge(
+        source=source,
+        source_alias="source",
+        target_alias="target",
+        predicate="target.id = source.id and target.active = true",
+        streamed_exec=streaming,
+    ).when_matched_update(updates={"value": "source.value"}).execute()
+
+    actual = (
+        QueryBuilder()
+        .register("tbl", dt)
+        .execute("select id, active, value from tbl order by id")
+        .read_all()
+    )
+    expected = Table(
+        {
+            "id": Array([1, 2], ArrowField("id", type=DataType.int64(), nullable=True)),
+            "active": Array(
+                [True, False], ArrowField("active", type=DataType.bool(), nullable=True)
+            ),
+            "value": Array(
+                ["new-1", "old-2"],
+                ArrowField("value", type=DataType.string_view(), nullable=True),
+            ),
+        }
+    )
+    assert actual == expected
+
+
+@pytest.mark.parametrize("streaming", (True, False))
 def test_merge_stats_columns_stats_provided(tmp_path: pathlib.Path, streaming: bool):
     data = Table(
         {

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1,3 +1,4 @@
+import json
 import multiprocessing
 import os
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
@@ -1126,6 +1127,94 @@ def test_read_query_builder():
 
     actual = qb.execute(query).read_all()
     assert expected == actual
+
+
+def test_query_builder_boolean_false_predicate_4490(tmp_path: Path):
+    table = Table(
+        {
+            "id": Array(
+                [1, 2, 3], ArrowField("id", type=DataType.int64(), nullable=True)
+            ),
+            "deprecated": Array(
+                [False, True, False],
+                ArrowField("deprecated", type=DataType.bool(), nullable=True),
+            ),
+            "chemsys": Array(
+                ["Li-O", "Fe-O", "Na-Cl"],
+                ArrowField("chemsys", type=DataType.string_view(), nullable=True),
+            ),
+        }
+    )
+    write_deltalake(tmp_path, table)
+
+    actual = (
+        QueryBuilder()
+        .register("materials", DeltaTable(tmp_path))
+        .execute(
+            """
+            SELECT chemsys
+            FROM materials
+            WHERE deprecated=false
+            ORDER BY chemsys
+            """
+        )
+        .read_all()
+    )
+    expected = Table(
+        {
+            "chemsys": Array(
+                ["Li-O", "Na-Cl"],
+                ArrowField("chemsys", type=DataType.string_view(), nullable=True),
+            )
+        }
+    )
+    assert actual == expected
+
+
+def test_query_builder_ignores_legacy_boolean_min_max_stats_4490(tmp_path: Path):
+    table = Table(
+        {
+            "id": Array(
+                [1, 2, 3], ArrowField("id", type=DataType.int64(), nullable=True)
+            ),
+            "deprecated": Array(
+                [False, True, False],
+                ArrowField("deprecated", type=DataType.bool(), nullable=True),
+            ),
+        }
+    )
+    write_deltalake(tmp_path, table)
+
+    log_path = tmp_path / "_delta_log" / "00000000000000000000.json"
+    rewritten_lines = []
+    for line in log_path.read_text().splitlines():
+        action = json.loads(line)
+        add = action.get("add")
+        if add and add.get("stats"):
+            stats = json.loads(add["stats"])
+            stats.setdefault("minValues", {})["deprecated"] = True
+            stats.setdefault("maxValues", {})["deprecated"] = True
+            add["stats"] = json.dumps(stats, separators=(",", ":"))
+        rewritten_lines.append(json.dumps(action, separators=(",", ":")))
+    log_path.write_text("\n".join(rewritten_lines) + "\n")
+
+    actual = (
+        QueryBuilder()
+        .register("materials", DeltaTable(tmp_path))
+        .execute(
+            """
+            SELECT id
+            FROM materials
+            WHERE deprecated=false
+            ORDER BY id
+            """
+        )
+        .read_all()
+    )
+    expected = Table(
+        {"id": Array([1, 3], ArrowField("id", type=DataType.int64(), nullable=True))}
+    )
+    assert actual == expected
 
 
 @pytest.mark.pyarrow


### PR DESCRIPTION
Fixes #4490.

Boolean min/max values stay in the public `Add.stats` schema for compatibility. Scan planning now filters boolean min/max stats before kernel parses scan stats.

This fix keeps file skipping for supported primitive types and falls back to scanning for boolean predicates. Also covers nested boolean fields and mixed predicates where another eligible column can still use stats.