### PR TITLE
refactor: reduce internal EagerSnapshot usage

### DIFF
--- a/crates/core/src/delta_datafusion/bench_support.rs
+++ b/crates/core/src/delta_datafusion/bench_support.rs
@@ -59,7 +59,7 @@ pub async fn find_files(
     predicate: Option<Expr>,
 ) -> DeltaResult<FindFilesResult> {
     prepare_session(session, &log_store)?;
-    super::find_files(snapshot, log_store, session, predicate)
+    super::find_files(snapshot.snapshot(), log_store, session, predicate)
         .await
         .map(Into::into)
 }
@@ -71,7 +71,7 @@ pub async fn find_files_scan(
     predicate: Expr,
 ) -> DeltaResult<Vec<Add>> {
     prepare_session(session, &log_store)?;
-    super::find_files_scan(snapshot, log_store, session, predicate).await
+    super::find_files_scan(snapshot.snapshot(), log_store, session, predicate).await
 }
 
 pub async fn scan_files_where_matches(
@@ -81,11 +81,11 @@ pub async fn scan_files_where_matches(
     predicate: Expr,
 ) -> DataFusionResult<Option<MatchedFilesScan>> {
     prepare_session(session, &log_store)?;
-    super::scan_files_where_matches(session, snapshot, log_store, predicate)
+    super::scan_files_where_matches(session, snapshot.snapshot(), log_store, predicate)
         .await
         .map(|scan| scan.map(MatchedFilesScan))
 }
 
 pub fn add_actions_partition_mem_table(snapshot: &EagerSnapshot) -> DeltaResult<Option<MemTable>> {
-    super::add_actions_partition_mem_table(snapshot)
+    super::add_actions_partition_mem_table(snapshot.snapshot())
 }

--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -30,7 +30,7 @@ use crate::delta_datafusion::{
     normalize_path_as_file_id, resolve_file_column_name,
 };
 use crate::errors::{DeltaResult, DeltaTableError};
-use crate::kernel::{ActiveAddOptions, Add, AddStatsPolicy, EagerSnapshot, LogicalFileView};
+use crate::kernel::{ActiveAddOptions, Add, AddStatsPolicy, LogicalFileView, Snapshot};
 use crate::logstore::{LogStore, LogStoreRef};
 
 #[derive(Debug, Hash, Eq, PartialEq)]
@@ -53,7 +53,7 @@ pub(crate) struct FindFiles {
     )
 )]
 pub(crate) async fn find_files(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: LogStoreRef,
     session: &dyn Session,
     predicate: Option<Expr>,
@@ -91,7 +91,7 @@ pub(crate) async fn find_files(
         None => {
             let result = FindFiles {
                 candidates: snapshot
-                    .file_views(&log_store, None)
+                    .file_views(log_store.as_ref(), None)
                     .map_ok(|f| f.to_add())
                     .try_collect()
                     .await?,
@@ -289,7 +289,7 @@ struct MatchingFilesScanSeed {
 
 async fn collect_matching_files(
     session: &dyn Session,
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: Option<&LogStoreRef>,
     predicate: Expr,
     file_column_name: &str,
@@ -310,7 +310,7 @@ async fn collect_matching_files(
     let predicate = analysis.predicate();
 
     let mut builder = DeltaScanNext::builder()
-        .with_snapshot(snapshot.snapshot().clone())
+        .with_snapshot(snapshot.clone())
         .with_file_skipping_predicates(skipping_pred.clone())
         .with_file_column(file_column_name);
     if let Some(log_store) = log_store {
@@ -412,13 +412,13 @@ fn join_batches_with_add_actions(
     )
 )]
 pub(in crate::delta_datafusion) async fn find_files_scan(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: LogStoreRef,
     session: &dyn Session,
     expression: Expr,
 ) -> DeltaResult<Vec<Add>> {
     let file_column_name = resolve_file_column_name(snapshot.input_schema().as_ref(), None)?;
-    let table_root = snapshot.snapshot().inner.table_root().clone();
+    let table_root = snapshot.inner.table_root().clone();
     let mut candidate_map: HashMap<_, _> = snapshot
         .file_views(log_store.as_ref(), None)
         .try_fold(HashMap::new(), |mut candidate_map, view| {
@@ -472,13 +472,13 @@ pub(in crate::delta_datafusion) async fn find_files_scan(
     Ok(result)
 }
 
-/// Build a partition-metadata MemTable from snapshot add actions.
+/// Build a MemTable with partition metadata from snapshot add actions.
 ///
 /// Projects only the `path` column and `partition.*` columns for evaluating
-/// partition predicates without materializing full add-action metadata.
+/// partition predicates without materializing full add action metadata.
 /// Returns `None` when the snapshot contains no add actions.
 pub(crate) fn add_actions_partition_mem_table(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
 ) -> DeltaResult<Option<MemTable>> {
     add_actions_partition_mem_table_from_batches(snapshot.add_actions_partition_batches()?)
 }
@@ -540,7 +540,7 @@ fn add_actions_partition_mem_table_from_batches(
 }
 
 async fn scan_memory_table(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: &dyn LogStore,
     predicate: &Expr,
 ) -> DeltaResult<Vec<Add>> {
@@ -548,10 +548,7 @@ async fn scan_memory_table(
         predicate: None,
         stats: AddStatsPolicy::None,
     };
-    let add_action_batches = snapshot
-        .snapshot()
-        .active_add_batches(log_store, options)
-        .await?;
+    let add_action_batches = snapshot.active_add_batches(log_store, options).await?;
     let actions: Vec<Add> = add_action_batches
         .iter()
         .flat_map(|batch| {
@@ -559,9 +556,7 @@ async fn scan_memory_table(
         })
         .collect_vec();
 
-    let partition_batches = snapshot
-        .snapshot()
-        .active_add_partition_batches_from(&add_action_batches)?;
+    let partition_batches = snapshot.active_add_partition_batches_from(&add_action_batches)?;
     let Some(mem_table) = add_actions_partition_mem_table_from_batches(partition_batches)? else {
         return Ok(vec![]);
     };
@@ -615,22 +610,19 @@ impl MatchedFilesScan {
 /// Create a table scan plan for reading all data from
 /// all files which contain any data matching a predicate.
 ///
-/// This is useful for DML where we need to re-write files by
-/// updating/removing some records so we require all records
-/// but only from matching files.
+/// This supports DML that updates or removes records and needs all rows from
+/// files that contain matches.
 ///
 /// ## Returns
 ///
 /// If no files contain matching data, `None` is returned.
 ///
-/// Otherwise:
-/// - The logical plan for reading data from matched files only.
-/// - The set of matched file URLs.
-/// - The potentially simplified predicate applied when matching data.
-/// - A kernel predicate (best effort) which can be used to filter log replays.
+/// Otherwise returns the logical plan for reading matched files, the matched
+/// file URLs, the predicate applied while matching data, and a best effort
+/// kernel predicate for filtering log replays.
 pub(crate) async fn scan_files_where_matches(
     session: &dyn Session,
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: LogStoreRef,
     predicate: Expr,
 ) -> Result<Option<MatchedFilesScan>> {
@@ -661,7 +653,7 @@ pub(crate) async fn scan_files_where_matches(
     )
     .with_missing_file_policy(MissingSelectedFilePolicy::Ignore);
     let selected_provider = DeltaScanNext::builder()
-        .with_snapshot(snapshot.snapshot().clone())
+        .with_snapshot(snapshot.clone())
         .with_file_skipping_predicates(file_skipping_predicates)
         .with_file_column(FILE_ID_COLUMN_DEFAULT)
         .with_log_store(log_store)
@@ -696,6 +688,7 @@ mod tests {
         delta_datafusion::{
             DataFusionMixins as _, DeltaSessionExt as _, create_session, resolve_file_column_name,
         },
+        kernel::EagerSnapshot,
         protocol::SaveMode,
         test_utils::{
             TestResult, multibatch_add_actions_for_partition,
@@ -752,7 +745,7 @@ mod tests {
         let log_store = table.log_store();
         let predicate = col("id").gt(lit(-1i64));
         let Some(scan) =
-            scan_files_where_matches(&session, &snapshot, log_store, predicate).await?
+            scan_files_where_matches(&session, snapshot.snapshot(), log_store, predicate).await?
         else {
             panic!("Expected at least one matching file");
         };
@@ -774,7 +767,7 @@ mod tests {
         let log_store = table.log_store();
         let predicate = col("id").gt(lit(-1i64));
         let Some(scan) =
-            scan_files_where_matches(&session, &snapshot, log_store, predicate).await?
+            scan_files_where_matches(&session, snapshot.snapshot(), log_store, predicate).await?
         else {
             panic!("Expected at least one matching file");
         };
@@ -803,7 +796,7 @@ mod tests {
         let file_column_name = resolve_file_column_name(snapshot.input_schema().as_ref(), None)?;
 
         let by_id = find_files_scan(
-            &snapshot,
+            snapshot.snapshot(),
             log_store.clone(),
             &session,
             col("id").eq(lit(7i64)),
@@ -820,7 +813,7 @@ mod tests {
         let matched_paths = by_id.iter().map(|add| add.path.as_str()).collect_vec();
 
         let matches = find_files_scan(
-            &snapshot,
+            snapshot.snapshot(),
             log_store.clone(),
             &session,
             col("id")
@@ -845,7 +838,7 @@ mod tests {
             "find_files test path",
         )?;
         let no_matches = find_files_scan(
-            &snapshot,
+            snapshot.snapshot(),
             log_store,
             &session,
             col("id")
@@ -874,8 +867,13 @@ mod tests {
         let ctx = create_session().into_inner();
         let session = ctx.state();
 
-        let matches =
-            find_files_scan(&snapshot, log_store, &session, col("id").eq(lit(7i64))).await?;
+        let matches = find_files_scan(
+            snapshot.snapshot(),
+            log_store,
+            &session,
+            col("id").eq(lit(7i64)),
+        )
+        .await?;
 
         assert_eq!(matches.len(), 1);
         assert!(matches[0].path.ends_with(".parquet"));
@@ -915,8 +913,13 @@ mod tests {
         let snapshot = table.snapshot()?.snapshot().clone();
         let log_store = table.log_store();
 
-        let matches =
-            find_files_scan(&snapshot, log_store, &session, col("price").eq(lit(10i64))).await?;
+        let matches = find_files_scan(
+            snapshot.snapshot(),
+            log_store,
+            &session,
+            col("price").eq(lit(10i64)),
+        )
+        .await?;
 
         assert_eq!(matches.len(), 1);
         assert_eq!(
@@ -995,7 +998,7 @@ mod tests {
         assert_eq!(file_column_name, format!("{PATH_COLUMN}_2"));
 
         let matches = find_files_scan(
-            &snapshot,
+            snapshot.snapshot(),
             log_store,
             &session,
             col("id")
@@ -1029,9 +1032,13 @@ mod tests {
         let ctx = create_session().into_inner();
         let session = ctx.state();
 
-        let Some(scan) =
-            scan_files_where_matches(&session, &snapshot, log_store, col("id").eq(lit(7i64)))
-                .await?
+        let Some(scan) = scan_files_where_matches(
+            &session,
+            snapshot.snapshot(),
+            log_store,
+            col("id").eq(lit(7i64)),
+        )
+        .await?
         else {
             panic!("Expected at least one matching file");
         };
@@ -1067,7 +1074,7 @@ mod tests {
             .await?;
         let predicate = col("modified").eq(lit("2021-02-02"));
         let matches = scan_memory_table(
-            table.snapshot()?.snapshot(),
+            table.snapshot()?.snapshot().snapshot(),
             table.log_store().as_ref(),
             &predicate,
         )
@@ -1091,7 +1098,8 @@ mod tests {
         let snapshot = table.snapshot()?.snapshot();
         let total_actions = snapshot.log_data().iter().count();
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let matches = scan_memory_table(snapshot, table.log_store().as_ref(), &predicate).await?;
+        let matches =
+            scan_memory_table(snapshot.snapshot(), table.log_store().as_ref(), &predicate).await?;
 
         assert!(!matches.is_empty());
         assert!(matches.len() < total_actions);
@@ -1119,7 +1127,8 @@ mod tests {
         assert!(!snapshot.snapshot().has_materialized_files_for_test());
 
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let matches = scan_memory_table(&snapshot, log_store.as_ref(), &predicate).await?;
+        let matches =
+            scan_memory_table(snapshot.snapshot(), log_store.as_ref(), &predicate).await?;
 
         assert!(!matches.is_empty());
         assert!(!snapshot.snapshot().has_materialized_files_for_test());
@@ -1162,7 +1171,8 @@ mod tests {
             .count();
 
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let matches = scan_memory_table(&snapshot, log_store.as_ref(), &predicate).await?;
+        let matches =
+            scan_memory_table(snapshot.snapshot(), log_store.as_ref(), &predicate).await?;
         let replay_reads = drain_recorded_ops(&mut operations)
             .await
             .into_iter()
@@ -1195,14 +1205,15 @@ mod tests {
             .await?;
 
         let snapshot = table.snapshot()?.snapshot();
-        let add_action_batches = snapshot.add_actions_partition_batches()?;
+        let add_action_batches = snapshot.snapshot().add_actions_partition_batches()?;
         assert!(
             add_action_batches.len() > 1,
             "expected multi-batch partition metadata fixture"
         );
 
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let matches = scan_memory_table(snapshot, table.log_store().as_ref(), &predicate).await?;
+        let matches =
+            scan_memory_table(snapshot.snapshot(), table.log_store().as_ref(), &predicate).await?;
 
         assert_eq!(matches.len(), expected_matches);
 

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -1382,7 +1382,7 @@ mod tests {
             .unwrap();
 
         let config = DeltaScanConfigBuilder::new()
-            .build(table.snapshot().unwrap().snapshot())
+            .build(table.snapshot().unwrap().snapshot().snapshot())
             .unwrap();
 
         let (log_store, mut operations) = recording_log_store(table.log_store());

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -1382,7 +1382,7 @@ mod tests {
             .unwrap();
 
         let config = DeltaScanConfigBuilder::new()
-            .build(table.snapshot().unwrap().snapshot().snapshot())
+            .build(table.snapshot().unwrap().snapshot())
             .unwrap();
 
         let (log_store, mut operations) = recording_log_store(table.log_store());

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -139,7 +139,7 @@ impl DeltaScanConfigBuilder {
     }
 
     /// Build a DeltaScanConfig and ensure no column name conflicts occur during downstream processing
-    pub fn build(&self, snapshot: &EagerSnapshot) -> DeltaResult<DeltaScanConfig> {
+    pub fn build(&self, snapshot: &Snapshot) -> DeltaResult<DeltaScanConfig> {
         let file_column_name = if self.include_file_column {
             Some(resolve_file_column_name(
                 snapshot.input_schema().as_ref(),
@@ -776,6 +776,19 @@ mod tests {
             err.to_string()
                 .contains("Unable to add file path column since column with name file_col exists")
         );
+    }
+
+    #[tokio::test]
+    async fn test_scan_config_builder_accepts_snapshot_without_eager_wrapper() {
+        let table = create_in_memory_id_table().await.unwrap();
+        let snapshot = table.snapshot().unwrap().snapshot().snapshot();
+
+        let config = DeltaScanConfigBuilder::new()
+            .with_file_column(true)
+            .build(snapshot)
+            .unwrap();
+
+        assert_eq!(config.file_column_name.as_deref(), Some(PATH_COLUMN));
     }
 
     #[tokio::test]

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -139,7 +139,11 @@ impl DeltaScanConfigBuilder {
     }
 
     /// Build a DeltaScanConfig and ensure no column name conflicts occur during downstream processing
-    pub fn build(&self, snapshot: &Snapshot) -> DeltaResult<DeltaScanConfig> {
+    pub fn build(&self, snapshot: &EagerSnapshot) -> DeltaResult<DeltaScanConfig> {
+        self.build_from_snapshot(snapshot.snapshot())
+    }
+
+    fn build_from_snapshot(&self, snapshot: &Snapshot) -> DeltaResult<DeltaScanConfig> {
         let file_column_name = if self.include_file_column {
             Some(resolve_file_column_name(
                 snapshot.input_schema().as_ref(),
@@ -779,9 +783,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_scan_config_builder_accepts_snapshot_without_eager_wrapper() {
+    async fn test_scan_config_builder_preserves_eager_snapshot_compatibility() {
         let table = create_in_memory_id_table().await.unwrap();
-        let snapshot = table.snapshot().unwrap().snapshot().snapshot();
+        let snapshot = table.snapshot().unwrap().snapshot();
 
         let config = DeltaScanConfigBuilder::new()
             .with_file_column(true)

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -295,7 +295,7 @@ impl TableProviderBuilder {
 
     /// Provide an eager snapshot to use for the table provider
     pub fn with_eager_snapshot(mut self, snapshot: impl Into<Arc<EagerSnapshot>>) -> Self {
-        self.snapshot = Some(SnapshotWrapper::EagerSnapshot(snapshot.into()));
+        self.snapshot = Some(SnapshotWrapper::from(snapshot.into()));
         self
     }
 

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -435,6 +435,7 @@ pub(crate) fn normalize_path_as_file_id(
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SnapshotWrapper {
     Snapshot(Arc<Snapshot>),
+    /// Compatibility for serialized scan payloads that still contain an eager snapshot.
     EagerSnapshot(Arc<EagerSnapshot>),
 }
 
@@ -452,13 +453,13 @@ impl From<Snapshot> for SnapshotWrapper {
 
 impl From<Arc<EagerSnapshot>> for SnapshotWrapper {
     fn from(esnap: Arc<EagerSnapshot>) -> Self {
-        SnapshotWrapper::EagerSnapshot(esnap)
+        SnapshotWrapper::Snapshot(esnap.snapshot().clone().into())
     }
 }
 
 impl From<EagerSnapshot> for SnapshotWrapper {
     fn from(esnap: EagerSnapshot) -> Self {
-        SnapshotWrapper::EagerSnapshot(esnap.into())
+        SnapshotWrapper::Snapshot(esnap.snapshot().clone().into())
     }
 }
 
@@ -1478,6 +1479,44 @@ mod tests {
             .unwrap_err();
         let err_str = err.to_string();
         assert!(err_str.contains("log_store"), "unexpected error: {err_str}");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_delta_scan_serde_accepts_legacy_eager_snapshot_wrapper() -> TestResult {
+        let log_store = TestTables::Simple.table_builder()?.build_storage()?;
+        let eager = EagerSnapshot::try_new(&log_store, Default::default(), None).await?;
+        let provider = DeltaScan::builder()
+            .with_snapshot(eager.snapshot().clone())
+            .build()
+            .await?;
+        let mut serialized = serde_json::to_value(&provider)?;
+
+        serialized
+            .as_object_mut()
+            .expect("serialized provider was not a JSON object")
+            .insert(
+                "snapshot".to_string(),
+                serde_json::json!({
+                    "EagerSnapshot": serde_json::to_value(&eager)?,
+                }),
+            );
+
+        let decoded: DeltaScan = serde_json::from_value(serialized)?;
+        let provider = decoded.with_log_store(log_store);
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+        let plan = provider.scan(&state, None, &[], None).await?;
+        let batches: Vec<_> = collect_partitioned(plan, session.task_ctx())
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
+        let expected = vec![
+            "+----+", "| id |", "+----+", "| 5  |", "| 7  |", "| 9  |", "+----+",
+        ];
+        assert_batches_sorted_eq!(&expected, &batches);
 
         Ok(())
     }
@@ -2738,6 +2777,51 @@ mod tests {
 
         let deletion_vectors = provider.deletion_vectors(&state).await?;
         assert_eq!(deletion_vectors, expected);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_builder_with_eager_snapshot_serializes_snapshot_wrapper_and_scans() -> TestResult
+    {
+        let log_store = TestTables::Simple.table_builder()?.build_storage()?;
+        let eager = EagerSnapshot::try_new(&log_store, Default::default(), None).await?;
+
+        let provider = DeltaScan::builder()
+            .with_log_store(log_store.clone())
+            .with_eager_snapshot(eager)
+            .build()
+            .await?;
+        let serialized = serde_json::to_value(&provider)?;
+        let snapshot_wrapper = serialized
+            .get("snapshot")
+            .and_then(|value| value.as_object())
+            .expect("serialized snapshot wrapper was not a JSON object");
+        let wrapper_keys = snapshot_wrapper.keys().collect::<Vec<_>>();
+        assert!(
+            snapshot_wrapper.contains_key("Snapshot"),
+            "new eager snapshot providers should serialize using the Snapshot wrapper; got keys {wrapper_keys:?}"
+        );
+        assert!(
+            !snapshot_wrapper.contains_key("EagerSnapshot"),
+            "new eager snapshot providers should not emit legacy EagerSnapshot wrappers; got keys {wrapper_keys:?}"
+        );
+
+        let decoded: DeltaScan = serde_json::from_value(serialized)?;
+        let provider = decoded.with_log_store(log_store);
+        let session = Arc::new(create_session().into_inner());
+        let state = session.state_ref().read().clone();
+        let plan = provider.scan(&state, None, &[], None).await?;
+        let batches: Vec<_> = collect_partitioned(plan, session.task_ctx())
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
+
+        let expected = vec![
+            "+----+", "| id |", "+----+", "| 5  |", "| 7  |", "| 9  |", "+----+",
+        ];
+        assert_batches_sorted_eq!(&expected, &batches);
 
         Ok(())
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -432,11 +432,29 @@ pub(crate) fn normalize_path_as_file_id(
     normalize_path_as_file_id_with_table_root(path, &table_root_url, context)
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 pub enum SnapshotWrapper {
     Snapshot(Arc<Snapshot>),
-    /// Compatibility for serialized scan payloads that still contain an eager snapshot.
-    EagerSnapshot(Arc<EagerSnapshot>),
+}
+
+impl<'de> Deserialize<'de> for SnapshotWrapper {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        enum SnapshotWrapperCompat {
+            Snapshot(Arc<Snapshot>),
+            EagerSnapshot(Arc<EagerSnapshot>),
+        }
+
+        Ok(match SnapshotWrapperCompat::deserialize(deserializer)? {
+            SnapshotWrapperCompat::Snapshot(snapshot) => SnapshotWrapper::Snapshot(snapshot),
+            SnapshotWrapperCompat::EagerSnapshot(snapshot) => {
+                SnapshotWrapper::Snapshot(snapshot.snapshot().clone().into())
+            }
+        })
+    }
 }
 
 impl From<Arc<Snapshot>> for SnapshotWrapper {
@@ -467,14 +485,12 @@ impl SnapshotWrapper {
     pub(crate) fn table_configuration(&self) -> &TableConfiguration {
         match self {
             SnapshotWrapper::Snapshot(snap) => snap.table_configuration(),
-            SnapshotWrapper::EagerSnapshot(esnap) => esnap.snapshot().table_configuration(),
         }
     }
 
     pub(crate) fn snapshot(&self) -> &Snapshot {
         match self {
             SnapshotWrapper::Snapshot(snap) => snap.as_ref(),
-            SnapshotWrapper::EagerSnapshot(esnap) => esnap.snapshot(),
         }
     }
 }
@@ -782,12 +798,11 @@ impl TableProvider for DeltaScan {
 
         super::update_datafusion_session(state, log_store.as_ref(), self.read_operation_id)?;
 
-        let snapshot = match &self.snapshot {
-            SnapshotWrapper::EagerSnapshot(esnap) => esnap.as_ref().clone(),
-            SnapshotWrapper::Snapshot(snap) => {
-                EagerSnapshot::try_new_with_snapshot(log_store.as_ref(), snap.clone()).await?
-            }
-        };
+        let snapshot = EagerSnapshot::try_new_with_snapshot(
+            log_store.as_ref(),
+            self.snapshot.snapshot().clone().into(),
+        )
+        .await?;
 
         let save_mode = match insert_op {
             InsertOp::Append => SaveMode::Append,

--- a/crates/core/src/kernel/transaction/protocol.rs
+++ b/crates/core/src/kernel/transaction/protocol.rs
@@ -7,7 +7,8 @@ use super::{TableReference, TransactionError};
 #[cfg(feature = "nanosecond-timestamps")]
 use crate::kernel::contains_timestamp_nanos;
 use crate::kernel::{
-    Action, Protocol, ProtocolExt as _, Schema, Snapshot, contains_timestampntz, contains_variant,
+    Action, EagerSnapshot, Protocol, ProtocolExt as _, Schema, Snapshot, contains_timestampntz,
+    contains_variant,
 };
 use crate::protocol::DeltaOperation;
 use crate::table::config::TablePropertiesExt as _;
@@ -89,8 +90,12 @@ impl ProtocolChecker {
         2
     }
 
-    /// Check append-only at the high level (operation level)
-    pub fn check_append_only(&self, snapshot: &Snapshot) -> Result<(), TransactionError> {
+    /// Check append only at the operation level.
+    pub fn check_append_only(&self, snapshot: &EagerSnapshot) -> Result<(), TransactionError> {
+        self.check_append_only_snapshot(snapshot.snapshot())
+    }
+
+    fn check_append_only_snapshot(&self, snapshot: &Snapshot) -> Result<(), TransactionError> {
         if snapshot.table_properties().append_only() {
             return Err(TransactionError::DeltaTableAppendOnly);
         }
@@ -122,6 +127,14 @@ impl ProtocolChecker {
     /// Check can write_timestamp_ntz
     pub fn check_can_write_timestamp_ntz(
         &self,
+        snapshot: &EagerSnapshot,
+        schema: &Schema,
+    ) -> Result<(), TransactionError> {
+        self.check_can_write_timestamp_ntz_snapshot(snapshot.snapshot(), schema)
+    }
+
+    fn check_can_write_timestamp_ntz_snapshot(
+        &self,
         snapshot: &Snapshot,
         schema: &Schema,
     ) -> Result<(), TransactionError> {
@@ -137,6 +150,15 @@ impl ProtocolChecker {
     /// Check can write_timestamp_nanos
     pub fn check_can_write_timestamp_nanos(
         &self,
+        snapshot: &EagerSnapshot,
+        schema: &Schema,
+    ) -> Result<(), TransactionError> {
+        self.check_can_write_timestamp_nanos_snapshot(snapshot.snapshot(), schema)
+    }
+
+    #[cfg(feature = "nanosecond-timestamps")]
+    fn check_can_write_timestamp_nanos_snapshot(
+        &self,
         snapshot: &Snapshot,
         schema: &Schema,
     ) -> Result<(), TransactionError> {
@@ -150,6 +172,14 @@ impl ProtocolChecker {
 
     /// Check can write variant
     pub fn check_can_write_variant(
+        &self,
+        snapshot: &EagerSnapshot,
+        schema: &Schema,
+    ) -> Result<(), TransactionError> {
+        self.check_can_write_variant_snapshot(snapshot.snapshot(), schema)
+    }
+
+    fn check_can_write_variant_snapshot(
         &self,
         snapshot: &Snapshot,
         schema: &Schema,
@@ -853,7 +883,7 @@ mod tests {
         .unwrap();
         assert!(
             checker
-                .check_can_write_variant(missing_feature.snapshot().snapshot(), &schema)
+                .check_can_write_variant(missing_feature.snapshot(), &schema)
                 .is_err()
         );
 
@@ -870,7 +900,7 @@ mod tests {
         .unwrap();
         assert!(
             checker
-                .check_can_write_variant(preview_feature.snapshot().snapshot(), &schema)
+                .check_can_write_variant(preview_feature.snapshot(), &schema)
                 .is_ok()
         );
     }

--- a/crates/core/src/kernel/transaction/protocol.rs
+++ b/crates/core/src/kernel/transaction/protocol.rs
@@ -7,8 +7,7 @@ use super::{TableReference, TransactionError};
 #[cfg(feature = "nanosecond-timestamps")]
 use crate::kernel::contains_timestamp_nanos;
 use crate::kernel::{
-    Action, EagerSnapshot, Protocol, ProtocolExt as _, Schema, contains_timestampntz,
-    contains_variant,
+    Action, Protocol, ProtocolExt as _, Schema, Snapshot, contains_timestampntz, contains_variant,
 };
 use crate::protocol::DeltaOperation;
 use crate::table::config::TablePropertiesExt as _;
@@ -91,7 +90,7 @@ impl ProtocolChecker {
     }
 
     /// Check append-only at the high level (operation level)
-    pub fn check_append_only(&self, snapshot: &EagerSnapshot) -> Result<(), TransactionError> {
+    pub fn check_append_only(&self, snapshot: &Snapshot) -> Result<(), TransactionError> {
         if snapshot.table_properties().append_only() {
             return Err(TransactionError::DeltaTableAppendOnly);
         }
@@ -100,7 +99,7 @@ impl ProtocolChecker {
 
     fn check_can_write_feature(
         &self,
-        snapshot: &EagerSnapshot,
+        snapshot: &Snapshot,
         contains_feature: bool,
         feature: TableFeature,
     ) -> Result<(), TransactionError> {
@@ -123,7 +122,7 @@ impl ProtocolChecker {
     /// Check can write_timestamp_ntz
     pub fn check_can_write_timestamp_ntz(
         &self,
-        snapshot: &EagerSnapshot,
+        snapshot: &Snapshot,
         schema: &Schema,
     ) -> Result<(), TransactionError> {
         trace!("checking to see if {snapshot:?} can write timestampntz");
@@ -138,7 +137,7 @@ impl ProtocolChecker {
     /// Check can write_timestamp_nanos
     pub fn check_can_write_timestamp_nanos(
         &self,
-        snapshot: &EagerSnapshot,
+        snapshot: &Snapshot,
         schema: &Schema,
     ) -> Result<(), TransactionError> {
         trace!("checking to see if {snapshot:?} can write timestampnanos");
@@ -152,7 +151,7 @@ impl ProtocolChecker {
     /// Check can write variant
     pub fn check_can_write_variant(
         &self,
-        snapshot: &EagerSnapshot,
+        snapshot: &Snapshot,
         schema: &Schema,
     ) -> Result<(), TransactionError> {
         trace!("checking to see if {snapshot:?} can write variant");
@@ -854,7 +853,7 @@ mod tests {
         .unwrap();
         assert!(
             checker
-                .check_can_write_variant(missing_feature.snapshot(), &schema)
+                .check_can_write_variant(missing_feature.snapshot().snapshot(), &schema)
                 .is_err()
         );
 
@@ -871,7 +870,7 @@ mod tests {
         .unwrap();
         assert!(
             checker
-                .check_can_write_variant(preview_feature.snapshot(), &schema)
+                .check_can_write_variant(preview_feature.snapshot().snapshot(), &schema)
                 .is_ok()
         );
     }

--- a/crates/core/src/operations/cdc.rs
+++ b/crates/core/src/operations/cdc.rs
@@ -4,7 +4,7 @@
 
 use crate::DeltaResult;
 use crate::delta_datafusion::logical::{LogicalPlanBuilderExt as _, LogicalPlanExt as _};
-use crate::kernel::EagerSnapshot;
+use crate::kernel::Snapshot;
 use crate::table::config::TablePropertiesExt as _;
 
 use datafusion::common::ScalarValue;
@@ -69,7 +69,7 @@ impl CDCTracker {
 /// > For Writer Version 7, all writers must respect the delta.enableChangeDataFeed configuration flag in
 /// > the metadata of the table only if the feature changeDataFeed exists in the table protocol's
 /// > writerFeatures.
-pub(crate) fn should_write_cdc(snapshot: &EagerSnapshot) -> DeltaResult<bool> {
+pub(crate) fn should_write_cdc(snapshot: &Snapshot) -> DeltaResult<bool> {
     if let Some(features) = &snapshot.protocol().writer_features() {
         // Features should only exist at writer version 7 but to avoid cases where
         // the Option<HashSet<T>> can get filled with an empty set, checking for the value
@@ -117,8 +117,8 @@ mod tests {
             .await
             .expect("Failed to make a table");
         table.load().await.expect("Failed to reload table");
-        let result =
-            should_write_cdc(table.snapshot().unwrap().snapshot()).expect("Failed to use table");
+        let result = should_write_cdc(table.snapshot().unwrap().snapshot().snapshot())
+            .expect("Failed to use table");
         assert!(!result, "A default table should not create CDC files");
     }
 
@@ -140,8 +140,8 @@ mod tests {
             .expect("failed to make a version 4 table with EnableChangeDataFeed");
         table.load().await.expect("Failed to reload table");
 
-        let result =
-            should_write_cdc(table.snapshot().unwrap().snapshot()).expect("Failed to use table");
+        let result = should_write_cdc(table.snapshot().unwrap().snapshot().snapshot())
+            .expect("Failed to use table");
         assert!(
             result,
             "A table with the EnableChangeDataFeed should create CDC files"
@@ -166,8 +166,8 @@ mod tests {
             .expect("failed to make a version 4 table with EnableChangeDataFeed");
         table.load().await.expect("Failed to reload table");
 
-        let result =
-            should_write_cdc(table.snapshot().unwrap().snapshot()).expect("Failed to use table");
+        let result = should_write_cdc(table.snapshot().unwrap().snapshot().snapshot())
+            .expect("Failed to use table");
         assert!(
             !result,
             "A v7 table must not write CDC files unless the writer feature is set"
@@ -196,8 +196,8 @@ mod tests {
             .expect("failed to make a version 4 table with EnableChangeDataFeed");
         table.load().await.expect("Failed to reload table");
 
-        let result =
-            should_write_cdc(table.snapshot().unwrap().snapshot()).expect("Failed to use table");
+        let result = should_write_cdc(table.snapshot().unwrap().snapshot().snapshot())
+            .expect("Failed to use table");
         assert!(
             result,
             "A v7 table must not write CDC files unless the writer feature is set"

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -76,7 +76,8 @@ use crate::delta_datafusion::{
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
 use crate::kernel::{
-    Action, ActiveAddOptions, AddStatsPolicy, EagerSnapshot, LogicalFileView, resolve_snapshot,
+    Action, ActiveAddOptions, AddStatsPolicy, EagerSnapshot, LogicalFileView, Snapshot,
+    resolve_snapshot,
 };
 use crate::logstore::{LogStore, LogStoreRef};
 use crate::operations::CustomExecuteHandler;
@@ -295,7 +296,7 @@ impl std::future::IntoFuture for DeleteBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
-            PROTOCOL.check_append_only(&snapshot)?;
+            PROTOCOL.check_append_only(snapshot.snapshot())?;
             PROTOCOL.can_write_to(&snapshot)?;
 
             let operation_id = this.get_operation_id();
@@ -332,7 +333,7 @@ impl std::future::IntoFuture for DeleteBuilder {
             let (actions, metrics) = execute(
                 predicate,
                 this.log_store.clone(),
-                snapshot.clone(),
+                snapshot.snapshot(),
                 &session,
                 operation_id,
             )
@@ -423,7 +424,7 @@ impl ExtensionPlanner for DeleteMetricExtensionPlanner {
 async fn execute(
     predicate: Option<Expr>,
     log_store: LogStoreRef,
-    snapshot: EagerSnapshot,
+    snapshot: &Snapshot,
     session: &dyn Session,
     operation_id: Uuid,
 ) -> DeltaResult<(Vec<Action>, DeleteMetrics)> {
@@ -439,7 +440,7 @@ async fn execute(
     let Some(predicate) = predicate else {
         // no predicate means all files match.
         // cdc actions are not written when table files are removed.
-        let full_file = collect_full_file_deletes(snapshot.snapshot().active_adds(
+        let full_file = collect_full_file_deletes(snapshot.active_adds(
             log_store.as_ref(),
             ActiveAddOptions {
                 predicate: None,
@@ -482,7 +483,7 @@ async fn execute(
                 // evaluating `partition_predicate` against `partitionValues_parsed` is exact:
                 // a file either fully matches or does not. It is therefore safe to treat this as
                 // the authoritative match set for DELETE.
-                collect_full_file_deletes(snapshot.snapshot().active_adds(
+                collect_full_file_deletes(snapshot.active_adds(
                     log_store.as_ref(),
                     ActiveAddOptions {
                         predicate: Some(Arc::new(delta_predicate)),
@@ -500,14 +501,13 @@ async fn execute(
                 let matching_paths = Arc::new(
                     find_file_paths_by_partition_predicate_datafusion(
                         session,
-                        &snapshot,
+                        snapshot,
                         &partition_predicate,
                     )
                     .await?,
                 );
                 collect_full_file_deletes(
                     snapshot
-                        .snapshot()
                         .active_adds(
                             log_store.as_ref(),
                             ActiveAddOptions {
@@ -535,7 +535,7 @@ async fn execute(
     }
 
     let maybe_scan_plan =
-        scan_files_where_matches(session, &snapshot, log_store.clone(), predicate).await?;
+        scan_files_where_matches(session, snapshot, log_store.clone(), predicate).await?;
     metrics.scan_time_ms = Instant::now().duration_since(scan_start).as_millis() as u64;
 
     let Some(files_scan) = maybe_scan_plan else {
@@ -547,7 +547,6 @@ async fn execute(
 
     let root_url = Arc::new(snapshot.table_configuration().table_root().clone());
     let removes: Vec<_> = snapshot
-        .snapshot()
         .active_adds(
             log_store.as_ref(),
             ActiveAddOptions {
@@ -595,7 +594,7 @@ async fn execute(
         }),
     });
 
-    let (write_plan, write_cdc) = if should_write_cdc(&snapshot)? {
+    let (write_plan, write_cdc) = if should_write_cdc(snapshot)? {
         // create change set entries for all records we deleted
         let cdc_deletes = files_scan
             .scan()
@@ -654,7 +653,7 @@ async fn execute(
 
 async fn find_file_paths_by_partition_predicate_datafusion(
     session: &dyn Session,
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     predicate: &Expr,
 ) -> DeltaResult<std::collections::HashSet<String>> {
     use arrow_array::StringArray;

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -296,7 +296,7 @@ impl std::future::IntoFuture for DeleteBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
-            PROTOCOL.check_append_only(snapshot.snapshot())?;
+            PROTOCOL.check_append_only(&snapshot)?;
             PROTOCOL.can_write_to(&snapshot)?;
 
             let operation_id = this.get_operation_id();

--- a/crates/core/src/operations/filesystem_check.rs
+++ b/crates/core/src/operations/filesystem_check.rs
@@ -33,7 +33,7 @@ use crate::DeltaTable;
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{Action, Add, Remove};
-use crate::kernel::{ActiveAddOptions, AddStatsPolicy, EagerSnapshot, resolve_snapshot};
+use crate::kernel::{ActiveAddOptions, AddStatsPolicy, EagerSnapshot, Snapshot, resolve_snapshot};
 use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
 use crate::table::state::DeltaTableState;
@@ -140,11 +140,10 @@ impl FileSystemCheckBuilder {
         self
     }
 
-    async fn create_fsck_plan(&self, snapshot: &EagerSnapshot) -> DeltaResult<FileSystemCheckPlan> {
+    async fn create_fsck_plan(&self, snapshot: &Snapshot) -> DeltaResult<FileSystemCheckPlan> {
         let mut files_relative: HashMap<String, Add> = HashMap::new();
         let log_store = self.log_store.clone();
         let mut file_stream = snapshot
-            .snapshot()
             .active_adds(
                 log_store.as_ref(),
                 ActiveAddOptions {
@@ -263,7 +262,7 @@ impl std::future::IntoFuture for FileSystemCheckBuilder {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
 
-            let plan = this.create_fsck_plan(&snapshot).await?;
+            let plan = this.create_fsck_plan(snapshot.snapshot()).await?;
             if this.dry_run {
                 return Ok((
                     DeltaTable::new_with_state(this.log_store, DeltaTableState::new(snapshot)),

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -37,7 +37,7 @@ use crate::delta_datafusion::{
 use crate::errors::{ColumnMappingOperation, DeltaResult};
 use crate::kernel::transaction::PROTOCOL;
 use crate::kernel::{
-    Action, Add, AddCDCFile, CommitInfo, EagerSnapshot, Version, resolve_snapshot,
+    Action, Add, AddCDCFile, CommitInfo, EagerSnapshot, Snapshot, Version, resolve_snapshot,
 };
 use crate::logstore::{LogStoreRef, get_actions};
 use crate::{delta_datafusion::cdf::*, kernel::Remove};
@@ -147,7 +147,7 @@ impl CdfLoadBuilder {
         self
     }
 
-    async fn calculate_earliest_version(&self, snapshot: &EagerSnapshot) -> DeltaResult<Version> {
+    async fn calculate_earliest_version(&self, snapshot: &Snapshot) -> DeltaResult<Version> {
         let ts = self.starting_timestamp.unwrap_or(DateTime::UNIX_EPOCH);
         for v in 0..snapshot.version() {
             if let Ok(Some(bytes)) = self.log_store.read_commit_entry(v).await
@@ -170,7 +170,7 @@ impl CdfLoadBuilder {
     /// than I have right now. I plan to extend the checks once we have a stable state of the initial implementation.
     async fn determine_files_to_read(
         &self,
-        snapshot: &EagerSnapshot,
+        snapshot: &Snapshot,
         partition_pruning: Option<&PartitionPruningPredicate>,
     ) -> DeltaResult<(
         Vec<CdcDataSpec<AddCDCFile>>,
@@ -467,7 +467,7 @@ impl CdfLoadBuilder {
         let partition_pruning =
             self.partition_pruning_predicate(session, &schema, partition_values)?;
         let (cdc, add, remove) = self
-            .determine_files_to_read(&snapshot, partition_pruning.as_ref())
+            .determine_files_to_read(snapshot.snapshot(), partition_pruning.as_ref())
             .await?;
         session.ensure_log_store_registered(self.log_store.as_ref())?;
 

--- a/crates/core/src/operations/merge/filter.rs
+++ b/crates/core/src/operations/merge/filter.rs
@@ -14,7 +14,7 @@ use either::{Left, Right};
 use futures::TryStreamExt as _;
 use itertools::Itertools;
 
-use crate::kernel::EagerSnapshot;
+use crate::kernel::Snapshot;
 use crate::{DeltaResult, DeltaTableError};
 
 #[derive(Debug)]
@@ -323,7 +323,7 @@ pub(crate) fn generalize_filter(
 
 pub(crate) async fn try_construct_early_filter(
     join_predicate: Expr,
-    table_snapshot: &EagerSnapshot,
+    table_snapshot: &Snapshot,
     session_state: &dyn Session,
     source: &LogicalPlan,
     source_name: &TableReference,
@@ -478,7 +478,7 @@ mod tests {
 
         let pred = try_construct_early_filter(
             join_predicate,
-            table.snapshot().unwrap().snapshot(),
+            table.snapshot().unwrap().snapshot().snapshot(),
             &ctx.state(),
             &source,
             &source_name,
@@ -569,7 +569,7 @@ mod tests {
 
         let pred = try_construct_early_filter(
             join_predicate,
-            table.snapshot().unwrap().snapshot(),
+            table.snapshot().unwrap().snapshot().snapshot(),
             &ctx.state(),
             &source,
             &source_name,
@@ -627,7 +627,7 @@ mod tests {
 
         let pred = try_construct_early_filter(
             join_predicate,
-            table.snapshot().unwrap().snapshot(),
+            table.snapshot().unwrap().snapshot().snapshot(),
             &ctx.state(),
             &source,
             &source_name,
@@ -690,7 +690,7 @@ mod tests {
 
         let pred = try_construct_early_filter(
             join_predicate,
-            table.snapshot().unwrap().snapshot(),
+            table.snapshot().unwrap().snapshot().snapshot(),
             &ctx.state(),
             &source_plan,
             &source_name,
@@ -759,7 +759,7 @@ mod tests {
 
         let pred = try_construct_early_filter(
             join_predicate,
-            table.snapshot().unwrap().snapshot(),
+            table.snapshot().unwrap().snapshot().snapshot(),
             &ctx.state(),
             &source_plan,
             &source_name,
@@ -831,7 +831,7 @@ mod tests {
 
         let pred = try_construct_early_filter(
             join_predicate,
-            table.snapshot().unwrap().snapshot(),
+            table.snapshot().unwrap().snapshot().snapshot(),
             &ctx.state(),
             &source_plan,
             &source_name,

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -87,7 +87,7 @@ use crate::delta_datafusion::{Expression, into_expr, maybe_into_expr};
 use crate::kernel::schema::cast::{merge_arrow_field, merge_arrow_schema};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
 use crate::kernel::{
-    Action, ActiveAddOptions, AddStatsPolicy, EagerSnapshot, StructTypeExt, new_metadata,
+    Action, ActiveAddOptions, AddStatsPolicy, EagerSnapshot, Snapshot, StructTypeExt, new_metadata,
     resolve_snapshot,
 };
 use crate::logstore::{LogStore, LogStoreRef};
@@ -852,9 +852,8 @@ async fn execute(
 
     let mut metrics = MergeMetrics::default();
     let exec_start = Instant::now();
-    // Determining whether we should write change data once so that computation of change data can
-    // be disabled in the common case(s)
-    let should_cdc = should_write_cdc(&snapshot)?;
+    // Determine once whether to write change data. The common cases skip change data work.
+    let should_cdc = should_write_cdc(snapshot.snapshot())?;
     // Change data may be collected and then written out at the completion of the merge
 
     if should_cdc {
@@ -892,7 +891,7 @@ async fn execute(
     let mut generated_col_exp = None;
     let mut missing_generated_col = None;
 
-    if gc_is_enabled(&snapshot) {
+    if gc_is_enabled(snapshot.snapshot()) {
         let generated_col_expressions = snapshot.schema().get_generated_columns()?;
         let (source_with_gc, missing_generated_columns) =
             add_missing_generated_columns(source, &generated_col_expressions)?;
@@ -924,7 +923,7 @@ async fn execute(
 
     let target_provider = provider_as_source(
         DeltaScanNext::builder()
-            .with_eager_snapshot(snapshot.clone())
+            .with_snapshot(snapshot.snapshot().clone())
             .with_log_store(log_store.clone())
             .with_session(state.clone().into())
             .with_file_column(file_column.as_str())
@@ -952,7 +951,7 @@ async fn execute(
     } else {
         try_construct_early_filter(
             predicate.clone(),
-            &snapshot,
+            snapshot.snapshot(),
             &state,
             &source,
             &source_name,
@@ -985,7 +984,7 @@ async fn execute(
 
     let target_provider = {
         let mut builder = DeltaScanNext::builder()
-            .with_eager_snapshot(snapshot.clone())
+            .with_snapshot(snapshot.snapshot().clone())
             .with_log_store(log_store.clone())
             .with_session(state.clone().into())
             .with_file_column(file_column.as_str());
@@ -1579,7 +1578,7 @@ async fn execute(
     let writer_stats_config = WriterStatsConfig::from_config(snapshot.table_configuration());
 
     let (mut actions, write_plan_metrics) = write_execution_plan_v2(
-        Some(&snapshot),
+        Some(snapshot.snapshot()),
         &state,
         write,
         table_partition_cols.to_vec(),
@@ -1663,7 +1662,7 @@ async fn execute(
     {
         metric
     } else {
-        let total_files = count_active_adds(&snapshot, log_store.as_ref()).await?;
+        let total_files = count_active_adds(snapshot.snapshot(), log_store.as_ref()).await?;
         let (derived, impossible_state) =
             derive_skipped_file_count(total_files, metrics.num_target_files_scanned);
         if impossible_state {
@@ -1799,12 +1798,8 @@ fn derive_skipped_file_count(total_files: usize, scanned_files: usize) -> (usize
     (total_files.saturating_sub(scanned_files), impossible_state)
 }
 
-async fn count_active_adds(
-    snapshot: &EagerSnapshot,
-    log_store: &dyn LogStore,
-) -> DeltaResult<usize> {
+async fn count_active_adds(snapshot: &Snapshot, log_store: &dyn LogStore) -> DeltaResult<usize> {
     let batches = snapshot
-        .snapshot()
         .active_add_batches(
             log_store,
             ActiveAddOptions {
@@ -2088,7 +2083,7 @@ mod tests {
 
         assert!(!snapshot.snapshot().has_materialized_files_for_test());
 
-        let total_files = super::count_active_adds(&snapshot, log_store.as_ref()).await?;
+        let total_files = super::count_active_adds(snapshot.snapshot(), log_store.as_ref()).await?;
 
         assert_eq!(total_files, 5);
         assert!(!snapshot.snapshot().has_materialized_files_for_test());
@@ -2273,7 +2268,7 @@ mod tests {
 
         let target_provider = provider_as_source(
             DeltaScanNext::builder()
-                .with_eager_snapshot(table.snapshot().unwrap().snapshot().clone())
+                .with_snapshot(table.snapshot().unwrap().snapshot().snapshot().clone())
                 .with_log_store(table.log_store.clone())
                 .with_session(state.clone().into())
                 .with_file_column(PATH_COLUMN)
@@ -2318,7 +2313,7 @@ mod tests {
 
         let target_provider = provider_as_source(
             DeltaScanNext::builder()
-                .with_eager_snapshot(table.snapshot().unwrap().snapshot().clone())
+                .with_snapshot(table.snapshot().unwrap().snapshot().snapshot().clone())
                 .with_log_store(table.log_store.clone())
                 .with_session(state.clone().into())
                 .with_file_column(PATH_COLUMN)

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -55,7 +55,7 @@ use crate::delta_datafusion::{
 };
 use crate::errors::{ColumnMappingOperation, DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, DEFAULT_RETRIES, PROTOCOL};
-use crate::kernel::{Action, Add, DataType, PartitionsExt, Remove, StructType, Version};
+use crate::kernel::{Action, Add, DataType, PartitionsExt, Remove, Snapshot, StructType, Version};
 use crate::kernel::{EagerSnapshot, resolve_snapshot};
 use crate::logstore::{LogStore, LogStoreRef, ObjectStoreRef};
 use crate::parquet_utils::default_writer_properties;
@@ -612,7 +612,7 @@ type ParquetReadStream = BoxStream<'static, Result<RecordBatch, ParquetError>>;
 
 #[derive(Clone)]
 struct SelectedFileScanFactory {
-    snapshot: EagerSnapshot,
+    snapshot: Snapshot,
     log_store: LogStoreRef,
     scan_config: DeltaScanConfig,
     read_operation_id: Option<Uuid>,
@@ -620,7 +620,7 @@ struct SelectedFileScanFactory {
 
 impl SelectedFileScanFactory {
     fn try_new(
-        snapshot: &EagerSnapshot,
+        snapshot: &Snapshot,
         log_store: LogStoreRef,
         session: &dyn Session,
         read_operation_id: Option<Uuid>,
@@ -837,7 +837,7 @@ impl MergePlan {
                     read_session.as_ref().clone(),
                 ));
                 let scan_factory = SelectedFileScanFactory::try_new(
-                    snapshot,
+                    snapshot.snapshot(),
                     log_store.clone(),
                     read_session.as_ref(),
                     Some(operation_id),
@@ -886,7 +886,7 @@ impl MergePlan {
                 )?);
                 let task_parameters = self.task_parameters.clone();
                 let scan_factory = SelectedFileScanFactory::try_new(
-                    snapshot,
+                    snapshot.snapshot(),
                     log_store.clone(),
                     read_session.as_ref(),
                     Some(operation_id),
@@ -1022,14 +1022,14 @@ pub async fn create_merge_plan(
     let (operations, metrics, planner_stats) = match optimize_type {
         OptimizeType::Compact => {
             info!("building compaction plan");
-            build_compaction_plan(log_store, snapshot, filters, target_size).await?
+            build_compaction_plan(log_store, snapshot.snapshot(), filters, target_size).await?
         }
         OptimizeType::ZOrder(zorder_columns) => {
             info!("building z-order plan");
             build_zorder_plan(
                 log_store,
                 zorder_columns,
-                snapshot,
+                snapshot.snapshot(),
                 partitions_keys,
                 filters,
             )
@@ -1195,7 +1195,7 @@ fn plan_compaction_bins_in_stable_order(
 
 async fn build_compaction_plan(
     log_store: &dyn LogStore,
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     filters: &[PartitionFilter],
     target_size: NonZeroU64,
 ) -> Result<(OptimizeOperations, Metrics, PlannerStats), DeltaTableError> {
@@ -1310,7 +1310,7 @@ fn validate_zorder_column(schema: &StructType, column: &str) -> Result<(), Delta
 async fn build_zorder_plan(
     log_store: &dyn LogStore,
     zorder_columns: Vec<String>,
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     partition_keys: &[String],
     filters: &[PartitionFilter],
 ) -> Result<(OptimizeOperations, Metrics, PlannerStats), DeltaTableError> {

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -65,7 +65,7 @@ use crate::{
         resolve_session_state,
     },
     kernel::{
-        Action, ActiveAddOptions, AddStatsPolicy, EagerSnapshot,
+        Action, ActiveAddOptions, AddStatsPolicy, EagerSnapshot, Snapshot,
         transaction::{CommitBuilder, CommitProperties, PROTOCOL},
     },
     table::config::TablePropertiesExt,
@@ -276,7 +276,7 @@ async fn execute(
     predicate: Expr,
     updates: HashMap<Column, Expression>,
     log_store: LogStoreRef,
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     session: &dyn Session,
     writer_properties: Option<WriterProperties>,
     operation_id: Uuid,
@@ -396,7 +396,6 @@ async fn execute(
 
     let root_url = Arc::new(snapshot.table_configuration().table_root().clone());
     let removes: Vec<_> = snapshot
-        .snapshot()
         .active_adds(
             log_store.as_ref(),
             ActiveAddOptions {
@@ -464,7 +463,7 @@ impl std::future::IntoFuture for UpdateBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
-            PROTOCOL.check_append_only(&snapshot)?;
+            PROTOCOL.check_append_only(snapshot.snapshot())?;
             PROTOCOL.can_write_to(&snapshot)?;
 
             let operation_id = this.get_operation_id();
@@ -510,7 +509,7 @@ impl std::future::IntoFuture for UpdateBuilder {
                 predicate,
                 this.updates,
                 this.log_store.clone(),
-                &snapshot,
+                snapshot.snapshot(),
                 &state,
                 this.writer_properties,
                 operation_id,

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -463,7 +463,7 @@ impl std::future::IntoFuture for UpdateBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
-            PROTOCOL.check_append_only(snapshot.snapshot())?;
+            PROTOCOL.check_append_only(&snapshot)?;
             PROTOCOL.can_write_to(&snapshot)?;
 
             let operation_id = this.get_operation_id();

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -36,7 +36,8 @@ use super::{CustomExecuteHandler, Operation};
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties};
 use crate::kernel::{
-    ActiveAddOptions, AddStatsPolicy, EagerSnapshot, TombstoneView, Version, resolve_snapshot,
+    ActiveAddOptions, AddStatsPolicy, EagerSnapshot, Snapshot, TombstoneView, Version,
+    resolve_snapshot,
 };
 use crate::logstore::{LogStore, LogStoreRef};
 use crate::protocol::DeltaOperation;
@@ -223,10 +224,7 @@ impl VacuumBuilder {
     }
 
     /// Determine which files can be deleted. Does not actually perform the deletion
-    async fn create_vacuum_plan(
-        &self,
-        snapshot: &EagerSnapshot,
-    ) -> Result<VacuumPlan, VacuumError> {
+    async fn create_vacuum_plan(&self, snapshot: &Snapshot) -> Result<VacuumPlan, VacuumError> {
         if self.mode == VacuumMode::Full {
             info!(
                 "Vacuum configured to run with 'VacuumMode::Full'. It will scan for orphaned parquet files in the Delta table directory and remove those as well!"
@@ -255,41 +253,7 @@ impl VacuumBuilder {
         };
 
         let keep_files = match &self.keep_versions {
-            Some(versions) => {
-                let mut sorted_versions = versions.clone();
-                sorted_versions.sort();
-                let mut sorted_versions = sorted_versions.into_iter();
-                match sorted_versions.next() {
-                    Some(initial_version) => {
-                        let mut keep_files: HashSet<String> = HashSet::new();
-                        let mut state = DeltaTableState::try_new(
-                            &self.log_store,
-                            DeltaTableConfig::default(),
-                            Some(initial_version),
-                        )
-                        .await?;
-                        let mut record_keep_files = |version: Version, state: &DeltaTableState| {
-                            let files: Vec<String> = state
-                                .log_data()
-                                .into_iter()
-                                .map(|add| add.object_store_path())
-                                .map(|path| path.to_string())
-                                .collect();
-                            debug!("keep version:{version}\n, {files:#?}");
-                            keep_files.extend(files);
-                        };
-
-                        record_keep_files(initial_version, &state);
-                        for version in sorted_versions {
-                            state.update(&self.log_store, Some(version)).await?;
-                            record_keep_files(version, &state);
-                        }
-
-                        keep_files
-                    }
-                    None => HashSet::new(),
-                }
-            }
+            Some(versions) => collect_keep_version_files(self.log_store.as_ref(), versions).await?,
             _ => HashSet::new(),
         };
 
@@ -306,7 +270,6 @@ impl VacuumBuilder {
             )
         };
         let valid_files: HashSet<_> = snapshot
-            .snapshot()
             .active_adds(
                 self.log_store.as_ref(),
                 ActiveAddOptions {
@@ -418,7 +381,7 @@ impl std::future::IntoFuture for VacuumBuilder {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
-            let plan = this.create_vacuum_plan(&snapshot).await?;
+            let plan = this.create_vacuum_plan(snapshot.snapshot()).await?;
 
             if this.dry_run {
                 return Ok((
@@ -606,12 +569,11 @@ fn ok_to_delete(
 }
 
 async fn collect_full_mode_tombstones(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     tombstone_retention_timestamp: i64,
     store: &dyn LogStore,
 ) -> DeltaResult<(Vec<TombstoneView>, TombstonePathSets)> {
     snapshot
-        .snapshot()
         .active_tombstones(store)
         .try_fold(
             (Vec::new(), TombstonePathSets::default()),
@@ -630,14 +592,13 @@ async fn collect_full_mode_tombstones(
 
 /// List files no longer referenced by a Delta table and are older than the retention threshold.
 async fn get_stale_files(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     retention_period: Duration,
     now_timestamp_millis: i64,
     store: &dyn LogStore,
 ) -> DeltaResult<Vec<TombstoneView>> {
     let tombstone_retention_timestamp = now_timestamp_millis - retention_period.num_milliseconds();
     snapshot
-        .snapshot()
         .active_tombstones(store)
         .try_filter(|tombstone| {
             ready(is_tombstone_expired(
@@ -647,6 +608,55 @@ async fn get_stale_files(
         })
         .try_collect::<Vec<_>>()
         .await
+}
+
+async fn collect_keep_version_files(
+    log_store: &dyn LogStore,
+    versions: &[Version],
+) -> DeltaResult<HashSet<String>> {
+    let mut sorted_versions = versions.to_vec();
+    sorted_versions.sort();
+    sorted_versions.dedup();
+
+    let mut snapshots = Vec::with_capacity(sorted_versions.len());
+    for version in sorted_versions {
+        snapshots.push(
+            Snapshot::try_new(
+                log_store,
+                DeltaTableConfig {
+                    require_files: false,
+                    ..Default::default()
+                },
+                Some(version),
+            )
+            .await?,
+        );
+    }
+
+    collect_keep_files_from_snapshots(log_store, snapshots.iter()).await
+}
+
+async fn collect_keep_files_from_snapshots<'a>(
+    log_store: &dyn LogStore,
+    snapshots: impl IntoIterator<Item = &'a Snapshot>,
+) -> DeltaResult<HashSet<String>> {
+    let mut keep_files = HashSet::new();
+    for snapshot in snapshots {
+        let files: Vec<String> = snapshot
+            .active_adds(
+                log_store,
+                ActiveAddOptions {
+                    predicate: None,
+                    stats: AddStatsPolicy::None,
+                },
+            )
+            .map_ok(|add| add.object_store_path().to_string())
+            .try_collect()
+            .await?;
+        debug!("keep version:{}\n, {files:#?}", snapshot.version());
+        keep_files.extend(files);
+    }
+    Ok(keep_files)
 }
 
 fn is_tombstone_expired(tombstone: &TombstoneView, tombstone_retention_timestamp: i64) -> bool {
@@ -839,6 +849,45 @@ mod tests {
         descending_files.sort();
 
         assert_eq!(descending_files, ascending_files);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_collect_keep_version_files_uses_lazy_snapshot_active_adds() -> DeltaResult<()> {
+        let table_loc = "../test/tests/data/simple_table";
+        let table_uri = ensure_table_uri(table_loc).unwrap();
+        let table = open_table(table_uri).await?;
+        let config = DeltaTableConfig {
+            require_files: false,
+            ..Default::default()
+        };
+        let version_2 =
+            Snapshot::try_new(table.log_store().as_ref(), config.clone(), Some(2)).await?;
+        let version_3 = Snapshot::try_new(table.log_store().as_ref(), config, Some(3)).await?;
+
+        assert!(!version_2.has_materialized_files_for_test());
+        assert!(!version_3.has_materialized_files_for_test());
+
+        let keep_files =
+            collect_keep_files_from_snapshots(table.log_store().as_ref(), [&version_2, &version_3])
+                .await?;
+
+        assert!(
+            keep_files
+                .contains("part-00003-53f42606-6cda-4f13-8d07-599a21197296-c000.snappy.parquet"),
+            "v2 active files should be retained for keep-version planning: {keep_files:#?}"
+        );
+        assert!(
+            keep_files
+                .contains("part-00000-f17fcbf5-e0dc-40ba-adae-ce66d1fcaef6-c000.snappy.parquet"),
+            "v3 active files should be retained for keep-version planning: {keep_files:#?}"
+        );
+        assert!(
+            !version_2.has_materialized_files_for_test()
+                && !version_3.has_materialized_files_for_test(),
+            "keep-version collection should not require eager materialized files"
+        );
+
         Ok(())
     }
 

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -31,7 +31,7 @@ use crate::delta_datafusion::{
     ColumnMappingState, DataValidationExec, generated_columns_to_exprs, validation_predicates,
 };
 use crate::errors::DeltaResult;
-use crate::kernel::{Action, Add, AddCDCFile, EagerSnapshot, StructType, StructTypeExt};
+use crate::kernel::{Action, Add, AddCDCFile, Snapshot, StructType, StructTypeExt};
 use crate::logstore::{LogStore, ObjectStoreRef};
 use crate::operations::cdc::CDC_COLUMN_NAME;
 use crate::operations::write::WriterStatsConfig;
@@ -312,7 +312,7 @@ pub(crate) struct WriteStreamMetrics {
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn write_execution_plan_cdc(
-    snapshot: Option<&EagerSnapshot>,
+    snapshot: Option<&Snapshot>,
     session: &dyn Session,
     plan: Arc<dyn ExecutionPlan>,
     partition_columns: Vec<String>,
@@ -359,7 +359,7 @@ pub(crate) async fn write_execution_plan_cdc(
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn write_execution_plan(
-    snapshot: Option<&EagerSnapshot>,
+    snapshot: Option<&Snapshot>,
     session: &dyn Session,
     plan: Arc<dyn ExecutionPlan>,
     partition_columns: Vec<String>,
@@ -389,7 +389,7 @@ pub(crate) async fn write_execution_plan(
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn write_execution_plan_v2(
-    snapshot: Option<&EagerSnapshot>,
+    snapshot: Option<&Snapshot>,
     session: &dyn Session,
     plan: Arc<dyn ExecutionPlan>,
     partition_columns: Vec<String>,

--- a/crates/core/src/operations/write/generated_columns.rs
+++ b/crates/core/src/operations/write/generated_columns.rs
@@ -11,13 +11,13 @@ use tracing::debug;
 use crate::{
     DeltaResult,
     delta_datafusion::expr::parse_generated_column_expression,
-    kernel::{DataCheck, EagerSnapshot},
+    kernel::{DataCheck, Snapshot},
     table::GeneratedColumn,
 };
 
 /// check if the writer version is able to write generated columns
 #[inline]
-pub fn gc_is_enabled(snapshot: &EagerSnapshot) -> bool {
+pub fn gc_is_enabled(snapshot: &Snapshot) -> bool {
     snapshot
         .table_configuration()
         .is_feature_enabled(&TableFeature::GeneratedColumns)

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -416,7 +416,7 @@ impl WriteBuilder {
                 }
 
                 if self.mode == SaveMode::Overwrite {
-                    PROTOCOL.check_append_only(snapshot.snapshot())?;
+                    PROTOCOL.check_append_only(snapshot)?;
                     if !snapshot.load_config().require_files {
                         return Err(DeltaTableError::NotInitializedWithFiles("WRITE".into()));
                     }
@@ -425,10 +425,10 @@ impl WriteBuilder {
                 PROTOCOL.can_write_to(snapshot)?;
 
                 if self.schema_mode.is_none() {
-                    PROTOCOL.check_can_write_timestamp_ntz(snapshot.snapshot(), &schema)?;
+                    PROTOCOL.check_can_write_timestamp_ntz(snapshot, &schema)?;
                     #[cfg(feature = "nanosecond-timestamps")]
-                    PROTOCOL.check_can_write_timestamp_nanos(snapshot.snapshot(), &schema)?;
-                    PROTOCOL.check_can_write_variant(snapshot.snapshot(), &schema)?;
+                    PROTOCOL.check_can_write_timestamp_nanos(snapshot, &schema)?;
+                    PROTOCOL.check_can_write_variant(snapshot, &schema)?;
                 }
                 match self.mode {
                     SaveMode::ErrorIfExists => {

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -416,7 +416,7 @@ impl WriteBuilder {
                 }
 
                 if self.mode == SaveMode::Overwrite {
-                    PROTOCOL.check_append_only(snapshot)?;
+                    PROTOCOL.check_append_only(snapshot.snapshot())?;
                     if !snapshot.load_config().require_files {
                         return Err(DeltaTableError::NotInitializedWithFiles("WRITE".into()));
                     }
@@ -425,10 +425,10 @@ impl WriteBuilder {
                 PROTOCOL.can_write_to(snapshot)?;
 
                 if self.schema_mode.is_none() {
-                    PROTOCOL.check_can_write_timestamp_ntz(snapshot, &schema)?;
+                    PROTOCOL.check_can_write_timestamp_ntz(snapshot.snapshot(), &schema)?;
                     #[cfg(feature = "nanosecond-timestamps")]
-                    PROTOCOL.check_can_write_timestamp_nanos(snapshot, &schema)?;
-                    PROTOCOL.check_can_write_variant(snapshot, &schema)?;
+                    PROTOCOL.check_can_write_timestamp_nanos(snapshot.snapshot(), &schema)?;
+                    PROTOCOL.check_can_write_variant(snapshot.snapshot(), &schema)?;
                 }
                 match self.mode {
                     SaveMode::ErrorIfExists => {
@@ -503,8 +503,9 @@ impl std::future::IntoFuture for WriteBuilder {
                 update_datafusion_session(&session, &this.log_store, Some(operation_id))?;
                 session.ensure_log_store_registered(this.log_store.as_ref())?;
 
+                let snapshot = this.snapshot.as_ref().map(EagerSnapshot::snapshot);
                 let prepared_write = plan::prepare_write(plan::WritePreparationInput {
-                    snapshot: this.snapshot.as_ref(),
+                    snapshot,
                     session: &session,
                     source,
                     mode: this.mode,
@@ -519,7 +520,7 @@ impl std::future::IntoFuture for WriteBuilder {
                 })?;
 
                 let overwrite_plan = plan::plan_overwrite_rewrite(
-                    this.snapshot.as_ref(),
+                    snapshot,
                     &this.log_store,
                     &session,
                     this.mode,
@@ -564,7 +565,7 @@ impl std::future::IntoFuture for WriteBuilder {
 
                 // Here we need to validate if the new data conforms to a predicate if one is provided
                 let (add_actions, _) = write_execution_plan_v2(
-                    this.snapshot.as_ref(),
+                    snapshot,
                     &session,
                     source_plan.clone(),
                     partition_columns.clone(),

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -34,8 +34,8 @@ use crate::delta_datafusion::{
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::schema::cast::{merge_arrow_schema, normalize_for_delta};
 use crate::kernel::{
-    Action, ActiveAddOptions, Add, AddStatsPolicy, DeletionVectorDescriptor, EagerSnapshot,
-    Metadata, ProtocolExt as _, Remove, StructType, StructTypeExt,
+    Action, ActiveAddOptions, Add, AddStatsPolicy, DeletionVectorDescriptor, Metadata,
+    ProtocolExt as _, Remove, Snapshot, StructType, StructTypeExt,
 };
 use crate::logstore::LogStoreRef;
 use crate::operations::cdc::{CDC_COLUMN_NAME, should_write_cdc};
@@ -87,7 +87,7 @@ pub(super) struct PreparedWrite {
 
 /// Inputs required to normalize source rows into table shaped insert data.
 pub(super) struct WritePreparationInput<'a> {
-    pub(super) snapshot: Option<&'a EagerSnapshot>,
+    pub(super) snapshot: Option<&'a Snapshot>,
     pub(super) session: &'a dyn Session,
     pub(super) source: LogicalPlan,
     pub(super) mode: SaveMode,
@@ -419,7 +419,7 @@ pub(super) fn prepare_write(input: WritePreparationInput<'_>) -> DeltaResult<Pre
 }
 
 pub(super) async fn plan_overwrite_rewrite(
-    snapshot: Option<&EagerSnapshot>,
+    snapshot: Option<&Snapshot>,
     log_store: &LogStoreRef,
     session: &dyn Session,
     mode: SaveMode,
@@ -575,12 +575,11 @@ fn planned_deletion_timestamp_ms() -> DeltaResult<i64> {
 }
 
 async fn collect_all_existing_files(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: &LogStoreRef,
 ) -> DeltaResult<MatchedExistingFiles> {
     Ok(MatchedExistingFiles::new(
         snapshot
-            .snapshot()
             .active_adds(
                 log_store.as_ref(),
                 ActiveAddOptions {
@@ -595,14 +594,13 @@ async fn collect_all_existing_files(
 }
 
 async fn collect_matched_existing_files(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: &LogStoreRef,
     files_scan: &crate::delta_datafusion::MatchedFilesScan,
 ) -> DeltaResult<MatchedExistingFiles> {
     let table_root = Arc::new(snapshot.table_configuration().table_root().clone());
     let valid_files = Arc::new(files_scan.files_set());
     let files = snapshot
-        .snapshot()
         .active_adds(
             log_store.as_ref(),
             ActiveAddOptions {
@@ -686,7 +684,7 @@ fn align_plan_to_schema(plan: LogicalPlan, target_plan: &LogicalPlan) -> DeltaRe
 }
 
 fn build_exec_options(
-    snapshot: Option<&EagerSnapshot>,
+    snapshot: Option<&Snapshot>,
     partition_columns: Vec<String>,
     target_file_size: Option<Option<NonZeroU64>>,
     write_batch_size: Option<usize>,
@@ -760,7 +758,7 @@ fn metadata_with_schema_and_partition_columns(
 }
 
 fn schema_delta_for_prepared_source(
-    snapshot: Option<&EagerSnapshot>,
+    snapshot: Option<&Snapshot>,
     insert_plan: &LogicalPlan,
     partition_columns: &[String],
     mode: SaveMode,
@@ -898,7 +896,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Append,
@@ -940,7 +938,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Overwrite,
@@ -1001,7 +999,13 @@ mod tests {
             .unwrap();
 
         let prepared_append = prepare_write(WritePreparationInput {
-            snapshot: Some(table_with_snapshot.snapshot().unwrap().snapshot()),
+            snapshot: Some(
+                table_with_snapshot
+                    .snapshot()
+                    .unwrap()
+                    .snapshot()
+                    .snapshot(),
+            ),
             session: &session,
             source: source_plan_for_batch(get_record_batch(None, false)),
             mode: SaveMode::Append,
@@ -1017,7 +1021,13 @@ mod tests {
         .unwrap();
 
         let overwrite_plan_append = plan_overwrite_rewrite(
-            Some(table_with_snapshot.snapshot().unwrap().snapshot()),
+            Some(
+                table_with_snapshot
+                    .snapshot()
+                    .unwrap()
+                    .snapshot()
+                    .snapshot(),
+            ),
             &table_with_snapshot.log_store(),
             &session,
             SaveMode::Append,
@@ -1040,7 +1050,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
             session: &session,
             source: source_plan_for_batch(get_record_batch(None, false)),
             mode: SaveMode::Append,
@@ -1056,7 +1066,7 @@ mod tests {
         .unwrap();
 
         let _ = plan_overwrite_rewrite(
-            Some(table.snapshot().unwrap().snapshot()),
+            Some(table.snapshot().unwrap().snapshot().snapshot()),
             &table.log_store(),
             &session,
             SaveMode::Overwrite,
@@ -1086,7 +1096,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Overwrite,
@@ -1102,7 +1112,7 @@ mod tests {
         .unwrap();
 
         let overwrite_plan = plan_overwrite_rewrite(
-            Some(table.snapshot().unwrap().snapshot()),
+            Some(table.snapshot().unwrap().snapshot().snapshot()),
             &table.log_store(),
             &session,
             SaveMode::Overwrite,
@@ -1142,7 +1152,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Overwrite,
@@ -1158,7 +1168,7 @@ mod tests {
         .unwrap();
 
         let overwrite_plan = plan_overwrite_rewrite(
-            Some(table.snapshot().unwrap().snapshot()),
+            Some(table.snapshot().unwrap().snapshot().snapshot()),
             &table.log_store(),
             &session,
             SaveMode::Overwrite,
@@ -1208,7 +1218,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Overwrite,
@@ -1224,7 +1234,7 @@ mod tests {
         .unwrap();
 
         let overwrite_plan = plan_overwrite_rewrite(
-            Some(table.snapshot().unwrap().snapshot()),
+            Some(table.snapshot().unwrap().snapshot().snapshot()),
             &table.log_store(),
             &session,
             SaveMode::Overwrite,
@@ -1270,7 +1280,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot()),
+            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Overwrite,
@@ -1286,7 +1296,7 @@ mod tests {
         .unwrap();
 
         let overwrite_plan = plan_overwrite_rewrite(
-            Some(table.snapshot().unwrap().snapshot()),
+            Some(table.snapshot().unwrap().snapshot().snapshot()),
             &table.log_store(),
             &session,
             SaveMode::Overwrite,

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -856,6 +856,10 @@ mod tests {
         .unwrap()
     }
 
+    fn snapshot_for_write_planning(table: &DeltaTable) -> &Snapshot {
+        table.snapshot().unwrap().snapshot().snapshot()
+    }
+
     fn assert_passthrough_overwrite_plan(
         overwrite_plan: &MatchedFilesRewritePlan,
         prepared: &PreparedWrite,
@@ -896,7 +900,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
+            snapshot: Some(snapshot_for_write_planning(&table)),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Append,
@@ -938,7 +942,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
+            snapshot: Some(snapshot_for_write_planning(&table)),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Overwrite,
@@ -998,14 +1002,9 @@ mod tests {
             .await
             .unwrap();
 
+        let snapshot = snapshot_for_write_planning(&table_with_snapshot);
         let prepared_append = prepare_write(WritePreparationInput {
-            snapshot: Some(
-                table_with_snapshot
-                    .snapshot()
-                    .unwrap()
-                    .snapshot()
-                    .snapshot(),
-            ),
+            snapshot: Some(snapshot),
             session: &session,
             source: source_plan_for_batch(get_record_batch(None, false)),
             mode: SaveMode::Append,
@@ -1021,13 +1020,7 @@ mod tests {
         .unwrap();
 
         let overwrite_plan_append = plan_overwrite_rewrite(
-            Some(
-                table_with_snapshot
-                    .snapshot()
-                    .unwrap()
-                    .snapshot()
-                    .snapshot(),
-            ),
+            Some(snapshot),
             &table_with_snapshot.log_store(),
             &session,
             SaveMode::Append,
@@ -1050,7 +1043,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
+            snapshot: Some(snapshot_for_write_planning(&table)),
             session: &session,
             source: source_plan_for_batch(get_record_batch(None, false)),
             mode: SaveMode::Append,
@@ -1066,7 +1059,7 @@ mod tests {
         .unwrap();
 
         let _ = plan_overwrite_rewrite(
-            Some(table.snapshot().unwrap().snapshot().snapshot()),
+            Some(snapshot_for_write_planning(&table)),
             &table.log_store(),
             &session,
             SaveMode::Overwrite,
@@ -1096,7 +1089,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
+            snapshot: Some(snapshot_for_write_planning(&table)),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Overwrite,
@@ -1112,7 +1105,7 @@ mod tests {
         .unwrap();
 
         let overwrite_plan = plan_overwrite_rewrite(
-            Some(table.snapshot().unwrap().snapshot().snapshot()),
+            Some(snapshot_for_write_planning(&table)),
             &table.log_store(),
             &session,
             SaveMode::Overwrite,
@@ -1152,7 +1145,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
+            snapshot: Some(snapshot_for_write_planning(&table)),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Overwrite,
@@ -1168,7 +1161,7 @@ mod tests {
         .unwrap();
 
         let overwrite_plan = plan_overwrite_rewrite(
-            Some(table.snapshot().unwrap().snapshot().snapshot()),
+            Some(snapshot_for_write_planning(&table)),
             &table.log_store(),
             &session,
             SaveMode::Overwrite,
@@ -1218,7 +1211,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
+            snapshot: Some(snapshot_for_write_planning(&table)),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Overwrite,
@@ -1234,7 +1227,7 @@ mod tests {
         .unwrap();
 
         let overwrite_plan = plan_overwrite_rewrite(
-            Some(table.snapshot().unwrap().snapshot().snapshot()),
+            Some(snapshot_for_write_planning(&table)),
             &table.log_store(),
             &session,
             SaveMode::Overwrite,
@@ -1280,7 +1273,7 @@ mod tests {
         let session = create_session().state();
         let configuration = HashMap::new();
         let prepared = prepare_write(WritePreparationInput {
-            snapshot: Some(table.snapshot().unwrap().snapshot().snapshot()),
+            snapshot: Some(snapshot_for_write_planning(&table)),
             session: &session,
             source: source_plan_for_batch(batch),
             mode: SaveMode::Overwrite,
@@ -1296,7 +1289,7 @@ mod tests {
         .unwrap();
 
         let overwrite_plan = plan_overwrite_rewrite(
-            Some(table.snapshot().unwrap().snapshot().snapshot()),
+            Some(snapshot_for_write_planning(&table)),
             &table.log_store(),
             &session,
             SaveMode::Overwrite,

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -457,13 +457,6 @@ impl EagerSnapshot {
     ) -> Result<Vec<arrow::record_batch::RecordBatch>, DeltaTableError> {
         self.snapshot().add_actions_batches(flatten)
     }
-
-    #[cfg(feature = "datafusion")]
-    pub(crate) fn add_actions_partition_batches(
-        &self,
-    ) -> Result<Vec<RecordBatch>, DeltaTableError> {
-        self.snapshot().add_actions_partition_batches()
-    }
 }
 
 /// Target number of rows per coalesced batch. Matches DataFusion's default batch size.
@@ -778,7 +771,7 @@ mod tests {
             .await?;
 
         let snapshot = table.snapshot()?.snapshot();
-        let batches = snapshot.add_actions_partition_batches()?;
+        let batches = snapshot.snapshot().add_actions_partition_batches()?;
         assert!(!batches.is_empty());
 
         let schema = batches[0].schema();


### PR DESCRIPTION
This removes internal `EagerSnapshot` dependencies where the code can use `Snapshot`, `Arc<Snapshot>`, active add APIs, tombstone APIs, `DeltaScanNext`, or `FileSelection` directly. Public compatibility stays intact.