### PR TITLE
fix: support simple pruning when binary partitions are used

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -1513,13 +1513,10 @@ mod tests {
         Ok(())
     }
 
-    /// Regression test documenting issue #1214:
-    /// Binary partition columns yield `None` from `pick_stats` (no natural order),
-    /// so `PruningPredicate` cannot prune any files for binary partition predicates.
-    /// All files pass through even when the predicate would logically exclude some.
+    /// Tests that binary partition columns support equality pruning (= / IN predicates)
+    /// even though they do not support range pruning (< / > predicates).
     ///
-    /// TODO(#1214): When/if binary partition pruning is implemented, update this
-    /// test to assert `kept_files.len() == 1` (only the matching file survives).
+    /// Resolves issue #1214.
     #[tokio::test]
     async fn test_files_matching_predicate_binary_partition_not_pruned() {
         use crate::delta_datafusion::files_matching_predicate;
@@ -1595,22 +1592,107 @@ mod tests {
             .collect();
         assert_eq!(all_files.len(), 2, "expected 2 files before pruning");
 
-        // Apply a predicate that would logically select only the "aaa" partition.
-        // Because Binary columns are skipped by pick_stats (issue #1214), the
-        // PruningPredicate cannot produce statistics for this column and keeps all
-        // files.  The test asserts the *current* conservative behavior: no files are
-        // incorrectly pruned away.
+        // Apply a predicate that selects only the "aaa" partition.
+        // `contained()` now handles binary exact-match pruning (issue #1214).
         let predicate = col("bin_part").eq(lit(ScalarValue::Binary(Some(b"aaa".to_vec()))));
         let kept_files: Vec<_> = files_matching_predicate(log_data.clone(), &[predicate])
             .unwrap()
             .collect();
 
-        // TODO(#1214): change to assert_eq!(kept_files.len(), 1) once binary
-        // partition pruning is supported.
         assert_eq!(
             kept_files.len(),
-            2,
-            "expected all files to survive pruning: binary partitions are not prunable (issue #1214)"
+            1,
+            "expected exactly the 'aaa' partition file to survive equality pruning"
+        );
+    }
+
+    /// Range predicates (`<`, `>`) on binary partition columns must NOT prune any files
+    /// because binary values have no natural ordering.  All files are conservatively kept.
+    #[tokio::test]
+    async fn test_files_matching_predicate_binary_partition_range_not_pruned() {
+        use crate::delta_datafusion::files_matching_predicate;
+        use arrow::array::BinaryArray;
+        use datafusion::common::ScalarValue;
+        use datafusion::logical_expr::{col, lit};
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", ArrowDataType::Int32, true),
+            Field::new("bin_part", ArrowDataType::Binary, true),
+        ]));
+
+        let batch_a = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(arrow::array::Int32Array::from(vec![1_i32])) as Arc<dyn Array>,
+                Arc::new(BinaryArray::from_vec(vec![b"aaa".as_ref()])) as Arc<dyn Array>,
+            ],
+        )
+        .unwrap();
+
+        let batch_b = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(arrow::array::Int32Array::from(vec![2_i32])) as Arc<dyn Array>,
+                Arc::new(BinaryArray::from_vec(vec![b"bbb".as_ref()])) as Arc<dyn Array>,
+            ],
+        )
+        .unwrap();
+
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_column(
+                "id",
+                delta_kernel::schema::DataType::Primitive(
+                    delta_kernel::schema::PrimitiveType::Integer,
+                ),
+                true,
+                None,
+            )
+            .with_column(
+                "bin_part",
+                delta_kernel::schema::DataType::Primitive(
+                    delta_kernel::schema::PrimitiveType::Binary,
+                ),
+                true,
+                None,
+            )
+            .with_partition_columns(["bin_part"])
+            .await
+            .unwrap();
+
+        let table = table
+            .write(vec![batch_a])
+            .with_save_mode(crate::protocol::SaveMode::Append)
+            .await
+            .unwrap();
+        let table = table
+            .write(vec![batch_b])
+            .with_save_mode(crate::protocol::SaveMode::Append)
+            .await
+            .unwrap();
+
+        let snapshot = table.snapshot().unwrap().snapshot().clone();
+        let log_data = snapshot.log_data();
+
+        // A `>` predicate on a binary column must keep all files — there are no
+        // min/max stats for binary, so datafusion cannot eliminate any file.
+        let gt_pred = col("bin_part").gt(lit(ScalarValue::Binary(Some(b"aaa".to_vec()))));
+        let kept = files_matching_predicate(log_data.clone(), &[gt_pred])
+            .unwrap()
+            .count();
+        assert_eq!(
+            kept, 2,
+            "range predicate '>' on binary partition must not prune any files"
+        );
+
+        // Likewise for `<`.
+        let lt_pred = col("bin_part").lt(lit(ScalarValue::Binary(Some(b"bbb".to_vec()))));
+        let kept = files_matching_predicate(log_data.clone(), &[lt_pred])
+            .unwrap()
+            .count();
+        assert_eq!(
+            kept, 2,
+            "range predicate '<' on binary partition must not prune any files"
         );
     }
 }

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -1512,4 +1512,105 @@ mod tests {
         let _ = df.collect().await?;
         Ok(())
     }
+
+    /// Regression test documenting issue #1214:
+    /// Binary partition columns yield `None` from `pick_stats` (no natural order),
+    /// so `PruningPredicate` cannot prune any files for binary partition predicates.
+    /// All files pass through even when the predicate would logically exclude some.
+    ///
+    /// TODO(#1214): When/if binary partition pruning is implemented, update this
+    /// test to assert `kept_files.len() == 1` (only the matching file survives).
+    #[tokio::test]
+    async fn test_files_matching_predicate_binary_partition_not_pruned() {
+        use crate::delta_datafusion::files_matching_predicate;
+        use arrow::array::BinaryArray;
+        use datafusion::common::ScalarValue;
+        use datafusion::logical_expr::{col, lit};
+
+        // Write two files into separate binary partitions.
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", ArrowDataType::Int32, true),
+            Field::new("bin_part", ArrowDataType::Binary, true),
+        ]));
+
+        let batch_a = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(arrow::array::Int32Array::from(vec![1_i32])) as Arc<dyn Array>,
+                Arc::new(BinaryArray::from_vec(vec![b"aaa".as_ref()])) as Arc<dyn Array>,
+            ],
+        )
+        .unwrap();
+
+        let batch_b = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(arrow::array::Int32Array::from(vec![2_i32])) as Arc<dyn Array>,
+                Arc::new(BinaryArray::from_vec(vec![b"bbb".as_ref()])) as Arc<dyn Array>,
+            ],
+        )
+        .unwrap();
+
+        // Two separate appends so each lands in its own partition file.
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_column(
+                "id",
+                delta_kernel::schema::DataType::Primitive(
+                    delta_kernel::schema::PrimitiveType::Integer,
+                ),
+                true,
+                None,
+            )
+            .with_column(
+                "bin_part",
+                delta_kernel::schema::DataType::Primitive(
+                    delta_kernel::schema::PrimitiveType::Binary,
+                ),
+                true,
+                None,
+            )
+            .with_partition_columns(["bin_part"])
+            .await
+            .unwrap();
+
+        let table = table
+            .write(vec![batch_a])
+            .with_save_mode(crate::protocol::SaveMode::Append)
+            .await
+            .unwrap();
+
+        let table = table
+            .write(vec![batch_b])
+            .with_save_mode(crate::protocol::SaveMode::Append)
+            .await
+            .unwrap();
+
+        let snapshot = table.snapshot().unwrap().snapshot().clone();
+        let log_data = snapshot.log_data();
+
+        // Without a predicate all files are returned.
+        let all_files: Vec<_> = files_matching_predicate(log_data.clone(), &[])
+            .unwrap()
+            .collect();
+        assert_eq!(all_files.len(), 2, "expected 2 files before pruning");
+
+        // Apply a predicate that would logically select only the "aaa" partition.
+        // Because Binary columns are skipped by pick_stats (issue #1214), the
+        // PruningPredicate cannot produce statistics for this column and keeps all
+        // files.  The test asserts the *current* conservative behavior: no files are
+        // incorrectly pruned away.
+        let predicate = col("bin_part").eq(lit(ScalarValue::Binary(Some(b"aaa".to_vec()))));
+        let kept_files: Vec<_> = files_matching_predicate(log_data.clone(), &[predicate])
+            .unwrap()
+            .collect();
+
+        // TODO(#1214): change to assert_eq!(kept_files.len(), 1) once binary
+        // partition pruning is supported.
+        assert_eq!(
+            kept_files.len(),
+            2,
+            "expected all files to survive pruning: binary partitions are not prunable (issue #1214)"
+        );
+    }
 }

--- a/crates/core/src/kernel/snapshot/log_data.rs
+++ b/crates/core/src/kernel/snapshot/log_data.rs
@@ -173,6 +173,109 @@ mod datafusion {
             )
             .ok()
         }
+
+        /// Evaluate the raw partition values for a `Binary`-typed partition column.
+        ///
+        /// Unlike [`pick_stats`], this does NOT bail out for binary types: binary values do
+        /// not support natural ordering (so `min_values`/`max_values` must stay `None`) but
+        /// they *do* support exact-match comparison via [`PruningStatistics::contained`].
+        fn pick_binary_partition_values(&self, column: &Column) -> Option<ArrayRef> {
+            let schema = self.config.logical_schema();
+            let field = schema.field(&column.name)?;
+            if field.data_type() != &DataType::Primitive(PrimitiveType::Binary) {
+                return None;
+            }
+            if !self
+                .config
+                .metadata()
+                .partition_columns()
+                .contains(&column.name)
+            {
+                return None;
+            }
+            let expression = Expression::column(["partitionValues_parsed", &column.name]);
+            let evaluator = ARROW_HANDLER
+                .new_expression_evaluator(
+                    crate::kernel::models::fields::log_schema_ref().clone(),
+                    expression.into(),
+                    field.data_type().clone(),
+                )
+                .ok()?;
+            let results: Vec<_> = self
+                .data
+                .iter()
+                .map(|data| -> DeltaResult<_> {
+                    Ok(evaluator.evaluate_arrow(data.clone())?.column(0).clone())
+                })
+                .try_collect()
+                .ok()?;
+            concat(
+                &results
+                    .iter()
+                    .map(|result| result.as_ref())
+                    .collect::<Vec<_>>(),
+            )
+            .ok()
+        }
+
+        /// Evaluate whether each file's binary partition value is a member of `values`.
+        ///
+        /// Returns `false` for a file when its partition value is definitely NOT in `values`
+        /// (safe to prune).  Returns `true` when it matches any value in the set, or when
+        /// the partition value is null (conservative: keep the file).
+        fn contained_binary(
+            &self,
+            column: &Column,
+            values: &HashSet<ScalarValue>,
+        ) -> Option<BooleanArray> {
+            use arrow_array::BinaryArray;
+
+            let partition_values = self.pick_binary_partition_values(column)?;
+            let binary_arr = partition_values.as_any().downcast_ref::<BinaryArray>()?;
+
+            // Binary partition values are serialized into the Delta log as unicode-escape
+            // hex strings (e.g. b"aaa" → "\\u0061\\u0061\\u0061") by
+            // `create_escaped_binary_string`, then parsed back into `Scalar::Binary` by
+            // `PrimitiveType::parse_scalar` via `raw.to_string().into_bytes()`.
+            // This means the stored bytes are the UTF-8 encoding of that escape string,
+            // NOT the original raw bytes.  We must apply the same encoding to the predicate
+            // scalars before comparing so that equality holds.
+            fn encode_binary_bytes(bytes: &[u8]) -> Vec<u8> {
+                bytes
+                    .iter()
+                    .flat_map(|&b| format!("\\u{b:04X}").into_bytes())
+                    .collect()
+            }
+
+            // Unwrap the dictionary wrapper that `_arrow_schema` adds to binary
+            // partition columns.
+            fn unwrap_binary_scalar(scalar: &ScalarValue) -> Option<Vec<u8>> {
+                match scalar {
+                    ScalarValue::Binary(Some(v)) | ScalarValue::LargeBinary(Some(v)) => {
+                        Some(encode_binary_bytes(v))
+                    }
+                    ScalarValue::Dictionary(_, inner) => unwrap_binary_scalar(inner),
+                    _ => None,
+                }
+            }
+
+            let mut contains = Vec::with_capacity(binary_arr.len());
+            for i in 0..binary_arr.len() {
+                if binary_arr.is_null(i) {
+                    // Null partition value: conservatively keep the file.
+                    contains.push(true);
+                } else {
+                    let pv: &[u8] = binary_arr.value(i);
+                    contains.push(
+                        values
+                            .iter()
+                            .filter_map(unwrap_binary_scalar)
+                            .any(|encoded| encoded.as_slice() == pv),
+                    );
+                }
+            }
+            Some(BooleanArray::from(contains))
+        }
     }
 
     impl PruningStatistics for LogDataHandler<'_> {
@@ -266,6 +369,18 @@ mod datafusion {
                     .contains(&column.name)
             {
                 return None;
+            }
+
+            // Binary partition columns support exact-match pruning but not range pruning
+            // (no natural ordering).  Delegate to a dedicated path that bypasses the
+            // ordering guard in `pick_stats`.  See issue #1214.
+            let schema = self.config.logical_schema();
+            if schema
+                .field(&column.name)
+                .map(|f| f.data_type() == &DataType::Primitive(PrimitiveType::Binary))
+                .unwrap_or(false)
+            {
+                return self.contained_binary(column, value);
             }
 
             // Retrieve the partition values for the column


### PR DESCRIPTION
This is a :parrot: generated bit of code, which is pretty straightforward for
implementing support for file pruning on binary partition columns.

Don't ask me _why_ somebody would have binary partition columns, but hey, we can now support them!

Fixes #1214
