### PR TITLE
feat: allow switching nanosecond timestamps on at runtime in Python

### DIFF
--- a/crates/core/src/kernel/arrow/engine_ext.rs
+++ b/crates/core/src/kernel/arrow/engine_ext.rs
@@ -478,6 +478,7 @@ fn should_include_column(column_name: &ColumnName, column_names: &[ColumnName]) 
 ///
 /// [`StatsProjection`]: crate::kernel::snapshot::StatsProjection
 pub(crate) fn is_public_min_max_stats_eligible_primitive(data_type: &PrimitiveType) -> bool {
+    #[cfg(not(feature = "nanosecond-timestamps"))]
     let matches_nanos = false;
     #[cfg(feature = "nanosecond-timestamps")]
     let matches_nanos = matches!(data_type, &PrimitiveType::TimestampNanos);

--- a/crates/core/src/kernel/schema/cast/mod.rs
+++ b/crates/core/src/kernel/schema/cast/mod.rs
@@ -10,11 +10,29 @@ use arrow_schema::{
     ArrowError, DataType, FieldRef, Fields, Schema, SchemaRef as ArrowSchemaRef, TimeUnit,
 };
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 mod merge_schema;
 pub(crate) use merge_schema::*;
 
 use crate::DeltaResult;
+
+/// The Python extension enables the nanosecond-timestamps feature, but wants to
+/// enable/disable them at runtime. We therefore make behavior conditional even
+/// when the feature is enabled.
+static CAST_NANOS_TS_TO_MICROS: AtomicBool =
+    AtomicBool::new(!cfg!(feature = "nanosecond-timestamps"));
+
+#[cfg(feature = "nanosecond-timestamps")]
+/// Set whether casting nanosecond timestamps to microsecond timestamps happens.
+pub fn set_cast_nanos_timestamps_to_micros(cast: bool) {
+    CAST_NANOS_TS_TO_MICROS.store(cast, Ordering::Release)
+}
+
+/// Check whether nanosecond timestamps should be cast to microseconds.
+fn should_cast_nanos_timestamps_to_micros() -> bool {
+    CAST_NANOS_TS_TO_MICROS.load(Ordering::Acquire)
+}
 
 fn cast_struct(
     struct_array: &StructArray,
@@ -234,13 +252,12 @@ fn normalize_datatype(dt: &DataType) -> Option<DataType> {
         | DataType::Timestamp(TimeUnit::Millisecond, tz) => {
             Some(DataType::Timestamp(TimeUnit::Microsecond, tz.clone()))
         }
-        #[cfg(not(feature = "nanosecond-timestamps"))]
         DataType::Timestamp(TimeUnit::Nanosecond, tz) => {
-            Some(DataType::Timestamp(TimeUnit::Microsecond, tz.clone()))
-        }
-        #[cfg(feature = "nanosecond-timestamps")]
-        DataType::Timestamp(TimeUnit::Nanosecond, tz) => {
-            Some(DataType::Timestamp(TimeUnit::Nanosecond, tz.clone()))
+            if should_cast_nanos_timestamps_to_micros() {
+                Some(DataType::Timestamp(TimeUnit::Microsecond, tz.clone()))
+            } else {
+                Some(DataType::Timestamp(TimeUnit::Nanosecond, tz.clone()))
+            }
         }
         DataType::Struct(fields) => {
             let mut changed = false;
@@ -273,7 +290,6 @@ fn normalize_field(field: &FieldRef) -> Option<FieldRef> {
         .map(|dt| Arc::new(field.as_ref().clone().with_data_type(dt)))
 }
 
-#[cfg(not(feature = "nanosecond-timestamps"))]
 fn has_nanosecond_timestamp(dt: &DataType) -> bool {
     match dt {
         DataType::Timestamp(TimeUnit::Nanosecond, _) => true,
@@ -304,19 +320,19 @@ pub fn normalize_for_delta(schema: &ArrowSchemaRef) -> ArrowSchemaRef {
         .collect();
 
     if changed {
-        #[cfg(not(feature = "nanosecond-timestamps"))]
-        let nanosecond_truncated_fields: Vec<&str> = schema
-            .fields()
-            .iter()
-            .filter(|f| has_nanosecond_timestamp(f.data_type()))
-            .map(|f| f.name().as_str())
-            .collect();
-        #[cfg(not(feature = "nanosecond-timestamps"))]
-        if !nanosecond_truncated_fields.is_empty() {
-            tracing::warn!(
-                fields = ?nanosecond_truncated_fields,
-                "Lossy timestamp conversion: Timestamp(Nanosecond) columns will be truncated to Timestamp(Microsecond) to comply with the Delta Lake protocol"
-            );
+        if should_cast_nanos_timestamps_to_micros() {
+            let nanosecond_truncated_fields: Vec<&str> = schema
+                .fields()
+                .iter()
+                .filter(|f| has_nanosecond_timestamp(f.data_type()))
+                .map(|f| f.name().as_str())
+                .collect();
+            if !nanosecond_truncated_fields.is_empty() {
+                tracing::warn!(
+                    fields = ?nanosecond_truncated_fields,
+                    "Lossy timestamp conversion: Timestamp(Nanosecond) columns will be truncated to Timestamp(Microsecond) to comply with the Delta Lake protocol"
+                );
+            }
         }
 
         Arc::new(Schema::new_with_metadata(

--- a/crates/core/src/kernel/schema/cast/mod.rs
+++ b/crates/core/src/kernel/schema/cast/mod.rs
@@ -242,7 +242,8 @@ pub fn cast_record_batch(
 /// unsupported Arrow types to their Delta-compatible equivalents:
 ///
 /// - `Date64` -> `Date32` (day precision)
-/// - `Timestamp(Second/Millisecond/Nanosecond, tz)` -> `Timestamp(Microsecond, tz)` (preserves timezone), unless the `nanosecond-timestamps` Cargo feature is enabled.
+/// - `Timestamp(Second/Millisecond/Nanosecond, tz)` -> `Timestamp(Microsecond, tz)` (preserves timezone),
+///   except for Nanosecond inputs when `CAST_NANOS_TS_TO_MICROS` is false.
 ///
 /// Recursively normalizes nested types (Struct, List, Map, etc.).
 fn normalize_datatype(dt: &DataType) -> Option<DataType> {

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -106,7 +106,7 @@ features = [
 ]
 
 [features]
-default = ["rustls"]
+default = ["rustls", "nanosecond-timestamps"]
 native-tls = ["deltalake/s3-native-tls", "deltalake/glue"]
 rustls = ["deltalake/s3", "deltalake/glue"]
 nanosecond-timestamps = ["deltalake/nanosecond-timestamps"]

--- a/python/deltalake/__init__.py
+++ b/python/deltalake/__init__.py
@@ -1,14 +1,16 @@
 import atexit
 from typing import Optional
 
+from deltalake import table
+from deltalake._internal import (
+    _NANOSECOND_TIMESTAMPS as _INTERNAL_NANOSECOND_TIMESTAMPS,
+)
 from deltalake._internal import (
     TableFeatures,
     Transaction,
     __version__,
     rust_core_version,
-    _NANOSECOND_TIMESTAMPS as _INTERNAL_NANOSECOND_TIMESTAMPS,
 )
-from deltalake import table
 from deltalake._internal import (
     init_tracing as _init_tracing,
 )

--- a/python/deltalake/__init__.py
+++ b/python/deltalake/__init__.py
@@ -88,6 +88,11 @@ _NANOSECOND_TIMESTAMPS: bool = False
 def enable_nanosecond_timestamps() -> None:
     """
     Enable experimental support for nanosecond timestamp primitive data types.
+
+    This takes effect process-wide.
+
+    Note that this feature may be changed or removed in a future release
+    without being considered a breaking change.
     """
     if not _INTERNAL_NANOSECOND_TIMESTAMPS:
         raise RuntimeError(

--- a/python/deltalake/__init__.py
+++ b/python/deltalake/__init__.py
@@ -6,7 +6,9 @@ from deltalake._internal import (
     Transaction,
     __version__,
     rust_core_version,
+    _NANOSECOND_TIMESTAMPS as _INTERNAL_NANOSECOND_TIMESTAMPS,
 )
+from deltalake import table
 from deltalake._internal import (
     init_tracing as _init_tracing,
 )
@@ -77,6 +79,57 @@ def init_tracing(endpoint: Optional[str] = None) -> None:
     atexit.register(_shutdown_tracing)
 
 
+# Support nanosecond timestamps:
+_NANOSECOND_TIMESTAMPS: bool = False
+
+
+def enable_nanosecond_timestamps() -> None:
+    """
+    Enable experimental support for nanosecond timestamp primitive data types.
+    """
+    if not _INTERNAL_NANOSECOND_TIMESTAMPS:
+        raise RuntimeError(
+            "Extension wasn't compiled with nanosecond-timestamps Cargo feature"
+        )
+
+    if _nanosecond_timestamps_enabled():
+        # Already called, no work necessary.
+        return
+
+    global _NANOSECOND_TIMESTAMPS
+    _NANOSECOND_TIMESTAMPS = True
+    table.SUPPORTED_WRITER_FEATURES.add("timestampNanos")
+    table.SUPPORTED_READER_FEATURES.add("timestampNanos")
+
+    from deltalake._internal import _set_cast_nanos_timestamps_to_micros
+
+    _set_cast_nanos_timestamps_to_micros(False)
+
+
+def _disable_nanosecond_timestamps() -> None:
+    """
+    Disable nanosecond timestamps, for unit tests.
+    """
+    if not _nanosecond_timestamps_enabled():
+        return
+
+    global _NANOSECOND_TIMESTAMPS
+    _NANOSECOND_TIMESTAMPS = False
+    table.SUPPORTED_WRITER_FEATURES.remove("timestampNanos")
+    table.SUPPORTED_READER_FEATURES.remove("timestampNanos")
+
+    from deltalake._internal import _set_cast_nanos_timestamps_to_micros
+
+    _set_cast_nanos_timestamps_to_micros(True)
+
+
+def _nanosecond_timestamps_enabled() -> bool:
+    """
+    Return whether nanosecond timestamps are enabled.
+    """
+    return _NANOSECOND_TIMESTAMPS
+
+
 __all__ = [
     "BloomFilterProperties",
     "ColumnProperties",
@@ -94,6 +147,7 @@ __all__ = [
     "WriterProperties",
     "__version__",
     "convert_to_deltalake",
+    "enable_nanosecond_timestamps",
     "init_tracing",
     "rust_core_version",
     "write_deltalake",

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 __version__: str
 _NANOSECOND_TIMESTAMPS: bool
 
-def _set_cast_nanos_timestamps_to_micros(cast: bool) -> bool: ...
+def _set_cast_nanos_timestamps_to_micros(cast: bool) -> None: ...
 
 class TableFeatures(Enum):
     # Mapping of one column to another

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 __version__: str
 _NANOSECOND_TIMESTAMPS: bool
 
+def _set_cast_nanos_timestamps_to_micros(cast: bool) -> bool: ...
+
 class TableFeatures(Enum):
     # Mapping of one column to another
     ColumnMapping = "ColumnMapping"

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -24,7 +24,6 @@ from arro3.core.types import (
 )
 
 from deltalake._internal import (
-    _NANOSECOND_TIMESTAMPS,
     DeltaError,
     PyMergeBuilder,
     RawDeltaTable,
@@ -71,9 +70,6 @@ NOT_SUPPORTED_READER_VERSION = 2
 SUPPORTED_READER_FEATURES = {"timestampNtz", "variantType", "variantType-preview"}
 
 FSCK_METRICS_FILES_REMOVED_LABEL = "files_removed"
-if _NANOSECOND_TIMESTAMPS:
-    SUPPORTED_WRITER_FEATURES.add("timestampNanos")
-    SUPPORTED_READER_FEATURES.add("timestampNanos")
 
 FilterLiteralType = tuple[str, str, Any]
 FilterConjunctionType = list[FilterLiteralType]

--- a/python/deltalake/writer/_conversion.py
+++ b/python/deltalake/writer/_conversion.py
@@ -9,7 +9,9 @@ def _convert_arro3_schema_to_delta(
     existing_schema: Arro3Schema | None = None,
 ) -> Arro3Schema:
     """Convert a arro3 schema to a schema compatible with Delta Lake. Converts unsigned to signed equivalent, and
-    converts all timestamps to `us` timestamps. Also handles null column types by converting them to match
+    converts all timestamps to `us` timestamps, except nanosecond timestamps when the experimental nanosecond
+    timestamp feature is enabled.
+    Also handles null column types by converting them to match
     corresponding fields in the existing table schema.
 
     Args:
@@ -19,6 +21,7 @@ def _convert_arro3_schema_to_delta(
     Returns:
         Arro3Schema: Delta-compatible schema with converted types.
     """
+    from deltalake import _nanosecond_timestamps_enabled
 
     def dtype_to_delta_dtype(
         dtype: DataType, field_name: str | None = None
@@ -51,7 +54,7 @@ def _convert_arro3_schema_to_delta(
         elif DataType.is_timestamp(dtype):
             if dtype.tz is None:
                 return DataType.timestamp("us")
-            elif dtype.time_unit == "ns":
+            elif dtype.time_unit == "ns" and _nanosecond_timestamps_enabled():
                 return DataType.timestamp("ns", tz="UTC")
             else:
                 return DataType.timestamp("us", tz="UTC")

--- a/python/docs/source/api_reference.rst
+++ b/python/docs/source/api_reference.rst
@@ -41,3 +41,9 @@ DeltaStorageHandler
 
 .. automodule:: deltalake.fs
     :members:
+
+
+Experimental functionality
+--------------------------
+
+.. autofunction:: deltalake.enable_nanosecond_timestamps

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -72,7 +72,7 @@ ignore = ["E501", "ANN401", "RUF040"]
 known-first-party = ["deltalake"]
 
 [tool.pytest.ini_options]
-addopts = "-v -x -m 'not integration and not benchmark and not no_pyarrow'"
+addopts = "-v -m 'not integration and not benchmark and not no_pyarrow'"
 testpaths = ["tests", "deltalake"]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -72,7 +72,7 @@ ignore = ["E501", "ANN401", "RUF040"]
 known-first-party = ["deltalake"]
 
 [tool.pytest.ini_options]
-addopts = "-v -m 'not integration and not benchmark and not no_pyarrow'"
+addopts = "-v -x -m 'not integration and not benchmark and not no_pyarrow'"
 testpaths = ["tests", "deltalake"]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -3162,6 +3162,13 @@ fn convert_to_deltalake(
     })
 }
 
+/// Enable or disable casting nanosecond timestamps to microseconds.
+#[cfg(feature = "nanosecond-timestamps")]
+#[pyfunction]
+fn _set_cast_nanos_timestamps_to_micros(cast: bool) {
+    deltalake::schema::cast::set_cast_nanos_timestamps_to_micros(cast);
+}
+
 #[pymodule(gil_used = true)]
 // module name need to match project name
 fn _internal(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -3215,6 +3222,16 @@ fn _internal(m: &Bound<'_, PyModule>) -> PyResult<()> {
         "_NANOSECOND_TIMESTAMPS",
         cfg!(feature = "nanosecond-timestamps"),
     )?;
+    #[cfg(feature = "nanosecond-timestamps")]
+    {
+        // Default is casting happens, since nanosecond timestamps will be
+        // disabled at runtime by default as an experimental feature.
+        _set_cast_nanos_timestamps_to_micros(true);
+        m.add_function(pyo3::wrap_pyfunction!(
+            _set_cast_nanos_timestamps_to_micros,
+            m
+        )?)?;
+    }
 
     Ok(())
 }

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -16,9 +16,9 @@ from azure.storage import blob
 from deltalake import (
     DeltaTable,
     WriterProperties,
-    write_deltalake,
-    enable_nanosecond_timestamps,
     _disable_nanosecond_timestamps,
+    enable_nanosecond_timestamps,
+    write_deltalake,
 )
 from deltalake._internal import _NANOSECOND_TIMESTAMPS
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -13,7 +13,13 @@ import pytest
 from arro3.core import Array, DataType, Field, Schema, Table
 from azure.storage import blob
 
-from deltalake import DeltaTable, WriterProperties, write_deltalake
+from deltalake import (
+    DeltaTable,
+    WriterProperties,
+    write_deltalake,
+    enable_nanosecond_timestamps,
+    _disable_nanosecond_timestamps,
+)
 from deltalake._internal import _NANOSECOND_TIMESTAMPS
 
 if TYPE_CHECKING:
@@ -232,18 +238,19 @@ def azurite_sas_creds(azurite_creds):
     return creds
 
 
-@pytest.fixture()
-def sample_data_pyarrow() -> "pa.Table":
+@pytest.fixture(params=[{"ns_timestamps": True}, {"ns_timestamps": False}])
+def sample_data_pyarrow(request) -> "pa.Table":
+    nanosecond_timestamps = request.param["ns_timestamps"] and _NANOSECOND_TIMESTAMPS
     nrows = 5
     import pyarrow as pa
 
     extras = {}
-    if _NANOSECOND_TIMESTAMPS:
+    if nanosecond_timestamps:
         extras["timestamp_ns"] = pa.array(
             [pa.scalar(i, type=pa.timestamp("ns", "UTC")) for i in range(nrows)]
         )
 
-    return pa.table(
+    table = pa.table(
         {
             "utf8": pa.array([str(x) for x in range(nrows)]),
             "int64": pa.array(list(range(nrows)), pa.int64()),
@@ -276,6 +283,12 @@ def sample_data_pyarrow() -> "pa.Table":
         }
         | extras
     )
+    try:
+        if nanosecond_timestamps:
+            enable_nanosecond_timestamps()
+        yield table
+    finally:
+        _disable_nanosecond_timestamps()
 
 
 @pytest.fixture()

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -395,3 +395,18 @@ def minio_s3_env(monkeypatch, minio_container):
 @pytest.fixture()
 def writer_properties():
     return WriterProperties(compression="GZIP", compression_level=0)
+
+
+@pytest.fixture()
+def nanosecond_timestamps_enabled():
+    from deltalake import _disable_nanosecond_timestamps, enable_nanosecond_timestamps
+    from deltalake._internal import _NANOSECOND_TIMESTAMPS
+
+    if not _NANOSECOND_TIMESTAMPS:
+        pytest.skip("Rust library built without nanosecond timestamp support")
+
+    enable_nanosecond_timestamps()
+    try:
+        yield
+    finally:
+        _disable_nanosecond_timestamps()

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -238,7 +238,10 @@ def azurite_sas_creds(azurite_creds):
     return creds
 
 
-@pytest.fixture(params=[{"ns_timestamps": True}, {"ns_timestamps": False}])
+@pytest.fixture(
+    params=[{"ns_timestamps": True}, {"ns_timestamps": False}],
+    ids=["base", "with_nanos"],
+)
 def sample_data_pyarrow(request) -> "pa.Table":
     nanosecond_timestamps = request.param["ns_timestamps"] and _NANOSECOND_TIMESTAMPS
     nrows = 5

--- a/python/tests/pyspark_integration/test_writer_readable.py
+++ b/python/tests/pyspark_integration/test_writer_readable.py
@@ -25,7 +25,12 @@ except ModuleNotFoundError:
 
 @pytest.mark.pyspark
 @pytest.mark.integration
-def test_basic_read(sample_data_pyarrow: "pa.Table", existing_table: DeltaTable):
+def test_basic_read(
+    request, sample_data_pyarrow: "pa.Table", existing_table: DeltaTable
+):
+    if "timestamp_ns" in sample_data_pyarrow.column_names:
+        pytest.skip("Nanosecond timestamps are not supported in PySpark at the moment")
+
     uri = existing_table._table.table_uri() + "/"
 
     assert_spark_read_equal(sample_data_pyarrow, uri)
@@ -40,6 +45,8 @@ def test_basic_read(sample_data_pyarrow: "pa.Table", existing_table: DeltaTable)
 @pytest.mark.pyarrow
 @pytest.mark.integration
 def test_partitioned(tmp_path: pathlib.Path, sample_data_pyarrow: "pa.Table"):
+    if "timestamp_ns" in sample_data_pyarrow.column_names:
+        pytest.skip("Nanosecond timestamps are not supported in PySpark at the moment")
     partition_cols = ["date32", "utf8", "timestamp", "bool"]
     import pyarrow as pa
 
@@ -63,6 +70,8 @@ def test_partitioned(tmp_path: pathlib.Path, sample_data_pyarrow: "pa.Table"):
 def test_overwrite(
     tmp_path: pathlib.Path, sample_data_pyarrow: "pa.Table", existing_table: DeltaTable
 ):
+    if "timestamp_ns" in sample_data_pyarrow.column_names:
+        pytest.skip("Nanosecond timestamps are not supported in PySpark at the moment")
     import pyarrow as pa
 
     path = str(tmp_path)

--- a/python/tests/test_alter.py
+++ b/python/tests/test_alter.py
@@ -9,9 +9,9 @@ from deltalake import (
     DeltaTable,
     PostCommitHookProperties,
     TableFeatures,
+    _nanosecond_timestamps_enabled,
     write_deltalake,
 )
-from deltalake._internal import _NANOSECOND_TIMESTAMPS
 from deltalake.exceptions import DeltaError
 from deltalake.schema import Field as DeltaField
 from deltalake.schema import PrimitiveType, StructType
@@ -414,7 +414,7 @@ def test_add_timestamp_ntz_column(tmp_path: pathlib.Path, sample_table: Table):
 
 
 @pytest.mark.skipif(
-    not _NANOSECOND_TIMESTAMPS, reason="nanosecond timestamps not enabled"
+    not _nanosecond_timestamps_enabled(), reason="nanosecond timestamps not enabled"
 )
 def test_add_timestamp_nanos_column(tmp_path: pathlib.Path, sample_table: Table):
     check_timestamp_column(

--- a/python/tests/test_alter.py
+++ b/python/tests/test_alter.py
@@ -9,7 +9,6 @@ from deltalake import (
     DeltaTable,
     PostCommitHookProperties,
     TableFeatures,
-    _nanosecond_timestamps_enabled,
     write_deltalake,
 )
 from deltalake.exceptions import DeltaError
@@ -413,9 +412,7 @@ def test_add_timestamp_ntz_column(tmp_path: pathlib.Path, sample_table: Table):
     check_timestamp_column(tmp_path, sample_table, "timestamp_ntz", {"timestampNtz"})
 
 
-@pytest.mark.skipif(
-    not _nanosecond_timestamps_enabled(), reason="nanosecond timestamps not enabled"
-)
+@pytest.mark.usefixtures("nanosecond_timestamps_enabled")
 def test_add_timestamp_nanos_column(tmp_path: pathlib.Path, sample_table: Table):
     check_timestamp_column(
         tmp_path, sample_table, "timestamp_nanos", {"timestampNanos", "timestampNtz"}

--- a/python/tests/test_cdf.py
+++ b/python/tests/test_cdf.py
@@ -503,7 +503,9 @@ def test_delete_unpartitioned_cdf(tmp_path, sample_data_pyarrow: "pa.Table"):
             column=[["delete"] * 2],
         )
     )
-    cdc_data = pq.read_table(cdc_path)
+    # Ensure the CDC data is read using the expected schema
+    # (eg. standard binary/string types rather than binary/string_view).
+    cdc_data = pq.read_table(cdc_path, schema=expected_data.schema)
 
     assert os.path.exists(cdc_path), "_change_data doesn't exist"
     assert cdc_data == expected_data

--- a/python/tests/test_cdf.py
+++ b/python/tests/test_cdf.py
@@ -506,7 +506,7 @@ def test_delete_unpartitioned_cdf(tmp_path, sample_data_pyarrow: "pa.Table"):
     cdc_data = pq.read_table(cdc_path)
 
     assert os.path.exists(cdc_path), "_change_data doesn't exist"
-    assert cdc_data.to_pydict() == expected_data.to_pydict()
+    assert cdc_data == expected_data
 
 
 @pytest.mark.pyarrow

--- a/python/tests/test_conversion.py
+++ b/python/tests/test_conversion.py
@@ -55,7 +55,7 @@ from deltalake.writer._conversion import _convert_arro3_schema_to_delta
             Schema(
                 fields=[Field("foo", DataType.timestamp("ns", tz="Europe/Amsterdam"))]
             ),
-            Schema(fields=[Field("foo", DataType.timestamp("ns", tz="UTC"))]),
+            Schema(fields=[Field("foo", DataType.timestamp("us", tz="UTC"))]),
         ),
         # Nullability variations
         (
@@ -393,6 +393,87 @@ from deltalake.writer._conversion import _convert_arro3_schema_to_delta
     ],
 )
 def test_schema_conversion(input_schema: Schema, expected_schema: Schema):
+    assert expected_schema == _convert_arro3_schema_to_delta(input_schema)
+
+
+@pytest.mark.usefixtures("nanosecond_timestamps_enabled")
+@pytest.mark.parametrize(
+    "input_schema,expected_schema",
+    [
+        # Nanosecond timestamps with a timezone are preserved
+        (
+            Schema(
+                fields=[Field("foo", DataType.timestamp("ns", tz="Europe/Amsterdam"))]
+            ),
+            Schema(fields=[Field("foo", DataType.timestamp("ns", tz="UTC"))]),
+        ),
+        # Nanosecond timestamps without a timezone are still converted to microseconds
+        (
+            Schema(fields=[Field("foo", DataType.timestamp("ns"), nullable=True)]),
+            Schema(fields=[Field("foo", DataType.timestamp("us"), nullable=True)]),
+        ),
+        # Nanosecond timestamp nested in a struct, with a timezone
+        (
+            Schema(
+                fields=[
+                    Field(
+                        "foo",
+                        DataType.struct(
+                            [
+                                Field("a", DataType.uint64()),
+                                Field(
+                                    "b",
+                                    DataType.timestamp("ns", tz="Europe/Amsterdam"),
+                                ),
+                                Field("c", DataType.uint32()),
+                            ]
+                        ),
+                    )
+                ]
+            ),
+            Schema(
+                fields=[
+                    Field(
+                        "foo",
+                        DataType.struct(
+                            [
+                                Field("a", DataType.int64()),
+                                Field("b", DataType.timestamp("ns", tz="UTC")),
+                                Field("c", DataType.int32()),
+                            ]
+                        ),
+                    )
+                ]
+            ),
+        ),
+        # Field metadata is preserved when keeping nanosecond timestamps
+        (
+            Schema(
+                fields=[
+                    Field(
+                        "bar",
+                        DataType.timestamp("ns", tz="Europe/Amsterdam"),
+                        nullable=True,
+                        metadata={"origin": "sensor_7"},
+                    )
+                ]
+            ),
+            Schema(
+                fields=[
+                    Field(
+                        "bar",
+                        DataType.timestamp("ns", tz="UTC"),
+                        nullable=True,
+                        metadata={"origin": "sensor_7"},
+                    )
+                ]
+            ),
+        ),
+    ],
+)
+def test_schema_conversion_nanoseconds_enabled(
+    input_schema: Schema, expected_schema: Schema
+):
     assert expected_schema == _convert_arro3_schema_to_delta(input_schema)
 
 

--- a/python/tests/test_fs.py
+++ b/python/tests/test_fs.py
@@ -1,5 +1,6 @@
 import pickle
 import urllib
+from uuid import uuid4
 from typing import TYPE_CHECKING
 
 import pytest
@@ -115,7 +116,7 @@ def test_roundtrip_s3_env(
     sample_data_pyarrow: "pa.Table",
     monkeypatch,
 ):
-    table_path = f"{s3_localstack_bucket_root_uri}/roundtrip"
+    table_path = f"{s3_localstack_bucket_root_uri}/roundtrip/{uuid4()}"
 
     # Create new table with path
     with pytest.raises(DeltaProtocolError, match="Atomic rename requires a LockClient"):
@@ -146,7 +147,7 @@ def test_roundtrip_s3_env(
 def test_roundtrip_s3_direct(
     s3_localstack_bucket_root_uri, s3_localstack_creds, sample_data_pyarrow: "pa.Table"
 ):
-    table_path = f"{s3_localstack_bucket_root_uri}/roundtrip2"
+    table_path = f"{s3_localstack_bucket_root_uri}/roundtrip2/{uuid4()}"
 
     # Fails without any credentials
     with pytest.raises(Exception):
@@ -189,7 +190,7 @@ def test_roundtrip_s3_direct(
 @pytest.mark.integration
 @pytest.mark.timeout(timeout=10, method="thread")
 def test_roundtrip_azure_env(azurite_env_vars, sample_data_pyarrow: "pa.Table"):
-    table_path = "abfs://deltars/roundtrip"
+    table_path = f"abfs://deltars/roundtrip/{uuid4()}"
 
     # Create new table with path
     write_deltalake(table_path, sample_data_pyarrow)
@@ -212,7 +213,7 @@ def test_roundtrip_azure_env(azurite_env_vars, sample_data_pyarrow: "pa.Table"):
 @pytest.mark.integration
 @pytest.mark.timeout(timeout=10, method="thread")
 def test_roundtrip_azure_direct(azurite_creds, sample_data_pyarrow: "pa.Table"):
-    table_path = "abfs://deltars/roundtrip2"
+    table_path = f"abfs://deltars/roundtrip2/{uuid4()}"
 
     # Can pass storage_options in directly
     write_deltalake(table_path, sample_data_pyarrow, storage_options=azurite_creds)
@@ -235,7 +236,7 @@ def test_roundtrip_azure_direct(azurite_creds, sample_data_pyarrow: "pa.Table"):
 @pytest.mark.integration
 @pytest.mark.timeout(timeout=10, method="thread")
 def test_roundtrip_azure_sas(azurite_sas_creds, sample_data_pyarrow: "pa.Table"):
-    table_path = "abfs://deltars/roundtrip3"
+    table_path = f"abfs://deltars/roundtrip3/{uuid4()}"
     write_deltalake(table_path, sample_data_pyarrow, storage_options=azurite_sas_creds)
     dt = DeltaTable(table_path, storage_options=azurite_sas_creds)
     table = dt.to_pyarrow_table()
@@ -250,7 +251,7 @@ def test_roundtrip_azure_sas(azurite_sas_creds, sample_data_pyarrow: "pa.Table")
 def test_roundtrip_azure_decoded_sas(
     azurite_sas_creds, sample_data_pyarrow: "pa.Table"
 ):
-    table_path = "abfs://deltars/roundtrip4"
+    table_path = f"abfs://deltars/roundtrip4/{uuid4()}"
     azurite_sas_creds["SAS_TOKEN"] = urllib.parse.unquote(
         azurite_sas_creds["SAS_TOKEN"]
     )

--- a/python/tests/test_fs.py
+++ b/python/tests/test_fs.py
@@ -1,7 +1,7 @@
 import pickle
 import urllib
-from uuid import uuid4
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import pytest
 

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -3398,3 +3398,77 @@ def test_merge_with_spill_config(tmp_path: pathlib.Path):
 
     assert result["num_target_rows_updated"] == 2
     assert result["num_target_rows_copied"] == 1
+
+
+@pytest.mark.pyarrow
+@pytest.mark.parametrize("enable_nanos", [False, True])
+def test_merge_schema_evolution_with_nanosecond_timestamps(
+    tmp_path: pathlib.Path,
+    enable_nanos: bool,
+):
+    """A schema-evolving merge that adds a new nanosecond timestamp
+    column must truncate it to microseconds when the experimental nanosecond
+    timestamp feature is disabled (the default).
+    """
+    import pyarrow as pa
+
+    from deltalake import _disable_nanosecond_timestamps, enable_nanosecond_timestamps
+    from deltalake._internal import _NANOSECOND_TIMESTAMPS
+
+    write_deltalake(
+        tmp_path,
+        pa.table({"id": pa.array(["1", "2"], pa.string())}),
+        mode="append",
+    )
+
+    dt = DeltaTable(tmp_path)
+
+    source_table = pa.table(
+        {
+            "id": pa.array(["3"], pa.string()),
+            "ts": pa.array([123_456_789], pa.timestamp("ns", tz="UTC")),
+        }
+    )
+
+    def do_merge():
+        dt.merge(
+            source=source_table,
+            predicate="t.id = s.id",
+            source_alias="s",
+            target_alias="t",
+            merge_schema=True,
+        ).when_not_matched_insert_all().execute()
+
+    if enable_nanos:
+        if not _NANOSECOND_TIMESTAMPS:
+            pytest.skip("Rust library not built with nanosecond-timestamps enabled")
+        # This currently errors because a merge doesn't automatically add
+        # the nanosecond timestamps feature to the table.
+        enable_nanosecond_timestamps()
+        try:
+            with pytest.raises(
+                DeltaError, match="does not have the required 'timestampNanos' feature"
+            ):
+                do_merge()
+        finally:
+            _disable_nanosecond_timestamps()
+
+    else:
+        do_merge()
+
+        dt = DeltaTable(tmp_path)
+
+        # The committed table schema must record microsecond precision.
+        assert dt.schema().to_arrow().field("ts").type == DataType.timestamp(
+            "us", tz="UTC"
+        )
+
+        result = (
+            QueryBuilder()
+            .register("tbl", dt)
+            .execute("select * from tbl order by id asc")
+            .read_all()
+        )
+
+        expected_array = pa.array([None, None, 123_456], pa.timestamp("us", tz="UTC"))
+        assert pa.chunked_array(result.column("ts")).combine_chunks() == expected_array

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -12,7 +12,15 @@ from arro3.core import Array, ChunkedArray, DataType, RecordBatchReader, Table
 from arro3.core import Field as ArrowField
 from arro3.core import Schema as ArrowSchema
 
-from deltalake import CommitProperties, DeltaTable, Transaction, write_deltalake, _nanosecond_timestamps_enabled
+from deltalake import (
+    CommitProperties,
+    DeltaTable,
+    Transaction,
+    write_deltalake,
+    _nanosecond_timestamps_enabled,
+    enable_nanosecond_timestamps,
+    _disable_nanosecond_timestamps,
+)
 from deltalake._internal import (
     CommitFailedError,
     Field,
@@ -52,6 +60,13 @@ def test_roundtrip_basic(
     tmp_path: pathlib.Path,
     sample_data_pyarrow: "pa.Table",
 ):
+    assert_roundtrips(tmp_path, sample_data_pyarrow)
+
+
+def assert_roundtrips(
+    tmp_path: pathlib.Path,
+    sample_data_pyarrow: "pa.Table",
+):
     # Check we can create the subdirectory
     import pyarrow as pa
 
@@ -80,6 +95,39 @@ def test_roundtrip_basic(
         modification_time = action["modificationTime"] / 1000  # convert back to seconds
         assert start_time < modification_time
         assert modification_time < end_time
+
+
+@pytest.mark.pyarrow
+def test_nanosecond_timestamps_cast_to_microsecond_by_default(tmp_path: pathlib.Path):
+    """
+    Unless ``enable_nanosecond_timestamps()`` is called, nanosecond timestamps
+    are cast to microseconds.
+    """
+    import pyarrow as pa
+
+    table = pa.table(
+        {"timestamp_ns": [pa.scalar(700123, type=pa.timestamp("ns", "UTC"))]}
+    )
+
+    # If nanoseconds are disabled when writing, the data is written as
+    # microseconds:
+    assert not _nanosecond_timestamps_enabled()
+    path = tmp_path / "ns_disabled"
+    write_deltalake(path, table)
+    result = DeltaTable(path).to_pyarrow_table()
+    # Should be rounded to microseconds:
+    assert result == pa.table(
+        {"timestamp_ns": [pa.scalar(700, type=pa.timestamp("us", "UTC"))]}
+    )
+
+    # If nanoseconds are enabled when writing, the data is written as
+    # nanoseconds:
+    enable_nanosecond_timestamps()
+    try:
+        assert _nanosecond_timestamps_enabled()
+        assert_roundtrips(tmp_path / "ns_enabled", table)
+    finally:
+        _disable_nanosecond_timestamps()
 
 
 @pytest.mark.parametrize("mode", ["append", "overwrite"])

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -16,10 +16,10 @@ from deltalake import (
     CommitProperties,
     DeltaTable,
     Transaction,
-    write_deltalake,
+    _disable_nanosecond_timestamps,
     _nanosecond_timestamps_enabled,
     enable_nanosecond_timestamps,
-    _disable_nanosecond_timestamps,
+    write_deltalake,
 )
 from deltalake._internal import (
     CommitFailedError,

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -2237,9 +2237,7 @@ def test_write_timestamp_ntz_nested(tmp_path: pathlib.Path, array):
     assert protocol.writer_features == ["timestampNtz"]
 
 
-@pytest.mark.skipif(
-    not _nanosecond_timestamps_enabled(), reason="nanosecond timestamps not enabled"
-)
+@pytest.mark.usefixtures("nanosecond_timestamps_enabled")
 @pytest.mark.pyarrow
 @pytest.mark.parametrize(
     "array",

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -22,6 +22,7 @@ from deltalake import (
     write_deltalake,
 )
 from deltalake._internal import (
+    _NANOSECOND_TIMESTAMPS,
     CommitFailedError,
     Field,
     PrimitiveType,
@@ -119,6 +120,9 @@ def test_nanosecond_timestamps_cast_to_microsecond_by_default(tmp_path: pathlib.
     assert result == pa.table(
         {"timestamp_ns": [pa.scalar(700, type=pa.timestamp("us", "UTC"))]}
     )
+
+    if not _NANOSECOND_TIMESTAMPS:
+        return
 
     # If nanoseconds are enabled when writing, the data is written as
     # nanoseconds:

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -12,9 +12,8 @@ from arro3.core import Array, ChunkedArray, DataType, RecordBatchReader, Table
 from arro3.core import Field as ArrowField
 from arro3.core import Schema as ArrowSchema
 
-from deltalake import CommitProperties, DeltaTable, Transaction, write_deltalake
+from deltalake import CommitProperties, DeltaTable, Transaction, write_deltalake, _nanosecond_timestamps_enabled
 from deltalake._internal import (
-    _NANOSECOND_TIMESTAMPS,
     CommitFailedError,
     Field,
     PrimitiveType,
@@ -1027,7 +1026,7 @@ def test_writer_stats(existing_table: DeltaTable, sample_data_pyarrow: "pa.Table
     # PyArrow added support for decimal and date32 in 8.0.0
     expected_mins["decimal"] = 10.0
     expected_mins["date32"] = "2022-01-01"
-    if _NANOSECOND_TIMESTAMPS:
+    if _nanosecond_timestamps_enabled():
         expected_mins["timestamp_ns"] = "1970-01-01T00:00:00Z"
 
     assert stats["minValues"] == expected_mins
@@ -1048,7 +1047,7 @@ def test_writer_stats(existing_table: DeltaTable, sample_data_pyarrow: "pa.Table
     # PyArrow added support for decimal and date32 in 8.0.0
     expected_maxs["decimal"] = 14.0
     expected_maxs["date32"] = "2022-01-05"
-    if _NANOSECOND_TIMESTAMPS:
+    if _nanosecond_timestamps_enabled():
         expected_maxs["timestamp_ns"] = "1970-01-01T00:00:00.000000004Z"
 
     assert stats["maxValues"] == expected_maxs
@@ -2191,7 +2190,7 @@ def test_write_timestamp_ntz_nested(tmp_path: pathlib.Path, array):
 
 
 @pytest.mark.skipif(
-    not _NANOSECOND_TIMESTAMPS, reason="nanosecond timestamps not enabled"
+    not _nanosecond_timestamps_enabled(), reason="nanosecond timestamps not enabled"
 )
 @pytest.mark.pyarrow
 @pytest.mark.parametrize(
@@ -3095,7 +3094,7 @@ def test_write_timestamp_ns_normalizes_to_us(tmp_path: pathlib.Path):
 
     delta_schema = dt.schema()
     ts_field = delta_schema.fields[1]
-    if _NANOSECOND_TIMESTAMPS:
+    if _nanosecond_timestamps_enabled():
         expected_type = PrimitiveType("timestamp_nanos")
     else:
         expected_type = PrimitiveType("timestamp")
@@ -3103,7 +3102,7 @@ def test_write_timestamp_ns_normalizes_to_us(tmp_path: pathlib.Path):
 
     result = dt.to_pyarrow_table()
     assert result.num_rows == 2
-    if _NANOSECOND_TIMESTAMPS:
+    if _nanosecond_timestamps_enabled():
         expected_resolution = "ns"
     else:
         expected_resolution = "us"


### PR DESCRIPTION
Follow up to adding nanosecond timestamp support (#4370). Allows use of this experimental feature from Python without turning it on by default, and also allows testing via Python.

Supersedes #4420
