### PR TITLE
feat: update schema mismatch error message

### DIFF
--- a/crates/core/src/kernel/schema/cast/mod.rs
+++ b/crates/core/src/kernel/schema/cast/mod.rs
@@ -7,8 +7,10 @@ use arrow_array::{
 };
 use arrow_cast::{CastOptions, cast_with_options};
 use arrow_schema::{
-    ArrowError, DataType, FieldRef, Fields, Schema, SchemaRef as ArrowSchemaRef, TimeUnit,
+    ArrowError, DataType, Field, FieldRef, Fields, Schema, SchemaRef as ArrowSchemaRef, TimeUnit,
 };
+use std::collections::HashSet;
+use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -350,6 +352,26 @@ pub fn normalize_for_delta(schema: &ArrowSchemaRef) -> ArrowSchemaRef {
     }
 }
 
+pub fn symmetric_differences<'a>(
+    new_schema: &'a ArrowSchemaRef,
+    expected_schema: &'a ArrowSchemaRef,
+) -> Option<Fields> {
+    if new_schema == expected_schema {
+        return None;
+    }
+
+    let new_schema_set: HashSet<&'a Field> = HashSet::from_iter(new_schema.flattened_fields());
+    let expected_schema_set: HashSet<&'a Field> =
+        HashSet::from_iter(expected_schema.flattened_fields());
+
+    Some(Fields::from(
+        new_schema_set
+            .symmetric_difference(&expected_schema_set)
+            .map(|f| Arc::new((**f).clone()))
+            .collect::<Vec<_>>(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -375,6 +397,7 @@ mod tests {
         ArrayType as DeltaArrayType, DataType as DeltaDataType, StructField as DeltaStructField,
         StructType as DeltaStructType,
     };
+    use crate::symmetric_differences;
 
     #[test]
     fn test_merge_arrow_schema_with_dict() {
@@ -694,6 +717,45 @@ mod tests {
         assert_eq!(
             result.column(1).deref().as_string::<i32>(),
             new_null_array(&DataType::Utf8, 3).deref().as_string()
+        );
+    }
+    #[test]
+    fn test_symmetric_differences_added_field_in_record_batch() {
+        let existing_schema = Arc::new(Schema::new(vec![Field::new(
+            "field1",
+            DataType::Int32,
+            false,
+        )]));
+
+        let new_schema = Arc::new(Schema::new(vec![
+            Field::new("field1", DataType::Int32, false),
+            Field::new("field2", DataType::Utf8, true),
+        ]));
+
+        let result = symmetric_differences(&new_schema, &existing_schema).unwrap();
+        assert_eq!(
+            result,
+            Fields::from(vec![Field::new("field2", DataType::Utf8, true)])
+        );
+    }
+
+    #[test]
+    fn test_symmetric_differences_missing_field_in_record_batch() {
+        let new_schema = Arc::new(Schema::new(vec![Field::new(
+            "field1",
+            DataType::Int32,
+            false,
+        )]));
+
+        let existing_schema = Arc::new(Schema::new(vec![
+            Field::new("field1", DataType::Int32, false),
+            Field::new("field2", DataType::Utf8, true),
+        ]));
+
+        let result = symmetric_differences(&new_schema, &existing_schema).unwrap();
+        assert_eq!(
+            result,
+            Fields::from(vec![Field::new("field2", DataType::Utf8, true)])
         );
     }
 

--- a/crates/core/src/kernel/schema/cast/mod.rs
+++ b/crates/core/src/kernel/schema/cast/mod.rs
@@ -351,7 +351,7 @@ pub fn normalize_for_delta(schema: &ArrowSchemaRef) -> ArrowSchemaRef {
     }
 }
 
-pub fn symmetric_differences<'a>(
+pub(crate) fn symmetric_differences<'a>(
     new_schema: &'a ArrowSchemaRef,
     expected_schema: &'a ArrowSchemaRef,
 ) -> Option<Fields> {

--- a/crates/core/src/kernel/schema/cast/mod.rs
+++ b/crates/core/src/kernel/schema/cast/mod.rs
@@ -10,7 +10,6 @@ use arrow_schema::{
     ArrowError, DataType, Field, FieldRef, Fields, Schema, SchemaRef as ArrowSchemaRef, TimeUnit,
 };
 use std::collections::HashSet;
-use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -757,6 +756,22 @@ mod tests {
             result,
             Fields::from(vec![Field::new("field2", DataType::Utf8, true)])
         );
+    }
+
+    #[test]
+    fn test_symmetric_differences_wrong_order() {
+        let new_schema = Arc::new(Schema::new(vec![
+            Field::new("field2", DataType::Utf8, true),
+            Field::new("field1", DataType::Int32, false),
+        ]));
+
+        let existing_schema = Arc::new(Schema::new(vec![
+            Field::new("field1", DataType::Int32, false),
+            Field::new("field2", DataType::Utf8, true),
+        ]));
+
+        let result = symmetric_differences(&new_schema, &existing_schema);
+        assert_eq!(result, Some(Fields::empty()));
     }
 
     #[test]

--- a/crates/core/src/writer/mod.rs
+++ b/crates/core/src/writer/mod.rs
@@ -1,6 +1,6 @@
 //! Abstractions and implementations for writing data to delta tables
 
-use arrow::{datatypes::SchemaRef, error::ArrowError};
+use arrow::{datatypes::FieldRef, datatypes::SchemaRef, error::ArrowError};
 use async_trait::async_trait;
 use object_store::Error as ObjectStoreError;
 use parquet::errors::ParquetError;
@@ -8,6 +8,8 @@ use serde_json::Value;
 
 use crate::DeltaTable;
 use crate::errors::{ColumnMappingOperation, DeltaTableError};
+use crate::errors::{DeltaTableError, unsupported_column_mapping_write};
+use crate::kernel::schema::symmetric_differences;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{Action, Add, Version};
 use crate::protocol::{ColumnCountStat, DeltaOperation, SaveMode};
@@ -50,9 +52,7 @@ pub(crate) enum DeltaWriterError {
     MissingPartitionColumn(String),
 
     /// The Arrow RecordBatch schema does not match the expected schema.
-    #[error(
-        "Arrow RecordBatch schema does not match: RecordBatch schema: {record_batch_schema}, {expected_schema}"
-    )]
+    #[error("{}", format_schema_mismatch(record_batch_schema, expected_schema))]
     SchemaMismatch {
         /// The record batch schema.
         record_batch_schema: SchemaRef,
@@ -144,6 +144,28 @@ impl From<DeltaWriterError> for DeltaTableError {
     }
 }
 
+fn format_schema_mismatch(record_batch_schema: &SchemaRef, expected_schema: &SchemaRef) -> String {
+    // We can safely assume this will succeed since we already know the schemas are different
+    let differences = symmetric_differences(record_batch_schema, expected_schema).unwrap();
+
+    let (expected_fields, different_fields): (Vec<&FieldRef>, Vec<&FieldRef>) =
+        differences.iter().partition(|f| {
+            expected_schema
+                .field_with_name(f.name())
+                .map_or(false, |e| e == f.as_ref()) // It possible the type are mismatch but the names matches
+        });
+
+    match (differences.is_empty(), expected_fields.is_empty()) {
+        (true, _) => "Arrow RecordBatch schema is in the wrong order".to_string(),
+        (false, false) => format!(
+            "Arrow RecordBatch schema does not match: Missing fields: {expected_fields:?} and Found fields {different_fields:?}"
+        ),
+        (false, true) => {
+            format!("Arrow RecordBatch schema does not match: Found extra fields {differences:?}")
+        }
+    }
+}
+
 /// Write mode for the [DeltaWriter]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum WriteMode {
@@ -212,7 +234,9 @@ mod tests {
 
     use super::*;
     use crate::DeltaResult;
+    use arrow_schema::{DataType as ArrowDataType, Field, Schema};
     use pretty_assertions::assert_ne;
+    use std::sync::Arc;
 
     /// This test doesn't have a great way to _validate_ that logs are not cleaned up as part of
     /// the second commit.
@@ -253,5 +277,75 @@ mod tests {
             "flush_and_commit did not create a version apparently?"
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_schema_mismatch_message_different_order() {
+        let new_schema = Arc::new(Schema::new(vec![
+            Field::new("field2", ArrowDataType::Utf8, true),
+            Field::new("field1", ArrowDataType::Int32, false),
+        ]));
+
+        let existing_schema = Arc::new(Schema::new(vec![
+            Field::new("field1", ArrowDataType::Int32, false),
+            Field::new("field2", ArrowDataType::Utf8, true),
+        ]));
+
+        let format_message = format_schema_mismatch(&new_schema, &existing_schema);
+        assert_eq!(
+            format_message,
+            "Arrow RecordBatch schema is in the wrong order".to_string()
+        );
+    }
+
+    #[test]
+    fn test_schema_mismatch_message_completely_different() {
+        let new_schema = Arc::new(Schema::new(vec![
+            Field::new("field3", ArrowDataType::Utf8, true),
+            Field::new("field4", ArrowDataType::Int32, false),
+        ]));
+
+        let existing_schema = Arc::new(Schema::new(vec![
+            Field::new("field1", ArrowDataType::Int32, false),
+            Field::new("field2", ArrowDataType::Utf8, true),
+        ]));
+
+        let format_message = format_schema_mismatch(&new_schema, &existing_schema);
+
+        let missing_field = vec![
+            Field::new("field1", ArrowDataType::Int32, false),
+            Field::new("field2", ArrowDataType::Utf8, true),
+        ];
+
+        let found_field = vec![
+            Field::new("field3", ArrowDataType::Utf8, true),
+            Field::new("field4", ArrowDataType::Int32, false),
+        ];
+        let expected = format!(
+            "Arrow RecordBatch schema does not match: Missing fields: {missing_field:?} and Found fields {found_field:?}"
+        );
+        assert_eq!(format_message, expected);
+    }
+
+    #[test]
+    fn test_schema_mismatch_message_extra_field() {
+        let new_schema = Arc::new(Schema::new(vec![
+            Field::new("field1", ArrowDataType::Int32, false),
+            Field::new("field2", ArrowDataType::Utf8, true),
+            Field::new("field3", ArrowDataType::Utf8, true),
+        ]));
+
+        let existing_schema = Arc::new(Schema::new(vec![
+            Field::new("field1", ArrowDataType::Int32, false),
+            Field::new("field2", ArrowDataType::Utf8, true),
+        ]));
+
+        let format_message = format_schema_mismatch(&new_schema, &existing_schema);
+
+        let extra_field = vec![Field::new("field3", ArrowDataType::Utf8, true)];
+
+        let expected =
+            format!("Arrow RecordBatch schema does not match: Found extra fields {extra_field:?}");
+        assert_eq!(format_message, expected);
     }
 }

--- a/crates/core/src/writer/mod.rs
+++ b/crates/core/src/writer/mod.rs
@@ -8,7 +8,6 @@ use serde_json::Value;
 
 use crate::DeltaTable;
 use crate::errors::{ColumnMappingOperation, DeltaTableError};
-use crate::errors::{DeltaTableError, unsupported_column_mapping_write};
 use crate::kernel::schema::symmetric_differences;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{Action, Add, Version};
@@ -152,7 +151,7 @@ fn format_schema_mismatch(record_batch_schema: &SchemaRef, expected_schema: &Sch
         differences.iter().partition(|f| {
             expected_schema
                 .field_with_name(f.name())
-                .map_or(false, |e| e == f.as_ref()) // It possible the type are mismatch but the names matches
+                .is_ok_and(|e| e == f.as_ref()) // It possible the types are mismatch given the names matches
         });
 
     match (differences.is_empty(), expected_fields.is_empty()) {

--- a/crates/core/src/writer/mod.rs
+++ b/crates/core/src/writer/mod.rs
@@ -311,19 +311,26 @@ mod tests {
 
         let format_message = format_schema_mismatch(&new_schema, &existing_schema);
 
-        let missing_field = vec![
-            Field::new("field1", ArrowDataType::Int32, false),
-            Field::new("field2", ArrowDataType::Utf8, true),
-        ];
+        let (missing_section, found_section) = format_message
+            .split_once(" and Found fields ")
+            .expect("Message should contain ' and Found fields '");
 
-        let found_field = vec![
-            Field::new("field3", ArrowDataType::Utf8, true),
-            Field::new("field4", ArrowDataType::Int32, false),
-        ];
-        let expected = format!(
-            "Arrow RecordBatch schema does not match: Missing fields: {missing_field:?} and Found fields {found_field:?}"
+        assert!(
+            missing_section.contains("field1"),
+            "field1 should be in missing fields"
         );
-        assert_eq!(format_message, expected);
+        assert!(
+            missing_section.contains("field2"),
+            "field2 should be in missing fields"
+        );
+        assert!(
+            found_section.contains("field3"),
+            "field3 should be in found fields"
+        );
+        assert!(
+            found_section.contains("field4"),
+            "field4 should be in found fields"
+        );
     }
 
     #[test]

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -979,6 +979,42 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_mismatched_schema_log_message() {
+            let table_dir = tempfile::tempdir().unwrap();
+            let table_path = table_dir.path().to_str().unwrap();
+
+            let batch = get_record_batch(None, false);
+            let partition_cols = vec![];
+            let table = create_initialized_table(table_path, &partition_cols).await;
+            let mut writer = RecordBatchWriter::for_table(&table).unwrap();
+
+            // Write the first batch with the first schema to the table
+            writer.write(batch).await.unwrap();
+            let adds = writer.flush().await.unwrap();
+            assert_eq!(adds.len(), 1);
+
+            // Create a second batch with a different schema
+            let second_schema = Arc::new(ArrowSchema::new(vec![
+                Field::new("id", DataType::Int32, true),
+                Field::new("name", DataType::Utf8, true),
+            ]));
+            let second_batch = RecordBatch::try_new(
+                second_schema,
+                vec![
+                    Arc::new(Int32Array::from(vec![Some(1), Some(2)])),
+                    Arc::new(StringArray::from(vec![Some("will"), Some("robert")])),
+                ],
+            )
+            .unwrap();
+
+            let result = writer.write(second_batch).await;
+            assert!(result.is_err());
+            let error_message: String = result.unwrap_err().to_string();
+
+            assert!(error_message.contains("Arrow RecordBatch schema does not match: Column 'id' type mismatch - expected Int64, found Int32"));
+        }
+
+        #[tokio::test]
         async fn test_write_schema_evolution() {
             let table_schema = get_delta_schema();
             let table_dir = tempfile::tempdir().unwrap();

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -979,42 +979,6 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_mismatched_schema_log_message() {
-            let table_dir = tempfile::tempdir().unwrap();
-            let table_path = table_dir.path().to_str().unwrap();
-
-            let batch = get_record_batch(None, false);
-            let partition_cols = vec![];
-            let table = create_initialized_table(table_path, &partition_cols).await;
-            let mut writer = RecordBatchWriter::for_table(&table).unwrap();
-
-            // Write the first batch with the first schema to the table
-            writer.write(batch).await.unwrap();
-            let adds = writer.flush().await.unwrap();
-            assert_eq!(adds.len(), 1);
-
-            // Create a second batch with a different schema
-            let second_schema = Arc::new(ArrowSchema::new(vec![
-                Field::new("id", DataType::Int32, true),
-                Field::new("name", DataType::Utf8, true),
-            ]));
-            let second_batch = RecordBatch::try_new(
-                second_schema,
-                vec![
-                    Arc::new(Int32Array::from(vec![Some(1), Some(2)])),
-                    Arc::new(StringArray::from(vec![Some("will"), Some("robert")])),
-                ],
-            )
-            .unwrap();
-
-            let result = writer.write(second_batch).await;
-            assert!(result.is_err());
-            let error_message: String = result.unwrap_err().to_string();
-
-            assert!(error_message.contains("Arrow RecordBatch schema does not match: Column 'id' type mismatch - expected Int64, found Int32"));
-        }
-
-        #[tokio::test]
         async fn test_write_schema_evolution() {
             let table_schema = get_delta_schema();
             let table_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
# Description
Updates the Schema Mismatch message to return the symmetric difference instead of the two full schema definition

# Related Issue(s)
<!---
For example:

- closes #106
--->
- closes #1652

# Documentation
I wrote all the tests myself and used AI for very specific task such as making my solution more idiomatic rust , Lifetime annotation which I am still learning, and reducing code while still passing the tests.
<!---
Share links to useful documentation
--->
