### PR TITLE
chore: be a little more exhaustive in our kernel expression matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ repository = "https://github.com/delta-io/delta.rs"
 
 [workspace.dependencies]
 #delta_kernel = { package = "buoyant_kernel", path = "../delta-kernel-rs/kernel", features = [
-#delta_kernel = { package = "buoyant_kernel", git = "https://github.com/buoyant-data/delta-kernel-rs", branch = "buoyant/main", features = [
-delta_kernel = { package = "buoyant_kernel", version = "0.22.0, <0.22.100", features = [
+delta_kernel = { package = "buoyant_kernel", git = "https://github.com/buoyant-data/delta-kernel-rs", branch = "buoyant/main", features = [
+#delta_kernel = { package = "buoyant_kernel", version = "0.24.0, <0.24.100", features = [
     "arrow-58",
     "internal-api",
 ] }

--- a/crates/core/src/delta_datafusion/engine/expressions/to_datafusion.rs
+++ b/crates/core/src/delta_datafusion/engine/expressions/to_datafusion.rs
@@ -930,7 +930,8 @@ mod tests {
         );
 
         // Test error case: empty column name
-        let expr = Expression::Column(ColumnName::new::<&str>([]));
+        let columns: [&str; 0] = [];
+        let expr = Expression::Column(ColumnName::new(columns));
         assert!(to_datafusion_expr(&expr, &DataType::BOOLEAN).is_err());
     }
 }

--- a/crates/core/src/delta_datafusion/engine/expressions/to_datafusion.rs
+++ b/crates/core/src/delta_datafusion/engine/expressions/to_datafusion.rs
@@ -52,15 +52,12 @@ pub(crate) fn to_datafusion_expr(expr: &Expression, output_type: &DataType) -> D
                 .try_collect()?;
             match expr.op {
                 VariadicExpressionOp::Coalesce => Ok(coalesce(exprs)),
+                others => {
+                    not_impl_err!("The {others} VariadicExpressionOp is not supported proerly")
+                }
             }
         }
-        Expression::Opaque(_) => not_impl_err!("Opaque expressions are not yet supported"),
-        Expression::Unknown(_) => not_impl_err!("Unknown expressions are not yet supported"),
-        Expression::Transform(_) => not_impl_err!("Transform expressions are not yet supported"),
-        Expression::ParseJson(_) => not_impl_err!("ParseJson expressions are not yet supported"),
-        Expression::MapToStruct(_) => {
-            not_impl_err!("MapToStruct expressions are not yet supported")
-        }
+        others => not_impl_err!("The {others} expression type is not yet supported"),
     }
 }
 

--- a/crates/core/src/kernel/snapshot/iterators/scan_row.rs
+++ b/crates/core/src/kernel/snapshot/iterators/scan_row.rs
@@ -584,7 +584,7 @@ fn primitive_partition_values_to_array(
             .with_precision_and_scale(decimal.precision(), decimal.scale() as i8)?,
         ) as ArrayRef,
         others => {
-            todo!("The primitive type {others} is not supported currenctly!");
+            todo!("The primitive type {others} is not supported currently!");
         }
     })
 }

--- a/crates/core/src/kernel/snapshot/iterators/scan_row.rs
+++ b/crates/core/src/kernel/snapshot/iterators/scan_row.rs
@@ -583,6 +583,9 @@ fn primitive_partition_values_to_array(
             )?)
             .with_precision_and_scale(decimal.precision(), decimal.scale() as i8)?,
         ) as ArrayRef,
+        others => {
+            todo!("The primitive type {others} is not supported currenctly!");
+        }
     })
 }
 

--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -10,8 +10,8 @@ use delta_kernel::expressions::Scalar;
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use indexmap::IndexMap;
 use itertools::Itertools;
-use parquet::basic::LogicalType;
 use parquet::basic::Type;
+use parquet::basic::{ConvertedType, LogicalType};
 use parquet::file::metadata::ParquetMetaData;
 use parquet::schema::types::{ColumnDescriptor, SchemaDescriptor};
 use parquet::{
@@ -224,7 +224,10 @@ fn stats_from_metadata(
                         );
                         None
                     } else {
-                        Some(AggregatedStats::from((s, column_descr.logical_type_ref())))
+                        let logical_type = column_descr
+                            .logical_type_ref()
+                            .or(converted_to_logical_type(column_descr.converted_type()));
+                        Some(AggregatedStats::from((s, logical_type)))
                     }
                 })
             })
@@ -661,6 +664,21 @@ fn apply_min_max_for_column(
         (_, None) => {
             unreachable!();
         }
+    }
+}
+
+/// Map the old (old!) [parquet::basic::ConvertedType] into the more modern
+/// [parquet::basic::LogicalType]
+///
+/// Because this is a legacy format helper function, ro types which might not be easy to convert
+/// from one struct to the other, it will just return `None`
+fn converted_to_logical_type(converted: ConvertedType) -> Option<&'static LogicalType> {
+    match converted {
+        ConvertedType::UTF8 => Some(&LogicalType::String),
+        ConvertedType::DATE => Some(&LogicalType::Date),
+        ConvertedType::JSON => Some(&LogicalType::Json),
+        ConvertedType::BSON => Some(&LogicalType::Bson),
+        _others => None,
     }
 }
 


### PR DESCRIPTION
regrettably these non-exhaustive match expressions are released into the
world which means that the next release of buoyant_kernel needs to bump
into the 100s and cannot be safely incorporated into the currently released 0.32.x crates

Signed-off-by: R. Tyler Croy <rtyler@brokenco.de>
