### PR TITLE
chore: simplify table root retrieval in table_provider

### DIFF
--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -428,12 +428,7 @@ pub(in crate::delta_datafusion) async fn find_files_scan(
     expression: Expr,
 ) -> DeltaResult<Vec<Add>> {
     let file_column_name = resolve_file_column_name(snapshot.input_schema().as_ref(), None)?;
-    let table_root = snapshot
-        .snapshot()
-        .scan_builder()
-        .build()?
-        .table_root()
-        .clone();
+    let table_root = snapshot.snapshot().inner.table_root().clone();
     let mut candidate_map: HashMap<_, _> = snapshot
         .file_views(log_store.as_ref(), None)
         .try_fold(HashMap::new(), |mut candidate_map, view| {
@@ -795,12 +790,7 @@ mod tests {
         .await?;
         assert!(!by_id.is_empty());
         let expected_path = by_id[0].path.clone();
-        let table_root = snapshot
-            .snapshot()
-            .scan_builder()
-            .build()?
-            .table_root()
-            .clone();
+        let table_root = snapshot.snapshot().inner.table_root().clone();
         let expected_file_id = crate::delta_datafusion::normalize_path_as_file_id(
             &expected_path,
             &table_root,

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -756,12 +756,7 @@ mod tests {
                 .await
                 .unwrap(),
         );
-        let table_root = snapshot
-            .scan_builder()
-            .build()
-            .unwrap()
-            .table_root()
-            .clone();
+        let table_root = snapshot.inner.table_root().clone();
         let selected_file_ids: Vec<String> = snapshot
             .file_views(log_store.as_ref(), None)
             .take(1)

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -408,9 +408,8 @@ impl TableProviderBuilder {
         };
 
         if let Some(log_store) = log_store.as_ref() {
-            let snapshot_root_identity = next::canonical_table_root_identity(
-                snapshot.snapshot().scan_builder().build()?.table_root(),
-            );
+            let snapshot_root_identity =
+                next::canonical_table_root_identity(snapshot.snapshot().inner.table_root());
             let log_store_root = log_store.table_root_url();
             let log_store_root_identity = next::canonical_table_root_identity(&log_store_root);
 
@@ -1019,12 +1018,7 @@ mod tests {
                 .await
                 .unwrap(),
         );
-        let table_root = snapshot
-            .scan_builder()
-            .build()
-            .unwrap()
-            .table_root()
-            .clone();
+        let table_root = snapshot.inner.table_root().clone();
         let missing_file_id = table_root
             .join("__does_not_exist__.parquet")
             .unwrap()

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -1791,7 +1791,7 @@ mod tests {
     async fn test_scan_with_file_selection_reads_only_selected_files() -> TestResult {
         let log_store = TestTables::Simple.table_builder()?.build_storage()?;
         let snapshot = Arc::new(Snapshot::try_new(&log_store, Default::default(), None).await?);
-        let table_root = snapshot.scan_builder().build()?.table_root().clone();
+        let table_root = snapshot.inner.table_root().clone();
         let total_file_count = snapshot
             .file_views(log_store.as_ref(), None)
             .try_fold(0usize, |count, _| async move { Ok(count + 1) })
@@ -1988,7 +1988,7 @@ mod tests {
     async fn test_scan_with_file_selection_applies_deletion_vectors() -> TestResult {
         let log_store = TestTables::WithDvSmall.table_builder()?.build_storage()?;
         let snapshot = Arc::new(Snapshot::try_new(&log_store, Default::default(), None).await?);
-        let table_root = snapshot.scan_builder().build()?.table_root().clone();
+        let table_root = snapshot.inner.table_root().clone();
 
         let session = Arc::new(create_session().into_inner());
         let state = session.state_ref().read().clone();
@@ -2102,7 +2102,7 @@ mod tests {
     async fn test_scan_with_file_selection_strict_missing_files_errors() -> TestResult {
         let log_store = TestTables::Simple.table_builder()?.build_storage()?;
         let snapshot = Arc::new(Snapshot::try_new(&log_store, Default::default(), None).await?);
-        let table_root = snapshot.scan_builder().build()?.table_root().clone();
+        let table_root = snapshot.inner.table_root().clone();
 
         let session = Arc::new(create_session().into_inner());
         let state = session.state_ref().read().clone();
@@ -2139,7 +2139,7 @@ mod tests {
     async fn test_scan_with_file_selection_missing_policy_ignore_skips_missing() -> TestResult {
         let log_store = TestTables::Simple.table_builder()?.build_storage()?;
         let snapshot = Arc::new(Snapshot::try_new(&log_store, Default::default(), None).await?);
-        let table_root = snapshot.scan_builder().build()?.table_root().clone();
+        let table_root = snapshot.inner.table_root().clone();
 
         let session = Arc::new(create_session().into_inner());
         let state = session.state_ref().read().clone();
@@ -2653,7 +2653,7 @@ mod tests {
     async fn test_deletion_vectors_file_selection_strict_missing_errors() -> TestResult {
         let log_store = TestTables::Simple.table_builder()?.build_storage()?;
         let snapshot = Snapshot::try_new(&log_store, Default::default(), None).await?;
-        let table_root = snapshot.scan_builder().build()?.table_root().clone();
+        let table_root = snapshot.inner.table_root().clone();
         let missing_path = table_root.join("__does_not_exist__.parquet")?.to_string();
         let provider = DeltaScan::new(snapshot, DeltaScanConfig::default())?
             .with_log_store(log_store)
@@ -2675,7 +2675,7 @@ mod tests {
     async fn test_deletion_vectors_file_selection_ignore_missing_is_empty() -> TestResult {
         let log_store = TestTables::Simple.table_builder()?.build_storage()?;
         let snapshot = Snapshot::try_new(&log_store, Default::default(), None).await?;
-        let table_root = snapshot.scan_builder().build()?.table_root().clone();
+        let table_root = snapshot.inner.table_root().clone();
         let missing_path = table_root.join("__does_not_exist__.parquet")?.to_string();
         let provider = DeltaScan::new(snapshot, DeltaScanConfig::default())?
             .with_log_store(log_store)


### PR DESCRIPTION
# Description

This is small code improvement that avoids building Scans to get table root path.

# Related Issue(s)
N/A

# Documentation
N/A