### PR TITLE
fix: consolidate table URL parsing for Python and Rust and logic dedup

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -208,21 +208,9 @@ pub fn crate_version() -> &'static str {
 /// Creates `DeltaTableBuilder` from verified table url.
 /// Will fail fast if specified `table_url` is a local path but doesn't exist.
 fn builder_from_valid_url(table_url: Url) -> Result<DeltaTableBuilder, DeltaTableError> {
-    if table_url.scheme() == "file" {
-        let p = table_url
-            .to_file_path()
-            .map_err(|_| DeltaTableError::InvalidTableLocation(table_url.as_str().to_string()))?;
+    let url = table::builder::parse_table_uri(table_url.as_str())?;
 
-        if !p.exists() {
-            let msg = format!(
-                "Local path \"{}\" does not exist or you don't have access!",
-                p.display(),
-            );
-            return Err(DeltaTableError::InvalidTableLocation(msg));
-        }
-    }
-
-    DeltaTableBuilder::from_url(table_url)
+    DeltaTableBuilder::from_url(url)
 }
 
 #[cfg(test)]
@@ -775,6 +763,39 @@ mod tests {
             error,
             DeltaTableError::InvalidTableLocation(_expected_error_msg),
         ))
+    }
+
+    #[test]
+    fn test_builder_from_valid_url_local_existing_path() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let table_url = Url::from_directory_path(tmp_dir.path()).unwrap();
+
+        let builder = builder_from_valid_url(table_url.clone()).unwrap();
+        let built = builder.build().unwrap();
+
+        assert_eq!(built.table_url(), &table_url);
+    }
+
+    #[test]
+    fn test_builder_from_valid_url_local_missing_path() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let missing_path = tmp_dir.path().join("missing-table");
+        assert!(!missing_path.exists());
+
+        let table_url = Url::from_directory_path(missing_path).unwrap();
+        let error = builder_from_valid_url(table_url).unwrap_err();
+
+        assert!(matches!(error, DeltaTableError::InvalidTableLocation(_)));
+    }
+
+    #[test]
+    fn test_builder_from_valid_url_remote_path() {
+        let table_url = Url::parse("memory:///table/path").unwrap();
+
+        let builder = builder_from_valid_url(table_url.clone()).unwrap();
+        let built = builder.build().unwrap();
+
+        assert_eq!(built.table_url(), &table_url);
     }
 
     /// <https://github.com/delta-io/delta-rs/issues/2152>

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -790,7 +790,7 @@ mod tests {
 
     #[test]
     fn test_builder_from_valid_url_remote_path() {
-        let table_url = Url::parse("memory:///table/path").unwrap();
+        let table_url = Url::parse("memory:///table/path/").unwrap();
 
         let builder = builder_from_valid_url(table_url.clone()).unwrap();
         let built = builder.build().unwrap();

--- a/crates/core/src/table/builder.rs
+++ b/crates/core/src/table/builder.rs
@@ -389,8 +389,11 @@ pub fn parse_table_uri(table_uri: impl AsRef<str>) -> DeltaResult<Url> {
 
     let mut url = match uri_type {
         UriType::LocalPath(path) => {
-            let path = std::fs::canonicalize(path).map_err(|err| {
-                let msg = format!("Invalid table location: {table_uri}\nError: {err:?}");
+            let path = std::fs::canonicalize(&path).map_err(|err| {
+                let msg = format!(
+                    "Local path \"{}\" does not exist or you don't have access!\nError: {err:?}",
+                    path.display(),
+                );
                 DeltaTableError::InvalidTableLocation(msg)
             })?;
             Url::from_directory_path(path).map_err(|_| {
@@ -702,6 +705,96 @@ mod tests {
         }
 
         std::fs::remove_dir_all(&test_dir).ok();
+    }
+
+    #[test]
+    fn test_parse_table_uri_remote_url() {
+        object_store_factories().insert(
+            Url::parse("s3://").unwrap(),
+            Arc::new(DefaultObjectStoreFactory::default()),
+        );
+
+        // Basic remote URL is returned as-is
+        let uri = parse_table_uri("s3://bucket/path");
+        assert!(uri.is_ok());
+        assert_eq!("s3://bucket/path", uri.unwrap().as_str());
+
+        // Trailing slashes are trimmed from the path component
+        let uri = parse_table_uri("s3://bucket/path/");
+        assert!(uri.is_ok());
+        assert_eq!("s3://bucket/path", uri.unwrap().as_str());
+
+        // Multiple trailing slashes are all trimmed
+        let uri = parse_table_uri("s3://bucket/path//");
+        assert!(uri.is_ok());
+        assert_eq!("s3://bucket/path", uri.unwrap().as_str());
+
+        // memory:// scheme is supported
+        let uri = parse_table_uri("memory:///test/table");
+        assert!(uri.is_ok());
+        assert_eq!("memory:///test/table", uri.unwrap().as_str());
+
+        // Percent-encoded paths are preserved (no double-encoding)
+        let uri = parse_table_uri("s3://bucket/my%20table");
+        assert!(uri.is_ok());
+        assert_eq!("s3://bucket/my%20table", uri.unwrap().as_str());
+    }
+
+    #[test]
+    fn test_parse_table_uri_local_existing_path() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let tmp_path = std::fs::canonicalize(tmp_dir.path()).unwrap();
+
+        // Existing absolute path returns a file:// URL
+        let uri = parse_table_uri(tmp_path.to_str().unwrap());
+        assert!(uri.is_ok());
+        let url = uri.unwrap();
+        assert!(url.scheme() == "file");
+        // Path should not have a trailing slash after parse_table_uri
+        assert!(!url.path().ends_with('/'));
+
+        // Existing path via file:// URL round-trips correctly
+        let file_url = Url::from_directory_path(&tmp_path).unwrap();
+        let uri = parse_table_uri(file_url.as_str());
+        assert!(uri.is_ok());
+        assert_eq!(
+            tmp_path.to_str().unwrap(),
+            uri.unwrap().to_file_path().unwrap().to_str().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_parse_table_uri_local_nonexistent_path_fails() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let tmp_path = std::fs::canonicalize(tmp_dir.path()).unwrap();
+        let nonexistent = tmp_path.join("does_not_exist");
+
+        // parse_table_uri does NOT create directories, so a non-existent local
+        // path must return an error (canonicalize fails).
+        let uri = parse_table_uri(nonexistent.to_str().unwrap());
+        assert!(
+            uri.is_err(),
+            "parse_table_uri should fail for non-existent local paths"
+        );
+    }
+
+    #[test]
+    fn test_parse_table_uri_current_dir() {
+        // "." resolves to the current working directory, which always exists
+        let uri = parse_table_uri(".");
+        assert!(uri.is_ok());
+        let url = uri.unwrap();
+        assert_eq!(url.scheme(), "file");
+    }
+
+    #[test]
+    fn test_parse_table_uri_invalid_scheme() {
+        // Unknown multi-character schemes should return an error
+        let uri = parse_table_uri("hdfs://namenode/path");
+        assert!(
+            uri.is_err(),
+            "parse_table_uri should fail for unknown schemes"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Description
Python and Rust table open APIs takes two separate but similar approaches to parse table path and fail for non-existent local paths. Additionally, Python API checks for registered schemas but Rust does not.

PR consolidates them and forces Rust API to use the same underlying code that Python uses so behaviour and logic shared and the same.

Tests are AI generated.

# Related Issue(s)

# Documentation

