### PR TITLE
fix: apply merge barrier before duplicate validation

### DIFF
--- a/crates/benchmarks/README.md
+++ b/crates/benchmarks/README.md
@@ -41,6 +41,7 @@ Filter a specific suite:
 cargo bench -p delta-benchmarks --bench merge -- delete_only
 cargo bench -p delta-benchmarks --bench merge -- multiple_insert_only
 cargo bench -p delta-benchmarks --bench merge -- upsert_file_matched
+cargo bench -p delta-benchmarks --bench merge -- noop_heavy_upsert
 ```
 
 ## Profiling script
@@ -49,14 +50,18 @@ A simple CLI is available to run a single merge with configurable parameters (us
 
 Run (from repo root):
 ```bash
-cargo run --profile profiling -p delta-benchmarks -- merge --op upsert --matched 0.01 --not-matched 0.10
+cargo run --profile profiling -p delta-benchmarks -- merge upsert --matched 0.01 --not-matched 0.10
+cargo run --profile profiling -p delta-benchmarks -- merge noop-heavy-upsert --matched 1.0 --not-matched 0.05
 ```
 
 Options:
-- `--op <upsert|delete|insert>`: operation to benchmark
+- `<upsert|noop-heavy-upsert|delete|insert>`: operation to benchmark
 - `--matched <fraction>`: fraction of rows that match existing keys (default 0.01)
 - `--not-matched <fraction>`: fraction of rows that do not match (default 0.10)
 - `--case <name>`: run one of the predefined merge scenarios mirrored from the Delta Spark suite
+
+The `noop-heavy-upsert` operation profiles matched rows with a false update predicate
+and inserted rows.
 
 List cases with:
 ```bash
@@ -72,5 +77,5 @@ To start,
 ```bash
 cargo install samply --locked
 cargo build --profile profiling -p delta-benchmarks
-samply record ./target/profiling/delta-benchmarks upsert
+samply record ./target/profiling/delta-benchmarks merge upsert
 ```

--- a/crates/benchmarks/benches/merge.rs
+++ b/crates/benchmarks/benches/merge.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use delta_benchmarks::{
-    delete_only_cases, insert_only_cases, prepare_source_and_table, upsert_cases, MergeTestCase,
+    delete_only_cases, insert_only_cases, noop_heavy_upsert_cases, prepare_source_and_table,
+    upsert_cases, MergeTestCase,
 };
 
 use divan::{AllocProfiler, Bencher};
@@ -50,5 +51,10 @@ fn delete_only(bencher: Bencher, case: &MergeTestCase) {
 
 #[divan::bench(args = upsert_cases())]
 fn upsert(bencher: Bencher, case: &MergeTestCase) {
+    bench_merge_case(bencher, case);
+}
+
+#[divan::bench(args = noop_heavy_upsert_cases())]
+fn noop_heavy_upsert(bencher: Bencher, case: &MergeTestCase) {
     bench_merge_case(bencher, case);
 }

--- a/crates/benchmarks/src/lib.rs
+++ b/crates/benchmarks/src/lib.rs
@@ -4,8 +4,8 @@ pub mod tpcds_queries;
 
 pub use merge::{
     delete_only_cases, insert_only_cases, merge_case_by_name, merge_case_names, merge_delete,
-    merge_insert, merge_test_cases, merge_upsert, prepare_source_and_table, upsert_cases, MergeOp,
-    MergePerfParams, MergeScenario, MergeTestCase,
+    merge_insert, merge_noop_heavy_upsert, merge_test_cases, merge_upsert, noop_heavy_upsert_cases,
+    prepare_source_and_table, upsert_cases, MergeOp, MergePerfParams, MergeScenario, MergeTestCase,
 };
 pub use smoke::{run_smoke_once, SmokeParams};
 pub use tpcds_queries::{

--- a/crates/benchmarks/src/main.rs
+++ b/crates/benchmarks/src/main.rs
@@ -6,15 +6,16 @@ use std::{
 use clap::{Parser, Subcommand, ValueEnum};
 
 use delta_benchmarks::{
-    merge_case_by_name, merge_case_names, merge_delete, merge_insert, merge_upsert,
-    prepare_source_and_table, register_tpcds_tables, run_smoke_once, tpcds_queries, tpcds_query,
-    MergeOp, MergePerfParams, MergeTestCase, SmokeParams,
+    merge_case_by_name, merge_case_names, merge_delete, merge_insert, merge_noop_heavy_upsert,
+    merge_upsert, prepare_source_and_table, register_tpcds_tables, run_smoke_once, tpcds_queries,
+    tpcds_query, MergeOp, MergePerfParams, MergeTestCase, SmokeParams,
 };
 use deltalake_core::ensure_table_uri;
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
 enum OpKind {
     Upsert,
+    NoopHeavyUpsert,
     Delete,
     Insert,
 }
@@ -107,11 +108,14 @@ async fn main() -> anyhow::Result<()> {
                 run_merge_case(merge_case, &parquet_dir).await?;
             } else {
                 let op = op.ok_or_else(|| {
-                    anyhow::anyhow!("specify an operation (upsert/delete/insert) or provide --case")
+                    anyhow::anyhow!(
+                        "specify an operation (upsert/noop-heavy-upsert/delete/insert) or provide --case"
+                    )
                 })?;
 
                 let op_fn: MergeOp = match op {
                     OpKind::Upsert => merge_upsert,
+                    OpKind::NoopHeavyUpsert => merge_noop_heavy_upsert,
                     OpKind::Delete => merge_delete,
                     OpKind::Insert => merge_insert,
                 };

--- a/crates/benchmarks/src/merge.rs
+++ b/crates/benchmarks/src/merge.rs
@@ -27,6 +27,7 @@ pub enum MergeScenario {
     MultipleInsertOnly,
     DeleteOnly,
     Upsert,
+    NoopHeavyUpsert,
 }
 
 type MergeValidator = fn(&MergeMetrics, &MergeTestCase) -> DeltaResult<()>;
@@ -58,6 +59,7 @@ impl MergeTestCase {
             MergeScenario::MultipleInsertOnly => merge_multiple_insert(source, table),
             MergeScenario::DeleteOnly => merge_delete(source, table),
             MergeScenario::Upsert => merge_upsert(source, table),
+            MergeScenario::NoopHeavyUpsert => merge_noop_heavy_upsert(source, table),
         }
     }
 
@@ -104,6 +106,29 @@ fn validate_upsert(metrics: &MergeMetrics, case: &MergeTestCase) -> DeltaResult<
     ensure_zero(
         metrics.num_target_rows_deleted,
         "num_target_rows_deleted",
+        case,
+    )
+}
+
+fn validate_noop_heavy_upsert(metrics: &MergeMetrics, case: &MergeTestCase) -> DeltaResult<()> {
+    ensure_zero(
+        metrics.num_target_rows_updated,
+        "num_target_rows_updated",
+        case,
+    )?;
+    ensure_zero(
+        metrics.num_target_rows_deleted,
+        "num_target_rows_deleted",
+        case,
+    )?;
+    ensure_zero(
+        metrics.num_target_rows_copied,
+        "num_target_rows_copied",
+        case,
+    )?;
+    ensure_zero(
+        metrics.num_target_files_removed,
+        "num_target_files_removed",
         case,
     )
 }
@@ -276,11 +301,23 @@ const UPSERT_CASES: [MergeTestCase; 9] = [
     },
 ];
 
+const NOOP_HEAVY_UPSERT_CASES: [MergeTestCase; 1] = [MergeTestCase {
+    name:
+        "noop_heavy_upsert_filesMatchedFraction_1.0_rowsMatchedNoopFraction_1.0_rowsNotMatchedFraction_0.05",
+    scenario: MergeScenario::NoopHeavyUpsert,
+    params: MergePerfParams {
+        sample_matched_rows: 1.0,
+        sample_not_matched_rows: 0.05,
+    },
+    validator: validate_noop_heavy_upsert,
+}];
+
 fn all_cases_iter() -> impl Iterator<Item = &'static MergeTestCase> {
     INSERT_ONLY_CASES
         .iter()
         .chain(DELETE_ONLY_CASES.iter())
         .chain(UPSERT_CASES.iter())
+        .chain(NOOP_HEAVY_UPSERT_CASES.iter())
 }
 
 pub fn insert_only_cases() -> &'static [MergeTestCase] {
@@ -293,6 +330,10 @@ pub fn delete_only_cases() -> &'static [MergeTestCase] {
 
 pub fn upsert_cases() -> &'static [MergeTestCase] {
     &UPSERT_CASES
+}
+
+pub fn noop_heavy_upsert_cases() -> &'static [MergeTestCase] {
+    &NOOP_HEAVY_UPSERT_CASES
 }
 
 pub fn merge_case_names() -> Vec<&'static str> {
@@ -378,6 +419,25 @@ pub fn merge_upsert(source: DataFrame, table: DeltaTable) -> Result<MergeBuilder
         .with_source_alias("source")
         .with_target_alias("target")
         .when_matched_update(apply_update_projection)?
+        .when_not_matched_insert(apply_insert_projection)
+}
+
+pub fn merge_noop_heavy_upsert(
+    source: DataFrame,
+    table: DeltaTable,
+) -> Result<MergeBuilder, DeltaTableError> {
+    table
+        .merge(
+            source,
+            "source.wr_item_sk = target.wr_item_sk and source.wr_order_number = target.wr_order_number",
+        )
+        .with_source_alias("source")
+        .with_target_alias("target")
+        .when_matched_update(|update| {
+            apply_update_projection(
+                update.predicate("source.wr_return_amt <> target.wr_return_amt"),
+            )
+        })?
         .when_not_matched_insert(apply_insert_projection)
 }
 

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -823,6 +823,32 @@ const DUPLICATE_MATCH_MARKER_COLUMNS: &[&str] = &[
     TARGET_MATCH_CARDINALITY_CLASS_COLUMN,
 ];
 
+fn build_merge_barrier_validation_plan(
+    input: LogicalPlan,
+    state: &SessionState,
+    ops: &[(
+        HashMap<Column, Expr>,
+        OperationType,
+        MatchParticipationClass,
+    )],
+    file_column: Arc<String>,
+    needs_duplicate_match_validation: bool,
+) -> DataFusionResult<LogicalPlan> {
+    let merge_barrier = LogicalPlan::Extension(Extension {
+        node: Arc::new(MergeBarrier {
+            input,
+            expr: col(file_column.as_str()),
+            file_column: Arc::clone(&file_column),
+        }),
+    });
+
+    if needs_duplicate_match_validation {
+        build_duplicate_match_validation_plan(merge_barrier, state, ops, file_column)
+    } else {
+        Ok(merge_barrier)
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, fields(operation = "merge", version = snapshot.version(), table_uri = %log_store.root_url()))]
 async fn execute(
@@ -1477,28 +1503,20 @@ async fn execute(
             .build()?
     };
 
-    let new_columns = if !match_operations.is_empty() {
-        build_duplicate_match_validation_plan(new_columns, &state, &ops, Arc::clone(&file_column))?
-    } else {
-        new_columns
-    };
-
-    let distribute_expr = col(file_column.as_str());
-
-    let merge_barrier = LogicalPlan::Extension(Extension {
-        node: Arc::new(MergeBarrier {
-            input: new_columns.clone(),
-            expr: distribute_expr,
-            file_column: Arc::clone(&file_column),
-        }),
-    });
+    let merge_output = build_merge_barrier_validation_plan(
+        new_columns,
+        &state,
+        &ops,
+        Arc::clone(&file_column),
+        needs_duplicate_match_validation,
+    )?;
 
     // We should observe the metrics before we union the merge plan with the cdf_merge plan
     // so that we get the metrics only for the merge plan.
     let operation_count = LogicalPlan::Extension(Extension {
         node: Arc::new(MetricObserver {
             id: OUTPUT_COUNT_ID.into(),
-            input: merge_barrier,
+            input: merge_output,
             enable_pushdown: false,
         }),
     });
@@ -1960,13 +1978,14 @@ mod tests {
         DataFusionMixins, DeltaScanNext, PATH_COLUMN, resolve_file_column_name,
     };
 
+    use super::barrier::MergeBarrier;
     use super::validation::MergeValidation;
     use super::{
         DELETE_COLUMN, MatchParticipationClass, MergeMetrics, OPERATION_COLUMN, OperationType,
         SOURCE_COLUMN, TARGET_COLUMN, TARGET_COPY_COLUMN, TARGET_DELETE_COLUMN,
         TARGET_INSERT_COLUMN, TARGET_MATCH_CARDINALITY_CLASS_COLUMN,
         TARGET_ROW_ORDINAL_IN_FILE_COLUMN, TARGET_UPDATE_COLUMN,
-        build_duplicate_match_validation_plan,
+        build_duplicate_match_validation_plan, build_merge_barrier_validation_plan,
     };
 
     pub(crate) async fn setup_table(partitions: Option<Vec<&str>>) -> DeltaTable {
@@ -2264,6 +2283,55 @@ mod tests {
         assert!(!field_names.contains(&TARGET_MATCH_CARDINALITY_CLASS_COLUMN));
     }
 
+    #[test]
+    fn test_noop_heavy_merge_applies_barrier_before_duplicate_validation() {
+        let input = duplicate_match_validation_input_plan();
+        let ops = vec![
+            (
+                HashMap::new(),
+                OperationType::Update,
+                MatchParticipationClass::MatchedAction,
+            ),
+            (
+                HashMap::new(),
+                OperationType::Insert,
+                MatchParticipationClass::Ignore,
+            ),
+            (
+                HashMap::new(),
+                OperationType::Copy,
+                MatchParticipationClass::MatchedNoop,
+            ),
+        ];
+        let state = SessionContext::new().state();
+
+        let plan = build_merge_barrier_validation_plan(
+            input,
+            &state,
+            &ops,
+            Arc::new(PATH_COLUMN.to_string()),
+            true,
+        )
+        .expect("merge barrier and duplicate validation plan builds");
+
+        let validation = find_merge_validation(&plan).expect("matched clauses require validation");
+        assert!(
+            contains_merge_barrier(&validation.input),
+            "expected MergeBarrier before duplicate validation; unchanged target files drop \
+             before validation buffers their rows: {}",
+            validation.input.display_indent()
+        );
+
+        let field_names = plan
+            .schema()
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect::<Vec<_>>();
+        assert!(!field_names.contains(&TARGET_ROW_ORDINAL_IN_FILE_COLUMN));
+        assert!(!field_names.contains(&TARGET_MATCH_CARDINALITY_CLASS_COLUMN));
+    }
+
     #[tokio::test]
     async fn test_target_row_ordinal_scan_plan_has_no_window_or_sort() {
         let schema = get_arrow_schema(&None);
@@ -2450,6 +2518,16 @@ mod tests {
         }
 
         plan.inputs().into_iter().find_map(find_merge_validation)
+    }
+
+    fn contains_merge_barrier(plan: &LogicalPlan) -> bool {
+        if let LogicalPlan::Extension(Extension { node }) = plan
+            && node.as_any().downcast_ref::<MergeBarrier>().is_some()
+        {
+            return true;
+        }
+
+        plan.inputs().into_iter().any(contains_merge_barrier)
     }
 
     fn count_unions(plan: &LogicalPlan) -> usize {

--- a/crates/core/tests/it_datafusion/command_merge.rs
+++ b/crates/core/tests/it_datafusion/command_merge.rs
@@ -477,6 +477,55 @@ async fn test_merge_large_single_file_unique_source_does_not_report_duplicate_ma
 }
 
 #[tokio::test]
+async fn test_merge_noop_heavy_matched_update_with_inserts_does_not_rewrite_target_file()
+-> DeltaResult<()> {
+    let target_rows = 25_000;
+    let inserted_rows = 1_000;
+    let total_source_rows = target_rows + inserted_rows;
+    let table = single_file_id_value_table(target_rows).await;
+
+    let config = SessionConfig::new().with_target_partitions(4);
+    let ctx = SessionContext::new_with_config(config);
+    let source = ctx
+        .read_batch(id_value_batch(
+            (0..total_source_rows).collect::<Vec<_>>(),
+            vec![1_i64; total_source_rows as usize],
+        ))
+        .unwrap();
+
+    let (table, metrics) = table
+        .merge(source, col("target.id").eq(col("source.id")))
+        .with_source_alias("source")
+        .with_target_alias("target")
+        .with_session_state(Arc::new(ctx.state()))
+        .when_matched_update(|update| {
+            update
+                .predicate(
+                    qualified_col("target", "value").not_eq(qualified_col("source", "value")),
+                )
+                .update("value", qualified_col("source", "value"))
+        })?
+        .when_not_matched_insert(|insert| {
+            insert
+                .set("id", qualified_col("source", "id"))
+                .set("value", qualified_col("source", "value"))
+        })?
+        .await?;
+
+    assert_eq!(metrics.num_source_rows, total_source_rows as usize);
+    assert_eq!(metrics.num_target_rows_updated, 0);
+    assert_eq!(metrics.num_target_rows_inserted, inserted_rows as usize);
+    assert_eq!(metrics.num_target_rows_deleted, 0);
+    assert_eq!(metrics.num_target_rows_copied, 0);
+    assert_eq!(metrics.num_output_rows, inserted_rows as usize);
+    assert_eq!(metrics.num_target_files_scanned, 1);
+    assert_eq!(metrics.num_target_files_removed, 0);
+
+    assert_id_value_table_complete(&table, total_source_rows, None, 0).await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_merge_batch_boundary_update_does_not_drop_target_rows() -> DeltaResult<()> {
     let table = single_file_id_value_table(8_193).await;
 


### PR DESCRIPTION
# Description
1. Route projected merge rows through `MergeBarrier` before duplicate match validation
2. Keep retained row index scan planning in place for duplicate detection
3. Add `noop heavy-upsert` benchmark coverage

# Related Issue(s)
- closes #4576 

<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
