### PR TITLE
ci: mark PRs as draft by default

### DIFF
--- a/.github/workflows/draft_pr.yml
+++ b/.github/workflows/draft_pr.yml
@@ -1,0 +1,30 @@
+name: draft_pr
+
+# Mark newly opened pull requests as drafts by default
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  mark-draft:
+    name: Mark new PR as draft
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write
+    # Only act on PRs that were opened as ready-for-review
+    if: github.event.pull_request.draft == false
+    steps:
+      # <https://github.com/actions/github-script/releases/tag/v8>
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          script: |
+            // The REST API cannot convert a PR to draft, so use GraphQL.
+            await github.graphql(
+              `mutation($id: ID!) {
+                convertPullRequestToDraft(input: { pullRequestId: $id }) {
+                  pullRequest { isDraft }
+                }
+              }`,
+              { id: context.payload.pull_request.node_id }
+            )


### PR DESCRIPTION
This change adds a workflow that converts PRs to draft on open, leaving PRs that were already opened as drafts untouched.

My goal with this policy change is that it becomes faster and easier to review PRs that are _ready_ which means: CI is green and the author marks them as ready for review.

GitHub provides no out of the box functionality which will default PRs to draft so unfortunately this little bit of automation is the next best thing