### PR TITLE
fix: redact Unity Catalog env log values

### DIFF
--- a/crates/catalog-unity/src/lib.rs
+++ b/crates/catalog-unity/src/lib.rs
@@ -467,7 +467,7 @@ impl UnityCatalogBuilder {
             {
                 tracing::debug!("Found relevant env: {key}");
                 if let Ok(config_key) = UnityCatalogConfigKey::from_str(&key.to_ascii_lowercase()) {
-                    tracing::debug!("Trying: {key} with {value}");
+                    tracing::debug!("Trying: {key}");
                     builder = builder.try_with_option(config_key, value).unwrap();
                 }
             }


### PR DESCRIPTION
## What changed

Redacts Unity Catalog environment variable values from debug logging. `from_env()` still logs the environment key it is trying, but no longer prints the associated value.

## Why

The previous debug message included values from matching `UNITY_` and `DATABRICKS_` environment variables. That can expose secrets such as Databricks tokens, Unity access tokens, or client secrets when debug logs are collected.

## Root cause

A debug trace added while parsing Unity Catalog environment configuration logged both the key and value before applying the option.

## Checks

- `cargo fmt --check`
- `cargo test -p deltalake-catalog-unity`