### PR TITLE
feat(core): expose `LogicalFileView::partition_values_map` as public API

### DIFF
--- a/crates/core/src/kernel/snapshot/iterators.rs
+++ b/crates/core/src/kernel/snapshot/iterators.rs
@@ -216,7 +216,7 @@ impl LogicalFileView {
     ///
     /// This preserves all partition columns even when `partitionValues_parsed` was narrowed to the
     /// predicate-referenced subset for data skipping.
-    fn partition_values_map(&self) -> HashMap<String, Option<String>> {
+    pub fn partition_values_map(&self) -> HashMap<String, Option<String>> {
         self.raw_partition_values()
             .filter(|partitions| partitions.is_valid(self.index))
             .and_then(|partitions| collect_string_map(&partitions.value(self.index)))

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -2602,6 +2602,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_partition_values_map_preserves_all_columns_under_narrowing_predicate()
+    -> TestResult {
+        use std::collections::BTreeSet;
+
+        // A predicate that references only a subset of the partition columns (year + month, but
+        // not day) makes the scan narrow `partition_values()` to the referenced columns for data
+        // skipping. `partition_values_map()` must still return every partition column so connectors
+        // can reconstruct the full partition identity of each file.
+        let base = TestTables::Delta0_8_0Partitioned
+            .table_builder()?
+            .build_storage()?;
+        let snapshot = Snapshot::try_new(base.as_ref(), Default::default(), None).await?;
+
+        let predicate = Arc::new(to_kernel_predicate(
+            &[
+                PartitionFilter::try_from(("year", "=", "2020"))?,
+                PartitionFilter::try_from(("month", "=", "2"))?,
+            ],
+            snapshot.schema().as_ref(),
+        )?);
+
+        let views: Vec<_> = snapshot
+            .file_views(base.as_ref(), Some(predicate))
+            .try_collect()
+            .await?;
+        assert_eq!(views.len(), 2, "predicate should match exactly two files");
+
+        for view in &views {
+            // The parsed accessor is narrowed to the predicate-referenced columns: `day` is dropped.
+            let narrowed: BTreeSet<String> = view
+                .partition_values()
+                .map(|values| {
+                    values
+                        .fields()
+                        .iter()
+                        .map(|f| f.name().to_string())
+                        .collect()
+                })
+                .unwrap_or_default();
+            assert!(
+                !narrowed.contains("day"),
+                "expected `day` to be narrowed out of partition_values(), got {narrowed:?}",
+            );
+
+            // The raw map preserves every partition column regardless of the scan predicate.
+            let full: BTreeSet<String> = view.partition_values_map().into_keys().collect();
+            assert_eq!(
+                full,
+                BTreeSet::from(["year".to_string(), "month".to_string(), "day".to_string()]),
+                "partition_values_map() must return all partition columns regardless of predicate",
+            );
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_eager_file_views_reuses_materialized_files_with_data_predicate() -> TestResult {
         let (_table_dir, table) = selective_stats_table().await?;
         let (log_store, mut operations) = recording_log_store(table.log_store());


### PR DESCRIPTION
# Description

`LogicalFileView::partition_values()` returns only the partition columns referenced by the scan predicate - the selective-stats / data-skipping projection narrows `partitionValues_parsed` to the predicate's columns. Connectors that enumerate files via `Snapshot::file_views(predicate)` and also read each file's partition values therefore lose the unreferenced partition columns whenever the predicate touches a strict subset of them (e.g. a `year = 2020` filter on a table partitioned by `year/month/day` drops `month` and `day`). The same method returns different values for the same file depending on the scan predicate, and there is no public accessor for the complete set.

The complete map already exists internally as `LogicalFileView::partition_values_map()`, which reads the raw `partitionValues` and is not narrowed by the predicate; it is simply private. This change makes it `pub`.

This is the read-path analogue of the optimize/write-path fix in #4556: that PR reconstructs the full partition identity from the raw `Add.partitionValues` map, but `partition_values()` on the read path remains narrowed, leaving external `file_views` consumers without a complete-partition accessor. The remaining alternatives are all unsatisfactory - `add_action().partition_values` is `#[deprecated(since = "0.31.0")]` (and builds a full `Add`, including stats, per file), `remove_action(false).partition_values` is semantically wrong for a read, and `full_partition_values()` is `pub(crate)` and gated behind the `datafusion` feature, so it is unreachable for connectors built with `default-features = false`.

# Related Issue(s)
- closes #4563
- Related: #4528 / #4556 (same root cause on the optimize/write path)

# Documentation
No new documentation. The existing rustdoc on `partition_values_map()` already documents that it preserves all partition columns even when `partitionValues_parsed` is narrowed for data skipping.

