### PR TITLE
fix: relax column nullability under SchemaMode::Merge

### DIFF
--- a/crates/core/src/delta_datafusion/data_validation.rs
+++ b/crates/core/src/delta_datafusion/data_validation.rs
@@ -259,29 +259,38 @@ pub(crate) fn validation_predicates(
     session: &dyn Session,
     source_schema: &DFSchema,
     table_configuration: &TableConfiguration,
+    relax_nullability: bool,
 ) -> Result<Vec<Expr>> {
     // find all columns that are non-nullable in the table schema but nullable
     // in the source schema and add IS NOT NULL checks for them.
-    let table_schema: Schema = table_configuration
-        .logical_schema()
-        .as_ref()
-        .try_into_arrow()?;
-    let non_nullable_table: HashSet<_> = collect_non_nullable_fields(&table_schema)
-        .into_iter()
-        .collect();
-    let non_nullable_source: HashSet<_> = collect_non_nullable_fields(source_schema.as_arrow())
-        .into_iter()
-        .collect();
-    let mut validations: Vec<_> = non_nullable_table
-        .difference(&non_nullable_source)
-        .map(|col| {
-            to_datafusion_expr(
-                &Expression::Column(col.clone()),
-                &delta_kernel::schema::DataType::BOOLEAN,
-            )
-        })
-        .map_ok(|e| e.is_not_null())
-        .try_collect()?;
+    //
+    // Under a schema-merge write (`relax_nullability`), these are exactly the
+    // columns being relaxed from non-nullable to nullable, so the NOT NULL
+    // constraint must not be enforced for them.
+    let mut validations: Vec<Expr> = if relax_nullability {
+        Vec::new()
+    } else {
+        let table_schema: Schema = table_configuration
+            .logical_schema()
+            .as_ref()
+            .try_into_arrow()?;
+        let non_nullable_table: HashSet<_> = collect_non_nullable_fields(&table_schema)
+            .into_iter()
+            .collect();
+        let non_nullable_source: HashSet<_> = collect_non_nullable_fields(source_schema.as_arrow())
+            .into_iter()
+            .collect();
+        non_nullable_table
+            .difference(&non_nullable_source)
+            .map(|col| {
+                to_datafusion_expr(
+                    &Expression::Column(col.clone()),
+                    &delta_kernel::schema::DataType::BOOLEAN,
+                )
+            })
+            .map_ok(|e| e.is_not_null())
+            .try_collect()?
+    };
 
     if table_configuration.is_feature_enabled(&TableFeature::Invariants) {
         let invariants = table_configuration

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1591,6 +1591,7 @@ async fn execute(
         None,
         should_cdc, // if true, write execution plan splits batches in [normal, cdc] data before writing
         None,
+        false,
     )
     .await?;
     if let Some(schema_metadata) = schema_action {

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -382,6 +382,7 @@ pub(crate) async fn write_execution_plan(
         None,
         false,
         None,
+        false,
     )
     .await?;
     Ok(actions)
@@ -401,6 +402,7 @@ pub(crate) async fn write_execution_plan_v2(
     predicate: Option<Expr>,
     contains_cdc: bool,
     insert_marker_column: Option<String>,
+    relax_nullability: bool,
 ) -> DeltaResult<(Vec<Action>, WriteExecutionPlanMetrics)> {
     // We always take the plan Schema since the data may contain Large/View arrow types,
     // the schema and batches were prior constructed with this in mind.
@@ -410,6 +412,7 @@ pub(crate) async fn write_execution_plan_v2(
             session,
             &plan.schema().to_dfschema()?,
             snapshot.table_configuration(),
+            relax_nullability,
         )?
     } else {
         debug!(

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -576,6 +576,7 @@ impl std::future::IntoFuture for WriteBuilder {
                     exact_validation,
                     contains_cdc,
                     insert_marker_column,
+                    this.schema_mode == Some(SchemaMode::Merge),
                 )
                 .await?;
 
@@ -1248,6 +1249,101 @@ mod tests {
 
         let write_metrics: WriteMetrics = get_write_metrics(&table).await;
         assert_common_write_metrics(write_metrics);
+    }
+
+    #[tokio::test]
+    async fn test_merge_schema_relaxes_nullability_with_null_batch() {
+        // <https://github.com/delta-io/delta-rs/issues/3688>
+        // Writing nullable data into a non-nullable column under SchemaMode::Merge
+        // should relax the column to nullable and accept the null values.
+        use arrow_array::{ArrayRef, RecordBatch};
+        let non_null = RecordBatch::try_from_iter_with_nullable(vec![(
+            "id",
+            Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef,
+            false,
+        )])
+        .unwrap();
+        let table = DeltaTable::new_in_memory()
+            .write(vec![non_null])
+            .with_save_mode(SaveMode::Append)
+            .await
+            .unwrap();
+        assert!(
+            !table
+                .snapshot()
+                .unwrap()
+                .schema()
+                .field("id")
+                .unwrap()
+                .is_nullable(),
+            "id should start non-nullable"
+        );
+
+        let null_batch = RecordBatch::try_from_iter_with_nullable(vec![(
+            "id",
+            Arc::new(Int32Array::from(vec![Some(1), None, Some(3)])) as ArrayRef,
+            true,
+        )])
+        .unwrap();
+        let table = table
+            .write(vec![null_batch])
+            .with_schema_mode(SchemaMode::Merge)
+            .with_save_mode(SaveMode::Append)
+            .await
+            .expect("merge write of nullable data should succeed");
+
+        assert!(
+            table
+                .snapshot()
+                .unwrap()
+                .schema()
+                .field("id")
+                .unwrap()
+                .is_nullable(),
+            "id should be relaxed to nullable after the merge write"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_schema_relaxes_nullability_with_empty_batch() {
+        // <https://github.com/delta-io/delta-rs/issues/3688>
+        // A nullability-only schema change (even with no rows) under
+        // SchemaMode::Merge must be committed to the table metadata.
+        use arrow_array::{ArrayRef, RecordBatch};
+        let non_null = RecordBatch::try_from_iter_with_nullable(vec![(
+            "id",
+            Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef,
+            false,
+        )])
+        .unwrap();
+        let table = DeltaTable::new_in_memory()
+            .write(vec![non_null])
+            .with_save_mode(SaveMode::Append)
+            .await
+            .unwrap();
+
+        let empty = RecordBatch::new_empty(Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            true,
+        )])));
+        let table = table
+            .write(vec![empty])
+            .with_schema_mode(SchemaMode::Merge)
+            .with_save_mode(SaveMode::Append)
+            .await
+            .expect("empty merge write should succeed");
+
+        assert!(
+            table
+                .snapshot()
+                .unwrap()
+                .schema()
+                .field("id")
+                .unwrap()
+                .is_nullable(),
+            "id should be relaxed to nullable after the empty merge write"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 use super::configs::WriterStatsConfig;
 use super::generated_columns::{gc_is_enabled, with_generated_columns};
 use super::metrics::SOURCE_COUNT_ID;
-use super::schema_evolution::try_cast_schema;
+use super::schema_evolution::{has_nullability_relaxation, try_cast_schema};
 use super::{SchemaMode, WriteError};
 use crate::delta_datafusion::logical::{LogicalPlanBuilderExt as _, MetricObserver};
 use crate::delta_datafusion::{
@@ -340,14 +340,26 @@ pub(super) fn prepare_write(input: WritePreparationInput<'_>) -> DeltaResult<Pre
             } else {
                 return Err(schema_err.into());
             }
-        } else if mode == SaveMode::Overwrite && schema_mode == Some(SchemaMode::Overwrite) {
-            new_schema = None;
         } else {
-            new_schema = Some(merge_arrow_schema(
-                table_schema.clone(),
-                source_schema.clone(),
-                schema_drift,
-            )?);
+            // The data types are castable, but a nullable source field can still
+            // relax a non-nullable table column. `try_cast_schema` ignores
+            // nullability, so detect that here: under `SchemaMode::Merge` it is a
+            // schema change that must be committed to the table metadata.
+            if schema_mode == Some(SchemaMode::Merge)
+                && has_nullability_relaxation(source_schema.fields(), table_schema.fields())
+            {
+                schema_drift = true;
+            }
+
+            if mode == SaveMode::Overwrite && schema_mode == Some(SchemaMode::Overwrite) {
+                new_schema = None;
+            } else {
+                new_schema = Some(merge_arrow_schema(
+                    table_schema.clone(),
+                    source_schema.clone(),
+                    schema_drift,
+                )?);
+            }
         }
     }
 

--- a/crates/core/src/operations/write/schema_evolution/mod.rs
+++ b/crates/core/src/operations/write/schema_evolution/mod.rs
@@ -1,6 +1,32 @@
 use arrow_cast::can_cast_types;
 use arrow_schema::{ArrowError, DataType, Fields};
 
+/// Returns `true` if any field in `from_fields` is nullable while the
+/// correspondingly-named field in `to_fields` is non-nullable (i.e. a
+/// nullability relaxation), recursing into struct fields.
+///
+/// Fields that are not present in `to_fields` are ignored here; those are new
+/// columns handled by the regular schema-merge path. This is used to detect
+/// that a `SchemaMode::Merge` write must relax a column from non-nullable to
+/// nullable, which [`try_cast_schema`] alone cannot detect because it only
+/// considers data-type castability.
+pub(crate) fn has_nullability_relaxation(from_fields: &Fields, to_fields: &Fields) -> bool {
+    from_fields.iter().any(|f| {
+        let Some((_, target_field)) = to_fields.find(f.name()) else {
+            return false;
+        };
+        if f.is_nullable() && !target_field.is_nullable() {
+            return true;
+        }
+        if let (DataType::Struct(from_nested), DataType::Struct(to_nested)) =
+            (f.data_type(), target_field.data_type())
+        {
+            return has_nullability_relaxation(from_nested, to_nested);
+        }
+        false
+    })
+}
+
 pub(crate) fn try_cast_schema(from_fields: &Fields, to_fields: &Fields) -> Result<(), ArrowError> {
     if from_fields.len() != to_fields.len() {
         return Err(ArrowError::SchemaError(format!(


### PR DESCRIPTION
# Description

Writing nullable data into a previously non-nullable column with `SchemaMode::Merge` did not relax the column to nullable. The relaxation was never committed to the table metadata, and any actual `null` values were rejected at write time by the `NOT NULL` data-validation check. This affected both non-empty batches (containing nulls) and empty/zero-row batches that only change nullability.

## Root cause

Two independent gaps:

1. **Schema metadata not updated.** `try_cast_schema` only checks data-type castability and *ignores nullability*, so a nullability-only difference (nullable source field → non-nullable table column) produced `schema_drift = false`. Because the `SchemaMode::Merge` metadata update is gated on `schema_drift`, the merged (relaxed) schema was never written, so the column stayed non-nullable.
2. **Data validation rejected the nulls.** `validation_predicates` derives `IS NOT NULL` checks from the **pre-write** snapshot (columns non-nullable in the table but nullable in the source — exactly the columns a merge write relaxes). These checks rejected the very nulls the merge was supposed to allow.

## Fix

- Add `has_nullability_relaxation(from_fields, to_fields)` (recursing into structs) in `schema_evolution`, and in `write/plan.rs` mark `schema_drift = true` under `SchemaMode::Merge` when a relaxation is detected, so the merged nullable schema is committed.
- Thread a `relax_nullability` flag through `write_execution_plan_v2` into `validation_predicates`; under `SchemaMode::Merge` the relaxation-column `NOT NULL` checks are skipped (the column is being relaxed). Invariants, check constraints, and generated-column validations are unaffected.

The change is scoped to `SchemaMode::Merge`: default and `Overwrite` schema modes keep their existing behavior (nulls into a non-nullable column are still rejected).

## Behavior

```rust
// table has non-nullable column `id`
let table = DeltaOps(table)
    .write(vec![nullable_id_batch])      // id typed nullable, may contain nulls
    .with_schema_mode(SchemaMode::Merge)
    .with_save_mode(SaveMode::Append)
    .await?;
// `id` is now nullable and the null rows are written
```

## Testing

- Added two regression tests in `operations::write::tests`:
  - `test_merge_schema_relaxes_nullability_with_null_batch` (non-empty batch with null values)
  - `test_merge_schema_relaxes_nullability_with_empty_batch` (nullability-only change, zero rows)
- `cargo test -p deltalake-core --features datafusion --lib` — **1018 passed, 0 failed, 2 ignored**.
- `cargo fmt --check` and `cargo clippy -p deltalake-core --features datafusion --tests` are clean (no new warnings).

# Related Issue(s)

- closes #3688

# Documentation

- Delta protocol — schema / `metaData` and column nullability: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#change-metadata

---

> [!NOTE]
> **AI assistance disclaimer:** This change was implemented with the help of an AI coding assistant (GitHub Copilot CLI). All changes were made under human oversight and review: the root-cause analysis, design, and scope decisions were reviewed by a human before submission, the failing scenario was reproduced first, and the full test suite, formatting, and lints were run and verified to pass. Feedback is welcome and will be addressed with the same human-in-the-loop process.