### PR TITLE
test: preserve eager snapshot state compatibility

### DIFF
--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -2145,6 +2145,10 @@ mod tests {
         let elements = value.as_array().expect("expected eager snapshot sequence");
         assert_eq!(elements.len(), 1);
 
+        let actual: EagerSnapshot = serde_json::from_value(value)?;
+        assert_eq!(actual.version(), snapshot.version());
+        assert_eq!(actual.metadata().id(), snapshot.metadata().id());
+
         Ok(())
     }
 
@@ -2152,13 +2156,18 @@ mod tests {
     async fn test_eager_snapshot_legacy_serde_preserves_materialized_state() -> TestResult {
         let log_store = TestTables::Simple.table_builder()?.build_storage()?;
         let snapshot = EagerSnapshot::try_new(&log_store, Default::default(), None).await?;
+
+        assert!(snapshot.snapshot().has_materialized_files_for_test());
+
         let legacy = legacy_eager_snapshot_payload(&snapshot);
 
         let actual: EagerSnapshot = serde_json::from_value(legacy)?;
 
+        assert_eq!(actual.version(), snapshot.version());
+        assert!(actual.snapshot().has_materialized_files_for_test());
         assert_eq!(
-            actual.log_data().num_files(),
-            snapshot.log_data().num_files()
+            actual.try_log_data()?.num_files(),
+            snapshot.try_log_data()?.num_files()
         );
 
         Ok(())

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -632,6 +632,72 @@ mod tests {
 
     #[cfg(feature = "datafusion")]
     #[tokio::test]
+    async fn test_delta_table_state_serde_roundtrip_preserves_add_actions() -> DeltaResult<()> {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(get_delta_schema().fields().cloned())
+            .await?;
+        let table = table
+            .write(vec![get_record_batch(None, false)])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let state = table.snapshot()?;
+        let before = state.add_actions_table(true)?;
+
+        let bytes = serde_json::to_vec(state)?;
+        let actual: DeltaTableState = serde_json::from_slice(&bytes)?;
+        let after = actual.add_actions_table(true)?;
+
+        assert_eq!(actual.version(), state.version());
+        assert_eq!(after, before);
+        Ok(())
+    }
+
+    #[cfg(feature = "datafusion")]
+    #[tokio::test]
+    async fn test_delta_table_state_without_files_roundtrip_stays_without_files() -> DeltaResult<()>
+    {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(get_delta_schema().fields().cloned())
+            .await?;
+        let table = table
+            .write(vec![get_record_batch(None, false)])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+
+        let config = DeltaTableConfig {
+            require_files: false,
+            ..Default::default()
+        };
+        let state = DeltaTableState::try_new(table.log_store().as_ref(), config, None).await?;
+        assert!(
+            !state
+                .snapshot()
+                .snapshot()
+                .has_materialized_files_for_test()
+        );
+
+        let bytes = serde_json::to_vec(&state)?;
+        let actual: DeltaTableState = serde_json::from_slice(&bytes)?;
+
+        assert_eq!(actual.version(), state.version());
+        assert!(
+            !actual
+                .snapshot()
+                .snapshot()
+                .has_materialized_files_for_test()
+        );
+        assert!(matches!(
+            actual.add_actions_table(true),
+            Err(DeltaTableError::NotInitializedWithFiles(_))
+        ));
+        Ok(())
+    }
+
+    #[cfg(feature = "datafusion")]
+    #[tokio::test]
     async fn test_add_actions_batches_non_empty_non_flatten_has_partition_struct() -> DeltaResult<()>
     {
         let table = DeltaTable::new_in_memory()

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -2913,6 +2913,37 @@ def _merge_with_type_mismatch_actions(merger, action_style: str):
 
 
 @pytest.mark.pyarrow
+def test_merge_from_without_files_table_preserves_state(tmp_path: pathlib.Path):
+    import pyarrow as pa
+
+    target = pa.table({"id": [1, 2], "value": ["a", "b"]})
+    source = pa.table({"id": [2, 3], "value": ["bb", "c"]})
+    write_deltalake(tmp_path, target)
+
+    dt = DeltaTable(tmp_path, without_files=True)
+    metrics = (
+        dt.merge(
+            source=source,
+            predicate="target.id = source.id",
+            source_alias="source",
+            target_alias="target",
+        )
+        .when_matched_update({"value": "source.value"})
+        .when_not_matched_insert({"id": "source.id", "value": "source.value"})
+        .execute()
+    )
+
+    assert int(metrics["num_target_rows_updated"]) == 1
+    assert int(metrics["num_target_rows_inserted"]) == 1
+
+    result = DeltaTable(tmp_path).to_pyarrow_table().sort_by("id")
+    assert result["value"].to_pylist() == ["a", "bb", "c"]
+
+    with pytest.raises(DeltaError, match="Table is instantiated without files\\."):
+        dt.get_add_actions(flatten=True)
+
+
+@pytest.mark.pyarrow
 @pytest.mark.parametrize("action_style", ("all", "explicit"))
 def test_merge_type_mismatch_default_castable_value_succeeds(
     tmp_path: pathlib.Path, action_style: str

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -15,7 +15,7 @@ from arro3.core import Field as ArrowField
 
 from deltalake import DeltaTable
 from deltalake._util import encode_partition_value
-from deltalake.exceptions import DeltaProtocolError
+from deltalake.exceptions import DeltaError, DeltaProtocolError
 from deltalake.query import QueryBuilder
 from deltalake.table import ProtocolVersions
 from deltalake.writer import write_deltalake
@@ -560,6 +560,33 @@ def test_get_add_actions_on_empty_table(tmp_path: Path):
     add_actions = dt.get_add_actions()
     assert add_actions.num_rows == 0
     assert dt.get_add_actions(flatten=True).num_rows == 0
+
+
+@pytest.mark.pyarrow
+def test_get_add_actions_without_files_raises():
+    table_path = "../crates/test/tests/data/simple_table"
+    dt = DeltaTable(table_path, without_files=True)
+
+    with pytest.raises(DeltaError, match="Table is instantiated without files\\."):
+        dt.get_add_actions(flatten=True)
+
+
+@pytest.mark.pyarrow
+def test_without_files_update_preserves_get_add_actions_error(tmp_path: Path):
+    import pyarrow as pa
+
+    data = pa.table({"id": pa.array([1, 2, 3], type=pa.int64())})
+    write_deltalake(tmp_path, data)
+
+    dt = DeltaTable(tmp_path, without_files=True)
+    assert dt.version() == 0
+
+    write_deltalake(tmp_path, data, mode="append")
+    dt.update_incremental()
+
+    assert dt.version() == 1
+    with pytest.raises(DeltaError, match="Table is instantiated without files\\."):
+        dt.get_add_actions(flatten=True)
 
 
 def assert_correct_files(dt: DeltaTable, partition_filters, expected_paths):

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -2992,7 +2992,9 @@ def test_write_table_with_deletion_vectors(tmp_path: pathlib.Path):
 
 
 @pytest.mark.pyarrow
-def test_without_files_delta_table_write_preserves_state(tmp_path: pathlib.Path) -> None:
+def test_without_files_delta_table_write_preserves_state(
+    tmp_path: pathlib.Path,
+) -> None:
     import pyarrow as pa
 
     initial = pa.table({"id": pa.array([1, 2], type=pa.int64())})

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -2992,6 +2992,24 @@ def test_write_table_with_deletion_vectors(tmp_path: pathlib.Path):
 
 
 @pytest.mark.pyarrow
+def test_without_files_delta_table_write_preserves_state(tmp_path: pathlib.Path) -> None:
+    import pyarrow as pa
+
+    initial = pa.table({"id": pa.array([1, 2], type=pa.int64())})
+    write_deltalake(tmp_path, initial)
+
+    dt = DeltaTable(tmp_path, without_files=True)
+    write_deltalake(dt, pa.table({"id": pa.array([3], type=pa.int64())}), mode="append")
+
+    latest = DeltaTable(tmp_path)
+    assert latest.version() == 1
+    assert latest.to_pyarrow_table().sort_by("id")["id"].to_pylist() == [1, 2, 3]
+
+    with pytest.raises(DeltaError, match="Table is instantiated without files\\."):
+        dt.get_add_actions(flatten=True)
+
+
+@pytest.mark.pyarrow
 def test_overwrite_with_partitions(tmp_path: pathlib.Path) -> None:
     """
     Calling create_write_transaction with mode="overwrite" and non-empty


### PR DESCRIPTION
Adds compatibility coverage for the remaining `EagerSnapshot` and `DeltaTableState` state surfaces while `Snapshot` migration work continues.