### PR TITLE
refactor: add Snapshot read capabilities

### DIFF
--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -30,8 +30,8 @@ use crate::delta_datafusion::{
     normalize_path_as_file_id, resolve_file_column_name,
 };
 use crate::errors::{DeltaResult, DeltaTableError};
-use crate::kernel::{Add, EagerSnapshot};
-use crate::logstore::LogStoreRef;
+use crate::kernel::{ActiveAddOptions, Add, AddStatsPolicy, EagerSnapshot, LogicalFileView};
+use crate::logstore::{LogStore, LogStoreRef};
 
 #[derive(Debug, Hash, Eq, PartialEq)]
 /// Representing the result of the [find_files] function.
@@ -40,17 +40,6 @@ pub(crate) struct FindFiles {
     pub candidates: Vec<Add>,
     /// Was a physical read to the datastore required to determine the candidates
     pub partition_scan: bool,
-}
-
-/// Abstraction over sources that can provide partition metadata add-action batches.
-pub(crate) trait PartitionAddActionsProvider {
-    fn add_actions_partition_batches(&self) -> DeltaResult<Vec<RecordBatch>>;
-}
-
-impl PartitionAddActionsProvider for EagerSnapshot {
-    fn add_actions_partition_batches(&self) -> DeltaResult<Vec<RecordBatch>> {
-        EagerSnapshot::add_actions_partition_batches(self)
-    }
 }
 
 /// Finds files in a snapshot that match the provided predicate.
@@ -78,7 +67,8 @@ pub(crate) async fn find_files(
             let predicate = analysis.predicate();
 
             if analysis.partition_only {
-                let candidates = scan_memory_table(snapshot, &predicate).await?;
+                let candidates =
+                    scan_memory_table(snapshot, log_store.as_ref(), &predicate).await?;
                 let result = FindFiles {
                     candidates,
                     partition_scan: true,
@@ -493,9 +483,14 @@ pub(in crate::delta_datafusion) async fn find_files_scan(
 /// partition predicates without materializing full add-action metadata.
 /// Returns `None` when the snapshot contains no add actions.
 pub(crate) fn add_actions_partition_mem_table(
-    snapshot: &(impl PartitionAddActionsProvider + ?Sized),
+    snapshot: &EagerSnapshot,
 ) -> DeltaResult<Option<MemTable>> {
-    let add_action_batches = snapshot.add_actions_partition_batches()?;
+    add_actions_partition_mem_table_from_batches(snapshot.add_actions_partition_batches()?)
+}
+
+fn add_actions_partition_mem_table_from_batches(
+    add_action_batches: Vec<RecordBatch>,
+) -> DeltaResult<Option<MemTable>> {
     if add_action_batches.is_empty() {
         return Ok(None);
     }
@@ -549,10 +544,30 @@ pub(crate) fn add_actions_partition_mem_table(
     )?))
 }
 
-async fn scan_memory_table(snapshot: &EagerSnapshot, predicate: &Expr) -> DeltaResult<Vec<Add>> {
-    let actions = snapshot.log_data().iter().map(|f| f.to_add()).collect_vec();
+async fn scan_memory_table(
+    snapshot: &EagerSnapshot,
+    log_store: &dyn LogStore,
+    predicate: &Expr,
+) -> DeltaResult<Vec<Add>> {
+    let options = ActiveAddOptions {
+        predicate: None,
+        stats: AddStatsPolicy::None,
+    };
+    let add_action_batches = snapshot
+        .snapshot()
+        .active_add_batches(log_store, options)
+        .await?;
+    let actions: Vec<Add> = add_action_batches
+        .iter()
+        .flat_map(|batch| {
+            (0..batch.num_rows()).map(|idx| LogicalFileView::new(batch.clone(), idx).to_add())
+        })
+        .collect_vec();
 
-    let Some(mem_table) = add_actions_partition_mem_table(snapshot)? else {
+    let partition_batches = snapshot
+        .snapshot()
+        .active_add_partition_batches_from(&add_action_batches)?;
+    let Some(mem_table) = add_actions_partition_mem_table_from_batches(partition_batches)? else {
         return Ok(vec![]);
     };
 
@@ -687,7 +702,13 @@ mod tests {
             DataFusionMixins as _, DeltaSessionExt as _, create_session, resolve_file_column_name,
         },
         protocol::SaveMode,
-        test_utils::{TestResult, multibatch_add_actions_for_partition, open_fs_path},
+        test_utils::{
+            TestResult, multibatch_add_actions_for_partition,
+            object_store::{
+                drain_recorded_object_store_operations as drain_recorded_ops, recording_log_store,
+            },
+            open_fs_path,
+        },
         writer::test_utils::{get_delta_schema, get_record_batch},
     };
 
@@ -1055,7 +1076,12 @@ mod tests {
             .with_partition_columns(["modified"])
             .await?;
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let matches = scan_memory_table(table.snapshot()?.snapshot(), &predicate).await?;
+        let matches = scan_memory_table(
+            table.snapshot()?.snapshot(),
+            table.log_store().as_ref(),
+            &predicate,
+        )
+        .await?;
         assert!(matches.is_empty());
         Ok(())
     }
@@ -1075,10 +1101,86 @@ mod tests {
         let snapshot = table.snapshot()?.snapshot();
         let total_actions = snapshot.log_data().iter().count();
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let matches = scan_memory_table(snapshot, &predicate).await?;
+        let matches = scan_memory_table(snapshot, table.log_store().as_ref(), &predicate).await?;
 
         assert!(!matches.is_empty());
         assert!(matches.len() < total_actions);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_memory_table_filters_lazy_snapshot_without_materializing() -> TestResult {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(get_delta_schema().fields().cloned())
+            .with_partition_columns(["modified"])
+            .await?;
+        let table = table
+            .write(vec![get_record_batch(None, false)])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+        let log_store = table.log_store().clone();
+        let config = crate::DeltaTableConfig {
+            require_files: false,
+            ..Default::default()
+        };
+        let snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, None).await?;
+
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+
+        let predicate = col("modified").eq(lit("2021-02-02"));
+        let matches = scan_memory_table(&snapshot, log_store.as_ref(), &predicate).await?;
+
+        assert!(!matches.is_empty());
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_memory_table_replays_lazy_snapshot_once() -> TestResult {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(get_delta_schema().fields().cloned())
+            .with_partition_columns(["modified"])
+            .await?;
+        let table = table
+            .write(vec![get_record_batch(None, false)])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+        let (log_store, mut operations) = recording_log_store(table.log_store());
+        let config = crate::DeltaTableConfig {
+            require_files: false,
+            ..Default::default()
+        };
+        let snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, None).await?;
+        drain_recorded_ops(&mut operations).await;
+
+        snapshot
+            .snapshot()
+            .active_add_batches(
+                log_store.as_ref(),
+                ActiveAddOptions {
+                    predicate: None,
+                    stats: AddStatsPolicy::None,
+                },
+            )
+            .await?;
+        let single_replay_reads = drain_recorded_ops(&mut operations)
+            .await
+            .into_iter()
+            .filter(|op| op.is_log_replay_read())
+            .count();
+
+        let predicate = col("modified").eq(lit("2021-02-02"));
+        let matches = scan_memory_table(&snapshot, log_store.as_ref(), &predicate).await?;
+        let replay_reads = drain_recorded_ops(&mut operations)
+            .await
+            .into_iter()
+            .filter(|op| op.is_log_replay_read())
+            .count();
+
+        assert!(!matches.is_empty());
+        assert_eq!(replay_reads, single_replay_reads);
         Ok(())
     }
 
@@ -1110,7 +1212,7 @@ mod tests {
         );
 
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let matches = scan_memory_table(snapshot, &predicate).await?;
+        let matches = scan_memory_table(snapshot, table.log_store().as_ref(), &predicate).await?;
 
         assert_eq!(matches.len(), expected_matches);
 
@@ -1123,26 +1225,6 @@ mod tests {
             .map(|idx| format!("modified=2021-02-02/file-{idx:05}.parquet"))
             .collect::<HashSet<_>>();
         assert_eq!(match_paths, expected_paths);
-        Ok(())
-    }
-
-    struct MockPartitionProvider {
-        batches: Vec<RecordBatch>,
-    }
-
-    impl PartitionAddActionsProvider for MockPartitionProvider {
-        fn add_actions_partition_batches(&self) -> DeltaResult<Vec<RecordBatch>> {
-            Ok(self.batches.clone())
-        }
-    }
-
-    #[test]
-    fn test_add_actions_partition_mem_table_accepts_generic_provider() -> DeltaResult<()> {
-        let provider = MockPartitionProvider {
-            batches: Vec::new(),
-        };
-        let mem_table = add_actions_partition_mem_table(&provider)?;
-        assert!(mem_table.is_none());
         Ok(())
     }
 }

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -66,6 +66,91 @@ mod stream;
 pub(crate) static SCAN_ROW_ARROW_SCHEMA: LazyLock<arrow_schema::SchemaRef> =
     LazyLock::new(|| Arc::new(scan_row_schema().as_ref().try_into_arrow().unwrap()));
 
+/// Stats payload requested when streaming active add actions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AddStatsPolicy {
+    /// Skip stats during log replay.
+    ///
+    /// Full table snapshots with cached parsed batches can return cached stats.
+    None,
+    /// Preserve raw JSON stats and row count, without parsed stats.
+    #[cfg(feature = "datafusion")]
+    RawJson,
+    /// Preserve parsed stats and raw JSON stats.
+    Parsed,
+}
+
+/// Active add stream options.
+#[derive(Debug, Clone)]
+pub(crate) struct ActiveAddOptions {
+    /// Kernel predicate used for replay pruning.
+    pub(crate) predicate: Option<PredicateRef>,
+    /// Stats payload requested for each add action.
+    pub(crate) stats: AddStatsPolicy,
+}
+
+/// Borrowed protocol, metadata, and table configuration for metadata planners.
+pub(crate) struct SnapshotMetadataRef<'a> {
+    /// Table protocol at this snapshot version.
+    pub(crate) protocol: &'a Protocol,
+    /// Table metadata at this snapshot version.
+    pub(crate) metadata: &'a Metadata,
+    /// Kernel table configuration from protocol, metadata, and properties.
+    pub(crate) table_configuration: &'a TableConfiguration,
+}
+
+/// Active add read set for optimistic transaction conflict checks.
+///
+/// The read set borrows materialized log data when available. Lazy snapshots
+/// store replayed add batches in the returned value, which keeps the snapshot
+/// file cache empty.
+pub(crate) struct ConflictReadSet<'a> {
+    inner: ConflictReadSetInner<'a>,
+}
+
+enum ConflictReadSetInner<'a> {
+    Borrowed(LogDataHandler<'a>),
+    Owned {
+        batches: Arc<Vec<RecordBatch>>,
+        table_configuration: &'a TableConfiguration,
+    },
+}
+
+impl<'a> ConflictReadSet<'a> {
+    fn from_log_data(log_data: LogDataHandler<'a>) -> Self {
+        Self {
+            inner: ConflictReadSetInner::Borrowed(log_data),
+        }
+    }
+
+    fn from_owned_batches(
+        batches: Vec<RecordBatch>,
+        table_configuration: &'a TableConfiguration,
+    ) -> Self {
+        Self {
+            inner: ConflictReadSetInner::Owned {
+                batches: Arc::new(batches),
+                table_configuration,
+            },
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_log_data_for_test(log_data: LogDataHandler<'a>) -> Self {
+        Self::from_log_data(log_data)
+    }
+
+    pub(crate) fn log_data(&self) -> LogDataHandler<'_> {
+        match &self.inner {
+            ConflictReadSetInner::Borrowed(log_data) => log_data.clone(),
+            ConflictReadSetInner::Owned {
+                batches,
+                table_configuration,
+            } => LogDataHandler::new(batches.as_ref().as_slice(), table_configuration),
+        }
+    }
+}
+
 /// A snapshot of a Delta table
 #[derive(Debug, Clone, PartialEq)]
 pub struct Snapshot {
@@ -297,6 +382,11 @@ impl Snapshot {
         self.materialized_files.as_ref()
     }
 
+    #[cfg(test)]
+    pub(crate) fn has_materialized_files_for_test(&self) -> bool {
+        self.materialized_files.is_some()
+    }
+
     pub(crate) async fn ensure_materialized_files(
         self: Arc<Self>,
         log_store: &dyn LogStore,
@@ -320,6 +410,74 @@ impl Snapshot {
         ))
     }
 
+    /// Stream active add actions without requiring `materialized_files`.
+    pub(crate) fn active_adds(
+        &self,
+        log_store: &dyn LogStore,
+        options: ActiveAddOptions,
+    ) -> BoxStream<'_, DeltaResult<LogicalFileView>> {
+        self.files_with_stats_policy(log_store, options.predicate, options.stats)
+            .map_ok(|batch| {
+                futures::stream::iter(0..batch.num_rows()).map(move |idx| {
+                    Ok::<_, DeltaTableError>(LogicalFileView::new(batch.clone(), idx))
+                })
+            })
+            .try_flatten()
+            .boxed()
+    }
+
+    /// Collect active add batches without requiring `materialized_files`.
+    pub(crate) async fn active_add_batches(
+        &self,
+        log_store: &dyn LogStore,
+        options: ActiveAddOptions,
+    ) -> DeltaResult<Vec<RecordBatch>> {
+        self.files_with_stats_policy(log_store, options.predicate, options.stats)
+            .try_collect()
+            .await
+    }
+
+    /// Stream active tombstones with the snapshot capability API.
+    ///
+    /// This matches [`Snapshot::tombstones`]. The named method gives maintenance
+    /// callers a `Snapshot` entry point instead of eager snapshot state.
+    pub(crate) fn active_tombstones(
+        &self,
+        log_store: &dyn LogStore,
+    ) -> BoxStream<'_, DeltaResult<TombstoneView>> {
+        self.tombstones(log_store)
+    }
+
+    /// Build active add input for conflict checking.
+    ///
+    /// Materialized snapshots borrow existing log data. Lazy snapshots replay
+    /// active adds with parsed stats and store those batches in the returned
+    /// read set while leaving this snapshot unmaterialized.
+    pub(crate) async fn conflict_read_set(
+        &self,
+        log_store: &dyn LogStore,
+    ) -> DeltaResult<ConflictReadSet<'_>> {
+        match self.try_log_data() {
+            Ok(log_data) => Ok(ConflictReadSet::from_log_data(log_data)),
+            Err(DeltaTableError::NotInitializedWithFiles(_)) => {
+                let batches = self
+                    .active_add_batches(
+                        log_store,
+                        ActiveAddOptions {
+                            predicate: None,
+                            stats: AddStatsPolicy::Parsed,
+                        },
+                    )
+                    .await?;
+                Ok(ConflictReadSet::from_owned_batches(
+                    batches,
+                    self.table_configuration(),
+                ))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
     /// Get the table root of the snapshot
     pub(crate) fn table_root_path(&self) -> DeltaResult<Path> {
         Ok(Path::from_url_path(self.inner.table_root().path())?)
@@ -333,6 +491,15 @@ impl Snapshot {
     /// Returns the resolved [`TableConfiguration`] (protocol, metadata and parsed properties).
     pub fn table_configuration(&self) -> &TableConfiguration {
         self.inner.table_configuration()
+    }
+
+    /// Return borrowed metadata state without materializing files.
+    pub(crate) fn metadata_state(&self) -> SnapshotMetadataRef<'_> {
+        SnapshotMetadataRef {
+            protocol: self.protocol(),
+            metadata: self.metadata(),
+            table_configuration: self.table_configuration(),
+        }
     }
 
     /// Get the active files for the current snapshot.
@@ -425,8 +592,22 @@ impl Snapshot {
         predicate: Option<PredicateRef>,
         stats_mode: FileStatsMode,
     ) -> SendableRBStream {
+        self.files_with_engine_materialized_with_skip_stats(
+            engine,
+            predicate,
+            stats_mode,
+            self.config.skip_stats,
+        )
+    }
+
+    fn files_with_engine_materialized_with_skip_stats(
+        &self,
+        engine: Arc<dyn Engine>,
+        predicate: Option<PredicateRef>,
+        stats_mode: FileStatsMode,
+        skip_stats: bool,
+    ) -> SendableRBStream {
         self.warn_if_skip_stats_with_predicate(&predicate);
-        let skip_stats = self.config.skip_stats;
         let scan = match self.scan_for_files(predicate, skip_stats, stats_mode) {
             Ok(scan) => scan,
             Err(err) => return Box::pin(once(ready(Err(err)))),
@@ -493,6 +674,54 @@ impl Snapshot {
         }
     }
 
+    fn files_with_stats_policy(
+        &self,
+        log_store: &dyn LogStore,
+        predicate: Option<PredicateRef>,
+        stats_policy: AddStatsPolicy,
+    ) -> SendableRBStream {
+        let skip_stats = matches!(stats_policy, AddStatsPolicy::None) || self.config.skip_stats;
+        if predicate.is_none()
+            && let Some(cached) = self.cached_parsed_batches()
+        {
+            return cached;
+        }
+
+        let stats_mode = match stats_policy {
+            AddStatsPolicy::None => FileStatsMode::PreserveRaw,
+            #[cfg(feature = "datafusion")]
+            AddStatsPolicy::RawJson => FileStatsMode::PreserveRaw,
+            AddStatsPolicy::Parsed => FileStatsMode::FullPreserveRaw,
+        };
+
+        match self
+            .materialized_files()
+            .and_then(|materialized_files| materialized_files.full_table_seed())
+        {
+            Some(materialized_seed) => {
+                let (existing_version, existing_data, existing_predicate) =
+                    materialized_seed.into_parts();
+                self.files_from_materialized_with_options(
+                    log_store.engine(None),
+                    predicate,
+                    existing_version,
+                    Box::new(existing_data),
+                    existing_predicate,
+                    FileMaterializationOptions {
+                        stats_mode,
+                        skip_stats,
+                    },
+                )
+            }
+            None => self.files_with_engine_materialized_with_skip_stats(
+                log_store.engine(None),
+                predicate,
+                stats_mode,
+                skip_stats,
+            ),
+        }
+    }
+
     pub(crate) fn files_from<T: Iterator<Item = RecordBatch> + Send + 'static>(
         &self,
         engine: Arc<dyn Engine>,
@@ -538,9 +767,30 @@ impl Snapshot {
         existing_predicate: Option<PredicateRef>,
         stats_mode: FileStatsMode,
     ) -> SendableRBStream {
+        self.files_from_materialized_with_options(
+            engine,
+            predicate,
+            existing_version,
+            existing_data,
+            existing_predicate,
+            FileMaterializationOptions {
+                stats_mode,
+                skip_stats: self.config.skip_stats,
+            },
+        )
+    }
+
+    fn files_from_materialized_with_options<T: Iterator<Item = RecordBatch> + Send + 'static>(
+        &self,
+        engine: Arc<dyn Engine>,
+        predicate: Option<PredicateRef>,
+        existing_version: Version,
+        existing_data: Box<T>,
+        existing_predicate: Option<PredicateRef>,
+        options: FileMaterializationOptions,
+    ) -> SendableRBStream {
         self.warn_if_skip_stats_with_predicate(&predicate);
-        let skip_stats = self.config.skip_stats;
-        let scan = match self.scan_for_files(predicate, skip_stats, stats_mode) {
+        let scan = match self.scan_for_files(predicate, options.skip_stats, options.stats_mode) {
             Ok(scan) => scan,
             Err(err) => return Box::pin(once(ready(Err(err)))),
         };
@@ -819,6 +1069,12 @@ enum FileStatsMode {
     PreserveRaw,
     /// Use raw JSON stats and the full parsed stats schema.
     FullPreserveRaw,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FileMaterializationOptions {
+    stats_mode: FileStatsMode,
+    skip_stats: bool,
 }
 
 /// Scope for materialized file replay data.
@@ -1548,6 +1804,211 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn snapshot_capability_metadata_state_does_not_materialize_files() -> TestResult {
+        let log_store = TestTables::Simple.table_builder()?.build_storage()?;
+        let snapshot = Snapshot::try_new(&log_store, Default::default(), None).await?;
+
+        let metadata = snapshot.metadata_state();
+
+        assert_eq!(metadata.protocol, snapshot.protocol());
+        assert_eq!(metadata.metadata, snapshot.metadata());
+        assert_eq!(metadata.table_configuration, snapshot.table_configuration());
+        assert!(!snapshot.has_materialized_files_for_test());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_capability_active_adds_without_stats_streams_from_lazy_snapshot() -> TestResult
+    {
+        let log_store = TestTables::Checkpoints.table_builder()?.build_storage()?;
+        let snapshot = Snapshot::try_new(log_store.as_ref(), Default::default(), Some(12)).await?;
+
+        let files: Vec<_> = snapshot
+            .active_adds(
+                log_store.as_ref(),
+                ActiveAddOptions {
+                    predicate: None,
+                    stats: AddStatsPolicy::None,
+                },
+            )
+            .try_collect()
+            .await?;
+
+        assert_eq!(files.len(), 12);
+        assert!(files.iter().all(|file| file.stats().is_none()));
+        assert!(!snapshot.has_materialized_files_for_test());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_capability_active_add_batches_match_stream_adapter() -> TestResult {
+        let log_store = TestTables::Checkpoints.table_builder()?.build_storage()?;
+        let snapshot = Snapshot::try_new(log_store.as_ref(), Default::default(), Some(12)).await?;
+        let options = ActiveAddOptions {
+            predicate: None,
+            stats: AddStatsPolicy::None,
+        };
+
+        let streamed_rows: usize = snapshot
+            .active_adds(log_store.as_ref(), options.clone())
+            .map_ok(|file| file.path_raw().to_string())
+            .try_collect::<Vec<_>>()
+            .await?
+            .len();
+        let batch_rows: usize = snapshot
+            .active_add_batches(log_store.as_ref(), options)
+            .await?
+            .iter()
+            .map(|batch| batch.num_rows())
+            .sum();
+
+        assert_eq!(batch_rows, streamed_rows);
+        assert!(!snapshot.has_materialized_files_for_test());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_capability_active_tombstones_delegates_to_snapshot_stream() -> TestResult {
+        let log_store = TestTables::Simple.table_builder()?.build_storage()?;
+        let snapshot = Snapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
+
+        let tombstones = snapshot
+            .active_tombstones(log_store.as_ref())
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        assert_eq!(tombstones.len(), 31);
+        assert!(!snapshot.has_materialized_files_for_test());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_capability_conflict_read_set_replays_lazy_snapshot() -> TestResult {
+        let log_store = TestTables::Simple.table_builder()?.build_storage()?;
+        let snapshot = Snapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
+
+        let read_set = snapshot.conflict_read_set(log_store.as_ref()).await?;
+
+        assert_eq!(read_set.log_data().num_files(), 5);
+        assert!(!snapshot.has_materialized_files_for_test());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_capability_conflict_read_set_matches_materialized_stats() -> TestResult {
+        let (_table_dir, table) = selective_stats_table().await?;
+        let log_store = table.log_store();
+        let lazy = Snapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
+        let materialized =
+            Arc::new(Snapshot::try_new(log_store.as_ref(), Default::default(), None).await?)
+                .ensure_materialized_files(log_store.as_ref())
+                .await?;
+
+        let lazy_read_set = lazy.conflict_read_set(log_store.as_ref()).await?;
+        let materialized_read_set = materialized.conflict_read_set(log_store.as_ref()).await?;
+        let lazy_log_data = lazy_read_set.log_data();
+        let materialized_log_data = materialized_read_set.log_data();
+        let lazy_files = lazy_log_data.iter().collect::<Vec<_>>();
+        let materialized_files = materialized_log_data.iter().collect::<Vec<_>>();
+
+        assert_eq!(lazy_files.len(), materialized_files.len());
+        assert_eq!(lazy_files[0].path_raw(), materialized_files[0].path_raw());
+        assert_eq!(lazy_files[0].stats(), materialized_files[0].stats());
+        assert!(lazy_files[0].min_values().is_some());
+        assert!(lazy_files[0].max_values().is_some());
+        assert!(lazy_files[0].null_counts().is_some());
+        assert!(!lazy.has_materialized_files_for_test());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_capability_active_adds_raw_json_preserves_row_counts_and_raw_stats()
+    -> TestResult {
+        let (_table_dir, table) = selective_stats_table().await?;
+        let log_store = table.log_store();
+        let snapshot = Snapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
+
+        let files: Vec<_> = snapshot
+            .active_adds(
+                log_store.as_ref(),
+                ActiveAddOptions {
+                    predicate: None,
+                    stats: AddStatsPolicy::RawJson,
+                },
+            )
+            .try_collect()
+            .await?;
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].num_records(), Some(3));
+        assert!(files[0].stats().is_some());
+        assert!(files[0].min_values().is_none());
+        assert!(!snapshot.has_materialized_files_for_test());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_capability_active_adds_paths_only_can_use_materialized_stats_cache()
+    -> TestResult {
+        let (_table_dir, table) = selective_stats_table().await?;
+        let log_store = table.log_store();
+        let snapshot = EagerSnapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
+
+        let files: Vec<_> = snapshot
+            .snapshot()
+            .active_adds(
+                log_store.as_ref(),
+                ActiveAddOptions {
+                    predicate: None,
+                    stats: AddStatsPolicy::None,
+                },
+            )
+            .try_collect()
+            .await?;
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].num_records(), Some(3));
+        assert!(files[0].min_values().is_some());
+        assert!(snapshot.snapshot().has_materialized_files_for_test());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_capability_active_adds_parsed_preserves_full_stats() -> TestResult {
+        let (_table_dir, table) = selective_stats_table().await?;
+        let log_store = table.log_store();
+        let snapshot = Snapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
+
+        let files: Vec<_> = snapshot
+            .active_adds(
+                log_store.as_ref(),
+                ActiveAddOptions {
+                    predicate: None,
+                    stats: AddStatsPolicy::Parsed,
+                },
+            )
+            .try_collect()
+            .await?;
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].num_records(), Some(3));
+        assert!(files[0].min_values().is_some());
+        assert!(files[0].max_values().is_some());
+        assert!(files[0].null_counts().is_some());
+        assert!(!snapshot.has_materialized_files_for_test());
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_eager_snapshot_log_data_is_non_panicking_without_files() -> TestResult {
         let log_store = TestTables::Simple.table_builder()?.build_storage()?;
         let config = DeltaTableConfig {
@@ -2057,11 +2518,11 @@ mod tests {
         };
         let mut snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, Some(11)).await?;
 
-        assert!(snapshot.snapshot().materialized_files().is_none());
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
 
         snapshot.update(log_store.as_ref(), Some(12)).await?;
 
-        assert!(snapshot.snapshot().materialized_files().is_none());
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
 
         drain_recorded_ops(&mut operations).await;
 

--- a/crates/core/src/kernel/transaction/conflict_checker.rs
+++ b/crates/core/src/kernel/transaction/conflict_checker.rs
@@ -9,7 +9,7 @@ use crate::DeltaTableError;
 use crate::delta_datafusion::DataFusionMixins;
 use crate::errors::DeltaResult;
 use crate::kernel::{
-    Action, Add, LogDataHandler, Metadata, Protocol, Remove, Transaction, Version,
+    Action, Add, ConflictReadSet, Metadata, Protocol, Remove, Transaction, Version,
 };
 use crate::logstore::{LogStore, get_actions};
 use crate::protocol::DeltaOperation;
@@ -111,7 +111,7 @@ pub(crate) struct TransactionInfo<'a> {
     /// delta log actions that the transaction wants to commit
     actions: &'a [Action],
     /// read [`DeltaTableState`] used for the transaction
-    read_snapshot: LogDataHandler<'a>,
+    read_snapshot: ConflictReadSet<'a>,
     /// Whether the transaction tainted the whole table
     read_whole_table: bool,
 }
@@ -119,7 +119,7 @@ pub(crate) struct TransactionInfo<'a> {
 impl<'a> TransactionInfo<'a> {
     #[cfg(feature = "datafusion")]
     pub fn try_new(
-        read_snapshot: LogDataHandler<'a>,
+        read_snapshot: ConflictReadSet<'a>,
         read_predicates: Option<String>,
         actions: &'a [Action],
         read_whole_table: bool,
@@ -127,8 +127,9 @@ impl<'a> TransactionInfo<'a> {
         use datafusion::prelude::SessionContext;
 
         let session = SessionContext::new();
+        let log_data = read_snapshot.log_data();
         let read_predicates = read_predicates
-            .map(|pred| read_snapshot.parse_predicate_expression(pred, &session.state()))
+            .map(|pred| log_data.parse_predicate_expression(pred, &session.state()))
             .transpose()?;
 
         let mut read_app_ids = HashSet::<String>::new();
@@ -148,7 +149,7 @@ impl<'a> TransactionInfo<'a> {
 
     #[cfg(feature = "datafusion")]
     pub fn new(
-        read_snapshot: LogDataHandler<'a>,
+        read_snapshot: ConflictReadSet<'a>,
         read_predicates: Option<Expr>,
         actions: &'a [Action],
         read_whole_table: bool,
@@ -171,7 +172,7 @@ impl<'a> TransactionInfo<'a> {
 
     #[cfg(not(feature = "datafusion"))]
     pub fn try_new(
-        read_snapshot: LogDataHandler<'a>,
+        read_snapshot: ConflictReadSet<'a>,
         read_predicates: Option<String>,
         actions: &'a Vec<Action>,
         read_whole_table: bool,
@@ -207,7 +208,7 @@ impl<'a> TransactionInfo<'a> {
         if let Some(predicate) = &self.read_predicates {
             Ok(Either::Left(
                 files_matching_predicate(
-                    self.read_snapshot.clone(),
+                    self.read_snapshot.log_data(),
                     std::slice::from_ref(predicate),
                 )
                 .map_err(|err| CommitConflictError::Predicate {
@@ -215,14 +216,23 @@ impl<'a> TransactionInfo<'a> {
                 })?,
             ))
         } else {
-            Ok(Either::Right(self.read_snapshot.iter().map(|f| f.to_add())))
+            Ok(Either::Right(
+                self.read_snapshot
+                    .log_data()
+                    .into_iter()
+                    .map(|f| f.to_add()),
+            ))
         }
     }
 
     #[cfg(not(feature = "datafusion"))]
     /// Files read by the transaction
     pub fn read_files(&self) -> Result<impl Iterator<Item = Add> + '_, CommitConflictError> {
-        Ok(self.read_snapshot.iter().map(|f| f.to_add()))
+        Ok(self
+            .read_snapshot
+            .log_data()
+            .into_iter()
+            .map(|f| f.to_add()))
     }
 
     /// Whether the whole table was read during the transaction
@@ -369,6 +379,7 @@ impl<'a> ConflictChecker<'a> {
                     op,
                     &transaction_info
                         .read_snapshot
+                        .log_data()
                         .table_properties()
                         .isolation_level(),
                 ) {
@@ -380,6 +391,7 @@ impl<'a> ConflictChecker<'a> {
             .unwrap_or_else(|| {
                 transaction_info
                     .read_snapshot
+                    .log_data()
                     .table_properties()
                     .isolation_level()
             });
@@ -410,11 +422,19 @@ impl<'a> ConflictChecker<'a> {
         for p in self.winning_commit_summary.protocol() {
             let (win_read, curr_read) = (
                 p.min_reader_version(),
-                self.txn_info.read_snapshot.protocol().min_reader_version(),
+                self.txn_info
+                    .read_snapshot
+                    .log_data()
+                    .protocol()
+                    .min_reader_version(),
             );
             let (win_write, curr_write) = (
                 p.min_writer_version(),
-                self.txn_info.read_snapshot.protocol().min_writer_version(),
+                self.txn_info
+                    .read_snapshot
+                    .log_data()
+                    .protocol()
+                    .min_writer_version(),
             );
             if curr_read < win_read || win_write < curr_write {
                 return Err(CommitConflictError::ProtocolChanged(format!(
@@ -479,10 +499,12 @@ impl<'a> ConflictChecker<'a> {
                     &self.txn_info.read_predicates,
                     self.txn_info.read_whole_table(),
                 ) {
-                    let arrow_schema = self.txn_info.read_snapshot.read_schema();
+                    let read_snapshot = self.txn_info.read_snapshot.log_data();
+                    let arrow_schema = read_snapshot.read_schema();
                     let partition_columns = self
                         .txn_info
                         .read_snapshot
+                        .log_data()
                         .metadata()
                         .partition_columns()
                         .to_vec();
@@ -717,8 +739,9 @@ mod tests {
         let setup_actions = setup.unwrap_or_else(init_table_actions);
         let state = DeltaTableState::from_actions(setup_actions).await.unwrap();
         let snapshot = state.snapshot();
+        let conflict_read_set = ConflictReadSet::from_log_data_for_test(snapshot.log_data());
         let transaction_info =
-            TransactionInfo::new(snapshot.log_data(), reads, &actions, read_whole_table);
+            TransactionInfo::new(conflict_read_set, reads, &actions, read_whole_table);
         let summary = WinningCommitSummary {
             actions: concurrent,
             commit_info: None,

--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -871,8 +871,12 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                                 (latest_version - steps) + 1,
                             )
                             .await?;
+                            let conflict_read_set = read_snapshot
+                                .snapshot()
+                                .conflict_read_set(this.log_store.as_ref())
+                                .await?;
                             let transaction_info = TransactionInfo::try_new(
-                                read_snapshot.log_data(),
+                                conflict_read_set,
                                 this.data.operation.read_predicate(),
                                 &this.data.actions,
                                 this.data.operation.read_whole_table(),

--- a/crates/core/src/operations/add_column.rs
+++ b/crates/core/src/operations/add_column.rs
@@ -12,7 +12,8 @@ use crate::errors::ColumnMappingOperation;
 use crate::kernel::schema::merge_delta_struct;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{
-    EagerSnapshot, MetadataExt, ProtocolExt as _, StructField, StructTypeExt, resolve_snapshot,
+    Action, EagerSnapshot, MetadataExt, ProtocolExt as _, SnapshotMetadataRef, StructField,
+    StructTypeExt, resolve_snapshot,
 };
 use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
@@ -70,6 +71,47 @@ impl AddColumnBuilder {
     }
 }
 
+fn plan_add_column_actions(
+    snapshot: SnapshotMetadataRef<'_>,
+    fields: Vec<StructField>,
+) -> DeltaResult<(Vec<Action>, DeltaOperation)> {
+    let mut metadata = snapshot.metadata.clone();
+    let fields_right = &StructType::try_new(fields.clone())?;
+
+    if !fields_right
+        .get_generated_columns()
+        .unwrap_or_default()
+        .is_empty()
+    {
+        return Err(DeltaTableError::Generic(
+            "New columns cannot be a generated column".to_string(),
+        ));
+    }
+
+    let table_schema = snapshot.table_configuration.logical_schema();
+    let new_table_schema = merge_delta_struct(table_schema.as_ref(), fields_right)?;
+
+    let current_protocol = snapshot.protocol;
+    let new_protocol = current_protocol
+        .clone()
+        .apply_column_metadata_to_protocol(&new_table_schema)?
+        .move_table_properties_into_features(metadata.configuration());
+
+    let operation = DeltaOperation::AddColumn {
+        fields: fields.into_iter().collect_vec(),
+    };
+
+    metadata = metadata.with_schema(&new_table_schema)?;
+
+    let mut actions = vec![metadata.into()];
+
+    if current_protocol != &new_protocol {
+        actions.push(new_protocol.into())
+    }
+
+    Ok((actions, operation))
+}
+
 impl std::future::IntoFuture for AddColumnBuilder {
     type Output = DeltaResult<DeltaTable>;
 
@@ -81,14 +123,19 @@ impl std::future::IntoFuture for AddColumnBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), false, None).await?;
-            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+            if snapshot
+                .snapshot()
+                .metadata_state()
+                .table_configuration
+                .column_mapping_mode()
+                != ColumnMappingMode::None
+            {
                 return Err(DeltaTableError::unsupported_column_mapping(
                     ColumnMappingOperation::Write,
                     "ADD COLUMN",
                 ));
             }
 
-            let mut metadata = snapshot.metadata().clone();
             let fields = match this.fields.clone() {
                 Some(v) => v,
                 None => return Err(DeltaTableError::Generic("No fields provided".to_string())),
@@ -96,39 +143,8 @@ impl std::future::IntoFuture for AddColumnBuilder {
             let operation_id = this.get_operation_id();
             this.pre_execute(operation_id).await?;
 
-            let fields_right = &StructType::try_new(fields.clone())?;
-
-            if !fields_right
-                .get_generated_columns()
-                .unwrap_or_default()
-                .is_empty()
-            {
-                return Err(DeltaTableError::Generic(
-                    "New columns cannot be a generated column".to_string(),
-                ));
-            }
-
-            let table_schema = snapshot.schema();
-            let new_table_schema = merge_delta_struct(table_schema.as_ref(), fields_right)?;
-
-            let current_protocol = snapshot.protocol();
-
-            let new_protocol = current_protocol
-                .clone()
-                .apply_column_metadata_to_protocol(&new_table_schema)?
-                .move_table_properties_into_features(metadata.configuration());
-
-            let operation = DeltaOperation::AddColumn {
-                fields: fields.into_iter().collect_vec(),
-            };
-
-            metadata = metadata.with_schema(&new_table_schema)?;
-
-            let mut actions = vec![metadata.into()];
-
-            if current_protocol != &new_protocol {
-                actions.push(new_protocol.into())
-            }
+            let (actions, operation) =
+                plan_add_column_actions(snapshot.snapshot().metadata_state(), fields)?;
 
             let commit = CommitBuilder::from(this.commit_properties.clone())
                 .with_actions(actions)
@@ -144,5 +160,45 @@ impl std::future::IntoFuture for AddColumnBuilder {
                 commit.snapshot(),
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kernel::{DataType, PrimitiveType};
+    use crate::{DeltaTableConfig, writer::test_utils::TestResult};
+
+    use super::*;
+
+    fn id_field() -> StructField {
+        StructField::new("id", DataType::Primitive(PrimitiveType::Integer), true)
+    }
+
+    fn added_field() -> StructField {
+        StructField::new("added", DataType::Primitive(PrimitiveType::String), true)
+    }
+
+    #[tokio::test]
+    async fn add_column_with_lazy_snapshot_does_not_materialize_files() -> TestResult {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([id_field()])
+            .await?;
+        let log_store = table.log_store().clone();
+        let config = DeltaTableConfig {
+            require_files: false,
+            ..Default::default()
+        };
+        let snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, None).await?;
+
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+
+        AddColumnBuilder::new(log_store, Some(snapshot.clone()))
+            .with_fields([added_field()])
+            .await?;
+
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+
+        Ok(())
     }
 }

--- a/crates/core/src/operations/add_feature.rs
+++ b/crates/core/src/operations/add_feature.rs
@@ -9,7 +9,9 @@ use itertools::Itertools;
 use super::{CustomExecuteHandler, Operation};
 use crate::DeltaTable;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
-use crate::kernel::{EagerSnapshot, ProtocolExt as _, TableFeatures, resolve_snapshot};
+use crate::kernel::{
+    Action, EagerSnapshot, ProtocolExt as _, SnapshotMetadataRef, TableFeatures, resolve_snapshot,
+};
 use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
 use crate::{DeltaResult, DeltaTableError};
@@ -83,6 +85,43 @@ impl AddTableFeatureBuilder {
     }
 }
 
+fn plan_add_table_feature_actions(
+    snapshot: SnapshotMetadataRef<'_>,
+    name: &[TableFeatures],
+    allow_protocol_versions_increase: bool,
+) -> DeltaResult<(Vec<Action>, DeltaOperation)> {
+    debug_assert!(!name.is_empty());
+
+    let (reader_features, writer_features): (Vec<Option<TableFeature>>, Vec<Option<TableFeature>>) =
+        name.iter().map(|v| v.to_reader_writer_features()).unzip();
+    let reader_features = reader_features.into_iter().flatten().collect_vec();
+    let writer_features = writer_features.into_iter().flatten().collect_vec();
+
+    let mut protocol = snapshot.protocol.clone();
+
+    if !allow_protocol_versions_increase {
+        if !reader_features.is_empty()
+            && !writer_features.is_empty()
+            && !(protocol.min_reader_version() == 3 && protocol.min_writer_version() == 7)
+        {
+            return Err(DeltaTableError::Generic("Table feature enables reader and writer feature, but reader is not v3, and writer not v7. Set allow_protocol_versions_increase or increase versions explicitly through set_tbl_properties".to_string()));
+        } else if !reader_features.is_empty() && protocol.min_reader_version() < 3 {
+            return Err(DeltaTableError::Generic("Table feature enables reader feature, but min_reader is not v3. Set allow_protocol_versions_increase or increase version explicitly through set_tbl_properties".to_string()));
+        } else if !writer_features.is_empty() && protocol.min_writer_version() < 7 {
+            return Err(DeltaTableError::Generic("Table feature enables writer feature, but min_writer is not v7. Set allow_protocol_versions_increase or increase version explicitly through set_tbl_properties".to_string()));
+        }
+    }
+
+    protocol = protocol.append_reader_features(&reader_features);
+    protocol = protocol.append_writer_features(&writer_features);
+
+    let operation = DeltaOperation::AddFeature {
+        name: name.to_vec(),
+    };
+
+    Ok((vec![protocol.into()], operation))
+}
+
 impl std::future::IntoFuture for AddTableFeatureBuilder {
     type Output = DeltaResult<DeltaTable>;
 
@@ -95,44 +134,17 @@ impl std::future::IntoFuture for AddTableFeatureBuilder {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), false, None).await?;
 
-            let name = if this.name.is_empty() {
+            if this.name.is_empty() {
                 return Err(DeltaTableError::Generic("No features provided".to_string()));
-            } else {
-                &this.name
-            };
+            }
             let operation_id = this.get_operation_id();
             this.pre_execute(operation_id).await?;
 
-            let (reader_features, writer_features): (
-                Vec<Option<TableFeature>>,
-                Vec<Option<TableFeature>>,
-            ) = name.iter().map(|v| v.to_reader_writer_features()).unzip();
-            let reader_features = reader_features.into_iter().flatten().collect_vec();
-            let writer_features = writer_features.into_iter().flatten().collect_vec();
-
-            let mut protocol = snapshot.protocol().clone();
-
-            if !this.allow_protocol_versions_increase {
-                if !reader_features.is_empty()
-                    && !writer_features.is_empty()
-                    && !(protocol.min_reader_version() == 3 && protocol.min_writer_version() == 7)
-                {
-                    return Err(DeltaTableError::Generic("Table feature enables reader and writer feature, but reader is not v3, and writer not v7. Set allow_protocol_versions_increase or increase versions explicitly through set_tbl_properties".to_string()));
-                } else if !reader_features.is_empty() && protocol.min_reader_version() < 3 {
-                    return Err(DeltaTableError::Generic("Table feature enables reader feature, but min_reader is not v3. Set allow_protocol_versions_increase or increase version explicitly through set_tbl_properties".to_string()));
-                } else if !writer_features.is_empty() && protocol.min_writer_version() < 7 {
-                    return Err(DeltaTableError::Generic("Table feature enables writer feature, but min_writer is not v7. Set allow_protocol_versions_increase or increase version explicitly through set_tbl_properties".to_string()));
-                }
-            }
-
-            protocol = protocol.append_reader_features(&reader_features);
-            protocol = protocol.append_writer_features(&writer_features);
-
-            let operation = DeltaOperation::AddFeature {
-                name: name.to_vec(),
-            };
-
-            let actions = vec![protocol.into()];
+            let (actions, operation) = plan_add_table_feature_actions(
+                snapshot.snapshot().metadata_state(),
+                &this.name,
+                this.allow_protocol_versions_increase,
+            )?;
 
             let commit = CommitBuilder::from(this.commit_properties.clone())
                 .with_actions(actions)

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -75,7 +75,9 @@ use crate::delta_datafusion::{
 };
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
-use crate::kernel::{Action, EagerSnapshot, LogicalFileView, resolve_snapshot};
+use crate::kernel::{
+    Action, ActiveAddOptions, AddStatsPolicy, EagerSnapshot, LogicalFileView, resolve_snapshot,
+};
 use crate::logstore::{LogStore, LogStoreRef};
 use crate::operations::CustomExecuteHandler;
 use crate::operations::cdc::CDC_COLUMN_NAME;
@@ -435,10 +437,16 @@ async fn execute(
     let scan_start = Instant::now();
 
     let Some(predicate) = predicate else {
-        // no predicate, so we are just dropping all files.
-        // we also don't need to write cdc actions if we are fropping all files.
-        let full_file =
-            collect_full_file_deletes(snapshot.file_views(log_store.as_ref(), None)).await?;
+        // no predicate means all files match.
+        // cdc actions are not written when table files are removed.
+        let full_file = collect_full_file_deletes(snapshot.snapshot().active_adds(
+            log_store.as_ref(),
+            ActiveAddOptions {
+                predicate: None,
+                stats: AddStatsPolicy::RawJson,
+            },
+        ))
+        .await?;
         metrics.num_removed_files = full_file.removed_files;
         metrics.num_deleted_rows = full_file.deleted_rows;
         metrics.scan_time_ms = Instant::now().duration_since(scan_start).as_millis() as u64;
@@ -474,9 +482,13 @@ async fn execute(
                 // evaluating `partition_predicate` against `partitionValues_parsed` is exact:
                 // a file either fully matches or does not. It is therefore safe to treat this as
                 // the authoritative match set for DELETE.
-                collect_full_file_deletes(
-                    snapshot.file_views(log_store.as_ref(), Some(Arc::new(delta_predicate))),
-                )
+                collect_full_file_deletes(snapshot.snapshot().active_adds(
+                    log_store.as_ref(),
+                    ActiveAddOptions {
+                        predicate: Some(Arc::new(delta_predicate)),
+                        stats: AddStatsPolicy::RawJson,
+                    },
+                ))
                 .await?
             }
             Err(err) => {
@@ -495,7 +507,14 @@ async fn execute(
                 );
                 collect_full_file_deletes(
                     snapshot
-                        .file_views(log_store.as_ref(), None)
+                        .snapshot()
+                        .active_adds(
+                            log_store.as_ref(),
+                            ActiveAddOptions {
+                                predicate: None,
+                                stats: AddStatsPolicy::RawJson,
+                            },
+                        )
                         .try_filter_map(|f| {
                             let matching_paths = Arc::clone(&matching_paths);
                             async move { Ok(matching_paths.contains(f.path_raw()).then_some(f)) }
@@ -528,7 +547,14 @@ async fn execute(
 
     let root_url = Arc::new(snapshot.table_configuration().table_root().clone());
     let removes: Vec<_> = snapshot
-        .file_views(log_store.as_ref(), Some(files_scan.delta_predicate.clone()))
+        .snapshot()
+        .active_adds(
+            log_store.as_ref(),
+            ActiveAddOptions {
+                predicate: Some(files_scan.delta_predicate.clone()),
+                stats: AddStatsPolicy::RawJson,
+            },
+        )
         .zip(stream::iter(std::iter::repeat((
             root_url,
             Arc::new(files_scan.files_set()),
@@ -1062,13 +1088,15 @@ mod tests {
 
         assert_eq!(metrics.num_added_files, 1);
         assert_eq!(metrics.num_removed_files, 1);
-        assert!(metrics.scan_time_ms > 0);
+        assert!(metrics.scan_time_ms <= metrics.execution_time_ms);
         assert_eq!(metrics.num_deleted_rows, Some(1));
         assert_eq!(metrics.num_copied_rows, 3);
 
         let last_commit = table.last_commit().await.unwrap();
         let parameters = last_commit.operation_parameters.clone().unwrap();
         assert_eq!(parameters["predicate"], json!("value = 1"));
+        let operation_metrics = last_delete_operation_metrics(&table).await;
+        assert!(operation_metrics.contains_key("scan_time_ms"));
 
         let expected = vec![
             "+----+-------+------------+",
@@ -1224,9 +1252,10 @@ mod tests {
         assert_eq!(metrics.num_removed_files, 1);
         assert_eq!(metrics.num_deleted_rows, Some(2));
         assert_eq!(metrics.num_copied_rows, 0);
-        assert!(metrics.scan_time_ms > 0);
+        assert!(metrics.scan_time_ms <= metrics.execution_time_ms);
 
         let operation_metrics = last_delete_operation_metrics(&table).await;
+        assert!(operation_metrics.contains_key("scan_time_ms"));
         assert_eq!(operation_metrics.get("num_deleted_rows"), Some(&json!(2)));
 
         let expected = vec![
@@ -1971,7 +2000,9 @@ mod tests {
         assert_eq!(metrics.num_removed_files, 1);
         assert_eq!(metrics.num_deleted_rows, Some(1));
         assert_eq!(metrics.num_copied_rows, 0);
-        assert!(metrics.scan_time_ms > 0);
+        assert!(metrics.scan_time_ms <= metrics.execution_time_ms);
+        let operation_metrics = last_delete_operation_metrics(&table).await;
+        assert!(operation_metrics.contains_key("scan_time_ms"));
 
         let expected = [
             "+----+-------+------------+",

--- a/crates/core/src/operations/drop_constraints.rs
+++ b/crates/core/src/operations/drop_constraints.rs
@@ -7,7 +7,7 @@ use futures::future::BoxFuture;
 use super::{CustomExecuteHandler, Operation};
 use crate::DeltaTable;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
-use crate::kernel::{Action, EagerSnapshot, MetadataExt, resolve_snapshot};
+use crate::kernel::{Action, EagerSnapshot, MetadataExt, SnapshotMetadataRef, resolve_snapshot};
 use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
 use crate::table::state::DeltaTableState;
@@ -75,6 +75,31 @@ impl DropConstraintBuilder {
     }
 }
 
+fn plan_drop_constraint_actions(
+    snapshot: SnapshotMetadataRef<'_>,
+    name: &str,
+    raise_if_not_exists: bool,
+) -> DeltaResult<Option<(Vec<Action>, DeltaOperation)>> {
+    let mut metadata = snapshot.metadata.clone();
+    let configuration_key = format!("delta.constraints.{name}");
+
+    if !metadata.configuration().contains_key(&configuration_key) {
+        if raise_if_not_exists {
+            return Err(DeltaTableError::Generic(format!(
+                "Constraint with name '{name}' does not exist."
+            )));
+        }
+        return Ok(None);
+    }
+
+    metadata = metadata.remove_config_key(&configuration_key)?;
+    let operation = DeltaOperation::DropConstraint {
+        name: name.to_string(),
+    };
+
+    Ok(Some((vec![Action::Metadata(metadata)], operation)))
+}
+
 impl std::future::IntoFuture for DropConstraintBuilder {
     type Output = DeltaResult<DeltaTable>;
 
@@ -96,25 +121,17 @@ impl std::future::IntoFuture for DropConstraintBuilder {
             let operation_id = this.get_operation_id();
             this.pre_execute(operation_id).await?;
 
-            let mut metadata = snapshot.metadata().clone();
-            let configuration_key = format!("delta.constraints.{name}");
-
-            if !metadata.configuration().contains_key(&configuration_key) {
-                if this.raise_if_not_exists {
-                    return Err(DeltaTableError::Generic(format!(
-                        "Constraint with name '{name}' does not exist."
-                    )));
-                }
+            let Some((actions, operation)) = plan_drop_constraint_actions(
+                snapshot.snapshot().metadata_state(),
+                &name,
+                this.raise_if_not_exists,
+            )?
+            else {
                 return Ok(DeltaTable::new_with_state(
                     this.log_store,
                     DeltaTableState::new(snapshot),
                 ));
-            }
-
-            metadata = metadata.remove_config_key(&configuration_key)?;
-            let operation = DeltaOperation::DropConstraint { name: name.clone() };
-
-            let actions = vec![Action::Metadata(metadata)];
+            };
 
             let commit = CommitBuilder::from(this.commit_properties.clone())
                 .with_operation_id(operation_id)

--- a/crates/core/src/operations/filesystem_check.rs
+++ b/crates/core/src/operations/filesystem_check.rs
@@ -31,10 +31,9 @@ use super::CustomExecuteHandler;
 use super::Operation;
 use crate::DeltaTable;
 use crate::errors::{DeltaResult, DeltaTableError};
-use crate::kernel::EagerSnapshot;
-use crate::kernel::resolve_snapshot;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{Action, Add, Remove};
+use crate::kernel::{ActiveAddOptions, AddStatsPolicy, EagerSnapshot, resolve_snapshot};
 use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
 use crate::table::state::DeltaTableState;
@@ -144,7 +143,16 @@ impl FileSystemCheckBuilder {
     async fn create_fsck_plan(&self, snapshot: &EagerSnapshot) -> DeltaResult<FileSystemCheckPlan> {
         let mut files_relative: HashMap<String, Add> = HashMap::new();
         let log_store = self.log_store.clone();
-        let mut file_stream = snapshot.file_views(&log_store, None).map_ok(|f| f.to_add());
+        let mut file_stream = snapshot
+            .snapshot()
+            .active_adds(
+                log_store.as_ref(),
+                ActiveAddOptions {
+                    predicate: None,
+                    stats: AddStatsPolicy::None,
+                },
+            )
+            .map_ok(|f| f.to_add());
         while let Some(active) = file_stream.next().await {
             let active = active?;
             if is_absolute_path(&active.path)? {

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -62,7 +62,7 @@ use datafusion::{
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow as _, TryIntoKernel as _};
 use delta_kernel::schema::{ColumnMetadataKey, StructType};
 use filter::try_construct_early_filter;
-use futures::future::BoxFuture;
+use futures::{TryStreamExt as _, future::BoxFuture};
 use parquet::file::properties::WriterProperties;
 use serde::Serialize;
 use tracing::*;
@@ -86,8 +86,11 @@ use crate::delta_datafusion::{
 use crate::delta_datafusion::{Expression, into_expr, maybe_into_expr};
 use crate::kernel::schema::cast::{merge_arrow_field, merge_arrow_schema};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
-use crate::kernel::{Action, EagerSnapshot, StructTypeExt, new_metadata, resolve_snapshot};
-use crate::logstore::LogStoreRef;
+use crate::kernel::{
+    Action, ActiveAddOptions, AddStatsPolicy, EagerSnapshot, StructTypeExt, new_metadata,
+    resolve_snapshot,
+};
+use crate::logstore::{LogStore, LogStoreRef};
 use crate::operations::cdc::*;
 use crate::operations::merge::barrier::find_node;
 use crate::operations::write::WriterStatsConfig;
@@ -1606,12 +1609,19 @@ async fn execute(
 
     let table_root = snapshot.table_configuration().table_root().clone();
 
-    for action in snapshot.log_data() {
-        let log_path = action.path_raw();
-
-        if should_remove_rewritten_file(&survivors, log_path, &table_root)? {
-            metrics.num_target_files_removed += 1;
-            actions.push(action.remove_action(true).into());
+    {
+        let mut active_adds = snapshot.snapshot().active_adds(
+            log_store.as_ref(),
+            ActiveAddOptions {
+                predicate: None,
+                stats: AddStatsPolicy::None,
+            },
+        );
+        while let Some(action) = active_adds.try_next().await? {
+            if should_remove_rewritten_file(&survivors, action.path_raw(), &table_root)? {
+                metrics.num_target_files_removed += 1;
+                actions.push(action.remove_action(true).into());
+            }
         }
     }
 
@@ -1649,31 +1659,31 @@ async fn execute(
         TARGET_FILES_SKIPPED_METRIC,
         TARGET_FILES_PRUNED_METRIC_LEGACY,
     ];
-    metrics.num_target_files_skipped_during_scan = get_metric_any_or(
-        &scan_count_metrics,
-        &target_files_skipped_metric_names,
-        || {
-            let total_files = snapshot.log_data().num_files();
-            let (derived, impossible_state) =
-                derive_skipped_file_count(total_files, metrics.num_target_files_scanned);
-            if impossible_state {
-                warn!(
-                    %operation_id,
-                    total_files,
-                    scanned_files = metrics.num_target_files_scanned,
-                    metric_names = ?target_files_skipped_metric_names,
-                    "Target scan metrics reported more scanned files than exist; clamping derived skipped-file count to zero"
-                );
-            }
+    metrics.num_target_files_skipped_during_scan = if let Some(metric) =
+        get_metric_any(&scan_count_metrics, &target_files_skipped_metric_names)
+    {
+        metric
+    } else {
+        let total_files = count_active_adds(&snapshot)?;
+        let (derived, impossible_state) =
+            derive_skipped_file_count(total_files, metrics.num_target_files_scanned);
+        if impossible_state {
             warn!(
                 %operation_id,
+                total_files,
+                scanned_files = metrics.num_target_files_scanned,
                 metric_names = ?target_files_skipped_metric_names,
-                derived,
-                "Missing target skipped-file metric; deriving from total-files minus scanned-files"
+                "Target scan metrics reported more scanned files than exist; clamping derived skipped-file count to zero"
             );
-            derived
-        },
-    );
+        }
+        warn!(
+            %operation_id,
+            metric_names = ?target_files_skipped_metric_names,
+            derived,
+            "Missing target skipped-file metric; deriving from total-files minus scanned-files"
+        );
+        derived
+    };
     metrics.execution_time_ms = Instant::now().duration_since(exec_start).as_millis() as u64;
 
     let app_metadata = &mut commit_properties.app_metadata;
@@ -1786,6 +1796,10 @@ fn build_file_skipping_predicates(
 fn derive_skipped_file_count(total_files: usize, scanned_files: usize) -> (usize, bool) {
     let impossible_state = scanned_files > total_files;
     (total_files.saturating_sub(scanned_files), impossible_state)
+}
+
+fn count_active_adds(snapshot: &EagerSnapshot) -> DeltaResult<usize> {
+    Ok(snapshot.snapshot().try_log_data()?.num_files())
 }
 
 fn get_metric_any(metrics: &MetricsSet, names: &[&str]) -> Option<usize> {

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1663,7 +1663,7 @@ async fn execute(
     {
         metric
     } else {
-        let total_files = count_active_adds(&snapshot)?;
+        let total_files = count_active_adds(&snapshot, log_store.as_ref()).await?;
         let (derived, impossible_state) =
             derive_skipped_file_count(total_files, metrics.num_target_files_scanned);
         if impossible_state {
@@ -1799,8 +1799,22 @@ fn derive_skipped_file_count(total_files: usize, scanned_files: usize) -> (usize
     (total_files.saturating_sub(scanned_files), impossible_state)
 }
 
-fn count_active_adds(snapshot: &EagerSnapshot) -> DeltaResult<usize> {
-    Ok(snapshot.snapshot().try_log_data()?.num_files())
+async fn count_active_adds(
+    snapshot: &EagerSnapshot,
+    log_store: &dyn LogStore,
+) -> DeltaResult<usize> {
+    let batches = snapshot
+        .snapshot()
+        .active_add_batches(
+            log_store,
+            ActiveAddOptions {
+                predicate: None,
+                stats: AddStatsPolicy::None,
+            },
+        )
+        .await?;
+
+    Ok(batches.iter().map(|batch| batch.num_rows()).sum())
 }
 
 fn get_metric_any(metrics: &MetricsSet, names: &[&str]) -> Option<usize> {
@@ -1902,15 +1916,16 @@ impl std::future::IntoFuture for MergeBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::DeltaTable;
     use crate::TableProperty;
-    use crate::kernel::{Action, DataType, PrimitiveType, StructField};
+    use crate::kernel::{Action, DataType, EagerSnapshot, PrimitiveType, StructField};
     use crate::operations::merge::filter::generalize_filter;
     use crate::protocol::*;
+    use crate::test_utils::{TestResult, TestTables};
     use crate::writer::test_utils::datafusion::{get_data, get_data_sorted};
     use crate::writer::test_utils::get_arrow_schema;
     use crate::writer::test_utils::get_delta_schema;
     use crate::writer::test_utils::setup_table_with_configuration;
+    use crate::{DeltaTable, DeltaTableConfig};
     use arrow::datatypes::Schema as ArrowSchema;
     use arrow::record_batch::RecordBatch;
     use arrow_schema::DataType as ArrowDataType;
@@ -2055,6 +2070,30 @@ mod tests {
             pre_merge_files.saturating_sub(metrics.num_target_files_scanned)
         );
         assert_eq!(metrics.num_target_files_skipped_during_scan, 1);
+    }
+
+    #[tokio::test]
+    async fn test_count_active_adds_replays_lazy_snapshot_without_materialized_files() -> TestResult
+    {
+        let log_store = TestTables::Simple.table_builder()?.build_storage()?;
+        let snapshot = EagerSnapshot::try_new(
+            &log_store,
+            DeltaTableConfig {
+                require_files: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+
+        let total_files = super::count_active_adds(&snapshot, log_store.as_ref()).await?;
+
+        assert_eq!(total_files, 5);
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+
+        Ok(())
     }
 
     #[test]

--- a/crates/core/src/operations/restore.rs
+++ b/crates/core/src/operations/restore.rs
@@ -37,7 +37,8 @@ use uuid::Uuid;
 use super::{CustomExecuteHandler, Operation};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{
-    Action, Add, EagerSnapshot, ProtocolExt as _, ProtocolInner, Remove, Version, resolve_snapshot,
+    Action, ActiveAddOptions, Add, AddStatsPolicy, EagerSnapshot, ProtocolExt as _, ProtocolInner,
+    Remove, Version, resolve_snapshot,
 };
 use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
@@ -204,10 +205,27 @@ async fn execute(
 
     let state_to_restore_files: Vec<_> = snapshot_restored
         .snapshot()
-        .file_views(&log_store, None)
+        .snapshot()
+        .active_adds(
+            log_store.as_ref(),
+            ActiveAddOptions {
+                predicate: None,
+                stats: AddStatsPolicy::None,
+            },
+        )
         .try_collect()
         .await?;
-    let latest_state_files: Vec<_> = snapshot.file_views(&log_store, None).try_collect().await?;
+    let latest_state_files: Vec<_> = snapshot
+        .snapshot()
+        .active_adds(
+            log_store.as_ref(),
+            ActiveAddOptions {
+                predicate: None,
+                stats: AddStatsPolicy::None,
+            },
+        )
+        .try_collect()
+        .await?;
     let state_to_restore_files_set =
         HashSet::<_>::from_iter(state_to_restore_files.iter().map(|f| f.path().to_string()));
     let latest_state_files_set =

--- a/crates/core/src/operations/set_tbl_properties.rs
+++ b/crates/core/src/operations/set_tbl_properties.rs
@@ -10,7 +10,10 @@ use crate::DeltaResult;
 use crate::DeltaTable;
 use crate::errors::{ColumnMappingOperation, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
-use crate::kernel::{Action, EagerSnapshot, MetadataExt as _, ProtocolExt as _, resolve_snapshot};
+use crate::kernel::{
+    Action, EagerSnapshot, MetadataExt as _, ProtocolExt as _, SnapshotMetadataRef,
+    resolve_snapshot,
+};
 use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
 use crate::table::config::TableProperty;
@@ -77,6 +80,41 @@ impl SetTablePropertiesBuilder {
     }
 }
 
+fn plan_set_table_properties_actions(
+    snapshot: SnapshotMetadataRef<'_>,
+    properties: HashMap<String, String>,
+    raise_if_not_exists: bool,
+) -> DeltaResult<(Vec<Action>, DeltaOperation)> {
+    if properties.contains_key(TableProperty::ColumnMappingMode.as_ref()) {
+        return Err(DeltaTableError::unsupported_column_mapping(
+            ColumnMappingOperation::Write,
+            "SET TBLPROPERTIES delta.columnMapping.mode",
+        ));
+    }
+
+    let mut metadata = snapshot.metadata.clone();
+    let current_protocol = snapshot.protocol;
+    let new_protocol = current_protocol
+        .clone()
+        .apply_properties_to_protocol(&properties, raise_if_not_exists)?;
+
+    for (key, value) in &properties {
+        metadata = metadata.add_config_key(key.clone(), value.to_string())?;
+    }
+
+    let final_protocol = new_protocol.move_table_properties_into_features(metadata.configuration());
+
+    let operation = DeltaOperation::SetTableProperties { properties };
+
+    let mut actions = vec![Action::Metadata(metadata)];
+
+    if current_protocol.ne(&final_protocol) {
+        actions.push(Action::Protocol(final_protocol));
+    }
+
+    Ok((actions, operation))
+}
+
 impl std::future::IntoFuture for SetTablePropertiesBuilder {
     type Output = DeltaResult<DeltaTable>;
 
@@ -92,36 +130,12 @@ impl std::future::IntoFuture for SetTablePropertiesBuilder {
             let operation_id = this.get_operation_id();
             this.pre_execute(operation_id).await?;
 
-            let mut metadata = snapshot.metadata().clone();
-
-            let current_protocol = snapshot.protocol();
             let properties = this.properties;
-
-            if properties.contains_key(TableProperty::ColumnMappingMode.as_ref()) {
-                return Err(DeltaTableError::unsupported_column_mapping(
-                    ColumnMappingOperation::Write,
-                    "SET TBLPROPERTIES delta.columnMapping.mode",
-                ));
-            }
-
-            let new_protocol = current_protocol
-                .clone()
-                .apply_properties_to_protocol(&properties, this.raise_if_not_exists)?;
-
-            for (key, value) in &properties {
-                metadata = metadata.add_config_key(key.clone(), value.to_string())?;
-            }
-
-            let final_protocol =
-                new_protocol.move_table_properties_into_features(metadata.configuration());
-
-            let operation = DeltaOperation::SetTableProperties { properties };
-
-            let mut actions = vec![Action::Metadata(metadata)];
-
-            if current_protocol.ne(&final_protocol) {
-                actions.push(Action::Protocol(final_protocol));
-            }
+            let (actions, operation) = plan_set_table_properties_actions(
+                snapshot.snapshot().metadata_state(),
+                properties,
+                this.raise_if_not_exists,
+            )?;
 
             let commit = CommitBuilder::from(this.commit_properties.clone())
                 .with_actions(actions.clone())

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -65,7 +65,7 @@ use crate::{
         resolve_session_state,
     },
     kernel::{
-        Action, EagerSnapshot,
+        Action, ActiveAddOptions, AddStatsPolicy, EagerSnapshot,
         transaction::{CommitBuilder, CommitProperties, PROTOCOL},
     },
     table::config::TablePropertiesExt,
@@ -396,7 +396,14 @@ async fn execute(
 
     let root_url = Arc::new(snapshot.table_configuration().table_root().clone());
     let removes: Vec<_> = snapshot
-        .file_views(log_store.as_ref(), Some(files_scan.delta_predicate.clone()))
+        .snapshot()
+        .active_adds(
+            log_store.as_ref(),
+            ActiveAddOptions {
+                predicate: Some(files_scan.delta_predicate.clone()),
+                stats: AddStatsPolicy::RawJson,
+            },
+        )
         .zip(stream::iter(std::iter::repeat((
             root_url,
             Arc::new(files_scan.files_set()),

--- a/crates/core/src/operations/update_field_metadata.rs
+++ b/crates/core/src/operations/update_field_metadata.rs
@@ -10,7 +10,10 @@ use itertools::Itertools;
 use super::{CustomExecuteHandler, Operation};
 use crate::DeltaTable;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
-use crate::kernel::{EagerSnapshot, MetadataExt as _, ProtocolExt as _, resolve_snapshot};
+use crate::kernel::{
+    Action, EagerSnapshot, MetadataExt as _, ProtocolExt as _, SnapshotMetadataRef,
+    resolve_snapshot,
+};
 use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
 use crate::{DeltaResult, DeltaTableError};
@@ -77,6 +80,68 @@ impl UpdateFieldMetadataBuilder {
     }
 }
 
+fn plan_update_field_metadata_actions(
+    snapshot: SnapshotMetadataRef<'_>,
+    field_name: &str,
+    metadata_update: HashMap<String, MetadataValue>,
+) -> DeltaResult<(Vec<Action>, DeltaOperation)> {
+    let table_schema = snapshot.table_configuration.logical_schema();
+
+    let Some(field) = table_schema.field(field_name) else {
+        return Err(DeltaTableError::Generic(
+            "No field with the provided name in the schema".to_string(),
+        ));
+    };
+    let mut field = field.clone();
+
+    for key in metadata_update.keys() {
+        if key.starts_with("delta.") {
+            return Err(DeltaTableError::Generic(
+                "Not allowed to modify protected metadata e.g. `delta.columnMapping.id`"
+                    .to_string(),
+            ));
+        }
+    }
+
+    metadata_update.into_iter().for_each(|(key, value)| {
+        field
+            .metadata
+            .entry(key)
+            .and_modify(|meta| {
+                *meta = value.clone();
+            })
+            .or_insert(value);
+    });
+
+    let updated_table_schema =
+        StructType::try_new(table_schema.fields().map(|f| match f.name == field.name {
+            true => field.clone(),
+            false => f.clone(),
+        }))?;
+
+    let mut metadata = snapshot.metadata.clone();
+
+    let current_protocol = snapshot.protocol;
+    let new_protocol = current_protocol
+        .clone()
+        .apply_column_metadata_to_protocol(&updated_table_schema)?
+        .move_table_properties_into_features(metadata.configuration());
+
+    let operation = DeltaOperation::UpdateFieldMetadata {
+        fields: updated_table_schema.fields().cloned().collect_vec(),
+    };
+
+    metadata = metadata.with_schema(&updated_table_schema)?;
+
+    let mut actions = vec![metadata.into()];
+
+    if current_protocol != &new_protocol {
+        actions.push(new_protocol.into())
+    }
+
+    Ok((actions, operation))
+}
+
 impl std::future::IntoFuture for UpdateFieldMetadataBuilder {
     type Output = DeltaResult<DeltaTable>;
 
@@ -92,70 +157,11 @@ impl std::future::IntoFuture for UpdateFieldMetadataBuilder {
             let operation_id = this.get_operation_id();
             this.pre_execute(operation_id).await?;
 
-            let table_schema = snapshot.schema();
-
-            // Check if the field exists in the schema. Otherwise, no need to continue the
-            // operation
-            let Some(field) = table_schema.field(&this.field_name) else {
-                return Err(DeltaTableError::Generic(
-                    "No field with the provided name in the schema".to_string(),
-                ));
-            };
-            let mut field = field.clone();
-
-            // DO NOT MODIFY PROTECTED METADATA.
-            // Since `delta_kernel::schema::ColumnMetadataKey` does not `impl` any parsing (e.g. `std::core::From``) - at the time of implementation -
-            // we hardcode the prefix
-            for key in this.metadata.keys() {
-                if key.starts_with("delta.") {
-                    return Err(DeltaTableError::Generic(
-                        "Not allowed to modify protected metadata e.g. `delta.columnMapping.id`"
-                            .to_string(),
-                    ));
-                }
-            }
-
-            // Get the field to modify - and insert or modify the metadata provided by the user
-            let updating_metadata = this.metadata.clone();
-            updating_metadata.into_iter().for_each(|(key, value)| {
-                field
-                    .metadata
-                    .entry(key)
-                    .and_modify(|meta| {
-                        *meta = value.clone();
-                    })
-                    .or_insert(value);
-            });
-
-            // This feels a little silly but I could not find a better way to modify the StructType
-            // "in place" as of delta-kernel-rs 0.16.0
-            let updated_table_schema = StructType::try_new(table_schema.fields().map(|f| {
-                match f.name == field.name {
-                    // return our modified field instead
-                    true => field.clone(),
-                    false => f.clone(),
-                }
-            }))?;
-
-            let mut metadata = snapshot.metadata().clone();
-
-            let current_protocol = snapshot.protocol();
-            let new_protocol = current_protocol
-                .clone()
-                .apply_column_metadata_to_protocol(&updated_table_schema)?
-                .move_table_properties_into_features(metadata.configuration());
-
-            let operation = DeltaOperation::UpdateFieldMetadata {
-                fields: updated_table_schema.fields().cloned().collect_vec(),
-            };
-
-            metadata = metadata.with_schema(&updated_table_schema)?;
-
-            let mut actions = vec![metadata.into()];
-
-            if current_protocol != &new_protocol {
-                actions.push(new_protocol.into())
-            }
+            let (actions, operation) = plan_update_field_metadata_actions(
+                snapshot.snapshot().metadata_state(),
+                &this.field_name,
+                this.metadata.clone(),
+            )?;
 
             let commit = CommitBuilder::from(this.commit_properties.clone())
                 .with_actions(actions)
@@ -171,5 +177,49 @@ impl std::future::IntoFuture for UpdateFieldMetadataBuilder {
                 commit.snapshot(),
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kernel::{DataType, PrimitiveType, StructField};
+    use crate::{DeltaTableConfig, writer::test_utils::TestResult};
+
+    use super::*;
+
+    fn id_field() -> StructField {
+        StructField::new("id", DataType::Primitive(PrimitiveType::Integer), true)
+    }
+
+    fn field_metadata() -> HashMap<String, MetadataValue> {
+        HashMap::from([(
+            "comment".to_string(),
+            MetadataValue::String("identifier".to_string()),
+        )])
+    }
+
+    #[tokio::test]
+    async fn update_field_metadata_with_lazy_snapshot_does_not_materialize_files() -> TestResult {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([id_field()])
+            .await?;
+        let log_store = table.log_store().clone();
+        let config = DeltaTableConfig {
+            require_files: false,
+            ..Default::default()
+        };
+        let snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, None).await?;
+
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+
+        UpdateFieldMetadataBuilder::new(log_store, Some(snapshot.clone()))
+            .with_field_name("id")
+            .with_metadata(field_metadata())
+            .await?;
+
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+
+        Ok(())
     }
 }

--- a/crates/core/src/operations/update_table_metadata.rs
+++ b/crates/core/src/operations/update_table_metadata.rs
@@ -8,7 +8,7 @@ use validator::Validate;
 use super::{CustomExecuteHandler, Operation};
 use crate::DeltaTable;
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
-use crate::kernel::{Action, EagerSnapshot, MetadataExt, resolve_snapshot};
+use crate::kernel::{Action, EagerSnapshot, MetadataExt, SnapshotMetadataRef, resolve_snapshot};
 use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
 use crate::{DeltaResult, DeltaTableError};
@@ -100,6 +100,26 @@ impl UpdateTableMetadataBuilder {
     }
 }
 
+fn plan_update_table_metadata_actions(
+    snapshot: SnapshotMetadataRef<'_>,
+    update: TableMetadataUpdate,
+) -> DeltaResult<(Vec<Action>, DeltaOperation)> {
+    let mut metadata = snapshot.metadata.clone();
+
+    if let Some(name) = &update.name {
+        metadata = metadata.with_name(name.clone())?;
+    }
+    if let Some(description) = &update.description {
+        metadata = metadata.with_description(description.clone())?;
+    }
+
+    let operation = DeltaOperation::UpdateTableMetadata {
+        metadata_update: update,
+    };
+
+    Ok((vec![Action::Metadata(metadata)], operation))
+}
+
 impl std::future::IntoFuture for UpdateTableMetadataBuilder {
     type Output = DeltaResult<DeltaTable>;
 
@@ -122,20 +142,8 @@ impl std::future::IntoFuture for UpdateTableMetadataBuilder {
                 .validate()
                 .map_err(|e| DeltaTableError::MetadataError(format!("{e}")))?;
 
-            let mut metadata = snapshot.metadata().clone();
-
-            if let Some(name) = &update.name {
-                metadata = metadata.with_name(name.clone())?;
-            }
-            if let Some(description) = &update.description {
-                metadata = metadata.with_description(description.clone())?;
-            }
-
-            let operation = DeltaOperation::UpdateTableMetadata {
-                metadata_update: update,
-            };
-
-            let actions = vec![Action::Metadata(metadata)];
+            let (actions, operation) =
+                plan_update_table_metadata_actions(snapshot.snapshot().metadata_state(), update)?;
 
             let commit = CommitBuilder::from(this.commit_properties.clone())
                 .with_actions(actions)
@@ -152,5 +160,91 @@ impl std::future::IntoFuture for UpdateTableMetadataBuilder {
                 commit.snapshot(),
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{Int32Array, RecordBatch};
+    use arrow_schema::{DataType as ArrowDataType, Field, Schema};
+
+    use crate::kernel::{DataType, EagerSnapshot, PrimitiveType, StructField};
+    use crate::{DeltaTableConfig, writer::test_utils::TestResult};
+
+    use super::*;
+
+    fn id_field() -> StructField {
+        StructField::new("id", DataType::Primitive(PrimitiveType::Integer), true)
+    }
+
+    fn metadata_update() -> TableMetadataUpdate {
+        TableMetadataUpdate {
+            name: Some("events".to_string()),
+            description: Some("event table".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn update_table_metadata_with_lazy_snapshot_does_not_materialize_files() -> TestResult {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([id_field()])
+            .await?;
+        let log_store = table.log_store().clone();
+        let config = DeltaTableConfig {
+            require_files: false,
+            ..Default::default()
+        };
+        let snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, None).await?;
+
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+
+        UpdateTableMetadataBuilder::new(log_store, Some(snapshot.clone()))
+            .with_update(metadata_update())
+            .await?;
+
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_table_metadata_with_lazy_snapshot_retries_after_concurrent_commit() -> TestResult
+    {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([id_field()])
+            .await?;
+        let log_store = table.log_store().clone();
+        let config = DeltaTableConfig {
+            require_files: false,
+            ..Default::default()
+        };
+        let snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, None).await?;
+
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "id",
+                ArrowDataType::Int32,
+                true,
+            )])),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )?;
+        let table = table.write(vec![batch]).await?;
+
+        assert_eq!(table.version(), Some(1));
+        assert_eq!(snapshot.version(), 0);
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+
+        let updated = UpdateTableMetadataBuilder::new(log_store, Some(snapshot.clone()))
+            .with_update(metadata_update())
+            .await?;
+
+        assert_eq!(updated.version(), Some(2));
+        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+
+        Ok(())
     }
 }

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -35,7 +35,9 @@ use tracing::*;
 use super::{CustomExecuteHandler, Operation};
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
-use crate::kernel::{EagerSnapshot, TombstoneView, Version, resolve_snapshot};
+use crate::kernel::{
+    ActiveAddOptions, AddStatsPolicy, EagerSnapshot, TombstoneView, Version, resolve_snapshot,
+};
 use crate::logstore::{LogStore, LogStoreRef};
 use crate::protocol::DeltaOperation;
 use crate::table::config::TablePropertiesExt as _;
@@ -304,7 +306,14 @@ impl VacuumBuilder {
             )
         };
         let valid_files: HashSet<_> = snapshot
-            .file_views(self.log_store.as_ref(), None)
+            .snapshot()
+            .active_adds(
+                self.log_store.as_ref(),
+                ActiveAddOptions {
+                    predicate: None,
+                    stats: AddStatsPolicy::None,
+                },
+            )
             .map_ok(|f| f.object_store_path())
             .try_collect()
             .await?;
@@ -603,7 +612,7 @@ async fn collect_full_mode_tombstones(
 ) -> DeltaResult<(Vec<TombstoneView>, TombstonePathSets)> {
     snapshot
         .snapshot()
-        .tombstones(store)
+        .active_tombstones(store)
         .try_fold(
             (Vec::new(), TombstonePathSets::default()),
             |(mut expired_tombstones, mut tombstone_path_sets), tombstone| {
@@ -629,7 +638,7 @@ async fn get_stale_files(
     let tombstone_retention_timestamp = now_timestamp_millis - retention_period.num_milliseconds();
     snapshot
         .snapshot()
-        .tombstones(store)
+        .active_tombstones(store)
         .try_filter(|tombstone| {
             ready(is_tombstone_expired(
                 tombstone,

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -34,8 +34,8 @@ use crate::delta_datafusion::{
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::schema::cast::{merge_arrow_schema, normalize_for_delta};
 use crate::kernel::{
-    Action, Add, DeletionVectorDescriptor, EagerSnapshot, Metadata, ProtocolExt as _, Remove,
-    StructType, StructTypeExt,
+    Action, ActiveAddOptions, Add, AddStatsPolicy, DeletionVectorDescriptor, EagerSnapshot,
+    Metadata, ProtocolExt as _, Remove, StructType, StructTypeExt,
 };
 use crate::logstore::LogStoreRef;
 use crate::operations::cdc::{CDC_COLUMN_NAME, should_write_cdc};
@@ -580,7 +580,14 @@ async fn collect_all_existing_files(
 ) -> DeltaResult<MatchedExistingFiles> {
     Ok(MatchedExistingFiles::new(
         snapshot
-            .file_views(log_store.as_ref(), None)
+            .snapshot()
+            .active_adds(
+                log_store.as_ref(),
+                ActiveAddOptions {
+                    predicate: None,
+                    stats: AddStatsPolicy::None,
+                },
+            )
             .map_ok(|file| MatchedExistingFile::from(file.to_add()))
             .try_collect()
             .await?,
@@ -595,7 +602,14 @@ async fn collect_matched_existing_files(
     let table_root = Arc::new(snapshot.table_configuration().table_root().clone());
     let valid_files = Arc::new(files_scan.files_set());
     let files = snapshot
-        .file_views(log_store.as_ref(), Some(files_scan.delta_predicate.clone()))
+        .snapshot()
+        .active_adds(
+            log_store.as_ref(),
+            ActiveAddOptions {
+                predicate: Some(files_scan.delta_predicate.clone()),
+                stats: AddStatsPolicy::RawJson,
+            },
+        )
         .try_filter_map(|file| {
             let table_root = Arc::clone(&table_root);
             let valid_files = Arc::clone(&valid_files);

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -139,7 +139,7 @@ impl DeltaTableState {
         &self,
         log_store: &dyn LogStore,
     ) -> BoxStream<'_, DeltaResult<TombstoneView>> {
-        self.snapshot.snapshot().tombstones(log_store)
+        self.snapshot.snapshot().active_tombstones(log_store)
     }
 
     /// Get the transaction version for the given application ID.
@@ -287,6 +287,40 @@ impl Snapshot {
         let expression = Expression::Struct(expressions, None);
         let table_schema = DataType::try_struct_type(fields)?;
         self.add_actions_batches_with_schema(true, expression, table_schema)
+    }
+
+    /// Project active add batches to path and partition columns.
+    #[cfg(feature = "datafusion")]
+    pub(crate) fn active_add_partition_batches_from(
+        &self,
+        batches: &[RecordBatch],
+    ) -> Result<Vec<RecordBatch>, DeltaTableError> {
+        let mut expressions = vec![column_expr_ref!("path")];
+        let mut fields = vec![StructField::not_null("path", DataType::STRING)];
+
+        if let Some(partition_schema) = self.inner.partitions_schema()? {
+            fields.push(StructField::nullable(
+                "partition",
+                DataType::try_struct_type(partition_schema.fields().cloned())?,
+            ));
+            expressions.push(column_expr_ref!("partitionValues_parsed"));
+        }
+
+        let expression = Expression::Struct(expressions, None);
+        let table_schema = DataType::try_struct_type(fields)?;
+
+        let evaluated_batches = batches.iter().map(|batch| {
+            let input_schema = Arc::new(batch.schema().as_ref().try_into_kernel()?);
+            let evaluator = ARROW_HANDLER.new_expression_evaluator(
+                input_schema,
+                expression.clone().into(),
+                table_schema.clone(),
+            )?;
+            let batch = evaluator.evaluate_arrow(batch.clone())?;
+            Ok(batch.normalize(".", None)?)
+        });
+
+        coalesce_batches(evaluated_batches)
     }
 
     fn add_actions_batches_with_schema(


### PR DESCRIPTION
This is part of our ongoing work to migrate `EagerSnapshot` to `Snapshot`

Moves operation reads from broad `EagerSnapshot ` file access to narrow `Snapshot` capability methods.

We are keeping `EagerSnapshot` as the compatibility wrapper for now. The new paths read metadata, active Add actions, tombstones, and conflict inputs from `Snapshot` without filling `materialized_files` unless the caller needs that state.

I ran benchmarking locally and did not see any obvious regressions, but would appreciate additional validation.

Changes:
- Add `metadata_state`, `active_adds`, `active_add_batches`, `active_tombstones`, and `conflict_read_set`
- Add `AddStatsPolicy` allowing callers to request no stats, raw json stats, or parsed stats
- Plan metadata operations from borrowed snapshot metadata
- Stream active Add actions in find files, delete, restore, vacuum, fsck, write, update, and merge
- Pass explicit conflict read sets through transaction retries

CC: @hntd187