### PR TITLE
chore: pin transitive dependencies which broke today (alloc-stdlib)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,6 +19,13 @@ deltalake-derive = { version = "1", path = "../derive" }
 
 delta_kernel.workspace = true
 
+# Incompatible dependencies were introduced into our transitives:
+# <https://github.com/dropbox/rust-brotli/issues/256>
+alloc-stdlib = "=0.2.2"
+brotli-decompressor = "=5.0.1"
+##
+
+
 # arrow
 arrow = { workspace = true }
 arrow-arith = { workspace = true }
@@ -150,4 +157,4 @@ name = "json_parsing"
 harness = false
 
 [package.metadata.cargo-machete]
-ignored = ["foyer"]
+ignored = ["foyer", "alloc-stdlib", "brotli-decompressor"]


### PR DESCRIPTION
Not that big of a deal, just requires pinning to unblock main again

upstream issue to keep an eye on: dropbox/rust-brotli#256
