### PR TITLE
fix: feature flag tests which require symbols in the datafusion build

### DIFF
--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -1927,6 +1927,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "datafusion")]
     #[tokio::test]
     async fn snapshot_capability_active_adds_raw_json_preserves_row_counts_and_raw_stats()
     -> TestResult {

--- a/crates/core/src/operations/update_table_metadata.rs
+++ b/crates/core/src/operations/update_table_metadata.rs
@@ -210,6 +210,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "datafusion")]
     #[tokio::test]
     async fn update_table_metadata_with_lazy_snapshot_retries_after_concurrent_commit() -> TestResult
     {


### PR DESCRIPTION
These slipped through CI somehow and I didn't notice that RawJson is only available in the `datafusion` feature build.
