### PR TITLE
fix: preserve full optimize partition identity

### DIFF
--- a/crates/core/src/kernel/snapshot/iterators.rs
+++ b/crates/core/src/kernel/snapshot/iterators.rs
@@ -12,6 +12,8 @@ use delta_kernel::engine::arrow_expression::evaluate_expression::to_json;
 use delta_kernel::expressions::{Scalar, StructData};
 use delta_kernel::scan::scan_row_schema;
 use delta_kernel::schema::DataType;
+#[cfg(any(test, feature = "datafusion"))]
+use indexmap::IndexMap;
 use object_store::ObjectMeta;
 use object_store::path::Path;
 use percent_encoding::percent_decode_str;
@@ -19,6 +21,8 @@ use percent_encoding::percent_decode_str;
 #[cfg(feature = "datafusion")]
 pub(crate) use self::scan_row::parse_stats_column_with_schema;
 pub use self::tombstones::TombstoneView;
+#[cfg(any(test, feature = "datafusion"))]
+use crate::kernel::StructType;
 use crate::kernel::scalars::ScalarExt;
 use crate::kernel::{Add, DeletionVectorDescriptor, Remove};
 use crate::{DeltaResult, DeltaTableError};
@@ -219,6 +223,20 @@ impl LogicalFileView {
             .unwrap_or_default()
     }
 
+    /// Builds the complete typed partition tuple in table metadata order.
+    #[cfg(feature = "datafusion")]
+    pub(crate) fn full_partition_values(
+        &self,
+        partition_columns: &[String],
+        table_schema: &StructType,
+    ) -> DeltaResult<IndexMap<String, Scalar>> {
+        typed_partition_values_from_raw_map(
+            &self.partition_values_map(),
+            partition_columns,
+            table_schema,
+        )
+    }
+
     /// Returns the parsed statistics as a StructArray, if available.
     fn stats_parsed(&self) -> Option<&StructArray> {
         self.files
@@ -339,6 +357,43 @@ impl LogicalFileView {
             default_row_commit_version: None,
         }
     }
+}
+
+#[cfg(any(test, feature = "datafusion"))]
+fn typed_partition_values_from_raw_map(
+    raw_partition_values: &HashMap<String, Option<String>>,
+    partition_columns: &[String],
+    table_schema: &StructType,
+) -> DeltaResult<IndexMap<String, Scalar>> {
+    let mut partition_values = IndexMap::with_capacity(partition_columns.len());
+
+    for column in partition_columns {
+        let field = table_schema
+            .field(column)
+            .ok_or_else(|| DeltaTableError::SchemaMismatch {
+                msg: format!("Partition column '{column}' is not present in table schema"),
+            })?;
+        let primitive_type = field.data_type().as_primitive_opt().ok_or_else(|| {
+            DeltaTableError::SchemaMismatch {
+                msg: format!("Partition column '{column}' is not a primitive type"),
+            }
+        })?;
+        let scalar = match raw_partition_values.get(column) {
+            Some(Some(raw)) => primitive_type.parse_scalar(raw.as_str())?,
+            Some(None) => Scalar::Null(field.data_type().clone()),
+            None => {
+                return Err(DeltaTableError::SchemaMismatch {
+                    msg: format!(
+                        "Add action for optimized file is missing partition value for '{column}'"
+                    ),
+                });
+            }
+        };
+
+        partition_values.insert(column.clone(), scalar);
+    }
+
+    Ok(partition_values)
 }
 
 /// Rounds up timestamp values to handle microsecond truncation in checkpoint statistics.
@@ -616,6 +671,102 @@ mod tests {
         ]);
 
         logical_file_view_with_stats(None, full_stats)
+    }
+
+    fn partition_identity_schema() -> StructType {
+        StructType::try_new([
+            crate::kernel::StructField::nullable("part_b", DataType::STRING),
+            crate::kernel::StructField::nullable("part_a", DataType::LONG),
+            crate::kernel::StructField::nullable("part_c", DataType::STRING),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn typed_partition_values_from_raw_map_preserves_metadata_order_and_parses_values() {
+        let raw_partition_values = HashMap::from([
+            ("part_a".to_string(), Some("42".to_string())),
+            ("part_b".to_string(), Some("x".to_string())),
+        ]);
+        let partition_columns = vec!["part_b".to_string(), "part_a".to_string()];
+
+        let partition_values = typed_partition_values_from_raw_map(
+            &raw_partition_values,
+            &partition_columns,
+            &partition_identity_schema(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            partition_values.keys().cloned().collect::<Vec<_>>(),
+            partition_columns
+        );
+        assert_eq!(
+            partition_values.get("part_b"),
+            Some(&Scalar::String("x".to_string()))
+        );
+        assert_eq!(partition_values.get("part_a"), Some(&Scalar::Long(42)));
+    }
+
+    #[test]
+    fn typed_partition_values_from_raw_map_preserves_typed_nulls() {
+        let raw_partition_values = HashMap::from([
+            ("part_b".to_string(), Some("x".to_string())),
+            ("part_a".to_string(), None),
+        ]);
+        let partition_columns = vec!["part_b".to_string(), "part_a".to_string()];
+
+        let partition_values = typed_partition_values_from_raw_map(
+            &raw_partition_values,
+            &partition_columns,
+            &partition_identity_schema(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            partition_values.get("part_a"),
+            Some(&Scalar::Null(DataType::LONG))
+        );
+    }
+
+    #[test]
+    fn typed_partition_values_from_raw_map_errors_on_missing_partition_column() {
+        let raw_partition_values = HashMap::from([("part_b".to_string(), Some("x".to_string()))]);
+        let partition_columns = vec!["part_b".to_string(), "part_a".to_string()];
+
+        let error = typed_partition_values_from_raw_map(
+            &raw_partition_values,
+            &partition_columns,
+            &partition_identity_schema(),
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing partition value for 'part_a'"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn typed_partition_values_from_raw_map_ignores_extra_raw_partition_keys() {
+        let raw_partition_values = HashMap::from([
+            ("part_a".to_string(), Some("42".to_string())),
+            ("part_b".to_string(), Some("x".to_string())),
+            ("part_c".to_string(), Some("extra".to_string())),
+        ]);
+        let partition_columns = vec!["part_b".to_string(), "part_a".to_string()];
+
+        let partition_values = typed_partition_values_from_raw_map(
+            &raw_partition_values,
+            &partition_columns,
+            &partition_identity_schema(),
+        )
+        .unwrap();
+
+        assert_eq!(partition_values.len(), 2);
+        assert!(!partition_values.contains_key("part_c"));
     }
 
     #[tokio::test]

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -1204,6 +1204,8 @@ async fn build_compaction_plan(
     let mut metrics = Metrics::default();
     let mut planner_stats = PlannerStats::preserve_locality();
     let mut partition_files: HashMap<String, PartitionFileEntry> = HashMap::new();
+    let partition_columns = snapshot.metadata().partition_columns();
+    let table_schema = snapshot.schema();
 
     let predicate = if filters.is_empty() {
         None
@@ -1221,16 +1223,8 @@ async fn build_compaction_plan(
         let file = file?;
         metrics.total_considered_files += 1;
         let object_meta = ObjectMeta::try_from(&file)?;
-        let partition_values = file
-            .partition_values()
-            .map(|v| {
-                v.fields()
-                    .iter()
-                    .zip(v.values().iter())
-                    .map(|(k, v)| (k.name().to_string(), v.clone()))
-                    .collect::<IndexMap<_, _>>()
-            })
-            .unwrap_or_default();
+        let partition_values =
+            file.full_partition_values(partition_columns, table_schema.as_ref())?;
         let partition_path = partition_values.hive_partition_path();
         let entry = partition_files
             .entry(partition_path)
@@ -1342,6 +1336,7 @@ async fn build_zorder_plan(
     let mut metrics = Metrics::default();
 
     let mut partition_files: HashMap<String, (IndexMap<String, Scalar>, MergeBin)> = HashMap::new();
+    let table_schema = snapshot.schema();
 
     let predicate = if filters.is_empty() {
         None
@@ -1355,16 +1350,7 @@ async fn build_zorder_plan(
     let mut file_stream = snapshot.file_views(log_store, predicate);
     while let Some(file) = file_stream.next().await {
         let file = file?;
-        let partition_values = file
-            .partition_values()
-            .map(|v| {
-                v.fields()
-                    .iter()
-                    .zip(v.values().iter())
-                    .map(|(k, v)| (k.name().to_string(), v.clone()))
-                    .collect::<IndexMap<_, _>>()
-            })
-            .unwrap_or_default();
+        let partition_values = file.full_partition_values(partition_keys, table_schema.as_ref())?;
         metrics.total_considered_files += 1;
         partition_files
             .entry(partition_values.hive_partition_path())
@@ -1373,6 +1359,7 @@ async fn build_zorder_plan(
             .add(file.to_add());
         debug!("partition_files inside the zorder plan: {partition_files:?}");
     }
+    metrics.partitions_optimized = partition_files.len() as u64;
 
     let max_bin_span_files = partition_files
         .values()

--- a/crates/core/tests/it_datafusion/command_optimize.rs
+++ b/crates/core/tests/it_datafusion/command_optimize.rs
@@ -1,11 +1,12 @@
 use std::num::NonZeroU64;
 use std::time::Duration;
 use std::{
+    collections::BTreeSet,
     error::Error,
     sync::{Arc, Mutex},
 };
 
-use arrow_array::{Int32Array, RecordBatch, StringArray};
+use arrow_array::{Int32Array, Int64Array, RecordBatch, StringArray};
 use arrow_schema::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
 use arrow_select::concat::concat_batches;
 use bytes::Bytes;
@@ -24,7 +25,9 @@ use deltalake_core::operations::optimize::{
 use deltalake_core::protocol::DeltaOperation;
 use deltalake_core::test_utils::TestTables;
 use deltalake_core::writer::{DeltaWriter, RecordBatchWriter};
-use deltalake_core::{DeltaTable, PartitionFilter, Path, open_table};
+use deltalake_core::{
+    DeltaTable, NULL_PARTITION_VALUE_DATA_PATH, PartitionFilter, Path, open_table,
+};
 use futures::TryStreamExt;
 use object_store::ObjectStoreExt as _;
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
@@ -197,6 +200,30 @@ fn ordered_range_batch(
     )?)
 }
 
+fn multi_partition_batch(
+    part_a: Option<i64>,
+    part_b: &str,
+    start: i64,
+    rows: usize,
+) -> Result<RecordBatch, Box<dyn Error>> {
+    let values = (start..start + rows as i64).collect::<Vec<_>>();
+    let part_a_values = vec![part_a; rows];
+    let part_b_values = vec![part_b.to_string(); rows];
+
+    Ok(RecordBatch::try_new(
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("part_a", ArrowDataType::Int64, true),
+            Field::new("part_b", ArrowDataType::Utf8, true),
+            Field::new("val", ArrowDataType::Int64, false),
+        ])),
+        vec![
+            Arc::new(Int64Array::from(part_a_values)),
+            Arc::new(StringArray::from(part_b_values)),
+            Arc::new(Int64Array::from(values)),
+        ],
+    )?)
+}
+
 fn single_int_batch(values: Vec<i32>) -> Result<RecordBatch, Box<dyn Error>> {
     Ok(RecordBatch::try_new(
         Arc::new(ArrowSchema::new(vec![Field::new(
@@ -249,6 +276,113 @@ async fn latest_commit_actions(table: &DeltaTable) -> Result<Vec<Action>, Box<dy
             std::io::Error::other(format!("missing commit entry for version {version}"))
         })?;
     Ok(get_actions(version, &commit_bytes)?)
+}
+
+async fn setup_multi_partition_optimize_table() -> Result<Context, Box<dyn Error>> {
+    let columns = vec![
+        StructField::new(
+            "part_a".to_owned(),
+            DataType::Primitive(PrimitiveType::Long),
+            true,
+        ),
+        StructField::new(
+            "part_b".to_owned(),
+            DataType::Primitive(PrimitiveType::String),
+            true,
+        ),
+        StructField::new(
+            "val".to_owned(),
+            DataType::Primitive(PrimitiveType::Long),
+            false,
+        ),
+    ];
+    let partition_columns = vec!["part_a".to_owned(), "part_b".to_owned()];
+
+    let tmp_dir = tempfile::tempdir()?;
+    let table_uri = tmp_dir.path().to_str().to_owned().unwrap();
+    let mut table = DeltaTable::try_from_url(
+        url::Url::from_directory_path(std::path::Path::new(table_uri)).unwrap(),
+    )
+    .await?
+    .create()
+    .with_columns(columns)
+    .with_partition_columns(partition_columns)
+    .await?;
+
+    let mut writer = RecordBatchWriter::for_table(&table)?;
+    for (part_a, writes, start_base) in [
+        (Some(1), 4, 1_000),
+        (Some(2), 3, 2_000),
+        (Some(3), 3, 3_000),
+        (None, 3, 4_000),
+    ] {
+        for write_idx in 0..writes {
+            write(
+                &mut writer,
+                &mut table,
+                multi_partition_batch(part_a, "x", start_base + write_idx * 10, 3)?,
+            )
+            .await?;
+        }
+    }
+
+    Ok(Context { tmp_dir, table })
+}
+
+async fn assert_latest_optimize_adds_preserve_full_partitions(
+    table: &DeltaTable,
+) -> Result<(), Box<dyn Error>> {
+    let actions = latest_commit_actions(table).await?;
+    let adds = actions
+        .iter()
+        .filter_map(|action| match action {
+            Action::Add(add) => Some(add),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(adds.len(), 4, "{adds:?}");
+
+    let mut actual_partitions = BTreeSet::new();
+    for add in adds {
+        assert!(
+            !add.path.starts_with("part_b=x/"),
+            "path was flattened to a partial partition: {}",
+            add.path
+        );
+        assert_eq!(add.partition_values.len(), 2, "{:?}", add.partition_values);
+        let part_a = add
+            .partition_values
+            .get("part_a")
+            .ok_or_else(|| std::io::Error::other(format!("missing part_a in {add:?}")))?;
+        let part_b = add
+            .partition_values
+            .get("part_b")
+            .and_then(|value| value.as_deref())
+            .ok_or_else(|| std::io::Error::other(format!("missing part_b in {add:?}")))?;
+
+        assert_eq!(part_b, "x");
+        let part_a_path_value = part_a.as_deref().unwrap_or(NULL_PARTITION_VALUE_DATA_PATH);
+        let expected_prefix = format!("part_a={part_a_path_value}/part_b=x/");
+        assert!(
+            add.path.starts_with(&expected_prefix),
+            "path {} did not start with {expected_prefix}",
+            add.path
+        );
+        actual_partitions.insert((part_a.clone(), part_b.to_owned()));
+    }
+
+    let expected_partitions = [
+        (Some("1".to_string()), "x".to_string()),
+        (Some("2".to_string()), "x".to_string()),
+        (Some("3".to_string()), "x".to_string()),
+        (None, "x".to_string()),
+    ]
+    .into_iter()
+    .collect::<BTreeSet<_>>();
+    assert_eq!(actual_partitions, expected_partitions);
+
+    Ok(())
 }
 
 struct DvSmallAppendedTable {
@@ -596,6 +730,48 @@ async fn write(
     writer.write(batch).await?;
     writer.flush_and_commit(table).await?;
     table.update_state().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_compact_subset_partition_filter_preserves_full_partition_values()
+-> Result<(), Box<dyn Error>> {
+    let context = setup_multi_partition_optimize_table().await?;
+    let filter = vec![PartitionFilter::try_from(("part_b", "=", "x"))?];
+
+    let (updated, metrics) = context
+        .table
+        .optimize()
+        .with_filters(&filter)
+        .with_target_size(NonZeroU64::new(1_000_000).unwrap())
+        .await?;
+
+    assert_eq!(metrics.num_files_added, 4);
+    assert_eq!(metrics.num_files_removed, 13);
+    assert_eq!(metrics.partitions_optimized, 4);
+    assert_latest_optimize_adds_preserve_full_partitions(&updated).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_zorder_subset_partition_filter_preserves_full_partition_values()
+-> Result<(), Box<dyn Error>> {
+    let context = setup_multi_partition_optimize_table().await?;
+    let filter = vec![PartitionFilter::try_from(("part_b", "=", "x"))?];
+
+    let (updated, metrics) = context
+        .table
+        .optimize()
+        .with_type(OptimizeType::ZOrder(vec!["val".to_string()]))
+        .with_filters(&filter)
+        .await?;
+
+    assert_eq!(metrics.num_files_added, 4);
+    assert_eq!(metrics.num_files_removed, 13);
+    assert_eq!(metrics.partitions_optimized, 4);
+    assert_latest_optimize_adds_preserve_full_partitions(&updated).await?;
+
     Ok(())
 }
 

--- a/python/tests/test_optimize.py
+++ b/python/tests/test_optimize.py
@@ -1,5 +1,6 @@
 import pathlib
 from datetime import timedelta
+from urllib.parse import urlparse
 
 import pytest
 from arro3.core import Array, DataType, Table
@@ -17,6 +18,65 @@ def ordered_range_table(start: int, rows: int) -> Table:
             "y": Array([value * 10 for value in values], type=DataType.int32()),
         }
     )
+
+
+def multi_partition_table(part_a: int | None, start: int = 0, rows: int = 5) -> Table:
+    values = list(range(start, start + rows))
+    return Table(
+        {
+            "part_a": Array(
+                [part_a] * rows,
+                ArrowField("part_a", type=DataType.int64(), nullable=True),
+            ),
+            "part_b": Array(
+                ["x"] * rows,
+                ArrowField("part_b", type=DataType.utf8(), nullable=True),
+            ),
+            "val": Array(values, type=DataType.int64()),
+        }
+    )
+
+
+def relative_file_dir(table_path: pathlib.Path, uri: str) -> str:
+    parsed = urlparse(uri)
+    path = pathlib.Path(parsed.path if parsed.scheme == "file" else uri)
+    return path.relative_to(table_path).parent.as_posix()
+
+
+def write_multi_partition_table(table_path: pathlib.Path):
+    write_deltalake(
+        table_path,
+        multi_partition_table(1),
+        partition_by=["part_a", "part_b"],
+        mode="overwrite",
+    )
+    for part_a, start_base in ((1, 1_000), (2, 2_000), (3, 3_000), (None, 4_000)):
+        for batch_idx in range(3):
+            write_deltalake(
+                table_path,
+                multi_partition_table(part_a, start=start_base + batch_idx * 100),
+                partition_by=["part_a", "part_b"],
+                mode="append",
+            )
+
+
+def assert_subset_filter_preserves_full_partitions(table_path: pathlib.Path):
+    refreshed = DeltaTable(table_path)
+    relative_dirs = {
+        relative_file_dir(table_path, uri) for uri in refreshed.file_uris()
+    }
+    assert relative_dirs == {
+        "part_a=1/part_b=x",
+        "part_a=2/part_b=x",
+        "part_a=3/part_b=x",
+        "part_a=__HIVE_DEFAULT_PARTITION__/part_b=x",
+    }
+
+    adds = refreshed.get_add_actions(flatten=True)
+    assert "partition.part_a" in adds.column_names
+    assert "partition.part_b" in adds.column_names
+    assert set(adds["partition.part_a"].to_pylist()) == {1, 2, 3, None}
+    assert set(adds["partition.part_b"].to_pylist()) == {"x"}
 
 
 def x_file_ranges(dt: DeltaTable) -> list[tuple[int, int, int]]:
@@ -172,6 +232,34 @@ def test_zorder_metrics_do_not_claim_preserve_insertion_order(
     assert metrics["preserveInsertionOrder"] is False
     assert metrics["maxBinSpanFiles"] == 2
     assert "maxInputDisplacement" not in metrics
+
+
+def test_compact_subset_partition_filter_preserves_full_partition_values(
+    tmp_path: pathlib.Path,
+):
+    write_multi_partition_table(tmp_path)
+
+    dt = DeltaTable(tmp_path)
+    metrics = dt.optimize.compact(partition_filters=[("part_b", "=", "x")])
+
+    assert metrics["numFilesAdded"] == 4
+    assert metrics["numFilesRemoved"] == 13
+    assert metrics["partitionsOptimized"] == 4
+    assert_subset_filter_preserves_full_partitions(tmp_path)
+
+
+def test_zorder_subset_partition_filter_preserves_full_partition_values(
+    tmp_path: pathlib.Path,
+):
+    write_multi_partition_table(tmp_path)
+
+    dt = DeltaTable(tmp_path)
+    metrics = dt.optimize.z_order(["val"], partition_filters=[("part_b", "=", "x")])
+
+    assert metrics["numFilesAdded"] == 4
+    assert metrics["numFilesRemoved"] == 13
+    assert metrics["partitionsOptimized"] == 4
+    assert_subset_filter_preserves_full_partitions(tmp_path)
 
 
 def test_compact_rejects_target_size_larger_than_i64_max(


### PR DESCRIPTION
This fixes optimized output for filters that reference a subset of partition columns. Rewritten Add actions keep the full partition map, and hive paths include null partitions as `__HIVE_DEFAULT_PARTITION__`.

Optimize now builds rewrite partition identity from raw `Add.partitionValues` in table metadata order. Compact and Z order still use `partition_filters` only to select files.

closes #4528

