### PR TITLE
chore: refactor column mapping related errors into stronger types

### DIFF
--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -26,6 +26,12 @@ impl std::fmt::Display for ColumnMappingOperation {
     }
 }
 
+pub(crate) fn unsupported_column_mapping_read(operation: &str) -> DeltaTableError {
+    DeltaTableError::Generic(format!(
+        "column mapping is not supported for {operation} yet"
+    ))
+}
+
 /// Delta Table specific error
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug)]

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -8,10 +8,22 @@ use crate::kernel::transaction::{CommitBuilderError, TransactionError};
 /// A result returned by delta-rs
 pub type DeltaResult<T, E = DeltaTableError> = Result<T, E>;
 
-pub(crate) fn unsupported_column_mapping_write(operation: &str) -> DeltaTableError {
-    DeltaTableError::Generic(format!(
-        "column mapping writes are not supported for {operation} yet"
-    ))
+/// Whether an unsupported column-mapping access was a read or a write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnMappingOperation {
+    /// A read-path operation.
+    Read,
+    /// A write-path operation.
+    Write,
+}
+
+impl std::fmt::Display for ColumnMappingOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ColumnMappingOperation::Read => f.write_str("read"),
+            ColumnMappingOperation::Write => f.write_str("write"),
+        }
+    }
 }
 
 /// Delta Table specific error
@@ -217,6 +229,16 @@ pub enum DeltaTableError {
 
     #[error("No starting version or timestamp provided for CDC")]
     NoStartingVersionOrTimestamp,
+
+    /// Error returned when an operation is attempted on a column-mapped table that does not
+    /// yet support column mapping.
+    #[error("Column mapping is not supported for {mode} operation '{operation}' yet")]
+    UnsupportedColumnMapping {
+        /// Whether the unsupported access was a read or a write.
+        mode: ColumnMappingOperation,
+        /// Human-readable description of the operation (e.g. "ADD COLUMN").
+        operation: String,
+    },
 }
 
 impl From<object_store::path::Error> for DeltaTableError {
@@ -246,5 +268,16 @@ impl DeltaTableError {
     /// Create a [Generic](DeltaTableError::Generic) error with the given message.
     pub fn generic(msg: impl ToString) -> Self {
         Self::Generic(msg.to_string())
+    }
+
+    /// Construct an [`UnsupportedColumnMapping`](DeltaTableError::UnsupportedColumnMapping) error.
+    pub fn unsupported_column_mapping(
+        mode: ColumnMappingOperation,
+        operation: impl ToString,
+    ) -> Self {
+        Self::UnsupportedColumnMapping {
+            mode,
+            operation: operation.to_string(),
+        }
     }
 }

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -26,12 +26,6 @@ impl std::fmt::Display for ColumnMappingOperation {
     }
 }
 
-pub(crate) fn unsupported_column_mapping_read(operation: &str) -> DeltaTableError {
-    DeltaTableError::Generic(format!(
-        "column mapping is not supported for {operation} yet"
-    ))
-}
-
 /// Delta Table specific error
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug)]

--- a/crates/core/src/operations/add_column.rs
+++ b/crates/core/src/operations/add_column.rs
@@ -8,7 +8,7 @@ use futures::future::BoxFuture;
 use itertools::Itertools;
 
 use super::{CustomExecuteHandler, Operation};
-use crate::errors::unsupported_column_mapping_write;
+use crate::errors::ColumnMappingOperation;
 use crate::kernel::schema::merge_delta_struct;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{
@@ -82,7 +82,10 @@ impl std::future::IntoFuture for AddColumnBuilder {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), false, None).await?;
             if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
-                return Err(unsupported_column_mapping_write("ADD COLUMN"));
+                return Err(DeltaTableError::unsupported_column_mapping(
+                    ColumnMappingOperation::Write,
+                    "ADD COLUMN",
+                ));
             }
 
             let mut metadata = snapshot.metadata().clone();

--- a/crates/core/src/operations/create.rs
+++ b/crates/core/src/operations/create.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use super::{CustomExecuteHandler, Operation};
-use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
+use crate::errors::{ColumnMappingOperation, DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL, TableReference};
 use crate::kernel::{
     Action, DataType, MetadataExt, ProtocolExt as _, ProtocolInner, StructField, StructType,
@@ -288,12 +288,14 @@ impl CreateBuilder {
             .get(TableProperty::ColumnMappingMode.as_ref())
             .is_some_and(|value| value.is_some())
         {
-            return Err(unsupported_column_mapping_write(
+            return Err(DeltaTableError::unsupported_column_mapping(
+                ColumnMappingOperation::Write,
                 "CREATE TABLE with delta.columnMapping.mode",
             ));
         }
         if self.columns.iter().any(field_has_column_mapping_metadata) {
-            return Err(unsupported_column_mapping_write(
+            return Err(DeltaTableError::unsupported_column_mapping(
+                ColumnMappingOperation::Write,
                 "CREATE TABLE with column mapping metadata",
             ));
         }

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -34,7 +34,7 @@ use crate::DeltaTableError;
 use crate::delta_datafusion::{
     DataFusionMixins, DeltaSessionExt, extract_partition_only_predicate,
 };
-use crate::errors::{DeltaResult, unsupported_column_mapping_read};
+use crate::errors::{ColumnMappingOperation, DeltaResult};
 use crate::kernel::transaction::PROTOCOL;
 use crate::kernel::{
     Action, Add, AddCDCFile, CommitInfo, EagerSnapshot, Version, resolve_snapshot,
@@ -455,7 +455,10 @@ impl CdfLoadBuilder {
         let snapshot = resolve_snapshot(&self.log_store, self.snapshot.clone(), true, None).await?;
         PROTOCOL.can_read_from(&snapshot)?;
         if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
-            return Err(unsupported_column_mapping_read("CHANGE DATA FEED scans"));
+            return Err(DeltaTableError::unsupported_column_mapping(
+                ColumnMappingOperation::Read,
+                "CHANGE DATA FEED scans",
+            ));
         }
 
         let partition_values = snapshot.metadata().partition_columns();
@@ -715,10 +718,8 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    async fn copied_column_mapping_cdf_table() -> Result<
-        (tempfile::TempDir, DeltaTable),
-        Box<dyn std::error::Error + 'static>,
-    > {
+    async fn copied_column_mapping_cdf_table()
+    -> Result<(tempfile::TempDir, DeltaTable), Box<dyn std::error::Error + 'static>> {
         let fixture = Path::new("../test/tests/data/table_with_column_mapping");
         let temp_dir = tempfile::tempdir()?;
         fs_extra::dir::copy(fixture, temp_dir.path(), &Default::default())?;
@@ -752,15 +753,14 @@ pub(crate) mod tests {
             .build(&ctx.state(), None)
             .await
             .expect_err("cdf scan should reject column-mapped tables before planning files");
-        let message = err.to_string();
-        assert!(
-            message.contains("column mapping"),
-            "unexpected error: {message}"
-        );
-        assert!(
-            message.contains("CHANGE DATA FEED"),
-            "expected CDF operation in error: {message}"
-        );
+
+        match err {
+            DeltaTableError::UnsupportedColumnMapping {
+                mode: _,
+                operation: _,
+            } => {}
+            _ => panic!("Unexpected error: {err:?}"),
+        }
 
         Ok(())
     }

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -27,13 +27,14 @@ use datafusion::physical_expr::{PhysicalExpr, expressions};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::union::UnionExec;
+use delta_kernel::table_features::ColumnMappingMode;
 use tracing::log;
 
 use crate::DeltaTableError;
 use crate::delta_datafusion::{
     DataFusionMixins, DeltaSessionExt, extract_partition_only_predicate,
 };
-use crate::errors::DeltaResult;
+use crate::errors::{DeltaResult, unsupported_column_mapping_read};
 use crate::kernel::transaction::PROTOCOL;
 use crate::kernel::{
     Action, Add, AddCDCFile, CommitInfo, EagerSnapshot, Version, resolve_snapshot,
@@ -453,6 +454,9 @@ impl CdfLoadBuilder {
     ) -> DeltaResult<Arc<dyn ExecutionPlan>> {
         let snapshot = resolve_snapshot(&self.log_store, self.snapshot.clone(), true, None).await?;
         PROTOCOL.can_read_from(&snapshot)?;
+        if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+            return Err(unsupported_column_mapping_read("CHANGE DATA FEED scans"));
+        }
 
         let partition_values = snapshot.metadata().partition_columns();
         let schema = snapshot.input_schema();
@@ -708,6 +712,56 @@ pub(crate) mod tests {
         let table = DeltaTable::try_from_url(table_uri).await?;
         let provider = DeltaCdfTableProvider::try_new(table.scan_cdf().with_starting_version(0))?;
         ctx.register_table("cdf", Arc::new(provider))?;
+        Ok(())
+    }
+
+    async fn copied_column_mapping_cdf_table() -> Result<
+        (tempfile::TempDir, DeltaTable),
+        Box<dyn std::error::Error + 'static>,
+    > {
+        let fixture = Path::new("../test/tests/data/table_with_column_mapping");
+        let temp_dir = tempfile::tempdir()?;
+        fs_extra::dir::copy(fixture, temp_dir.path(), &Default::default())?;
+        let table_path = temp_dir.path().join("table_with_column_mapping");
+        let log_path = table_path.join("_delta_log/00000000000000000000.json");
+        let log = std::fs::read_to_string(&log_path)?;
+        let updated_log = log.replace(
+            "\"delta.columnMapping.mode\":\"name\"",
+            "\"delta.enableChangeDataFeed\":\"true\",\"delta.columnMapping.mode\":\"name\"",
+        );
+        assert_ne!(
+            log, updated_log,
+            "expected column mapping table fixture metadata to contain column mapping mode"
+        );
+        std::fs::write(log_path, updated_log)?;
+
+        let table_uri =
+            Url::from_directory_path(std::fs::canonicalize(table_path).unwrap()).unwrap();
+        let table = DeltaTable::try_from_url(table_uri).await?;
+        Ok((temp_dir, table))
+    }
+
+    #[tokio::test]
+    async fn cdf_scan_rejects_column_mapping_tables() -> TestResult {
+        let ctx: SessionContext = SessionContext::new();
+        let (_temp_dir, table) = copied_column_mapping_cdf_table().await?;
+
+        let err = table
+            .scan_cdf()
+            .with_starting_version(0)
+            .build(&ctx.state(), None)
+            .await
+            .expect_err("cdf scan should reject column-mapped tables before planning files");
+        let message = err.to_string();
+        assert!(
+            message.contains("column mapping"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("CHANGE DATA FEED"),
+            "expected CDF operation in error: {message}"
+        );
+
         Ok(())
     }
 

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -53,7 +53,7 @@ use crate::delta_datafusion::{
     DataFusionMixins, DeltaScanConfig, DeltaScanNext, SessionFallbackPolicy, SessionResolveContext,
     create_session_state_with_spill_config, resolve_session_state, update_datafusion_session,
 };
-use crate::errors::{DeltaResult, DeltaTableError, unsupported_column_mapping_write};
+use crate::errors::{ColumnMappingOperation, DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, DEFAULT_RETRIES, PROTOCOL};
 use crate::kernel::{Action, Add, DataType, PartitionsExt, Remove, StructType, Version};
 use crate::kernel::{EagerSnapshot, resolve_snapshot};
@@ -417,7 +417,10 @@ impl<'a> std::future::IntoFuture for OptimizeBuilder<'a> {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
             if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
-                return Err(unsupported_column_mapping_write("OPTIMIZE"));
+                return Err(DeltaTableError::unsupported_column_mapping(
+                    ColumnMappingOperation::Write,
+                    "OPTIMIZE",
+                ));
             }
             PROTOCOL.can_write_to(&snapshot)?;
 

--- a/crates/core/src/operations/set_tbl_properties.rs
+++ b/crates/core/src/operations/set_tbl_properties.rs
@@ -8,7 +8,7 @@ use futures::future::BoxFuture;
 use super::{CustomExecuteHandler, Operation};
 use crate::DeltaResult;
 use crate::DeltaTable;
-use crate::errors::unsupported_column_mapping_write;
+use crate::errors::{ColumnMappingOperation, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{Action, EagerSnapshot, MetadataExt as _, ProtocolExt as _, resolve_snapshot};
 use crate::logstore::LogStoreRef;
@@ -98,7 +98,8 @@ impl std::future::IntoFuture for SetTablePropertiesBuilder {
             let properties = this.properties;
 
             if properties.contains_key(TableProperty::ColumnMappingMode.as_ref()) {
-                return Err(unsupported_column_mapping_write(
+                return Err(DeltaTableError::unsupported_column_mapping(
+                    ColumnMappingOperation::Write,
                     "SET TBLPROPERTIES delta.columnMapping.mode",
                 ));
             }

--- a/crates/core/src/writer/mod.rs
+++ b/crates/core/src/writer/mod.rs
@@ -7,7 +7,7 @@ use parquet::errors::ParquetError;
 use serde_json::Value;
 
 use crate::DeltaTable;
-use crate::errors::{DeltaTableError, unsupported_column_mapping_write};
+use crate::errors::{ColumnMappingOperation, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{Action, Add, Version};
 use crate::protocol::{ColumnCountStat, DeltaOperation, SaveMode};
@@ -33,7 +33,10 @@ pub(crate) fn ensure_legacy_writer_supports_table(
         .column_mapping_mode
         .is_some_and(|mode| mode != delta_kernel::table_features::ColumnMappingMode::None)
     {
-        return Err(unsupported_column_mapping_write(operation));
+        return Err(DeltaTableError::unsupported_column_mapping(
+            ColumnMappingOperation::Write,
+            operation,
+        ));
     }
 
     Ok(())

--- a/crates/core/tests/it/column_mapping_guardrails.rs
+++ b/crates/core/tests/it/column_mapping_guardrails.rs
@@ -5,7 +5,7 @@ use deltalake_core::kernel::{
     ColumnMetadataKey, DataType, MetadataValue, StructField, TableFeatures,
 };
 use deltalake_core::writer::{JsonWriter, RecordBatchWriter};
-use deltalake_core::{DeltaTable, DeltaTableError, open_table};
+use deltalake_core::{ColumnMappingOperation, DeltaTable, DeltaTableError, open_table};
 use tempfile::TempDir;
 use url::Url;
 
@@ -15,10 +15,12 @@ use datafusion::common::assert_batches_sorted_eq;
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 fn assert_unsupported_column_mapping_write(err: &DeltaTableError, operation: &str) {
-    let expected = format!("column mapping writes are not supported for {operation} yet");
     match err {
-        DeltaTableError::Generic(message) => assert_eq!(message, &expected),
-        other => panic!("expected a Generic column-mapping error, got: {other:?}"),
+        DeltaTableError::UnsupportedColumnMapping {
+            mode: ColumnMappingOperation::Write,
+            operation: op,
+        } => assert_eq!(op, operation),
+        other => panic!("expected an UnsupportedColumnMapping write error, got: {other:?}"),
     }
 }
 


### PR DESCRIPTION
# Description

Some AI :parrot: changes along the way added some ugly functions where error
types should exist. This PR fixes that and brings the changes from #4498 along

# Related Issue(s)

Closes #4498
<!---
For example:

- closes #106
--->

# Documentation

HA!

<!---
Share links to useful documentation
--->
