### PR TITLE
chore: upgrade to codecov-action 7

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -7,11 +7,10 @@ runs:
   using: "composite"
   steps:
     - name: Upload coverage to Codecov
-      # https://github.com/codecov/codecov-action/releases/tag/v6.0.0>
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+      # https://github.com/codecov/codecov-action/releases/tag/v7.0.0>
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
       with:
         files: codecov.json
         fail_ci_if_error: true
-        use_pypi: true
       env:
         CODECOV_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,11 +136,6 @@ jobs:
             --exclude deltalake-hdfs \
             --exclude deltalake-lakefs
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+      - uses: ./.github/actions/upload-coverage
         with:
-          files: codecov.json
-          fail_ci_if_error: true
-          use_pypi: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This also refactors the last copypasta call site to use our
repo-internal shared action

Signed-off-by: R. Tyler Croy <rtyler@brokenco.de>
