### PR TITLE
fix: preserve container values with bad null counts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/delta-io/delta.rs"
 
 [workspace.dependencies]
 #delta_kernel = { package = "buoyant_kernel", path = "../delta-kernel-rs/kernel", features = [
-delta_kernel = { package = "buoyant_kernel", git = "https://github.com/buoyant-data/delta-kernel-rs", branch = "buoyant/main", features = [
+delta_kernel = { package = "buoyant_kernel", git = "https://github.com/buoyant-data/delta-kernel-rs", rev = "393fbf662f56c4bb04445e1d36805a33e32b8fbc", features = [
 #delta_kernel = { package = "buoyant_kernel", version = "0.24.0, <0.24.100", features = [
     "arrow-58",
     "internal-api",

--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -544,44 +544,6 @@ impl AddAssign for AggregatedStats {
     }
 }
 
-/// For a list field, we don't want the inner field names. We need to chuck out
-/// the list and items fields from the path, but also need to handle the
-/// peculiar case where the user named the list field "list" or "item".
-///
-/// NOTE: As of delta_kernel 0.3.1 the name switched from `item` to `element` to line up with the
-/// parquet spec, see
-/// [here](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists)
-///
-/// For example:
-///
-/// * ["some_nested_list", "list", "item", "list", "item"] -> "some_nested_list"
-/// * ["some_list", "list", "item"] -> "some_list"
-/// * ["list", "list", "item"] -> "list"
-/// * ["item", "list", "item"] -> "item"
-fn get_list_field_name(column_descr: &Arc<ColumnDescriptor>) -> Option<String> {
-    let max_rep_levels = column_descr.max_rep_level();
-    let column_path_parts = column_descr.path().parts();
-
-    // If there are more nested names, we can't handle them yet.
-    if column_path_parts.len() > (2 * max_rep_levels + 1) as usize {
-        return None;
-    }
-
-    let mut column_path_parts = column_path_parts.to_vec();
-    let mut items_seen = 0;
-    let mut lists_seen = 0;
-    while let Some(part) = column_path_parts.pop() {
-        match (part.as_str(), lists_seen, items_seen) {
-            ("list", seen, _) if seen == max_rep_levels => return Some("list".to_string()),
-            ("element", _, seen) if seen == max_rep_levels => return Some("element".to_string()),
-            ("list", _, _) => lists_seen += 1,
-            ("element", _, _) => items_seen += 1,
-            (other, _, _) => return Some(other.to_string()),
-        }
-    }
-    None
-}
-
 fn apply_min_max_for_column(
     statistics: AggregatedStats,
     column_descr: Arc<ColumnDescriptor>,
@@ -590,14 +552,8 @@ fn apply_min_max_for_column(
     max_values: &mut HashMap<String, ColumnValueStat>,
     null_counts: &mut HashMap<String, ColumnCountStat>,
 ) -> Result<(), DeltaWriterError> {
-    // Special handling for list column
+    // Repeated leaf null counts describe nested values only.
     if column_descr.max_rep_level() > 0 {
-        let key = get_list_field_name(&column_descr);
-
-        if let Some(key) = key {
-            null_counts.insert(key, ColumnCountStat::Value(statistics.null_count as i64));
-        }
-
         return Ok(());
     }
 
@@ -932,8 +888,7 @@ mod tests {
         let stats = add[0].get_stats().unwrap().unwrap();
 
         let min_max_keys = vec!["meta", "some_int", "some_string", "some_bool", "uuid"];
-        let mut null_count_keys = vec!["some_list", "some_nested_list"];
-        null_count_keys.extend_from_slice(min_max_keys.as_slice());
+        let null_count_keys = min_max_keys.clone();
 
         assert_eq!(
             min_max_keys.len(),
@@ -1032,13 +987,89 @@ mod tests {
                 ("some_int", ColumnCountStat::Value(v)) => assert_eq!(100, *v),
                 ("some_bool", ColumnCountStat::Value(v)) => assert_eq!(100, *v),
                 ("some_string", ColumnCountStat::Value(v)) => assert_eq!(100, *v),
-                ("some_list", ColumnCountStat::Value(v)) => assert_eq!(100, *v),
-                ("some_nested_list", ColumnCountStat::Value(v)) => assert_eq!(100, *v),
                 ("date", ColumnCountStat::Value(v)) => assert_eq!(0, *v),
                 ("uuid", ColumnCountStat::Value(v)) => assert_eq!(0, *v),
                 k => panic!("Key {k:?} should not be present in null_count"),
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_repeated_leaf_stats_skip_container_null_counts() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let table_path = temp_dir.path();
+        let schema = json!({
+            "type": "struct",
+            "fields": [
+                { "name": "id", "type": "string", "nullable": true, "metadata": {} },
+                {
+                    "name": "b",
+                    "type": {
+                        "type": "array",
+                        "elementType": "integer",
+                        "containsNull": true
+                    },
+                    "nullable": true, "metadata": {}
+                },
+                {
+                    "name": "m",
+                    "type": {
+                        "type": "map",
+                        "keyType": "string",
+                        "valueType": "integer",
+                        "valueContainsNull": true
+                    },
+                    "nullable": true, "metadata": {}
+                }
+            ]
+        });
+        create_temp_table_with_schema(table_path, &schema);
+
+        let table_uri = Url::from_directory_path(table_path).unwrap();
+        let table = load_table(&table_uri, HashMap::new()).await.unwrap();
+
+        let mut writer = RecordBatchWriter::for_table(&table).unwrap();
+        writer = writer.with_writer_properties(
+            WriterProperties::builder()
+                .set_compression(Compression::SNAPPY)
+                .build(),
+        );
+
+        let arrow_schema = writer.arrow_schema();
+        let rows = [
+            json!({
+                "id": "with_null_element",
+                "b": [1, null, 2],
+                "m": {"a": 1, "b": null},
+            }),
+            json!({
+                "id": "empty",
+                "b": [],
+                "m": {},
+            }),
+        ];
+        let batch = record_batch_from_message(arrow_schema, rows.as_slice()).unwrap();
+
+        writer.write(batch).await.unwrap();
+        let add = writer.flush().await.unwrap();
+        assert_eq!(add.len(), 1);
+        let stats = add[0].get_stats().unwrap().unwrap();
+
+        assert!(
+            !stats.null_count.contains_key("b"),
+            "writer copied list element null counts into list nullCount: {:?}",
+            stats.null_count
+        );
+        assert!(
+            !stats.null_count.contains_key("m"),
+            "writer copied map value null counts into map nullCount: {:?}",
+            stats.null_count
+        );
+        assert_eq!(
+            Some(&ColumnCountStat::Value(0)),
+            stats.null_count.get("id"),
+            "writer kept scalar null counts"
+        );
     }
 
     // Regression test for delta-io/delta-rs#3172: leaves under a nested
@@ -1149,6 +1180,37 @@ mod tests {
         std::fs::write(
             log_path.join("00000000000000000000.json"),
             V0_COMMIT.as_str(),
+        )
+        .unwrap();
+    }
+
+    fn create_temp_table_with_schema(table_path: &Path, schema: &Value) {
+        let log_path = table_path.join("_delta_log");
+        let schema_string = serde_json::to_string(schema).unwrap();
+        let jsons = [
+            json!({
+                "protocol":{"minReaderVersion":1,"minWriterVersion":2}
+            }),
+            json!({
+                "metaData": {
+                    "id": "22ef18ba-191c-4c36-a606-3dad5cdf3830",
+                    "format": {
+                        "provider": "parquet", "options": {}
+                    },
+                    "schemaString": schema_string,
+                    "partitionColumns": [], "configuration": {}, "createdTime": 1564524294376i64
+                }
+            }),
+        ];
+
+        std::fs::create_dir(log_path.as_path()).unwrap();
+        std::fs::write(
+            log_path.join("00000000000000000000.json"),
+            jsons
+                .iter()
+                .map(|j| serde_json::to_string(j).unwrap())
+                .collect::<Vec<String>>()
+                .join("\n"),
         )
         .unwrap();
     }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -16,7 +16,10 @@ use datafusion_ffi::table_provider::FFI_TableProvider;
 use delta_kernel::expressions::Scalar;
 use delta_kernel::schema::{MetadataValue, StructField};
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
-use deltalake::arrow::{self, datatypes::Schema as ArrowSchema};
+use deltalake::arrow::{
+    self,
+    datatypes::{DataType as ArrowDataType, Schema as ArrowSchema},
+};
 use deltalake::checkpoints::{cleanup_metadata, create_checkpoint};
 use deltalake::datafusion::catalog::TableProvider;
 use deltalake::datafusion::datasource::provider_as_source;
@@ -2527,7 +2530,12 @@ fn filestats_to_expression_next<'py>(
     // NOTE: null_counts should always return a struct scalar.
     if let Some(Scalar::Struct(data)) = file_info.null_counts() {
         for (field, value) in data.fields().iter().zip(data.values().iter()) {
+            let is_opaque_container_field = schema
+                .field_with_name(field.name())
+                .map(|field| is_opaque_container_arrow_type(field.data_type()))
+                .unwrap_or(false);
             if stats_columns.contains(field.name())
+                && !is_opaque_container_field
                 && let Scalar::Long(val) = value
             {
                 if *val == 0 {
@@ -2607,6 +2615,16 @@ fn filestats_to_expression_next<'py>(
             .reduce(|accum, item| accum?.call_method1("__and__", (item?,)))
             .transpose()
     }
+}
+
+fn is_opaque_container_arrow_type(data_type: &ArrowDataType) -> bool {
+    matches!(
+        data_type,
+        ArrowDataType::List(_)
+            | ArrowDataType::LargeList(_)
+            | ArrowDataType::FixedSizeList(_, _)
+            | ArrowDataType::Map(_, _)
+    )
 }
 
 #[pyfunction]

--- a/python/tests/test_merge.py
+++ b/python/tests/test_merge.py
@@ -3402,6 +3402,48 @@ def test_merge_streamed_exec_does_not_rescan_single_use_source(tmp_path: pathlib
 
 
 @pytest.mark.pyarrow
+def test_merge_when_matched_update_preserves_list_with_null_element(
+    tmp_path: pathlib.Path,
+):
+    import pyarrow as pa
+
+    list_type = pa.list_(pa.field("element", pa.int32()))
+    schema = pa.schema([pa.field("id", pa.string()), pa.field("b", list_type)])
+    initial = pa.table(
+        {
+            "id": pa.array(["row1"], type=pa.string()),
+            "b": pa.array([[1, 2, None]], type=list_type),
+        },
+        schema=schema,
+    )
+    write_deltalake(tmp_path, initial)
+
+    source = pa.table(
+        {
+            "id": pa.array(["row1"], type=pa.string()),
+            "b": pa.array([[-9999, -9999, None]], type=list_type),
+        },
+        schema=schema,
+    )
+
+    (
+        DeltaTable(tmp_path)
+        .merge(
+            source=source,
+            source_alias="source",
+            target_alias="target",
+            predicate="source.id = target.id",
+        )
+        .when_matched_update(updates={"b": "source.b"})
+        .execute()
+    )
+
+    result = DeltaTable(tmp_path).to_pyarrow_table()
+    row_b = result.filter(pa.compute.equal(result["id"], "row1"))["b"][0].as_py()
+    assert row_b == [-9999, -9999, None]
+
+
+@pytest.mark.pyarrow
 def test_merge_with_spill_config(tmp_path: pathlib.Path):
     """Verify merge accepts and uses spill configuration without error."""
     import pyarrow as pa

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1136,6 +1136,92 @@ def test_writer_null_stats(tmp_path: pathlib.Path):
     assert stats["nullCount"] == expected_nulls
 
 
+@pytest.mark.pyarrow
+def test_list_values_with_null_elements_and_empty_lists_read_with_default_stats(
+    tmp_path: pathlib.Path,
+):
+    import pyarrow as pa
+
+    list_type = pa.list_(pa.field("element", pa.int32()))
+    schema = pa.schema([pa.field("id", pa.string()), pa.field("b", list_type)])
+    data = pa.table(
+        {
+            "id": pa.array(
+                ["with_element_null", "only_null_element", "empty", "true_null"],
+                type=pa.string(),
+            ),
+            "b": pa.array([[1, 2, None], [None], [], None], type=list_type),
+        },
+        schema=schema,
+    )
+
+    write_deltalake(tmp_path, data)
+
+    dt = DeltaTable(tmp_path)
+    result_by_id = {row["id"]: row["b"] for row in dt.to_pyarrow_table().to_pylist()}
+    assert result_by_id == {
+        "with_element_null": [1, 2, None],
+        "only_null_element": [None],
+        "empty": [],
+        "true_null": None,
+    }
+
+    fragment_expressions = [
+        str(fragment.partition_expression)
+        for fragment in dt.to_pyarrow_dataset().get_fragments()
+    ]
+    assert all("is_null(b" not in expression for expression in fragment_expressions)
+
+
+@pytest.mark.pyarrow
+@pytest.mark.parametrize(
+    ("case_name", "expected"),
+    [
+        ("list", [[1, 2], [3, None]]),
+        ("large_list", [[1, 2], [3, None]]),
+        ("fixed_size_list", [[1, 2], [3, None]]),
+        ("map", [[("a", 1), ("b", None)], [("c", 2)]]),
+    ],
+)
+def test_container_null_count_stats_keep_parquet_values(
+    tmp_path: pathlib.Path,
+    case_name: str,
+    expected,
+):
+    import pyarrow as pa
+
+    if case_name == "list":
+        arrow_type = pa.list_(pa.field("element", pa.int32()))
+    elif case_name == "large_list":
+        arrow_type = pa.large_list(pa.field("element", pa.int32()))
+    elif case_name == "fixed_size_list":
+        arrow_type = pa.list_(pa.field("element", pa.int32()), 2)
+    elif case_name == "map":
+        arrow_type = pa.map_(pa.string(), pa.int32())
+    else:
+        raise AssertionError(f"unexpected case: {case_name}")
+
+    data = pa.table({"b": pa.array(expected, type=arrow_type)})
+    write_deltalake(tmp_path, data)
+    dt = DeltaTable(tmp_path)
+    stats = get_stats(dt)
+    assert "b" not in stats["nullCount"]
+
+    log_path = tmp_path / "_delta_log" / ("0" * 20 + ".json")
+    rewritten_lines = []
+    for line in log_path.read_text().splitlines():
+        action = json.loads(line)
+        if add := action.get("add"):
+            stats = json.loads(add["stats"])
+            stats.setdefault("nullCount", {})["b"] = stats["numRecords"]
+            add["stats"] = json.dumps(stats, separators=(",", ":"))
+        rewritten_lines.append(json.dumps(action, separators=(",", ":")))
+    log_path.write_text("\n".join(rewritten_lines) + "\n")
+
+    dt = DeltaTable(tmp_path)
+    assert dt.to_pyarrow_table()["b"].to_pylist() == expected
+
+
 def test_try_get_table_and_table_uri(tmp_path: pathlib.Path):
     def _normalize_path(t):  # who does not love Windows? ;)
         return t[0], t[1].replace("\\", "/") if t[1] else t[1]


### PR DESCRIPTION
# Description
Fixes #4578.

This patch stops writer stats from copying repeated leaf null counts into list and map container `nullCount` fields.

It also makes the Python dataset expression builder ignore `nullCount` stats for opaque container columns. That keeps stale or malformed stats from forcing list, large list, fixed size list, or map values to read as null.

# Related Issue(s)
- closes #4578
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
