### PR TITLE
docs(core): document public API surface for 1.0 release

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -12,5 +12,6 @@ runs:
       with:
         files: codecov.json
         fail_ci_if_error: true
+        use_pypi: true
       env:
         CODECOV_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,5 +141,6 @@ jobs:
         with:
           files: codecov.json
           fail_ci_if_error: true
+          use_pypi: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/crates/core/src/data_catalog/mod.rs
+++ b/crates/core/src/data_catalog/mod.rs
@@ -37,8 +37,10 @@ pub enum DataCatalogError {
         key: String,
     },
 
+    /// A request to the underlying catalog service failed.
     #[error("Error in request: {source}")]
     RequestError {
+        /// The underlying transport or service error that caused the request to fail.
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 }
@@ -46,6 +48,7 @@ pub enum DataCatalogError {
 /// Abstractions for data catalog for the Delta table. To add support for new cloud, simply implement this trait.
 #[async_trait::async_trait]
 pub trait DataCatalog: Send + Sync + Debug {
+    /// Error type returned by catalog operations.
     type Error;
 
     /// Get the table storage location from the Data Catalog

--- a/crates/core/src/delta_datafusion/cdf/mod.rs
+++ b/crates/core/src/delta_datafusion/cdf/mod.rs
@@ -8,6 +8,7 @@ pub(crate) use self::scan_utils::*;
 use crate::DeltaResult;
 use crate::kernel::{Add, AddCDCFile, Remove, Version};
 
+/// Scan-related types and helpers for reading Change Data Feed (CDF) batches.
 pub mod scan;
 mod scan_utils;
 

--- a/crates/core/src/delta_datafusion/cdf/scan.rs
+++ b/crates/core/src/delta_datafusion/cdf/scan.rs
@@ -19,6 +19,12 @@ use crate::{
 
 use super::ADD_PARTITION_SCHEMA;
 
+/// A DataFusion [`TableProvider`](datafusion::catalog::TableProvider) that exposes a Delta
+/// table's Change Data Feed (CDF) as a queryable relation.
+///
+/// Wraps a [`CdfLoadBuilder`] together with the resolved output schema so the CDF stream
+/// (insertions, updates and deletions across versions) can be scanned through the normal
+/// DataFusion planning machinery.
 #[derive(Debug)]
 pub struct DeltaCdfTableProvider {
     cdf_builder: CdfLoadBuilder,

--- a/crates/core/src/delta_datafusion/engine/mod.rs
+++ b/crates/core/src/delta_datafusion/engine/mod.rs
@@ -23,14 +23,24 @@ pub struct DataFusionEngine {
 }
 
 impl DataFusionEngine {
+    /// Create an engine from a DataFusion [`Session`], reusing its task context and the
+    /// current Tokio runtime handle. This is the convenient entry point when wiring the
+    /// kernel engine into an active query session.
     pub fn new_from_session(session: &dyn Session) -> Arc<Self> {
         Self::new(session.task_ctx(), Handle::current()).into()
     }
 
+    /// Create an engine directly from a DataFusion [`TaskContext`], using the current Tokio
+    /// runtime handle. Useful inside physical operators where only the task context is
+    /// available.
     pub fn new_from_context(ctx: Arc<TaskContext>) -> Arc<Self> {
         Self::new(ctx, Handle::current()).into()
     }
 
+    /// Create an engine from an explicit [`TaskContext`] and Tokio runtime [`Handle`].
+    ///
+    /// The other constructors delegate here; call this directly when you need to bind the
+    /// engine to a specific runtime handle rather than the ambient one.
     pub fn new(ctx: Arc<TaskContext>, handle: Handle) -> Self {
         let storage = Arc::new(DataFusionStorageHandler::new(ctx.clone(), handle.clone()));
         let formats = Arc::new(DataFusionFileFormatHandler::new(ctx, handle));

--- a/crates/core/src/delta_datafusion/engine/storage.rs
+++ b/crates/core/src/delta_datafusion/engine/storage.rs
@@ -110,7 +110,10 @@ impl StorageHandler for DataFusionStorageHandler {
     }
 }
 
+/// Conversion to a DataFusion [`ObjectStoreUrl`], the key used to register and look up an
+/// object store in a session's runtime environment.
 pub trait AsObjectStoreUrl {
+    /// Return the [`ObjectStoreUrl`] that identifies the object store backing `self`.
     fn as_object_store_url(&self) -> ObjectStoreUrl;
 }
 

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -89,6 +89,7 @@ pub mod bench_support;
 pub mod cdf;
 mod column_mapping;
 mod data_validation;
+/// DataFusion-backed kernel engine and its storage/format handlers.
 pub mod engine;
 pub mod expr;
 mod file_id;

--- a/crates/core/src/delta_datafusion/planner.rs
+++ b/crates/core/src/delta_datafusion/planner.rs
@@ -58,6 +58,10 @@ static DELTA_PLANNER: LazyLock<Arc<DeltaPlanner>> = LazyLock::new(|| Arc::new(De
 pub struct DeltaPlanner;
 
 impl DeltaPlanner {
+    /// Return the shared, lazily-initialized [`DeltaPlanner`] instance.
+    ///
+    /// The planner is stateless, so a single cached instance is reused rather than
+    /// allocating a new one per query.
     pub fn new() -> Arc<Self> {
         DELTA_PLANNER.clone()
     }
@@ -79,9 +83,12 @@ impl QueryPlanner for DeltaPlanner {
     }
 }
 
+/// Extension [`PhysicalPlanner`](datafusion::physical_planner::PhysicalPlanner) that knows
+/// how to lower delta-rs custom logical nodes into executable physical plans.
 pub struct DeltaExtensionPlanner;
 
 impl DeltaExtensionPlanner {
+    /// Construct a new extension planner.
     pub fn new() -> Arc<Self> {
         Arc::new(Self {})
     }

--- a/crates/core/src/delta_datafusion/session.rs
+++ b/crates/core/src/delta_datafusion/session.rs
@@ -19,6 +19,8 @@ use crate::delta_datafusion::planner::DeltaPlanner;
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::logstore::LogStore;
 
+/// Create a default [`DeltaSessionContext`], a DataFusion session pre-configured with the
+/// settings delta-rs relies on (custom planner, object-store registration, etc.).
 pub fn create_session() -> DeltaSessionContext {
     DeltaSessionContext::default()
 }
@@ -304,24 +306,29 @@ pub struct DeltaRuntimeEnvBuilder {
 }
 
 impl DeltaRuntimeEnvBuilder {
+    /// Create a new builder with DataFusion's default runtime settings.
     pub fn new() -> Self {
         Self {
             inner: RuntimeEnvBuilder::new(),
         }
     }
 
+    /// Cap in-memory usage by installing a [`FairSpillPool`] of `size` bytes, allowing
+    /// operators to spill to disk once the budget is exhausted.
     pub fn with_max_spill_size(mut self, size: usize) -> Self {
         let memory_pool = FairSpillPool::new(size);
         self.inner = self.inner.with_memory_pool(Arc::new(memory_pool));
         self
     }
 
+    /// Limit the total bytes the disk manager may use for temporary spill files to `size`.
     pub fn with_max_temp_directory_size(mut self, size: u64) -> Self {
         let disk_manager = DiskManagerBuilder::default().with_max_temp_directory_size(size);
         self.inner = self.inner.with_disk_manager_builder(disk_manager);
         self
     }
 
+    /// Finalize the configuration and build the shared [`RuntimeEnv`].
     pub fn build(self) -> Arc<RuntimeEnv> {
         self.inner.build_arc().unwrap()
     }
@@ -362,10 +369,12 @@ impl DeltaSessionContext {
         Self { inner }
     }
 
+    /// Consume the wrapper and return the underlying DataFusion [`SessionContext`].
     pub fn into_inner(self) -> SessionContext {
         self.inner
     }
 
+    /// Return a snapshot of the underlying [`SessionState`] for planning or execution.
     pub fn state(&self) -> SessionState {
         self.inner.state()
     }

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -194,6 +194,8 @@ impl DeltaScanConfig {
         }
     }
 
+    /// Create a config seeded from an active DataFusion [`Session`], inheriting its
+    /// Parquet pushdown and view-type settings so the scan matches the session's behavior.
     pub fn new_from_session(session: &dyn Session) -> Self {
         let config_options = session.config().options();
         Self {
@@ -205,6 +207,7 @@ impl DeltaScanConfig {
         }
     }
 
+    /// Set the name of the synthetic column that exposes each row's source file path.
     pub fn with_file_column_name<S: ToString>(mut self, name: S) -> Self {
         self.file_column_name = Some(name.to_string());
         self
@@ -369,6 +372,7 @@ impl TableProviderBuilder {
         self
     }
 
+    /// Consume the builder and resolve it into an executable [`next::DeltaScan`].
     pub async fn build(self) -> Result<next::DeltaScan> {
         let TableProviderBuilder {
             log_store,

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -478,6 +478,12 @@ impl SnapshotWrapper {
     }
 }
 
+/// An executable, serializable Delta table scan.
+///
+/// `DeltaScan` captures everything needed to read a consistent set of data files from a
+/// table snapshot — the resolved schemas, optional file-skipping predicates, deletion-vector
+/// aware file selection and the originating log store. It is the unit produced by
+/// [`TableProviderBuilder`] and consumed by DataFusion's execution layer.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DeltaScan {
     snapshot: SnapshotWrapper,
@@ -505,7 +511,10 @@ pub struct DeletionVectorSelection {
 }
 
 impl DeltaScan {
-    // create new delta scan
+    /// Create a new scan over the given `snapshot` using `config`.
+    ///
+    /// Validates that the snapshot only uses reader features delta-rs supports and resolves
+    /// the scan and provider (public) schemas, including the optional file-id column.
     pub fn new(snapshot: impl Into<SnapshotWrapper>, config: DeltaScanConfig) -> Result<Self> {
         let snapshot = snapshot.into();
         Self::validate_supported_reader_features(&snapshot)
@@ -692,6 +701,7 @@ impl DeltaScan {
             .map(Some)
     }
 
+    /// Start building a scan/table provider with a fluent [`TableProviderBuilder`].
     pub fn builder() -> TableProviderBuilder {
         TableProviderBuilder::new()
     }

--- a/crates/core/src/kernel/mod.rs
+++ b/crates/core/src/kernel/mod.rs
@@ -10,8 +10,10 @@ use tracing::dispatcher;
 
 pub mod arrow;
 pub mod error;
+/// Core Delta log action models (Add, Remove, Metadata, Protocol, ...) and related types.
 pub mod models;
 pub mod scalars;
+/// Delta and Arrow schema types, conversions, casting and partition handling.
 pub mod schema;
 pub(crate) mod snapshot;
 pub mod transaction;

--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -43,16 +43,22 @@ pub fn new_metadata(
 /// while the update / mutation APIs are being implemented. It allows us to implement
 /// additional APIs on the Metadata action and hide specifics of how we do the updates.
 pub trait MetadataExt {
+    /// Return a copy of the metadata with its unique table identifier replaced.
     fn with_table_id(self, table_id: String) -> DeltaResult<Metadata>;
 
+    /// Return a copy of the metadata with the user-facing table name set.
     fn with_name(self, name: String) -> DeltaResult<Metadata>;
 
+    /// Return a copy of the metadata with the table description set.
     fn with_description(self, description: String) -> DeltaResult<Metadata>;
 
+    /// Return a copy of the metadata whose schema string is replaced with `schema`.
     fn with_schema(self, schema: &StructType) -> DeltaResult<Metadata>;
 
+    /// Return a copy of the metadata with a single configuration key set to `value`.
     fn add_config_key(self, key: String, value: String) -> DeltaResult<Metadata>;
 
+    /// Return a copy of the metadata with the given configuration key removed.
     fn remove_config_key(self, key: &str) -> DeltaResult<Metadata>;
 }
 
@@ -697,6 +703,7 @@ pub enum TableFeatures {
     VariantTypePreview,
     /// Preview shredded variant support
     VariantShreddingPreview,
+    /// Support for materializing partition column values into data files.
     MaterializePartitionColumns,
 }
 

--- a/crates/core/src/kernel/schema/cast/mod.rs
+++ b/crates/core/src/kernel/schema/cast/mod.rs
@@ -305,6 +305,11 @@ fn has_nanosecond_timestamp(dt: &DataType) -> bool {
     }
 }
 
+/// Normalize an Arrow schema so it can be safely written to a Delta table.
+///
+/// Delta does not support all Arrow types verbatim (for example nanosecond timestamps);
+/// this rewrites such fields to the closest Delta-compatible representation, returning the
+/// original schema untouched when no changes are required.
 pub fn normalize_for_delta(schema: &ArrowSchemaRef) -> ArrowSchemaRef {
     let mut changed = false;
     let new_fields: Vec<FieldRef> = schema

--- a/crates/core/src/kernel/schema/mod.rs
+++ b/crates/core/src/kernel/schema/mod.rs
@@ -15,5 +15,6 @@ pub trait DataCheck {
     /// The SQL expression to use for the check
     fn get_expression(&self) -> &str;
 
+    /// Upcast to [`Any`] so callers can downcast to the concrete check implementation.
     fn as_any(&self) -> &dyn Any;
 }

--- a/crates/core/src/kernel/snapshot/iterators/tombstones.rs
+++ b/crates/core/src/kernel/snapshot/iterators/tombstones.rs
@@ -9,6 +9,10 @@ use percent_encoding::percent_decode_str;
 
 use crate::kernel::snapshot::iterators::get_string_value;
 
+/// A lightweight, cloneable view over a single tombstone (`Remove` action) row.
+///
+/// Rather than materializing a `Remove` struct, this borrows into the backing
+/// [`RecordBatch`] and decodes individual fields on demand.
 #[derive(Clone)]
 pub struct TombstoneView {
     data: RecordBatch,
@@ -30,6 +34,7 @@ impl TombstoneView {
         percent_decode_str(raw).decode_utf8_lossy()
     }
 
+    /// Returns the deletion timestamp (milliseconds since epoch), if recorded.
     pub fn deletion_timestamp(&self) -> Option<i64> {
         static FIELD_INDEX: LazyLock<usize> = LazyLock::new(|| {
             Remove::to_schema()
@@ -43,6 +48,7 @@ impl TombstoneView {
             .map(|a| a.value(self.index))
     }
 
+    /// Returns whether removing this file represents a data change (vs. a compaction-style rewrite).
     pub fn data_change(&self) -> bool {
         static FIELD_INDEX: LazyLock<usize> = LazyLock::new(|| {
             Remove::to_schema()
@@ -56,6 +62,7 @@ impl TombstoneView {
             .value(self.index)
     }
 
+    /// Returns the size of the removed file in bytes, if recorded.
     pub fn size(&self) -> Option<i64> {
         static FIELD_INDEX: LazyLock<usize> =
             LazyLock::new(|| Remove::to_schema().field_with_index("size").unwrap().0);

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -83,10 +83,12 @@ impl<'a> LogDataHandler<'a> {
     }
 
     /// The number of files in the log data.
+    /// Returns the total number of files represented across all underlying record batches.
     pub fn num_files(&self) -> usize {
         self.data.iter().map(|batch| batch.num_rows()).sum()
     }
 
+    /// Iterate over each file as a [`LogicalFileView`] without materializing all of them at once.
     pub fn iter(&self) -> impl Iterator<Item = LogicalFileView> + '_ {
         self.data.iter().flat_map(|batch| {
             (0..batch.num_rows()).map(move |idx| LogicalFileView::new(batch.clone(), idx))

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -78,6 +78,10 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
+    /// Build a snapshot of the table at `table_root` using the provided kernel `engine`.
+    ///
+    /// When `version` is `None` the latest available version is loaded. This is the engine-aware
+    /// constructor used when callers want to control the kernel [`Engine`] backing log replay.
     pub async fn try_new_with_engine(
         engine: Arc<dyn Engine>,
         table_root: Url,
@@ -132,10 +136,12 @@ impl Snapshot {
         Self::try_new_with_engine(engine, table_root, config, version).await
     }
 
+    /// Create a [`ScanBuilder`] borrowing this snapshot to configure a read of the table.
     pub fn scan_builder(&self) -> ScanBuilder {
         ScanBuilder::new(self.inner.clone())
     }
 
+    /// Consume this snapshot and create a [`ScanBuilder`] that owns the underlying state.
     pub fn into_scan_builder(self) -> ScanBuilder {
         ScanBuilder::new(self.inner)
     }
@@ -324,6 +330,7 @@ impl Snapshot {
         self.inner.table_properties()
     }
 
+    /// Returns the resolved [`TableConfiguration`] (protocol, metadata and parsed properties).
     pub fn table_configuration(&self) -> &TableConfiguration {
         self.inner.table_configuration()
     }
@@ -1074,6 +1081,7 @@ impl EagerSnapshot {
         self.snapshot.table_properties()
     }
 
+    /// Returns the resolved [`TableConfiguration`] (protocol, metadata and parsed properties).
     pub fn table_configuration(&self) -> &TableConfiguration {
         self.snapshot.table_configuration()
     }
@@ -1123,6 +1131,10 @@ impl EagerSnapshot {
         self.snapshot.file_views(log_store, predicate)
     }
 
+    /// Stream the file views matching the given partition `filters`.
+    ///
+    /// Deprecated in favor of [`file_views`](Self::file_views) with a kernel predicate, which
+    /// supports richer expressions than simple partition equality filters.
     #[deprecated(since = "0.29.0", note = "Use `files` with kernel predicate instead.")]
     pub fn file_views_by_partitions(
         &self,
@@ -1139,7 +1151,10 @@ impl EagerSnapshot {
         self.file_views(log_store, Some(predicate))
     }
 
-    /// Iterate over all latest app transactions
+    /// Return the latest committed transaction version for the given application id, if any.
+    ///
+    /// This is used to implement idempotent writes: an application records its own monotonic
+    /// version via a transaction action, and readers can recover the last value seen.
     pub async fn transaction_version(
         &self,
         log_store: &dyn LogStore,
@@ -1150,6 +1165,7 @@ impl EagerSnapshot {
             .await
     }
 
+    /// Return the configuration string stored for the given metadata `domain`, if present.
     pub async fn domain_metadata(
         &self,
         log_store: &dyn LogStore,
@@ -1210,6 +1226,7 @@ mod tests {
     };
 
     impl Snapshot {
+        /// Build an in-memory snapshot from the given commits for use in tests.
         pub async fn new_test<'a>(
             commits: impl IntoIterator<Item = &'a CommitData>,
         ) -> DeltaResult<(Self, Arc<dyn LogStore>)> {
@@ -1247,6 +1264,7 @@ mod tests {
     }
 
     impl EagerSnapshot {
+        /// Build an in-memory eager snapshot from the given commits for use in tests.
         pub async fn new_test<'a>(
             commits: impl IntoIterator<Item = &'a CommitData>,
         ) -> DeltaResult<Self> {

--- a/crates/core/src/kernel/snapshot/scan.rs
+++ b/crates/core/src/kernel/snapshot/scan.rs
@@ -18,6 +18,7 @@ use super::stats_projection::{FileStatsMaterialization, StatsProjection, StatsSo
 use crate::DeltaResult;
 use crate::kernel::{ReceiverStreamBuilder, scan_row_in_eval};
 
+/// A boxed, `Send`able stream of [`ScanMetadata`] results produced while scanning a snapshot.
 pub type SendableScanMetadataStream = Pin<Box<dyn Stream<Item = DeltaResult<ScanMetadata>> + Send>>;
 
 /// Builder to scan a snapshot of a table.
@@ -100,6 +101,7 @@ impl ScanBuilder {
         self
     }
 
+    /// Finalize the builder into a [`Scan`], validating the configured schema and predicate.
     pub fn build(self) -> DeltaResult<Scan> {
         let Self {
             snapshot,
@@ -300,6 +302,10 @@ mod tests {
     }
 }
 
+/// A configured, executable scan over a table snapshot.
+///
+/// Produced by [`ScanBuilder::build`]; drives log replay to enumerate the data files (and the
+/// statistics materialization strategy) that satisfy the scan's schema and predicate.
 #[derive(Debug)]
 pub struct Scan {
     inner: Arc<KernelScan>,
@@ -380,10 +386,12 @@ impl Scan {
     }
 
     /// Get the predicate [`PredicateRef`] of the scan.
+    /// Returns the predicate pushed down to the physical scan, if any was derived.
     pub fn physical_predicate(&self) -> Option<PredicateRef> {
         self.inner.physical_predicate()
     }
 
+    /// Stream the per-file [`ScanMetadata`] for this scan, driving log replay on `engine`.
     pub fn scan_metadata(&self, engine: Arc<dyn Engine>) -> SendableScanMetadataStream {
         // TODO: which capacity to choose?
         let mut builder = ReceiverStreamBuilder::<ScanMetadata>::new(100);
@@ -425,6 +433,11 @@ impl Scan {
         }
     }
 
+    /// Stream [`ScanMetadata`] incrementally starting from a previously observed state.
+    ///
+    /// Given the data already known at `existing_version` (and the predicate used to produce it),
+    /// only the log changes since that version are replayed, avoiding a full scan when refreshing
+    /// an already-loaded snapshot.
     pub fn scan_metadata_from<T: Iterator<Item = RecordBatch> + Send + 'static>(
         &self,
         engine: Arc<dyn Engine>,

--- a/crates/core/src/kernel/snapshot/stream.rs
+++ b/crates/core/src/kernel/snapshot/stream.rs
@@ -51,6 +51,8 @@ pub trait RecordBatchStream: Stream<Item = DeltaResult<RecordBatch>> {
 /// `Ready(None)` is recommended.
 pub type SendableRecordBatchStream = Pin<Box<dyn RecordBatchStream + Send>>;
 
+/// A boxed, `Send`able stream of [`RecordBatch`] results, without the schema guarantees of
+/// [`SendableRecordBatchStream`].
 pub type SendableRBStream = Pin<Box<dyn Stream<Item = DeltaResult<RecordBatch>> + Send>>;
 
 /// Creates a stream from a collection of producing tasks, routing panics to the stream.

--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -135,6 +135,7 @@ const RESERVED_COMMIT_INFO_KEYS: &[&str] = &[
 ];
 
 #[derive(Default, Debug, PartialEq, Clone, Serialize, Deserialize)]
+/// Metrics describing the work performed to land a single commit.
 #[serde(rename_all = "camelCase")]
 pub struct CommitMetrics {
     /// Number of retries before a successful commit
@@ -142,6 +143,7 @@ pub struct CommitMetrics {
 }
 
 #[derive(Default, Debug, PartialEq, Clone, Serialize, Deserialize)]
+/// Metrics describing work performed by post-commit hooks (checkpointing, log cleanup).
 #[serde(rename_all = "camelCase")]
 pub struct PostCommitMetrics {
     /// Whether a new checkpoint was created as part of this commit
@@ -152,6 +154,7 @@ pub struct PostCommitMetrics {
 }
 
 #[derive(Default, Debug, PartialEq, Clone, Serialize, Deserialize)]
+/// Aggregate metrics for a commit, combining commit-time and post-commit measurements.
 #[serde(rename_all = "camelCase")]
 pub struct Metrics {
     /// Number of retries before a successful commit

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -75,7 +75,7 @@
 //! };
 //! ```
 
-// #![deny(missing_docs)]
+#![warn(missing_docs)]
 #![allow(rustdoc::invalid_html_tags)]
 #![allow(clippy::nonminimal_bool)]
 pub mod data_catalog;
@@ -88,6 +88,8 @@ pub mod protocol;
 pub use kernel::schema;
 pub mod table;
 
+/// Test fixtures and helpers (reference tables, env scoping, batch assertions) exposed for
+/// integration tests of this crate and downstream crates.
 #[cfg(any(test, feature = "integration_test"))]
 pub mod test_utils;
 
@@ -181,11 +183,21 @@ pub async fn open_table_with_ds(
 
 static CLIENT_VERSION: OnceLock<String> = OnceLock::new();
 
+/// Record the client version reported by `crate_version`.
+///
+/// Bindings (such as the Python package) call this once at startup so that user agents and
+/// telemetry identify the embedding client rather than the bare core crate version. Subsequent
+/// calls after the first are ignored.
 pub fn init_client_version(version: &str) {
     let _ = CLIENT_VERSION.set(version.to_string());
 }
 
 /// Returns Rust core version or custom set client_version such as the py-binding
+///
+/// ```
+/// // Always returns a non-empty version string.
+/// assert!(!deltalake_core::crate_version().is_empty());
+/// ```
 pub fn crate_version() -> &'static str {
     CLIENT_VERSION
         .get()

--- a/crates/core/src/logstore/config.rs
+++ b/crates/core/src/logstore/config.rs
@@ -15,6 +15,10 @@ use super::storage::{CertificateConfig, LimitConfig};
 use super::{IORuntime, storage::runtime::RuntimeConfig};
 use crate::{DeltaResult, DeltaTableError};
 
+/// A configuration type that can be incrementally populated from string key/value pairs.
+///
+/// Implemented by the various storage configuration structs so that options coming from user
+/// input or the environment can be applied generically by key name.
 pub trait TryUpdateKey: Default {
     /// Update an internal field in the configuration.
     ///
@@ -47,6 +51,7 @@ pub struct ParseResult<T: std::fmt::Debug> {
 }
 
 impl<T: std::fmt::Debug> ParseResult<T> {
+    /// Return an error if any key/value pair failed to parse, otherwise `Ok(())`.
     pub fn raise_errors(&self) -> DeltaResult<()> {
         if !self.errors.is_empty() {
             return Err(DeltaTableError::Generic(format!(
@@ -87,6 +92,10 @@ where
     }
 }
 
+/// Resolved configuration for constructing and decorating an object store backend.
+///
+/// Aggregates the optional dedicated IO runtime, retry/limit/certificate settings and the raw
+/// passthrough options used to build the underlying [`ObjectStore`].
 #[derive(Default, Debug, Clone)]
 pub struct StorageConfig {
     /// Runtime configuration.
@@ -188,6 +197,7 @@ where
 }
 
 impl StorageConfig {
+    /// Iterate over the raw, unparsed key/value options retained on this config.
     pub fn raw(&self) -> impl Iterator<Item = (&String, &String)> {
         self.raw.iter()
     }
@@ -241,7 +251,7 @@ impl StorageConfig {
         Ok(props)
     }
 
-    // Provide an IO Runtime directly
+    /// Attach a dedicated IO [`IORuntime`] used to execute storage operations.
     pub fn with_io_runtime(mut self, rt: IORuntime) -> Self {
         self.runtime = Some(rt);
         self
@@ -260,12 +270,26 @@ where
     Ok((result.config, result.unparsed))
 }
 
+/// Parse a string into a `usize`, returning a descriptive error on failure.
+///
+/// ```
+/// use deltalake_core::logstore::config::parse_usize;
+/// assert_eq!(parse_usize("42").unwrap(), 42);
+/// assert!(parse_usize("not_a_number").is_err());
+/// ```
 pub fn parse_usize(value: &str) -> DeltaResult<usize> {
     value
         .parse::<usize>()
         .map_err(|_| DeltaTableError::Generic(format!("failed to parse \"{value}\" as usize")))
 }
 
+/// Parse a string into an `f64`, returning a descriptive error on failure.
+///
+/// ```
+/// use deltalake_core::logstore::config::parse_f64;
+/// assert_eq!(parse_f64("3.14").unwrap(), 3.14);
+/// assert!(parse_f64("not_a_number").is_err());
+/// ```
 pub fn parse_f64(value: &str) -> DeltaResult<f64> {
     value
         .parse::<f64>()
@@ -278,10 +302,20 @@ pub fn parse_duration(value: &str) -> DeltaResult<std::time::Duration> {
         .map_err(|_| DeltaTableError::Generic(format!("failed to parse \"{value}\" as Duration")))
 }
 
+/// Parse a string into a `bool`, accepting common truthy spellings (e.g. "1", "true").
+///
+/// ```
+/// use deltalake_core::logstore::config::parse_bool;
+/// assert!(parse_bool("true").unwrap());
+/// assert!(parse_bool("1").unwrap());
+/// assert!(!parse_bool("false").unwrap());
+/// assert!(!parse_bool("0").unwrap());
+/// ```
 pub fn parse_bool(value: &str) -> DeltaResult<bool> {
     Ok(str_is_truthy(value))
 }
 
+/// Parse a configuration value as a plain string (an infallible identity conversion).
 pub fn parse_string(value: &str) -> DeltaResult<String> {
     Ok(value.to_string())
 }

--- a/crates/core/src/logstore/mod.rs
+++ b/crates/core/src/logstore/mod.rs
@@ -322,19 +322,24 @@ pub struct LogStoreConfig {
 }
 
 impl LogStoreConfig {
+    /// Create a new config for the given table `location`, normalizing the URL form.
     pub fn new(location: &Url, options: StorageConfig) -> Self {
         let location = normalize_table_url(location);
         Self { location, options }
     }
 
+    /// Returns the normalized root URL of the table this config describes.
     pub fn location(&self) -> &Url {
         &self.location
     }
 
+    /// Returns the storage options used to build and decorate the object store.
     pub fn options(&self) -> &StorageConfig {
         &self.options
     }
 
+    /// Wrap a raw object `store` with the decorators (retry, limit, runtime, ...) implied by
+    /// this configuration, scoped to `table_root` (defaulting to the config's location).
     pub fn decorate_store<T: ObjectStore + Clone>(
         &self,
         store: T,
@@ -344,6 +349,7 @@ impl LogStoreConfig {
         self.options.decorate_store(store, table_url)
     }
 
+    /// Returns the global registry of object store factories used for backend discovery.
     pub fn object_store_factory(&self) -> ObjectStoreFactoryRegistry {
         self::factories::object_store_factories()
     }
@@ -397,8 +403,11 @@ pub trait LogStore: Send + Sync + AsAny {
     /// Get object store, can pass operation_id for object stores linked to an operation
     fn object_store(&self, operation_id: Option<Uuid>) -> Arc<dyn ObjectStore>;
 
+    /// Get the object store rooted at the table root (not the delta log), optionally scoped to
+    /// an operation.
     fn root_object_store(&self, operation_id: Option<Uuid>) -> Arc<dyn ObjectStore>;
 
+    /// Get a kernel [`Engine`] backed by this log store's root object store.
     fn engine(&self, operation_id: Option<Uuid>) -> Arc<dyn Engine> {
         let store = self.root_object_store(operation_id);
         get_engine(store)

--- a/crates/core/src/logstore/storage/mod.rs
+++ b/crates/core/src/logstore/storage/mod.rs
@@ -23,6 +23,8 @@ static DELTA_LOG_PATH: LazyLock<Path> = LazyLock::new(|| Path::from("_delta_log"
 /// Sharable reference to [`ObjectStore`]
 pub type ObjectStoreRef = Arc<DynObjectStore>;
 
+/// A registry mapping URLs to [`ObjectStore`] instances, supporting registration and lookup
+/// (with optional lazy, ad-hoc discovery on miss).
 pub trait ObjectStoreRegistry: Send + Sync + std::fmt::Debug + 'static {
     /// If a store with the same key existed before, it is replaced and returned
     fn register_store(
@@ -52,6 +54,7 @@ impl Default for DefaultObjectStoreRegistry {
 }
 
 impl DefaultObjectStoreRegistry {
+    /// Create an empty registry with no stores registered.
     pub fn new() -> Self {
         let object_stores: DashMap<Url, Arc<dyn ObjectStore>> = DashMap::new();
         Self { object_stores }

--- a/crates/core/src/logstore/storage/runtime.rs
+++ b/crates/core/src/logstore/storage/runtime.rs
@@ -109,6 +109,7 @@ impl IORuntime {
 /// Wraps any object store and runs IO in it's own runtime [EXPERIMENTAL]
 #[derive(Clone)]
 pub struct DeltaIOStorageBackend<T: ObjectStore + Clone> {
+    /// The wrapped object store that performs the actual IO.
     pub inner: T,
     rt: IORuntime,
 }
@@ -117,6 +118,7 @@ impl<T> DeltaIOStorageBackend<T>
 where
     T: ObjectStore + Clone,
 {
+    /// Wrap `store` so that its IO operations are executed on the dedicated runtime `rt`.
     pub fn new(store: T, rt: IORuntime) -> Self {
         Self { inner: store, rt }
     }

--- a/crates/core/src/operations/mod.rs
+++ b/crates/core/src/operations/mod.rs
@@ -115,11 +115,13 @@ impl DeltaTable {
         }
     }
 
+    /// Create a new Delta table at this location, returning a [`CreateBuilder`].
     #[must_use]
     pub fn create(&self) -> CreateBuilder {
         CreateBuilder::default().with_log_store(self.log_store())
     }
 
+    /// Restore the table to an earlier version or timestamp, returning a [`RestoreBuilder`].
     #[must_use]
     pub fn restore(self) -> RestoreBuilder {
         RestoreBuilder::new(
@@ -181,6 +183,7 @@ impl DeltaTable {
 
 #[cfg(feature = "datafusion")]
 impl DeltaTable {
+    /// Read the table's data into Arrow record batches, returning a [`LoadBuilder`].
     #[must_use]
     pub fn scan_table(&self) -> LoadBuilder {
         LoadBuilder::new(
@@ -195,6 +198,7 @@ impl DeltaTable {
         CdfLoadBuilder::new(self.log_store(), self.state.map(|s| s.snapshot))
     }
 
+    /// Write the given record batches to the table, returning a [`WriteBuilder`].
     #[must_use]
     pub fn write(self, batches: impl IntoIterator<Item = RecordBatch>) -> WriteBuilder {
         WriteBuilder::new(self.log_store(), self.state.clone().map(|s| s.snapshot))
@@ -247,15 +251,20 @@ impl DeltaTable {
     }
 }
 
+/// Hook for embedding custom behavior into the lifecycle of a Delta operation.
+///
+/// Implementors can run arbitrary async code around an operation's execution and its post-commit
+/// hook, e.g. to integrate external transaction coordination, metrics, or cleanup. Each callback
+/// receives the operation's [`LogStoreRef`] and a unique `operation_id`.
 #[async_trait]
 pub trait CustomExecuteHandler: Send + Sync {
-    // Execute arbitrary code at the start of a delta operation
+    /// Execute arbitrary code at the start of a delta operation.
     async fn pre_execute(&self, log_store: &LogStoreRef, operation_id: Uuid) -> DeltaResult<()>;
 
-    // Execute arbitrary code at the end of a delta operation
+    /// Execute arbitrary code at the end of a delta operation.
     async fn post_execute(&self, log_store: &LogStoreRef, operation_id: Uuid) -> DeltaResult<()>;
 
-    // Execute arbitrary code at the start of the post commit hook
+    /// Execute arbitrary code at the start of the post commit hook.
     async fn before_post_commit_hook(
         &self,
         log_store: &LogStoreRef,
@@ -263,7 +272,7 @@ pub trait CustomExecuteHandler: Send + Sync {
         operation_id: Uuid,
     ) -> DeltaResult<()>;
 
-    // Execute arbitrary code at the end of the post commit hook
+    /// Execute arbitrary code at the end of the post commit hook.
     async fn after_post_commit_hook(
         &self,
         log_store: &LogStoreRef,

--- a/crates/core/src/operations/set_tbl_properties.rs
+++ b/crates/core/src/operations/set_tbl_properties.rs
@@ -142,12 +142,14 @@ impl std::future::IntoFuture for SetTablePropertiesBuilder {
 }
 
 #[cfg(test)]
+/// Tests for the set-table-properties operation.
 pub mod tests {
     use crate::writer::test_utils::create_initialized_table;
     use std::collections::HashMap;
     use tempfile::tempdir;
 
     #[tokio::test]
+    /// Verify that setting table properties is persisted to table metadata.
     pub async fn test_set_tbl_properties() -> crate::DeltaResult<()> {
         let temp_loc = tempdir()?;
         let ops = create_initialized_table(temp_loc.path().to_str().unwrap(), &[]).await;

--- a/crates/core/src/operations/update_table_metadata.rs
+++ b/crates/core/src/operations/update_table_metadata.rs
@@ -18,7 +18,11 @@ use crate::{DeltaResult, DeltaTableError};
     function = "validate_at_least_one_field",
     message = "No metadata update specified"
 ))]
+/// A validated set of metadata fields to update on a Delta table.
+///
+/// At least one field must be provided; lengths are validated to stay within Delta's limits.
 pub struct TableMetadataUpdate {
+    /// New table name. When set, must be 1-255 characters.
     #[validate(length(
         min = 1,
         max = 255,
@@ -26,6 +30,7 @@ pub struct TableMetadataUpdate {
     ))]
     pub name: Option<String>,
 
+    /// New table description. When set, must be at most 4000 characters.
     #[validate(length(
         max = 4000,
         message = "Table description cannot exceed 4000 characters"

--- a/crates/core/src/operations/write/configs.rs
+++ b/crates/core/src/operations/write/configs.rs
@@ -26,6 +26,7 @@ impl WriterStatsConfig {
         }
     }
 
+    /// Derive writer statistics configuration from a table's [`TableConfiguration`].
     pub fn from_config(config: &TableConfiguration) -> Self {
         let properties = stats_table_properties(
             config.logical_schema().as_ref(),

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -64,6 +64,7 @@ use crate::kernel::{Action, EagerSnapshot, StructType};
 use crate::logstore::LogStoreRef;
 use crate::protocol::{DeltaOperation, SaveMode};
 
+/// Configuration types controlling how data and statistics are written.
 pub mod configs;
 pub(crate) mod execution;
 pub(crate) mod generated_columns;

--- a/crates/core/src/table/columns.rs
+++ b/crates/core/src/table/columns.rs
@@ -62,6 +62,7 @@ impl GeneratedColumn {
         }
     }
 
+    /// Returns the SQL expression used to generate this column's values.
     pub fn get_generation_expression(&self) -> &str {
         &self.generation_expr
     }

--- a/crates/core/src/table/config.rs
+++ b/crates/core/src/table/config.rs
@@ -203,6 +203,8 @@ pub const DEFAULT_NUM_INDEX_COLS: u64 = 32;
 /// Default target file size
 pub const DEFAULT_TARGET_FILE_SIZE: NonZeroU64 = NonZeroU64::new(100 * 1024 * 1024).unwrap();
 
+/// Convenience accessors for reading well-known Delta table properties with their defaults
+/// applied, layered on top of the raw [`TableProperties`] parsed from table metadata.
 pub trait TablePropertiesExt {
     /// true for this Delta table to be append-only. If append-only, existing records cannot be
     /// deleted, and existing values cannot be updated. See [append-only tables] in the protocol.
@@ -229,14 +231,19 @@ pub trait TablePropertiesExt {
     /// Number of columns to be indexed.
     fn num_indexed_cols(&self) -> DataSkippingNumIndexedCols;
 
+    /// Target size in bytes for data files produced by writes and compaction.
     fn target_file_size(&self) -> NonZero<u64>;
 
+    /// Whether the Change Data Feed is enabled for this table.
     fn enable_change_data_feed(&self) -> bool;
 
+    /// How long removed data files are retained before they may be physically deleted by vacuum.
     fn deleted_file_retention_duration(&self) -> Duration;
 
+    /// The isolation level used when checking for conflicts during commits.
     fn isolation_level(&self) -> IsolationLevel;
 
+    /// The list of constraints (e.g. CHECK constraints) declared on the table.
     fn get_constraints(&self) -> Vec<Constraint>;
 }
 

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -35,6 +35,7 @@ pub struct DeltaTableState {
 }
 
 impl DeltaTableState {
+    /// Wrap an already-loaded [`EagerSnapshot`] as the in-memory state of a table.
     pub fn new(snapshot: EagerSnapshot) -> Self {
         Self { snapshot }
     }
@@ -403,6 +404,10 @@ impl Snapshot {
 }
 
 impl EagerSnapshot {
+    /// Materialize the table's active `Add` actions as a single Arrow [`RecordBatch`].
+    ///
+    /// When `flatten` is true, nested fields (e.g. partition values and statistics) are flattened
+    /// into top-level columns for easier inspection.
     pub fn add_actions_table(
         &self,
         flatten: bool,
@@ -410,6 +415,8 @@ impl EagerSnapshot {
         self.snapshot().add_actions_table(flatten)
     }
 
+    /// Like [`add_actions_table`](Self::add_actions_table) but yields the actions as a sequence of
+    /// record batches instead of a single concatenated batch.
     pub fn add_actions_batches(
         &self,
         flatten: bool,

--- a/crates/core/src/test_utils/factories/actions.rs
+++ b/crates/core/src/test_utils/factories/actions.rs
@@ -15,9 +15,11 @@ use crate::kernel::transaction::PROTOCOL;
 use crate::kernel::{Add, Metadata, Protocol, Remove, StructType};
 use crate::kernel::{ProtocolInner, partitions_schema};
 
+/// Factory for constructing Delta log actions (`Add`, `Remove`, `Protocol`, `Metadata`) in tests.
 pub struct ActionFactory;
 
 impl ActionFactory {
+    /// Build an `Add` action directly from object metadata and pre-computed statistics.
     pub fn add_raw(
         meta: ObjectMeta,
         stats: FileStats,
@@ -39,6 +41,7 @@ impl ActionFactory {
         }
     }
 
+    /// Build an `Add` action by generating a random data file for `schema` within `bounds`.
     pub fn add(
         schema: &StructType,
         bounds: HashMap<&str, (&str, &str)>,
@@ -101,10 +104,12 @@ impl ActionFactory {
         ActionFactory::add_raw(meta, stats, partition_values, data_change)
     }
 
+    /// Build a `Remove` action that tombstones the given `Add`.
     pub fn remove(add: &Add, data_change: bool) -> Remove {
         add_as_remove(add, data_change)
     }
 
+    /// Build a `Protocol` action, defaulting reader/writer versions when not specified.
     pub fn protocol(
         max_reader: Option<i32>,
         max_writer: Option<i32>,
@@ -120,6 +125,7 @@ impl ActionFactory {
         .as_kernel()
     }
 
+    /// Build a `Metadata` action for the given schema, partition columns and configuration.
     pub fn metadata(
         schema: &StructType,
         partition_columns: Option<impl IntoIterator<Item = impl ToString>>,
@@ -141,6 +147,7 @@ impl ActionFactory {
     }
 }
 
+/// Convert an `Add` action into the corresponding `Remove` (tombstone) action.
 pub fn add_as_remove(add: &Add, data_change: bool) -> Remove {
     Remove {
         path: add.path.clone(),

--- a/crates/core/src/test_utils/factories/data.rs
+++ b/crates/core/src/test_utils/factories/data.rs
@@ -16,9 +16,11 @@ use super::FileStats;
 use crate::kernel::scalars::ScalarExt;
 use crate::kernel::{DataType, PrimitiveType, StructType};
 
+/// Factory for generating random Arrow data and statistics for tests.
 pub struct DataFactory;
 
 impl DataFactory {
+    /// Generate a random [`RecordBatch`] for `schema` with `length` rows, honoring `bounds`.
     pub fn record_batch(
         schema: &StructType,
         length: usize,
@@ -27,10 +29,12 @@ impl DataFactory {
         generate_random_batch(schema, length, bounds)
     }
 
+    /// Compute min/max/null statistics for the given batch.
     pub fn file_stats(batch: &RecordBatch) -> TestResult<FileStats> {
         get_stats(batch)
     }
 
+    /// Generate a random array of `data_type` with `length` elements within the given bounds.
     pub fn array(
         data_type: DataType,
         length: usize,
@@ -70,6 +74,7 @@ fn generate_random_batch(
         })
 }
 
+/// Generate a random [`ArrayRef`] of the given `data_type`, optionally bounded by min/max strings.
 pub fn generate_random_array(
     data_type: DataType,
     length: usize,

--- a/crates/core/src/test_utils/factories/mod.rs
+++ b/crates/core/src/test_utils/factories/mod.rs
@@ -13,15 +13,21 @@ pub use actions::*;
 pub use data::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Per-file statistics fixture mirroring the `stats` JSON written into `Add` actions.
 #[serde(rename_all = "camelCase")]
 pub struct FileStats {
+    /// Number of records in the file.
     pub num_records: i64,
+    /// Per-column null counts.
     pub null_count: HashMap<String, Value>,
+    /// Per-column minimum values.
     pub min_values: HashMap<String, Value>,
+    /// Per-column maximum values.
     pub max_values: HashMap<String, Value>,
 }
 
 impl FileStats {
+    /// Create empty statistics for a file with `num_records` rows.
     pub fn new(num_records: i64) -> Self {
         Self {
             num_records,
@@ -32,6 +38,7 @@ impl FileStats {
     }
 }
 
+/// Collection of reusable test schemas.
 pub struct TestSchemas;
 
 impl TestSchemas {

--- a/crates/core/src/test_utils/mod.rs
+++ b/crates/core/src/test_utils/mod.rs
@@ -28,6 +28,7 @@ use crate::{DeltaResult, DeltaTableBuilder};
 #[cfg(test)]
 use futures::TryStreamExt;
 
+/// Convenient result type for tests, boxing any error so `?` works with heterogeneous errors.
 pub type TestResult<T = ()> = Result<T, Box<dyn std::error::Error + 'static>>;
 
 #[cfg(test)]
@@ -108,20 +109,32 @@ pub(crate) async fn file_paths_from(
 
 /// Reference tables from the test data folder
 pub enum TestTables {
+    /// The canonical `simple_table` fixture.
     Simple,
+    /// A simple table that includes a checkpoint.
     SimpleWithCheckpoint,
+    /// A table containing a Spark-written variant-type checkpoint.
     SparkVariantCheckpoint,
+    /// A minimal table used for commit-related tests.
     SimpleCommit,
+    /// The "golden" reader fixture (data-reader-array-primitives).
     Golden,
+    /// A Delta 0.8.0 partitioned table.
     Delta0_8_0Partitioned,
+    /// A Delta 0.8.0 table with special characters in partition values.
     Delta0_8_0SpecialPartitioned,
+    /// A table with multiple checkpoints.
     Checkpoints,
+    /// A table whose latest version is not checkpointed.
     LatestNotCheckpointed,
+    /// A small table that uses deletion vectors.
     WithDvSmall,
+    /// A custom, caller-named table (path resolution is not provided).
     Custom(String),
 }
 
 impl TestTables {
+    /// Return the on-disk path of this fixture within the test data folder.
     pub fn as_path(&self) -> PathBuf {
         let data_path = find_git_root().join("crates/test/tests/data");
         match self {
@@ -140,6 +153,7 @@ impl TestTables {
         }
     }
 
+    /// Return the canonical name of this fixture (used as a directory/table name).
     pub fn as_name(&self) -> String {
         match self {
             Self::Simple => "simple".into(),
@@ -156,6 +170,7 @@ impl TestTables {
         }
     }
 
+    /// Join this fixture's name onto `root_uri` to form a table URI.
     pub fn uri_for_table(&self, root_uri: impl AsRef<str>) -> String {
         let root_uri = root_uri.as_ref();
         if root_uri.ends_with('/') {
@@ -165,6 +180,7 @@ impl TestTables {
         }
     }
 
+    /// Build a [`DeltaTableBuilder`] pointed at this fixture's location.
     pub fn table_builder(&self) -> DeltaResult<DeltaTableBuilder> {
         let url = Url::from_directory_path(self.as_path()).map_err(|_| {
             crate::DeltaTableError::InvalidTableLocation(
@@ -218,6 +234,10 @@ pub fn with_env(vars: Vec<(&str, &str)>) -> impl Drop {
     EnvCleanup(original_values)
 }
 
+/// Assert that two collections of record batches are equal after sorting their data rows.
+///
+/// The header and footer lines of the pretty-printed output are left in place; only the data
+/// rows are sorted, making the comparison order-insensitive for test assertions.
 #[macro_export]
 macro_rules! assert_batches_sorted_eq {
     ($EXPECTED_LINES: expr, $CHUNKS: expr) => {

--- a/crates/core/src/writer/test_utils.rs
+++ b/crates/core/src/writer/test_utils.rs
@@ -12,8 +12,10 @@ use crate::kernel::{
 };
 use crate::operations::create::CreateBuilder;
 use crate::{DeltaTable, DeltaTableBuilder, TableProperty};
+/// Result type for writer unit tests, boxing any error for convenient use with `?`.
 pub type TestResult = Result<(), Box<dyn std::error::Error + 'static>>;
 
+/// Return a sample record batch, optionally filtered to a partition and/or containing nulls.
 pub fn get_record_batch(part: Option<String>, with_null: bool) -> RecordBatch {
     let (base_int, base_str, base_mod) = if with_null {
         data_with_null()
@@ -48,6 +50,7 @@ pub fn get_record_batch(part: Option<String>, with_null: bool) -> RecordBatch {
     }
 }
 
+/// Return the Arrow schema matching the columns produced by [`get_record_batch`] for `part`.
 pub fn get_arrow_schema(part: &Option<String>) -> Arc<ArrowSchema> {
     match part {
         Some(key) if key.contains("/id=") => Arc::new(ArrowSchema::new(vec![Field::new(
@@ -131,6 +134,7 @@ fn data_without_null() -> (Int32Array, StringArray, StringArray) {
     (base_int, base_str, base_mod)
 }
 
+/// Return the canonical sample Delta schema (id, value, modified).
 pub fn get_delta_schema() -> StructType {
     StructType::try_new(vec![
         StructField::new(
@@ -152,6 +156,7 @@ pub fn get_delta_schema() -> StructType {
     .unwrap()
 }
 
+/// Return table metadata for the sample schema with the given partition columns.
 pub fn get_delta_metadata(partition_cols: &[String]) -> Metadata {
     let table_schema = get_delta_schema();
     new_metadata(
@@ -162,6 +167,7 @@ pub fn get_delta_metadata(partition_cols: &[String]) -> Metadata {
     .unwrap()
 }
 
+/// Return a sample record batch that includes a nested struct column.
 pub fn get_record_batch_with_nested_struct() -> RecordBatch {
     let nested_schema = Arc::new(ArrowSchema::new(vec![Field::new(
         "count",
@@ -246,6 +252,7 @@ pub fn get_record_batch_with_nested_struct() -> RecordBatch {
     .unwrap()
 }
 
+/// Return the sample Delta schema extended with a nested struct column.
 pub fn get_delta_schema_with_nested_struct() -> StructType {
     StructType::try_new(vec![
         StructField::new(
@@ -279,6 +286,7 @@ pub fn get_delta_schema_with_nested_struct() -> StructType {
     .unwrap()
 }
 
+/// Create an in-memory table with a single configuration property set.
 pub async fn setup_table_with_configuration(
     key: TableProperty,
     value: Option<impl Into<String>>,
@@ -292,6 +300,7 @@ pub async fn setup_table_with_configuration(
         .expect("Failed to create table")
 }
 
+/// Create an empty, uninitialized table backed by a temporary directory.
 pub fn create_bare_table() -> DeltaTable {
     let table_dir = tempfile::tempdir().unwrap();
     let table_path = table_dir.path();
@@ -302,6 +311,7 @@ pub fn create_bare_table() -> DeltaTable {
         .unwrap()
 }
 
+/// Create and initialize a table at `table_path` with the sample schema and given partitions.
 pub async fn create_initialized_table(table_path: &str, partition_cols: &[String]) -> DeltaTable {
     let table_schema: StructType = get_delta_schema();
     CreateBuilder::new()
@@ -314,6 +324,7 @@ pub async fn create_initialized_table(table_path: &str, partition_cols: &[String
         .unwrap()
 }
 
+/// DataFusion-backed helpers for reading table data back in tests.
 #[cfg(feature = "datafusion")]
 pub mod datafusion {
     use arrow_array::RecordBatch;
@@ -322,6 +333,7 @@ pub mod datafusion {
     use crate::DeltaTable;
     use crate::writer::SaveMode;
 
+    /// Read all rows of `table` into record batches via a DataFusion `SELECT *`.
     pub async fn get_data(table: &DeltaTable) -> Vec<RecordBatch> {
         let table =
             DeltaTable::new_with_state(table.log_store.clone(), table.snapshot().unwrap().clone());
@@ -337,6 +349,7 @@ pub mod datafusion {
             .unwrap()
     }
 
+    /// Read `columns` from `table` ordered by those columns, for deterministic assertions.
     pub async fn get_data_sorted(table: &DeltaTable, columns: &str) -> Vec<RecordBatch> {
         let table = DeltaTable::new_with_state(
             table.log_store.clone(),
@@ -354,6 +367,7 @@ pub mod datafusion {
             .unwrap()
     }
 
+    /// Append a single record batch to `table` and return the updated table.
     pub async fn write_batch(table: DeltaTable, batch: RecordBatch) -> DeltaTable {
         table
             .write(vec![batch.clone()])

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -96,6 +96,7 @@ fn generate_config_keys(name: &Ident, fields: &[&Field]) -> Result<proc_macro2::
         })
         .collect::<Result<_>>()?;
     Ok(quote! {
+        #[doc = "Enumeration of recognized configuration keys, generated from the struct fields."]
         #[automatically_derived]
         pub enum #enum_name {
             #(#variants),*


### PR DESCRIPTION
Add rustdoc to every undocumented public item in deltalake-core (and the
DeltaConfig derive macro), enable #![warn(missing_docs)], and add doctests
for the simple pure functions that have corresponding unit tests
(parse_usize/parse_f64/parse_bool, crate_version).

I figured a little something is better than a little nothing :thinking:

Co-Authored-By: Claude (claude-opus-4) <noreply@anthropic.com>
Signed-off-by: R Tyler Croy <rtyler@brokenco.de>
