### PR TITLE
chore: upgrade to datafusion 54

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,12 @@ arrow-select = { version = "58" }
 object_store = { version = "0.13.2" }
 parquet = { version = "58" }
 
-# datafusion 53
-datafusion = { version = "53.1.0" }
-datafusion-datasource = { version = "53.1.0" }
-datafusion-physical-expr-adapter = { version = "53.1.0" }
-datafusion-ffi = { version = "53.1.0" }
-datafusion-proto = { version = "53.1.0" }
+# datafusion 54
+datafusion = { version = "54.0.0" }
+datafusion-datasource = { version = "54.0.0" }
+datafusion-physical-expr-adapter = { version = "54.0.0" }
+datafusion-ffi = { version = "54.0.0" }
+datafusion-proto = { version = "54.0.0" }
 
 # serde
 serde = { version = "1.0.194", features = ["derive"] }

--- a/crates/catalog-unity/src/datafusion.rs
+++ b/crates/catalog-unity/src/datafusion.rs
@@ -8,7 +8,6 @@ use datafusion::common::DataFusionError;
 use datafusion::datasource::TableProvider;
 use moka::Expiry;
 use moka::future::Cache;
-use std::any::Any;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::error;
@@ -49,10 +48,6 @@ impl UnityCatalogList {
 }
 
 impl CatalogProviderList for UnityCatalogList {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn register_catalog(
         &self,
         name: String,
@@ -104,10 +99,6 @@ impl UnityCatalogProvider {
 }
 
 impl CatalogProvider for UnityCatalogProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema_names(&self) -> Vec<String> {
         self.schemas.iter().map(|c| c.key().clone()).collect()
     }
@@ -211,10 +202,6 @@ impl UnitySchemaProvider {
 
 #[async_trait::async_trait]
 impl SchemaProvider for UnitySchemaProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn table_names(&self) -> Vec<String> {
         self.table_names.clone()
     }

--- a/crates/core/src/data_catalog/storage/mod.rs
+++ b/crates/core/src/data_catalog/storage/mod.rs
@@ -1,5 +1,4 @@
 //! listing_schema contains a SchemaProvider that scans ObjectStores for tables automatically
-use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
@@ -102,10 +101,6 @@ fn normalize_table_name(path: &Path) -> Result<String, DataFusionError> {
 
 #[async_trait]
 impl SchemaProvider for ListingSchemaProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn table_names(&self) -> Vec<String> {
         self.tables.iter().map(|t| t.key().clone()).collect()
     }

--- a/crates/core/src/delta_datafusion/cdf/scan.rs
+++ b/crates/core/src/delta_datafusion/cdf/scan.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use arrow::datatypes::{Schema, SchemaRef};
@@ -55,10 +54,6 @@ impl DeltaCdfTableProvider {
 
 #[async_trait::async_trait]
 impl TableProvider for DeltaCdfTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/crates/core/src/delta_datafusion/cdf/scan_utils.rs
+++ b/crates/core/src/delta_datafusion/cdf/scan_utils.rs
@@ -129,8 +129,9 @@ pub fn create_partition_values<F: FileAction>(
                 range: None,
                 statistics: None,
                 ordering: None,
-                extensions: None,
+                extensions: Default::default(),
                 metadata_size_hint: None,
+                table_reference: None,
             };
 
             file_groups.entry(new_part_values).or_default().push(part);

--- a/crates/core/src/delta_datafusion/column_mapping.rs
+++ b/crates/core/src/delta_datafusion/column_mapping.rs
@@ -9,7 +9,6 @@
 //! Only names and metadata change — Arrow types and buffers are preserved (so Large/View types
 //! survive), making the rewrite effectively zero-copy.
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -167,10 +166,6 @@ impl DisplayAs for ColumnMappingExec {
 }
 
 impl ExecutionPlan for ColumnMappingExec {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         "ColumnMappingExec"
     }
@@ -211,7 +206,7 @@ impl ExecutionPlan for ColumnMappingExec {
         }))
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
         self.input.partition_statistics(partition)
     }
 

--- a/crates/core/src/delta_datafusion/data_validation.rs
+++ b/crates/core/src/delta_datafusion/data_validation.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::pin::Pin;
@@ -446,10 +445,6 @@ impl DisplayAs for DataValidationExec {
 }
 
 impl ExecutionPlan for DataValidationExec {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         "DataValidationExec"
     }
@@ -491,7 +486,7 @@ impl ExecutionPlan for DataValidationExec {
         )))
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
         self.input.partition_statistics(partition)
     }
 
@@ -1186,10 +1181,7 @@ mod tests {
             DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
 
         // Check that maintains_input_order returns true
-        let downcast = validated_exec
-            .as_any()
-            .downcast_ref::<DataValidationExec>()
-            .unwrap();
+        let downcast = validated_exec.downcast_ref::<DataValidationExec>().unwrap();
         assert_eq!(downcast.maintains_input_order(), vec![true]);
 
         Ok(())
@@ -1233,12 +1225,7 @@ mod tests {
 
         // Create new plan with different child
         let new_exec = validated_exec.with_new_children(vec![memory_exec2])?;
-        assert!(
-            new_exec
-                .as_any()
-                .downcast_ref::<DataValidationExec>()
-                .is_some()
-        );
+        assert!(new_exec.downcast_ref::<DataValidationExec>().is_some());
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/engine/expressions/to_json.rs
+++ b/crates/core/src/delta_datafusion/engine/expressions/to_json.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::{any::Any, sync::LazyLock};
+use std::sync::LazyLock;
 
 use arrow::datatypes::DataType;
 use datafusion::common::Result;
@@ -45,10 +45,6 @@ fn get_doc() -> &'static Documentation {
 }
 
 impl ScalarUDFImpl for ToJson {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         "to_json"
     }

--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -38,7 +38,8 @@ use datafusion::functions_nested::planner::{FieldAccessPlanner, NestedFunctionPl
 use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::planner::ExprPlanner;
 use datafusion::logical_expr::{
-    AggregateUDF, Between, BinaryExpr, Cast, Expr, Like, ScalarFunctionArgs, TableSource,
+    AggregateUDF, Between, BinaryExpr, Cast, Expr, HigherOrderUDF, Like, ScalarFunctionArgs,
+    TableSource,
 };
 // Needed for MakeParquetArray
 use datafusion::functions::core::planner::CoreFunctionPlanner;
@@ -80,10 +81,6 @@ impl MakeParquetArray {
 }
 
 impl ScalarUDFImpl for MakeParquetArray {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn name(&self) -> &str {
         "make_parquet_array"
     }
@@ -244,6 +241,10 @@ impl ContextProvider for DeltaContextProvider<'_> {
         self.state.scalar_functions().get(name).cloned()
     }
 
+    fn get_higher_order_meta(&self, name: &str) -> Option<Arc<HigherOrderUDF>> {
+        self.state.higher_order_functions().get(name).cloned()
+    }
+
     fn get_aggregate_meta(&self, name: &str) -> Option<Arc<AggregateUDF>> {
         self.state.aggregate_functions().get(name).cloned()
     }
@@ -262,6 +263,14 @@ impl ContextProvider for DeltaContextProvider<'_> {
 
     fn udf_names(&self) -> Vec<String> {
         self.state.scalar_functions().keys().cloned().collect()
+    }
+
+    fn higher_order_function_names(&self) -> Vec<String> {
+        self.state
+            .higher_order_functions()
+            .keys()
+            .cloned()
+            .collect()
     }
 
     fn udaf_names(&self) -> Vec<String> {
@@ -524,7 +533,8 @@ impl Display for SqlFormat<'_> {
             Expr::IsNotUnknown(expr) => write!(f, "{} IS NOT UNKNOWN", SqlFormat { expr }),
             Expr::BinaryExpr(expr) => write!(f, "{}", BinaryExprFormat { expr }),
             Expr::ScalarFunction(func) => fmt_function(f, func.func.name(), false, &func.args),
-            Expr::Cast(Cast { expr, data_type }) => {
+            Expr::Cast(Cast { expr, field }) => {
+                let data_type = field.data_type();
                 write!(f, "arrow_cast({}, '{data_type}')", SqlFormat { expr })
             }
             Expr::Between(Between {
@@ -1075,10 +1085,7 @@ mod test {
         // String expression that we output must be parsable for conflict resolution.
         let tests = vec![
             ParseTest {
-                expr: Expr::Cast(Cast {
-                    expr: Box::new(lit(1_i64)),
-                    data_type: ArrowDataType::Int32
-                }),
+                expr: Expr::Cast(Cast::new(Box::new(lit(1_i64)), ArrowDataType::Int32)),
                 expected: "arrow_cast(1, 'Int32')".to_string(),
                 override_expected_expr: Some(
                     datafusion::logical_expr::Expr::ScalarFunction(
@@ -1292,24 +1299,20 @@ mod test {
                 expr: col("_date").eq(lit(ScalarValue::Date32(Some(18262)))),
                 expected: "_date = '2020-01-01'::date".to_string(),
                 override_expected_expr: Some(col("_date").eq(
-                    Expr::Cast(
-                        Cast {
-                            expr: Box::from(lit("2020-01-01")),
-                            data_type: arrow_schema::DataType::Date32
-                        }
-                    )
+                    Expr::Cast(Cast::new(
+                        Box::from(lit("2020-01-01")),
+                        arrow_schema::DataType::Date32
+                    ))
                 )),
             },
             ParseTest {
                 expr: col("_decimal").eq(lit(ScalarValue::Decimal128(Some(1),2,2))),
                 expected: "_decimal = '1'::decimal(2, 2)".to_string(),
                 override_expected_expr: Some(col("_decimal").eq(
-                    Expr::Cast(
-                        Cast {
-                            expr: Box::from(lit("1")),
-                            data_type: arrow_schema::DataType::Decimal128(2, 2)
-                        }
-                    )
+                    Expr::Cast(Cast::new(
+                        Box::from(lit("1")),
+                        arrow_schema::DataType::Decimal128(2, 2)
+                    ))
                 )),
             },
         ];

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -474,7 +474,6 @@ impl PhysicalExtensionCodec for DeltaPhysicalCodec {
         buf: &mut Vec<u8>,
     ) -> Result<(), DataFusionError> {
         let delta_scan = node
-            .as_any()
             .downcast_ref::<DeltaScan>()
             .ok_or_else(|| DataFusionError::Internal("Not a legacy delta scan!".to_string()))?;
 
@@ -522,13 +521,9 @@ impl LogicalExtensionCodec for DeltaLogicalCodec {
         node: Arc<dyn TableProvider>,
         buf: &mut Vec<u8>,
     ) -> Result<(), DataFusionError> {
-        let scan = node
-            .as_ref()
-            .as_any()
-            .downcast_ref::<DeltaScanNext>()
-            .ok_or_else(|| {
-                DataFusionError::Internal("Can't encode non-delta tables".to_string())
-            })?;
+        let scan = node.downcast_ref::<DeltaScanNext>().ok_or_else(|| {
+            DataFusionError::Internal("Can't encode non-delta tables".to_string())
+        })?;
         serde_json::to_writer(buf, scan)
             .map_err(|_| DataFusionError::Internal("Error encoding delta table".to_string()))
     }
@@ -798,11 +793,7 @@ mod tests {
                 &ctx.task_ctx(),
             )
             .unwrap();
-        let decoded_provider = decoded
-            .as_ref()
-            .as_any()
-            .downcast_ref::<DeltaScanNext>()
-            .unwrap();
+        let decoded_provider = decoded.downcast_ref::<DeltaScanNext>().unwrap();
 
         let serialized = serde_json::to_value(decoded_provider).unwrap();
         let decoded_file_ids = serialized
@@ -866,11 +857,7 @@ mod tests {
                 &ctx.task_ctx(),
             )
             .unwrap();
-        let decoded_provider = decoded
-            .as_ref()
-            .as_any()
-            .downcast_ref::<DeltaScanNext>()
-            .unwrap();
+        let decoded_provider = decoded.downcast_ref::<DeltaScanNext>().unwrap();
         let serialized = serde_json::to_value(decoded_provider).unwrap();
         let file_selection = serialized.get("file_selection").unwrap();
         let file_selection_json = serde_json::to_string(file_selection).unwrap();
@@ -928,11 +915,7 @@ mod tests {
                 &ctx.task_ctx(),
             )
             .unwrap();
-        let decoded_provider = decoded
-            .as_ref()
-            .as_any()
-            .downcast_ref::<DeltaScanNext>()
-            .unwrap();
+        let decoded_provider = decoded.downcast_ref::<DeltaScanNext>().unwrap();
         let serialized = serde_json::to_value(decoded_provider).unwrap();
         let file_selection = serialized.get("file_selection").unwrap();
         let file_selection_json = serde_json::to_string(file_selection).unwrap();
@@ -1362,7 +1345,7 @@ mod tests {
             .unwrap();
 
         let df = datafusion
-            .sql("select * from snapshot where id > 10000 and id < 20000")
+            .sql(r#"select * from snapshot where "vaLue" > 10000 and "vaLue" < 20000"#)
             .await
             .unwrap();
 

--- a/crates/core/src/delta_datafusion/physical.rs
+++ b/crates/core/src/delta_datafusion/physical.rs
@@ -78,10 +78,6 @@ impl ExecutionPlan for MetricObserverExec {
         Self::static_name()
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn schema(&self) -> arrow_schema::SchemaRef {
         self.parent.schema()
     }
@@ -111,7 +107,7 @@ impl ExecutionPlan for MetricObserverExec {
     fn partition_statistics(
         &self,
         partition: Option<usize>,
-    ) -> datafusion::common::Result<Statistics> {
+    ) -> datafusion::common::Result<Arc<Statistics>> {
         self.parent.partition_statistics(partition)
     }
 
@@ -166,7 +162,7 @@ pub(crate) fn find_metric_node(
     parent: &Arc<dyn ExecutionPlan>,
 ) -> Option<Arc<dyn ExecutionPlan>> {
     //! Used to locate the physical MetricCountExec Node after the planner converts the logical node
-    if let Some(metric) = parent.as_any().downcast_ref::<MetricObserverExec>()
+    if let Some(metric) = parent.downcast_ref::<MetricObserverExec>()
         && metric.id().eq(id)
     {
         return Some(parent.to_owned());

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
 
@@ -595,10 +594,6 @@ impl ExecutionPlan for DeltaScan {
         Self::static_name()
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.parquet_scan.schema()
     }
@@ -660,7 +655,7 @@ impl ExecutionPlan for DeltaScan {
         Some(self.metrics.clone_inner())
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
         self.parquet_scan.partition_statistics(partition)
     }
 
@@ -680,7 +675,7 @@ pub(crate) fn simplify_expr(
     expr: Expr,
 ) -> Result<Arc<dyn PhysicalExpr>> {
     let execution_props = session.execution_props();
-    let context = SimplifyContext::default()
+    let context = SimplifyContext::builder()
         .with_schema(df_schema.clone())
         .with_query_execution_start_time(execution_props.query_execution_start_time)
         .with_config_options(
@@ -688,7 +683,8 @@ pub(crate) fn simplify_expr(
                 .config_options()
                 .cloned()
                 .unwrap_or_else(|| session.config().options().clone()),
-        );
+        )
+        .build();
     let simplifier = ExprSimplifier::new(context).with_max_cycles(10);
     session.create_physical_expr(simplifier.simplify(expr)?, df_schema.as_ref())
 }

--- a/crates/core/src/delta_datafusion/table_provider/data_sink.rs
+++ b/crates/core/src/delta_datafusion/table_provider/data_sink.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, fmt, sync::Arc};
+use std::{fmt, sync::Arc};
 
 use arrow_schema::SchemaRef;
 use datafusion::{
@@ -90,10 +90,6 @@ impl DeltaDataSink {
 /// to write the data to the delta table
 #[async_trait::async_trait]
 impl DataSink for DeltaDataSink {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -26,7 +26,7 @@
 //! - applying Delta features by transforming the physical data into the table's logical schema
 //!
 use std::collections::HashSet;
-use std::{any::Any, borrow::Cow, fmt, sync::Arc};
+use std::{borrow::Cow, fmt, sync::Arc};
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::common::{DataFusionError, Result};
@@ -709,10 +709,6 @@ impl DeltaScan {
 
 #[async_trait::async_trait]
 impl TableProvider for DeltaScan {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.full_schema.clone()
     }
@@ -996,7 +992,6 @@ mod tests {
         ) -> Result<bool, DataFusionError> {
             let Some(scan_config) = datasource_exec
                 .data_source()
-                .as_any()
                 .downcast_ref::<FileScanConfig>()
             else {
                 return Ok(true);
@@ -1016,11 +1011,11 @@ mod tests {
         type Error = DataFusionError;
 
         fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
-            if let Some(delta_scan_exec) = plan.as_any().downcast_ref::<scan::DeltaScanExec>() {
+            if let Some(delta_scan_exec) = plan.downcast_ref::<scan::DeltaScanExec>() {
                 return self.pre_visit_delta_scan(delta_scan_exec);
             };
 
-            if let Some(datasource_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
+            if let Some(datasource_exec) = plan.downcast_ref::<DataSourceExec>() {
                 return self.pre_visit_data_source(datasource_exec);
             }
 
@@ -1038,20 +1033,16 @@ mod tests {
         type Error = DataFusionError;
 
         fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
-            let Some(datasource_exec) = plan.as_any().downcast_ref::<DataSourceExec>() else {
+            let Some(datasource_exec) = plan.downcast_ref::<DataSourceExec>() else {
                 return Ok(true);
             };
             let Some(scan_config) = datasource_exec
                 .data_source()
-                .as_any()
                 .downcast_ref::<FileScanConfig>()
             else {
                 return Ok(true);
             };
-            let Some(parquet_source) = scan_config
-                .file_source
-                .as_any()
-                .downcast_ref::<ParquetSource>()
+            let Some(parquet_source) = scan_config.file_source.downcast_ref::<ParquetSource>()
             else {
                 return Ok(true);
             };

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -1077,7 +1077,6 @@ mod tests {
             )
             .await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("expected DeltaScanExec");
 
@@ -1112,7 +1111,6 @@ mod tests {
 
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("expected DeltaScanExec");
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -3,7 +3,6 @@
 //! This module implements [`DeltaScanExec`], the core execution plan that reads Parquet files
 //! and applies Delta Lake protocol transformations to produce logical table data.
 
-use std::any::Any;
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -280,10 +279,6 @@ impl ExecutionPlan for DeltaScanExec {
         "DeltaScanExec"
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
@@ -403,10 +398,10 @@ impl ExecutionPlan for DeltaScanExec {
         Some(Arc::new(new_plan))
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
-        self.input
-            .partition_statistics(partition)
-            .and_then(|stats| self.map_statistics(stats))
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
+        let stats = self.input.partition_statistics(partition)?;
+        self.map_statistics(Arc::unwrap_or_clone(stats))
+            .map(Arc::new)
     }
 
     fn gather_filters_for_pushdown(
@@ -852,7 +847,7 @@ mod tests {
             .scan(&session.state(), None, &[col("letter").eq(lit("b"))], None)
             .await?;
 
-        let downcast = scan.as_any().downcast_ref::<DeltaScanExec>();
+        let downcast = scan.downcast_ref::<DeltaScanExec>();
         assert!(downcast.is_some());
         assert_eq!(downcast.unwrap().file_id_column.as_deref(), Some("file_id"));
 
@@ -929,7 +924,7 @@ mod tests {
             .scan(&session.state(), Some(&vec![id_idx]), &[], None)
             .await?;
 
-        let downcast = scan.as_any().downcast_ref::<DeltaScanExec>();
+        let downcast = scan.downcast_ref::<DeltaScanExec>();
         assert!(downcast.is_some());
         assert!(downcast.unwrap().file_id_column.is_none());
 
@@ -964,7 +959,6 @@ mod tests {
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("expected DeltaScanExec");
 
@@ -999,7 +993,6 @@ mod tests {
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("expected DeltaScanExec");
 
@@ -1037,7 +1030,6 @@ mod tests {
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("expected DeltaScanExec");
 
@@ -1159,7 +1151,6 @@ mod tests {
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("expected DeltaScanExec");
 
@@ -1196,7 +1187,6 @@ mod tests {
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("expected DeltaScanExec");
 
@@ -1254,7 +1244,7 @@ mod tests {
             .scan(&session.state(), None, &[col("letter").eq(lit("b"))], None)
             .await?;
 
-        let downcast = scan.as_any().downcast_ref::<DeltaScanExec>();
+        let downcast = scan.downcast_ref::<DeltaScanExec>();
         assert!(downcast.is_some());
         assert!(downcast.unwrap().file_id_column.is_none());
 
@@ -1407,7 +1397,7 @@ mod tests {
         let filename_col = batches[0]
             .column_by_name("filename")
             .unwrap()
-            .as_string::<i32>();
+            .as_string_view();
 
         for i in 0..filename_col.len() {
             let filename = filename_col.value(i);
@@ -1594,7 +1584,7 @@ mod tests {
 
         let scan = provider.scan(&session.state(), None, &[], None).await?;
 
-        let downcast = scan.as_any().downcast_ref::<DeltaScanExec>();
+        let downcast = scan.downcast_ref::<DeltaScanExec>();
         assert!(downcast.is_some(), "Expected DeltaScanExec for DV test");
 
         let batches = collect(scan, session.task_ctx()).await?;
@@ -1624,7 +1614,6 @@ mod tests {
 
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("Expected DeltaScanExec");
 
@@ -1652,7 +1641,6 @@ mod tests {
 
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("Expected DeltaScanExec");
 
@@ -1801,7 +1789,6 @@ mod tests {
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("expected DeltaScanExec");
 
@@ -1841,7 +1828,6 @@ mod tests {
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("expected DeltaScanExec");
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -3,7 +3,6 @@
 //! This module implements [`DeltaScanMetaExec`], which answers queries using only file
 //! metadata and statistics, avoiding the cost of reading actual Parquet data files.
 
-use std::any::Any;
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
@@ -197,10 +196,6 @@ impl ExecutionPlan for DeltaScanMetaExec {
         "DeltaScanMetaExec"
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
@@ -295,12 +290,12 @@ impl ExecutionPlan for DeltaScanMetaExec {
         None
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
-        Ok(Statistics {
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
+        Ok(Arc::new(Statistics {
             num_rows: Precision::Exact(self.exact_num_rows(partition)?),
             total_byte_size: Precision::Absent,
             column_statistics: Statistics::unknown_column(self.schema().as_ref()),
-        })
+        }))
     }
 
     fn gather_filters_for_pushdown(
@@ -689,7 +684,7 @@ mod tests {
             .scan(&session.state(), Some(&empty_projection), &[], None)
             .await?;
         assert!(
-            scan.as_any().downcast_ref::<DeltaScanMetaExec>().is_some(),
+            scan.downcast_ref::<DeltaScanMetaExec>().is_some(),
             "expected metadata-only scan\n{diagnostics}"
         );
         assert_eq!(
@@ -810,7 +805,7 @@ mod tests {
             )
             .await?;
 
-        let downcast = scan.as_any().downcast_ref::<DeltaScanMetaExec>();
+        let downcast = scan.downcast_ref::<DeltaScanMetaExec>();
         assert!(downcast.is_some());
 
         session.register_table("delta_table", provider).unwrap();
@@ -863,7 +858,7 @@ mod tests {
             )
             .await?;
 
-        let downcast = scan.as_any().downcast_ref::<DeltaScanMetaExec>();
+        let downcast = scan.downcast_ref::<DeltaScanMetaExec>();
         assert!(downcast.is_some());
 
         let expected = vec![
@@ -964,7 +959,7 @@ mod tests {
             )
             .await?;
 
-        let downcast = scan.as_any().downcast_ref::<DeltaScanMetaExec>();
+        let downcast = scan.downcast_ref::<DeltaScanMetaExec>();
         assert!(downcast.is_some());
 
         let data = collect_partitioned(scan, session.task_ctx())
@@ -991,7 +986,7 @@ mod tests {
         let scan = provider
             .scan(&session.state(), Some(&vec![data_idx]), &[], None)
             .await?;
-        let downcast = scan.as_any().downcast_ref::<DeltaScanMetaExec>();
+        let downcast = scan.downcast_ref::<DeltaScanMetaExec>();
         assert!(downcast.is_some());
         assert_eq!(
             scan.schema()
@@ -1115,7 +1110,6 @@ mod tests {
             .scan(&session.state(), Some(&empty_projection), &[], None)
             .await?;
         let template = scan
-            .as_any()
             .downcast_ref::<DeltaScanMetaExec>()
             .expect("expected metadata-only scan");
 
@@ -1159,7 +1153,6 @@ mod tests {
         );
 
         let repartitioned = repartitioned
-            .as_any()
             .downcast_ref::<DeltaScanMetaExec>()
             .expect("expected repartitioned DeltaScanMetaExec");
         assert_eq!(repartitioned.input.len(), 2);

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -943,11 +943,9 @@ mod tests {
 
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
-            .as_any()
             .downcast_ref::<DeltaScanExec>()
             .expect("expected DeltaScanExec");
         let data_source = exec.children()[0]
-            .as_any()
             .downcast_ref::<DataSourceExec>()
             .expect("expected DataSourceExec child");
         let (file_scan_config, _) = data_source

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -930,7 +930,7 @@ mod tests {
         )
         .await?;
 
-        assert!(plan.as_any().is::<EmptyExec>());
+        assert!(plan.is::<EmptyExec>());
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/utils.rs
+++ b/crates/core/src/delta_datafusion/utils.rs
@@ -29,7 +29,7 @@ impl Expression {
         // Coerce literal types to match schema column types for parsed string predicates
         let expr = coerce_predicate_literals(expr, schema.as_ref())?;
         let execution_props = session.execution_props();
-        let context = SimplifyContext::default()
+        let context = SimplifyContext::builder()
             .with_schema(schema)
             .with_query_execution_start_time(execution_props.query_execution_start_time)
             .with_config_options(
@@ -37,7 +37,8 @@ impl Expression {
                     .config_options()
                     .cloned()
                     .unwrap_or_else(|| session.config().options().clone()),
-            );
+            )
+            .build();
         let simplifier = ExprSimplifier::new(context);
         simplifier.simplify(expr)
     }

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -209,7 +209,7 @@ mod datafusion {
                 return arrow_cast::cast(counts.as_ref(), &ArrowDataType::UInt64).ok();
             }
             let partition_values = self.pick_stats(column, "__dummy__")?;
-            let row_counts = self.row_counts(column)?;
+            let row_counts = self.row_counts()?;
             let row_counts = row_counts.as_any().downcast_ref::<UInt64Array>()?;
             let mut null_counts = Vec::with_capacity(partition_values.len());
             for i in 0..partition_values.len() {
@@ -223,11 +223,10 @@ mod datafusion {
             Some(Arc::new(UInt64Array::from(null_counts)))
         }
 
-        /// return the number of rows for the named column in each container
-        /// as an `Option<UInt64Array>`.
+        /// return the number of rows in each container as an `Option<UInt64Array>`.
         ///
         /// Note: the returned array must contain `num_containers()` rows
-        fn row_counts(&self, _column: &Column) -> Option<ArrayRef> {
+        fn row_counts(&self) -> Option<ArrayRef> {
             static ROW_COUNTS_EVAL: LazyLock<Arc<dyn ExpressionEvaluator>> = LazyLock::new(|| {
                 ARROW_HANDLER
                     .new_expression_evaluator(

--- a/crates/core/src/kernel/transaction/state.rs
+++ b/crates/core/src/kernel/transaction/state.rs
@@ -157,11 +157,10 @@ impl PruningStatistics for AddContainer<'_> {
         ScalarValue::iter_to_array(values).ok()
     }
 
-    /// return the number of rows for the named column in each container
-    /// as an `Option<UInt64Array>`.
+    /// return the number of rows in each container as an `Option<UInt64Array>`.
     ///
     /// Note: the returned array must contain `num_containers()` rows
-    fn row_counts(&self, _column: &Column) -> Option<ArrayRef> {
+    fn row_counts(&self) -> Option<ArrayRef> {
         let values = self.inner.iter().map(|add| {
             if let Ok(Some(statistics)) = add.get_stats() {
                 ScalarValue::UInt64(Some(statistics.num_records as u64))
@@ -206,12 +205,11 @@ impl PruningStatistics for EagerSnapshot {
         self.log_data().null_counts(column)
     }
 
-    /// return the number of rows for the named column in each container
-    /// as an `Option<UInt64Array>`.
+    /// return the number of rows in each container as an `Option<UInt64Array>`.
     ///
     /// Note: the returned array must contain `num_containers()` rows
-    fn row_counts(&self, column: &Column) -> Option<ArrayRef> {
-        self.log_data().row_counts(column)
+    fn row_counts(&self) -> Option<ArrayRef> {
+        self.log_data().row_counts()
     }
 
     // This function is required since DataFusion 35.0, but is implemented as a no-op

--- a/crates/core/src/operations/merge/barrier.rs
+++ b/crates/core/src/operations/merge/barrier.rs
@@ -72,10 +72,6 @@ impl ExecutionPlan for MergeBarrierExec {
         Self::static_name()
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn schema(&self) -> arrow_schema::SchemaRef {
         self.input.schema()
     }
@@ -435,11 +431,11 @@ impl UserDefinedLogicalNodeCore for MergeBarrier {
     }
 }
 
-pub(crate) fn find_node<T: 'static>(
+pub(crate) fn find_node<T: ExecutionPlan>(
     parent: &Arc<dyn ExecutionPlan>,
 ) -> Option<Arc<dyn ExecutionPlan>> {
     //! Used to locate a Node::<T> after the planner converts the logical node
-    if parent.as_any().downcast_ref::<T>().is_some() {
+    if parent.downcast_ref::<T>().is_some() {
         return Some(parent.to_owned());
     }
 

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1599,7 +1599,6 @@ async fn execute(
     metrics.num_target_files_added = actions.len();
 
     let survivors = barrier
-        .as_any()
         .downcast_ref::<MergeBarrierExec>()
         .unwrap()
         .survivors();
@@ -1761,7 +1760,9 @@ fn remove_table_alias(expr: Expr, table_alias: &str) -> Expr {
 
 fn normalize_target_subset_filter(target_schema: DFSchemaRef, expr: Expr) -> DeltaResult<Expr> {
     let expr = coerce_predicate_literals(expr, target_schema.as_ref())?;
-    let simplify_context = SimplifyContext::default().with_schema(target_schema);
+    let simplify_context = SimplifyContext::builder()
+        .with_schema(target_schema)
+        .build();
     let simplifier = ExprSimplifier::new(simplify_context).with_max_cycles(10);
     Ok(simplifier.simplify(expr)?)
 }

--- a/crates/core/src/operations/merge/validation.rs
+++ b/crates/core/src/operations/merge/validation.rs
@@ -56,10 +56,6 @@ impl ExecutionPlan for MergeValidationExec {
         Self::static_name()
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.input.schema()
     }

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -1545,7 +1545,6 @@ pub(super) mod zorder {
         use ::datafusion::prelude::SessionContext;
         use arrow_schema::DataType;
         use itertools::Itertools;
-        use std::any::Any;
 
         pub const ZORDER_UDF_NAME: &str = "zorder_key";
 
@@ -1574,10 +1573,6 @@ pub(super) mod zorder {
         pub struct ZOrderUDF;
 
         impl ScalarUDFImpl for ZOrderUDF {
-            fn as_any(&self) -> &dyn Any {
-                self
-            }
-
             fn name(&self) -> &str {
                 ZORDER_UDF_NAME
             }

--- a/crates/core/src/test_utils/datafusion.rs
+++ b/crates/core/src/test_utils/datafusion.rs
@@ -11,9 +11,10 @@ use datafusion::execution::TaskContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::execution::session_state::SessionState;
 use datafusion::logical_expr::execution_props::ExecutionProps;
+use datafusion::logical_expr::registry::ExtensionTypeRegistryRef;
 use datafusion::logical_expr::{
-    AggregateUDF, ColumnarValue, Expr, LogicalPlan, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl,
-    Signature, TypeSignature, Volatility, WindowUDF,
+    AggregateUDF, ColumnarValue, Expr, HigherOrderUDF, LogicalPlan, ScalarFunctionArgs, ScalarUDF,
+    ScalarUDFImpl, Signature, TypeSignature, Volatility, WindowUDF,
 };
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::ExecutionPlan;
@@ -29,10 +30,6 @@ struct TestScalarUdf {
 }
 
 impl ScalarUDFImpl for TestScalarUdf {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.name
     }
@@ -114,12 +111,20 @@ impl DataFusionSession for WrapperSession {
         DataFusionSession::scalar_functions(&self.inner)
     }
 
+    fn higher_order_functions(&self) -> &HashMap<String, Arc<HigherOrderUDF>> {
+        DataFusionSession::higher_order_functions(&self.inner)
+    }
+
     fn aggregate_functions(&self) -> &HashMap<String, Arc<AggregateUDF>> {
         DataFusionSession::aggregate_functions(&self.inner)
     }
 
     fn window_functions(&self) -> &HashMap<String, Arc<WindowUDF>> {
         DataFusionSession::window_functions(&self.inner)
+    }
+
+    fn extension_type_registry(&self) -> &ExtensionTypeRegistryRef {
+        DataFusionSession::extension_type_registry(&self.inner)
     }
 
     fn runtime_env(&self) -> &Arc<RuntimeEnv> {

--- a/crates/core/tests/it_datafusion/integration_datafusion.rs
+++ b/crates/core/tests/it_datafusion/integration_datafusion.rs
@@ -132,10 +132,10 @@ mod local {
             &mut self,
             plan: &dyn ExecutionPlan,
         ) -> std::result::Result<bool, Self::Error> {
-            if let Some(exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
+            if let Some(exec) = plan.downcast_ref::<DataSourceExec>() {
                 let files = get_scanned_files(exec);
                 self.scanned_files.extend(files);
-            } else if let Some(exec) = plan.as_any().downcast_ref::<DeltaScanExec>() {
+            } else if let Some(exec) = plan.downcast_ref::<DeltaScanExec>() {
                 self.keep_count = exec
                     .metrics()
                     .and_then(|m| m.sum_by_name("count_files_scanned").map(|v| v.as_usize()))

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -32,7 +32,7 @@ arrow-cast = { workspace = true }
 
 # datafusion
 datafusion-ffi = { workspace = true }
-datafusion-execution = { version = "53.0.0" }
+datafusion-execution = { version = "54.0.0" }
 
 # serde
 serde = { workspace = true }

--- a/python/src/datafusion.rs
+++ b/python/src/datafusion.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::borrow::Cow;
 use std::sync::Arc;
 
@@ -41,10 +40,6 @@ impl LazyTableProvider {
 
 #[async_trait::async_trait]
 impl TableProvider for LazyTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> Arc<ArrowSchema> {
         self.schema.clone()
     }
@@ -152,10 +147,6 @@ impl TokioDeltaScan {
 
 #[async_trait::async_trait]
 impl TableProvider for TokioDeltaScan {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.inner.schema()
     }
@@ -203,6 +194,7 @@ impl TableProvider for TokioDeltaScan {
 mod tests {
     use super::*;
 
+    use std::any::Any;
     use std::sync::Arc;
 
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
@@ -382,7 +374,7 @@ mod tests {
 
         // The plan should include a LimitExec
         // We can verify this by checking that the plan type is correct
-        assert!(plan.as_any().downcast_ref::<GlobalLimitExec>().is_some());
+        assert!(plan.downcast_ref::<GlobalLimitExec>().is_some());
     }
 
     #[tokio::test]
@@ -419,6 +411,6 @@ mod tests {
 
         // The resulting plan should have a chain of operations:
         // GlobalLimitExec -> ProjectionExec -> FilterExec -> LazyMemoryExec
-        assert!(plan.as_any().downcast_ref::<GlobalLimitExec>().is_some());
+        assert!(plan.downcast_ref::<GlobalLimitExec>().is_some());
     }
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -136,7 +136,7 @@ struct RawDeltaTableMetaData {
 
 type StringVec = Vec<String>;
 
-const REQUIRED_DATAFUSION_PY_MAJOR: u32 = 53;
+const REQUIRED_DATAFUSION_PY_MAJOR: u32 = 54;
 static FALLBACK_TASK_CTX_PROVIDER: OnceLock<Arc<SessionContext>> = OnceLock::new();
 const MAX_OPTIMIZE_TARGET_SIZE: u64 = i64::MAX as u64;
 

--- a/python/src/writer.rs
+++ b/python/src/writer.rs
@@ -31,7 +31,10 @@ pub fn to_lazy_table(
     )?))
 }
 pub struct ReaderWrapper {
-    reader: Mutex<Box<dyn RecordBatchReader + Send + 'static>>,
+    /// The underlying reader. `None` once it has been handed off to a fresh
+    /// generator by [`ArrowStreamBatchGenerator::reset_state`], since a
+    /// one-shot stream can only be consumed once.
+    reader: Mutex<Option<Box<dyn RecordBatchReader + Send + 'static>>>,
 }
 
 impl fmt::Debug for ReaderWrapper {
@@ -61,7 +64,7 @@ impl ArrowStreamBatchGenerator {
     pub fn new(array_stream: Box<dyn RecordBatchReader + Send + 'static>) -> Self {
         Self {
             array_stream: ReaderWrapper {
-                reader: Mutex::new(array_stream),
+                reader: Mutex::new(Some(array_stream)),
             },
         }
     }
@@ -81,7 +84,15 @@ impl LazyBatchGenerator for ArrowStreamBatchGenerator {
             )
         })?;
 
-        match stream_reader.next() {
+        let Some(reader) = stream_reader.as_mut() else {
+            return Err(deltalake::datafusion::error::DataFusionError::Execution(
+                "Stream-based generator cannot be reset; the original stream has been consumed. \
+                 Buffer input data if plan re-execution is required."
+                    .to_string(),
+            ));
+        };
+
+        match reader.next() {
             Some(Ok(record_batch)) => Ok(Some(record_batch)),
             Some(Err(err)) => Err(deltalake::datafusion::error::DataFusionError::ArrowError(
                 Box::new(err),
@@ -91,8 +102,19 @@ impl LazyBatchGenerator for ArrowStreamBatchGenerator {
         }
     }
 
+    /// DataFusion 54's `LazyMemoryExec::execute` calls `reset_state` on every
+    /// execution (including the first) to obtain a fresh stream. Since the
+    /// underlying reader is one-shot, we hand it off to the new generator the
+    /// first time and leave an [`ExhaustedStreamGenerator`] behind so any later
+    /// re-execution fails loudly rather than silently yielding no rows.
     fn reset_state(&self) -> Arc<RwLock<dyn LazyBatchGenerator>> {
-        Arc::new(RwLock::new(ExhaustedStreamGenerator))
+        match self.array_stream.reader.lock() {
+            Ok(mut guard) => match guard.take() {
+                Some(reader) => Arc::new(RwLock::new(ArrowStreamBatchGenerator::new(reader))),
+                None => Arc::new(RwLock::new(ExhaustedStreamGenerator)),
+            },
+            Err(_) => Arc::new(RwLock::new(ExhaustedStreamGenerator)),
+        }
     }
 }
 

--- a/python/tests/test_datafusion.py
+++ b/python/tests/test_datafusion.py
@@ -124,9 +124,13 @@ def test_datafusion_table_provider(tmp_path):
             "DataFusion Python integration tests are disabled by default; set DELTALAKE_RUN_DATAFUSION_TESTS=1"
         )
 
+    # This deltalake build exports a DataFusion 54.x FFI TableProvider; the
+    # installed datafusion-python wheel must match that major or the runtime
+    # guard rejects it. datafusion-python has no 54.x release yet, so skip until
+    # one is published rather than fail.
     datafusion_major = _datafusion_major_version()
-    if datafusion_major is None or datafusion_major < 53:
-        pytest.skip("DataFusion Python integration requires datafusion>=53 wheels")
+    if datafusion_major != 54:
+        pytest.skip("DataFusion Python integration requires datafusion==54.x wheels")
     nrows = 5
     table = Table(
         {

--- a/python/tests/test_datafusion.py
+++ b/python/tests/test_datafusion.py
@@ -22,8 +22,8 @@ def test_datafusion_table_provider_incompatible_version_errors(tmp_path, monkeyp
         assert pkg == "datafusion"
         call_count["count"] += 1
         if call_count["count"] == 1:
-            return "52.0.0"
-        return "53.0.0"
+            return "53.0.0"
+        return "54.0.0"
 
     monkeypatch.setattr("importlib.metadata.version", fake_version)
 
@@ -41,7 +41,7 @@ def test_datafusion_table_provider_incompatible_version_errors(tmp_path, monkeyp
 
     msg = str(exc_info.value)
     assert "datafusion" in msg
-    assert "datafusion==53" in msg
+    assert "datafusion==54" in msg
     assert "QueryBuilder" in msg
 
 
@@ -71,7 +71,7 @@ def test_datafusion_table_provider_accepts_session_keyword_argument(
 ):
     def fake_version(pkg: str) -> str:
         assert pkg == "datafusion"
-        return "53.0.0"
+        return "54.0.0"
 
     monkeypatch.setattr("importlib.metadata.version", fake_version)
 
@@ -93,7 +93,7 @@ def test_datafusion_table_provider_invalid_task_ctx_capsule_name_errors(
 
     def fake_version(pkg: str) -> str:
         assert pkg == "datafusion"
-        return "53.0.0"
+        return "54.0.0"
 
     monkeypatch.setattr("importlib.metadata.version", fake_version)
 


### PR DESCRIPTION
## Description

Bumps the workspace from DataFusion 53.1.0 to 54.0.0. arrow (58) and
object_store (0.13.2) already match DataFusion 54's requirements, so this is a
pure DataFusion bump.

### Rust API changes

**Dropped `as_any` (now `Any` supertraits with inherent `downcast_ref`/`is`):**
`ExecutionPlan`, `TableProvider`, `SchemaProvider`, `ScalarUDFImpl`, `DataSink`,
`CatalogProvider`, `CatalogProviderList`, `DataSource`, `FileSource`. Call sites
that did `plan.as_any().downcast_ref::<T>()` on an `Arc<dyn ExecutionPlan>` now
call `plan.downcast_ref::<T>()` directly (this includes the next-scan test
helpers).

**Other API changes:**
- `Session` / `ContextProvider`: implement the new higher-order-function and
  extension-type registry methods
- `partition_statistics()` now returns `Arc<Statistics>`
- `PruningStatistics::row_counts()` drops the `column` arg
- `Cast` moved to its `FieldRef` field
- `PartitionedFile`: fill in the new fields
- `SimplifyContext`: use the builder

### Python / FFI

The exported FFI `TableProvider` is now DataFusion 54.x, so the runtime guard
(`REQUIRED_DATAFUSION_PY_MAJOR`) requires a datafusion-python major of 54.
datafusion-python has no 54.x wheel published yet, so the
`test_datafusion_table_provider` integration test is gated on `==54` and skips
otherwise (the install pin stays at the latest available `53.*` until a 54
wheel ships). The version-mismatch unit tests assert the guard rejects a 53
wheel with a `datafusion==54` message.

### Verification

`cargo fmt --check`, `cargo clippy --workspace --all-features`,
`cargo build --workspace --all-features`, and
`cargo test -p deltalake-core --all-features` all pass.

Generated-by: Claude (Anthropic), with human review and testing
