### PR TITLE
fix: correct format for timestampNtz statistics

### DIFF
--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -266,6 +266,7 @@ enum StatsScalar {
     Float64(f64),
     Date(chrono::NaiveDate),
     Timestamp(chrono::NaiveDateTime),
+    TimestampNtz(chrono::NaiveDateTime),
     // We are serializing to f64 later and the ordering should be the same
     // Scale is stored to handle scale=0 serialization correctly
     Decimal { value: f64, scale: i32 },
@@ -308,10 +309,13 @@ impl StatsScalar {
             }
             (Statistics::Int32(v), _) => Ok(Self::Int32(get_stat!(v))),
             // Int64 can be timestamp, decimal, or integer
-            (Statistics::Int64(v), Some(LogicalType::Timestamp { unit, .. })) => {
-                // For now, we assume timestamps are adjusted to UTC. Non-UTC timestamps
-                // are behind a feature gate in Delta:
-                // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#timestamp-without-timezone-timestampntz
+            (
+                Statistics::Int64(v),
+                Some(LogicalType::Timestamp {
+                    is_adjusted_to_u_t_c,
+                    unit,
+                }),
+            ) => {
                 let v = get_stat!(v);
                 let timestamp = match unit {
                     TimeUnit::MILLIS => chrono::DateTime::from_timestamp_millis(v),
@@ -326,7 +330,11 @@ impl StatsScalar {
                     debug_value: v.to_string(),
                     logical_type: logical_type.cloned(),
                 })?;
-                Ok(Self::Timestamp(timestamp.naive_utc()))
+                if *is_adjusted_to_u_t_c {
+                    Ok(Self::Timestamp(timestamp.naive_utc()))
+                } else {
+                    Ok(Self::TimestampNtz(timestamp.naive_utc()))
+                }
             }
             (Statistics::Int64(v), Some(LogicalType::Decimal { scale, .. })) => {
                 let val = get_stat!(v) as f64 / 10.0_f64.powi(*scale);
@@ -450,6 +458,9 @@ impl From<StatsScalar> for serde_json::Value {
             StatsScalar::Date(v) => serde_json::Value::from(v.format("%Y-%m-%d").to_string()),
             StatsScalar::Timestamp(v) => {
                 serde_json::Value::from(v.format("%Y-%m-%dT%H:%M:%S%.fZ").to_string())
+            }
+            StatsScalar::TimestampNtz(v) => {
+                serde_json::Value::from(v.format("%Y-%m-%d %H:%M:%S%.f").to_string())
             }
             StatsScalar::Decimal { value, scale } => {
                 // For scale=0, serialize as integer since serde_json would otherwise

--- a/crates/core/tests/it_datafusion/integration_datafusion.rs
+++ b/crates/core/tests/it_datafusion/integration_datafusion.rs
@@ -1102,9 +1102,8 @@ mod local {
             let column = column.to_owned();
             // TODO: The following types don't have proper stats written.
             // See issue #1208 for decimal type
-            // See issue #1209 for dates
             // Min and Max is not calculated for binary columns. This matches the Spark writer
-            if column == "decimal" || column == "date" || column == "binary" {
+            if column == "decimal" || column == "binary" {
                 continue;
             }
             println!("[Unwrapped] Test Column: {column} value: {file1_value}");
@@ -1203,7 +1202,6 @@ mod local {
             // TODO: Float and decimal partitions are not supported by the writer
             // binary fails since arrow does not implement a natural order
             // The current Datafusion pruning implementation does not work for binary columns since they do not have a natural order. See #1214
-            // Timestamp and date are disabled since the hive path contains illegal Windows values. see #1215
             if column == "int64"
                 || column == "int32"
                 || column == "int16"
@@ -1212,7 +1210,6 @@ mod local {
                 || column == "float64"
                 || column == "decimal"
                 || column == "binary"
-                || column == "date"
             {
                 continue;
             }

--- a/crates/core/tests/it_datafusion/integration_datafusion.rs
+++ b/crates/core/tests/it_datafusion/integration_datafusion.rs
@@ -915,17 +915,28 @@ mod local {
             )),
             Arc::new(decimal),
             //Convert to seconds
+            Arc::new(
+                TimestampMicrosecondArray::from_iter(
+                    (0..not_null_rows)
+                        .map(|x| Some(((x + offset) * 1_000_000) as i64))
+                        .chain((0..null_rows).map(|_| None)),
+                )
+                .with_timezone("UTC"),
+            ),
             Arc::new(TimestampMicrosecondArray::from_iter(
                 (0..not_null_rows)
                     .map(|x| Some(((x + offset) * 1_000_000) as i64))
                     .chain((0..null_rows).map(|_| None)),
             )),
             #[cfg(feature = "nanosecond-timestamps")]
-            Arc::new(TimestampNanosecondArray::from_iter(
-                (0..not_null_rows)
-                    .map(|x| Some(((x + offset) * 1_000_000_000) as i64))
-                    .chain((0..null_rows).map(|_| None)),
-            )),
+            Arc::new(
+                TimestampNanosecondArray::from_iter(
+                    (0..not_null_rows)
+                        .map(|x| Some(((x + offset) * 1_000_000_000) as i64))
+                        .chain((0..null_rows).map(|_| None)),
+                )
+                .with_timezone("UTC"),
+            ),
             Arc::new(Date32Array::from_iter(
                 (0..not_null_rows)
                     .map(|x| Some((x + offset) as i32))
@@ -946,13 +957,18 @@ mod local {
             ArrowField::new("decimal", ArrowDataType::Decimal128(10, 2), true),
             ArrowField::new(
                 "timestamp",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                true,
+            ),
+            ArrowField::new(
+                "timestamp_ntz",
                 ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
                 true,
             ),
             #[cfg(feature = "nanosecond-timestamps")]
             ArrowField::new(
                 "timestamp_nanos",
-                ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
+                ArrowDataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
                 true,
             ),
             ArrowField::new("date", ArrowDataType::Date32, true),
@@ -1036,7 +1052,8 @@ mod local {
         assert_eq!(metrics.num_scanned_files(), 3);
         assert_eq!(metrics.num_scanned_files(), metrics.keep_count);
 
-        // (Column name, value from file 1, value from file 2, value from file 3, non existent value)
+        // For each type to test, provide the column name and a
+        // function to generate a valid value from an i64.
         let tests = [
             TestCase::new("utf8", |value| {
                 lit(ScalarValue::Utf8View(Some(value.to_string())))
@@ -1047,12 +1064,21 @@ mod local {
             TestCase::new("int8", |value| lit(value as i8)),
             TestCase::new("float64", |value| lit(value as f64)),
             TestCase::new("float32", |value| lit(value as f32)),
-            TestCase::new("timestamp", |value| {
+            TestCase::new("timestamp_ntz", |value| {
                 lit(TimestampMicrosecond(Some(value * 1_000_000), None))
+            }),
+            TestCase::new("timestamp", |value| {
+                lit(TimestampMicrosecond(
+                    Some(value * 1_000_000),
+                    Some("UTC".into()),
+                ))
             }),
             #[cfg(feature = "nanosecond-timestamps")]
             TestCase::new("timestamp_nanos", |value| {
-                lit(TimestampNanosecond(Some(value * 1_000_000_000), None))
+                lit(TimestampNanosecond(
+                    Some(value * 1_000_000_000),
+                    Some("UTC".into()),
+                ))
             }),
             // TODO: I think decimal statistics are being written to the log incorrectly. The underlying i128 is written
             // not the proper string representation as specified by the precision and scale
@@ -1078,12 +1104,7 @@ mod local {
             // See issue #1208 for decimal type
             // See issue #1209 for dates
             // Min and Max is not calculated for binary columns. This matches the Spark writer
-            if column == "decimal"
-                || column == "date"
-                || column == "binary"
-                || column == "timestamp"
-                || (cfg!(feature = "nanosecond-timestamps") && column == "timestamp_nanos")
-            {
+            if column == "decimal" || column == "date" || column == "binary" {
                 continue;
             }
             println!("[Unwrapped] Test Column: {column} value: {file1_value}");
@@ -1144,11 +1165,20 @@ mod local {
             TestCase::new_wrapped("float64", |value| lit(value as f64)),
             TestCase::new_wrapped("float32", |value| lit(value as f32)),
             TestCase::new_wrapped("timestamp", |value| {
+                lit(TimestampMicrosecond(
+                    Some(value * 1_000_000),
+                    Some("UTC".into()),
+                ))
+            }),
+            TestCase::new_wrapped("timestamp_ntz", |value| {
                 lit(TimestampMicrosecond(Some(value * 1_000_000), None))
             }),
             #[cfg(feature = "nanosecond-timestamps")]
             TestCase::new_wrapped("timestamp_nanos", |value| {
-                lit(TimestampNanosecond(Some(value * 1_000_000_000), None))
+                lit(TimestampNanosecond(
+                    Some(value * 1_000_000_000),
+                    Some("UTC".into()),
+                ))
             }),
             // TODO: I think decimal statistics are being written to the log incorrectly. The underlying i128 is written
             // not the proper string representation as specified by the precision and scale
@@ -1182,9 +1212,7 @@ mod local {
                 || column == "float64"
                 || column == "decimal"
                 || column == "binary"
-                || column == "timestamp"
                 || column == "date"
-                || (cfg!(feature = "nanosecond-timestamps") && column == "timestamp_nanos")
             {
                 continue;
             }

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -259,7 +259,12 @@ def sample_data_pyarrow() -> "pa.Table":
                 [date(2022, 1, 1) + timedelta(days=x) for x in range(nrows)]
             ),
             "timestamp": pa.array(
-                [datetime(2022, 1, 1) + timedelta(hours=x) for x in range(nrows)]
+                [datetime(2022, 1, 1) + timedelta(hours=x) for x in range(nrows)],
+                type=pa.timestamp("us", "UTC"),
+            ),
+            "timestamp_ntz": pa.array(
+                [datetime(2022, 1, 1) + timedelta(hours=x) for x in range(nrows)],
+                type=pa.timestamp("us", None),
             ),
             "struct": pa.array([{"x": x, "y": str(x)} for x in range(nrows)]),
             "list": pa.array(

--- a/python/tests/pyspark_integration/utils.py
+++ b/python/tests/pyspark_integration/utils.py
@@ -31,7 +31,7 @@ def assert_spark_read_equal(
     df = spark.read.format("delta").load(uri)
 
     # Spark and pyarrow don't convert these types to the same Pandas values
-    incompatible_types = ["timestamp", "struct"]
+    incompatible_types = ["timestamp", "timestamp_ntz", "struct"]
 
     assert_frame_equal(
         df.toPandas()

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1018,6 +1018,7 @@ def test_writer_stats(existing_table: DeltaTable, sample_data_pyarrow: "pa.Table
         "float64": -0.0,
         "bool": False,
         "timestamp": "2022-01-01T00:00:00Z",
+        "timestamp_ntz": "2022-01-01 00:00:00",
         "struct": {
             "x": 0,
             "y": "0",
@@ -1041,6 +1042,7 @@ def test_writer_stats(existing_table: DeltaTable, sample_data_pyarrow: "pa.Table
         "float64": 4.0,
         "bool": True,
         "timestamp": "2022-01-01T04:00:00Z",
+        "timestamp_ntz": "2022-01-01 04:00:00",
         "struct": {"x": 4, "y": "4"},
     }
     # PyArrow added support for decimal and date32 in 8.0.0


### PR DESCRIPTION
# Description

Changes how min and max-value statistics are formatted for `timestampNtz` columns so they aren't formatted as UTC timestamps. Previously they weren't treated any different to `timestamp` typed colums and used the ISO8601 format with a "Z" suffix.

# Related Issue(s)

- closes #4503
