### PR TITLE
feat: true DNF filters and SQL predicates for the file listing APIs [wip]

### DIFF
--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -26,11 +26,13 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use arrow_array::{Array, GenericListArray};
-use arrow_schema::{DataType, Field};
+use arrow_schema::{DataType, Field, Schema};
 use chrono::{DateTime, NaiveDate};
 use datafusion::catalog::Session;
 use datafusion::common::Result as DFResult;
-use datafusion::common::{DFSchema, Result, ScalarValue, TableReference, config::ConfigOptions};
+use datafusion::common::{
+    DFSchema, Result, ScalarValue, TableReference, ToDFSchema, config::ConfigOptions,
+};
 use datafusion::execution::context::SessionState;
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::functions_nested::make_array::MakeArray;
@@ -56,6 +58,8 @@ use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
 use datafusion::sql::sqlparser::tokenizer::Tokenizer;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+use delta_kernel::expressions::Predicate;
+use delta_kernel::schema::StructType;
 use tracing::log::*;
 
 use crate::delta_datafusion::session::DeltaParserOptions;
@@ -289,6 +293,31 @@ pub fn parse_predicate_expression(
     session: &dyn Session,
 ) -> DeltaResult<Expr> {
     sql_expr_to_df_expr(session, schema, parse_sql_expr(expr)?)
+}
+
+/// Parse a SQL predicate string into a kernel [`Predicate`] for file skipping
+/// during log replay.
+///
+/// The predicate is resolved against the table's logical schema, coercing
+/// literals to the referenced column types the same way operation predicates
+/// (delete, update, merge) are resolved. Only constructs the kernel can
+/// evaluate against file-level metadata are accepted.
+pub fn parse_sql_predicate_to_kernel(
+    predicate: impl AsRef<str>,
+    table_schema: &StructType,
+    session: &dyn Session,
+) -> DeltaResult<Predicate> {
+    let predicate = predicate.as_ref();
+    let schema: Schema = table_schema.try_into_arrow()?;
+    let df_schema = schema.to_dfschema_ref()?;
+    let expr = crate::delta_datafusion::utils::Expression::String(predicate.to_string())
+        .resolve(session, df_schema)?;
+    crate::delta_datafusion::engine::to_delta_predicate(&expr).map_err(|err| {
+        DeltaTableError::Generic(format!(
+            "Cannot use predicate {predicate:?} for file skipping: {err}. Supported are \
+             column comparisons, IS [NOT] NULL, [NOT] IN, [NOT] BETWEEN, NOT, AND and OR."
+        ))
+    })
 }
 
 fn parse_sql_expr(expr: impl AsRef<str>) -> DeltaResult<SqlExpr> {
@@ -1352,6 +1381,112 @@ mod test {
 
         for test in unsupported_types {
             assert!(fmt_expr_to_sql(&test.expr).is_err());
+        }
+    }
+
+    mod sql_predicate_to_kernel {
+        use delta_kernel::expressions::{Expression as KernelExpression, Scalar};
+
+        use super::super::parse_sql_predicate_to_kernel;
+        use super::*;
+        use crate::kernel::schema::partitions::{
+            FilterValue, dnf_to_kernel_predicate, literal_to_kernel_predicate,
+        };
+
+        fn test_schema() -> StructType {
+            StructType::try_new(vec![
+                StructField::new("year", DataType::Primitive(PrimitiveType::Integer), true),
+                StructField::new("month", DataType::Primitive(PrimitiveType::Integer), true),
+                StructField::new("name", DataType::Primitive(PrimitiveType::String), true),
+            ])
+            .unwrap()
+        }
+
+        #[tokio::test]
+        async fn parses_coerced_comparison() {
+            let session = SessionContext::new();
+            let schema = test_schema();
+
+            let predicate =
+                parse_sql_predicate_to_kernel("year > 2020", &schema, &session.state()).unwrap();
+
+            let expected = KernelExpression::column(["year"]).gt(Scalar::Integer(2020));
+            assert_eq!(predicate, expected);
+        }
+
+        #[tokio::test]
+        async fn parses_boolean_logic_matching_dnf() {
+            let session = SessionContext::new();
+            let schema = test_schema();
+
+            let from_sql = parse_sql_predicate_to_kernel(
+                "(year = 2020 AND month = 2) OR (year = 2021 AND month = 12)",
+                &schema,
+                &session.state(),
+            )
+            .unwrap();
+
+            let from_dnf = dnf_to_kernel_predicate(
+                &[
+                    vec![
+                        ("year", "=", FilterValue::Scalar("2020")),
+                        ("month", "=", FilterValue::Scalar("2")),
+                    ],
+                    vec![
+                        ("year", "=", FilterValue::Scalar("2021")),
+                        ("month", "=", FilterValue::Scalar("12")),
+                    ],
+                ],
+                &schema,
+            )
+            .unwrap();
+
+            assert_eq!(from_sql, from_dnf);
+        }
+
+        #[tokio::test]
+        async fn parses_in_list_and_null_checks() {
+            let session = SessionContext::new();
+            let schema = test_schema();
+
+            let from_sql =
+                parse_sql_predicate_to_kernel("year IN (2020, 2021)", &schema, &session.state())
+                    .unwrap();
+            let from_literal = literal_to_kernel_predicate(
+                &("year", "in", FilterValue::Set(vec!["2020", "2021"])),
+                &schema,
+            )
+            .unwrap();
+            assert_eq!(from_sql, from_literal);
+
+            let null_check =
+                parse_sql_predicate_to_kernel("name IS NULL", &schema, &session.state()).unwrap();
+            assert_eq!(null_check, KernelExpression::column(["name"]).is_null());
+        }
+
+        #[tokio::test]
+        async fn unknown_column_errors_with_name() {
+            let session = SessionContext::new();
+            let schema = test_schema();
+
+            let err = parse_sql_predicate_to_kernel("nope = 1", &schema, &session.state())
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("nope"), "unexpected error: {err}");
+        }
+
+        #[tokio::test]
+        async fn unsupported_construct_errors_with_predicate() {
+            let session = SessionContext::new();
+            let schema = test_schema();
+
+            let err = parse_sql_predicate_to_kernel("name LIKE 'a%'", &schema, &session.state())
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("name LIKE 'a%'") && err.contains("file skipping"),
+                "unexpected error: {err}"
+            );
         }
     }
 }

--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -26,11 +26,13 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use arrow_array::{Array, GenericListArray};
-use arrow_schema::{DataType, Field};
+use arrow_schema::{DataType, Field, Schema};
 use chrono::{DateTime, NaiveDate};
 use datafusion::catalog::Session;
 use datafusion::common::Result as DFResult;
-use datafusion::common::{DFSchema, Result, ScalarValue, TableReference, config::ConfigOptions};
+use datafusion::common::{
+    DFSchema, Result, ScalarValue, TableReference, ToDFSchema, config::ConfigOptions,
+};
 use datafusion::execution::context::SessionState;
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::functions_nested::make_array::MakeArray;
@@ -56,6 +58,8 @@ use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
 use datafusion::sql::sqlparser::tokenizer::Tokenizer;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+use delta_kernel::expressions::Predicate;
+use delta_kernel::schema::StructType;
 use tracing::log::*;
 
 use crate::delta_datafusion::session::DeltaParserOptions;
@@ -289,6 +293,31 @@ pub fn parse_predicate_expression(
     session: &dyn Session,
 ) -> DeltaResult<Expr> {
     sql_expr_to_df_expr(session, schema, parse_sql_expr(expr)?)
+}
+
+/// Parse a SQL predicate string into a kernel [`Predicate`] for file skipping
+/// during log replay.
+///
+/// The predicate is resolved against the table's logical schema, coercing
+/// literals to the referenced column types the same way operation predicates
+/// (delete, update, merge) are resolved. Only constructs the kernel can
+/// evaluate against file-level metadata are accepted.
+pub fn parse_sql_predicate_to_kernel(
+    predicate: impl AsRef<str>,
+    table_schema: &StructType,
+    session: &dyn Session,
+) -> DeltaResult<Predicate> {
+    let predicate = predicate.as_ref();
+    let schema: Schema = table_schema.try_into_arrow()?;
+    let df_schema = schema.to_dfschema_ref()?;
+    let expr = crate::delta_datafusion::utils::Expression::String(predicate.to_string())
+        .resolve(session, df_schema)?;
+    crate::delta_datafusion::engine::to_delta_predicate(&expr).map_err(|err| {
+        DeltaTableError::Generic(format!(
+            "Cannot use predicate {predicate:?} for file skipping: {err}. Supported are \
+             column comparisons, IS [NOT] NULL, [NOT] IN, [NOT] BETWEEN, NOT, AND and OR."
+        ))
+    })
 }
 
 fn parse_sql_expr(expr: impl AsRef<str>) -> DeltaResult<SqlExpr> {
@@ -1377,6 +1406,112 @@ mod test {
 
         for test in unsupported_types {
             assert!(fmt_expr_to_sql(&test.expr).is_err());
+        }
+    }
+
+    mod sql_predicate_to_kernel {
+        use delta_kernel::expressions::{Expression as KernelExpression, Scalar};
+
+        use super::super::parse_sql_predicate_to_kernel;
+        use super::*;
+        use crate::kernel::schema::partitions::{
+            FilterValue, dnf_to_kernel_predicate, literal_to_kernel_predicate,
+        };
+
+        fn test_schema() -> StructType {
+            StructType::try_new(vec![
+                StructField::new("year", DataType::Primitive(PrimitiveType::Integer), true),
+                StructField::new("month", DataType::Primitive(PrimitiveType::Integer), true),
+                StructField::new("name", DataType::Primitive(PrimitiveType::String), true),
+            ])
+            .unwrap()
+        }
+
+        #[tokio::test]
+        async fn parses_coerced_comparison() {
+            let session = SessionContext::new();
+            let schema = test_schema();
+
+            let predicate =
+                parse_sql_predicate_to_kernel("year > 2020", &schema, &session.state()).unwrap();
+
+            let expected = KernelExpression::column(["year"]).gt(Scalar::Integer(2020));
+            assert_eq!(predicate, expected);
+        }
+
+        #[tokio::test]
+        async fn parses_boolean_logic_matching_dnf() {
+            let session = SessionContext::new();
+            let schema = test_schema();
+
+            let from_sql = parse_sql_predicate_to_kernel(
+                "(year = 2020 AND month = 2) OR (year = 2021 AND month = 12)",
+                &schema,
+                &session.state(),
+            )
+            .unwrap();
+
+            let from_dnf = dnf_to_kernel_predicate(
+                &[
+                    vec![
+                        ("year", "=", FilterValue::Scalar("2020")),
+                        ("month", "=", FilterValue::Scalar("2")),
+                    ],
+                    vec![
+                        ("year", "=", FilterValue::Scalar("2021")),
+                        ("month", "=", FilterValue::Scalar("12")),
+                    ],
+                ],
+                &schema,
+            )
+            .unwrap();
+
+            assert_eq!(from_sql, from_dnf);
+        }
+
+        #[tokio::test]
+        async fn parses_in_list_and_null_checks() {
+            let session = SessionContext::new();
+            let schema = test_schema();
+
+            let from_sql =
+                parse_sql_predicate_to_kernel("year IN (2020, 2021)", &schema, &session.state())
+                    .unwrap();
+            let from_literal = literal_to_kernel_predicate(
+                &("year", "in", FilterValue::Set(vec!["2020", "2021"])),
+                &schema,
+            )
+            .unwrap();
+            assert_eq!(from_sql, from_literal);
+
+            let null_check =
+                parse_sql_predicate_to_kernel("name IS NULL", &schema, &session.state()).unwrap();
+            assert_eq!(null_check, KernelExpression::column(["name"]).is_null());
+        }
+
+        #[tokio::test]
+        async fn unknown_column_errors_with_name() {
+            let session = SessionContext::new();
+            let schema = test_schema();
+
+            let err = parse_sql_predicate_to_kernel("nope = 1", &schema, &session.state())
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("nope"), "unexpected error: {err}");
+        }
+
+        #[tokio::test]
+        async fn unsupported_construct_errors_with_predicate() {
+            let session = SessionContext::new();
+            let schema = test_schema();
+
+            let err = parse_sql_predicate_to_kernel("name LIKE 'a%'", &schema, &session.state())
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("name LIKE 'a%'") && err.contains("file skipping"),
+                "unexpected error: {err}"
+            );
         }
     }
 }

--- a/crates/core/src/delta_datafusion/utils.rs
+++ b/crates/core/src/delta_datafusion/utils.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use datafusion::common::DFSchemaRef;
 use datafusion::common::tree_node::{Transformed, TreeNode as _};
 use datafusion::error::Result;
+use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::simplify::SimplifyContext;
 use datafusion::logical_expr::{BinaryExpr, Expr, ExprSchemable as _};
 use datafusion::logical_expr_common::operator::Operator;
@@ -173,6 +174,32 @@ pub(crate) fn coerce_predicate_literals(expr: Expr, schema: &DFSchema) -> Result
                         high,
                     },
                 )))
+            }
+            Expr::InList(in_list) => {
+                let expr_type = in_list.expr.get_type(schema)?;
+                let mut changed = false;
+
+                let list = in_list
+                    .list
+                    .iter()
+                    .map(|item| match item {
+                        Expr::Literal(value, _) if value.data_type() != expr_type => {
+                            changed = true;
+                            Ok(Expr::Literal(value.cast_to(&expr_type)?, None))
+                        }
+                        _ => Ok(item.clone()),
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                if !changed {
+                    return Ok(Transformed::no(e));
+                }
+
+                Ok(Transformed::yes(Expr::InList(InList {
+                    expr: in_list.expr.clone(),
+                    list,
+                    negated: in_list.negated,
+                })))
             }
             _ => Ok(Transformed::no(e)),
         }

--- a/crates/core/src/kernel/schema/partitions.rs
+++ b/crates/core/src/kernel/schema/partitions.rs
@@ -183,8 +183,149 @@ impl TryFrom<&str> for DeltaTablePartition {
     }
 }
 
-#[allow(unused)] // TODO: remove once we use this in kernel log replay
-pub(crate) fn to_kernel_predicate(
+/// The value of a `(column, op, value)` filter literal: a single partition-value
+/// encoded string, or a set of them for `in` / `not in`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FilterValue<'a> {
+    /// A single encoded value, compared with one of `=`, `!=`, `<`, `<=`, `>`, `>=`.
+    Scalar(&'a str),
+    /// A set of encoded values, compared with `in` or `not in`.
+    Set(Vec<&'a str>),
+}
+
+/// A `(column, op, value)` comparison, mirroring the tuple filters accepted by
+/// the Python bindings.
+pub type FilterLiteral<'a> = (&'a str, &'a str, FilterValue<'a>);
+
+/// Translate a single filter literal into a kernel [`Predicate`].
+///
+/// The raw value is parsed against the schema type of `column`. A null scalar
+/// under `=` / `!=` becomes an IS [NOT] NULL check: in SQL NULL compares equal
+/// to nothing, itself included, but these filters have always allowed equality
+/// against the null partition value.
+pub fn literal_to_kernel_predicate(
+    literal: &FilterLiteral<'_>,
+    table_schema: &StructType,
+) -> DeltaResult<Predicate> {
+    let (column, op, value) = literal;
+    let op_matches_value = match value {
+        FilterValue::Scalar(_) => matches!(*op, "=" | "!=" | "<" | "<=" | ">" | ">="),
+        FilterValue::Set(_) => matches!(*op, "in" | "not in"),
+    };
+    if column.is_empty() || !op_matches_value {
+        return Err(invalid_filter_error(literal));
+    }
+    let Some(field) = table_schema.field(column) else {
+        return Err(DeltaTableError::SchemaMismatch {
+            msg: format!("Field '{column}' is not a root table field."),
+        });
+    };
+    let Some(dt) = field.data_type().as_primitive_opt() else {
+        return Err(DeltaTableError::SchemaMismatch {
+            msg: format!("Field '{}' is not a primitive type", field.name()),
+        });
+    };
+
+    let col = Expression::column([field.name()]);
+    Ok(match (*op, value) {
+        ("=", FilterValue::Scalar(raw)) => {
+            let scalar = dt.parse_scalar(raw)?;
+            if scalar.is_null() {
+                col.is_null()
+            } else {
+                col.eq(scalar)
+            }
+        }
+        ("!=", FilterValue::Scalar(raw)) => {
+            let scalar = dt.parse_scalar(raw)?;
+            if scalar.is_null() {
+                col.is_not_null()
+            } else {
+                col.ne(scalar)
+            }
+        }
+        ("<", FilterValue::Scalar(raw)) => col.lt(dt.parse_scalar(raw)?),
+        ("<=", FilterValue::Scalar(raw)) => col.le(dt.parse_scalar(raw)?),
+        (">", FilterValue::Scalar(raw)) => col.gt(dt.parse_scalar(raw)?),
+        (">=", FilterValue::Scalar(raw)) => col.ge(dt.parse_scalar(raw)?),
+        (op @ ("in" | "not in"), FilterValue::Set(raws)) => {
+            let values = raws
+                .iter()
+                .map(|v| dt.parse_scalar(v))
+                .collect::<Result<Vec<_>, _>>()?;
+            let (term, junction): (Box<dyn Fn(Scalar) -> Predicate>, _) = if op == "in" {
+                (Box::new(|v| col.clone().eq(v)), JunctionPredicateOp::Or)
+            } else {
+                (Box::new(|v| col.clone().ne(v)), JunctionPredicateOp::And)
+            };
+            let predicates = values.into_iter().map(term).collect::<Vec<_>>();
+            Predicate::junction(junction, predicates)
+        }
+        _ => unreachable!("op/value shapes checked above"),
+    })
+}
+
+fn invalid_filter_error(literal: &FilterLiteral<'_>) -> DeltaTableError {
+    let (column, op, value) = literal;
+    let value = match value {
+        FilterValue::Scalar(v) => format!("{v:?}"),
+        FilterValue::Set(vs) => format!("{vs:?}"),
+    };
+    DeltaTableError::InvalidPartitionFilter {
+        partition_filter: format!("({column:?}, {op:?}, {value})"),
+    }
+}
+
+/// Translate a conjunction (AND) of filter literals into a kernel [`Predicate`].
+///
+/// Errors on an empty conjunction: an empty AND is vacuously true and would
+/// silently match every file.
+pub fn conjunction_to_kernel_predicate(
+    literals: &[FilterLiteral<'_>],
+    table_schema: &StructType,
+) -> DeltaResult<Predicate> {
+    if literals.is_empty() {
+        return Err(DeltaTableError::Generic(
+            "empty conjunction in filter; pass no filter to match all files".to_string(),
+        ));
+    }
+    let mut predicates = literals
+        .iter()
+        .map(|literal| literal_to_kernel_predicate(literal, table_schema))
+        .collect::<DeltaResult<Vec<_>>>()?;
+    Ok(match predicates.len() {
+        1 => predicates.pop().unwrap(),
+        _ => Predicate::junction(JunctionPredicateOp::And, predicates),
+    })
+}
+
+/// Translate filters in disjunctive normal form -- an OR across conjunctions
+/// (AND groups) of `(column, op, value)` literals -- into a kernel [`Predicate`].
+pub fn dnf_to_kernel_predicate(
+    dnf: &[Vec<FilterLiteral<'_>>],
+    table_schema: &StructType,
+) -> DeltaResult<Predicate> {
+    if dnf.is_empty() {
+        return Err(DeltaTableError::Generic(
+            "empty filter; pass no filter to match all files".to_string(),
+        ));
+    }
+    let mut groups = dnf
+        .iter()
+        .map(|conjunction| conjunction_to_kernel_predicate(conjunction, table_schema))
+        .collect::<DeltaResult<Vec<_>>>()?;
+    Ok(match groups.len() {
+        1 => groups.pop().unwrap(),
+        _ => Predicate::junction(JunctionPredicateOp::Or, groups),
+    })
+}
+
+/// Translate a conjunction of [`PartitionFilter`]s into a kernel [`Predicate`].
+///
+/// Unlike [`dnf_to_kernel_predicate`], an empty slice yields an empty AND
+/// junction, which is vacuously true: callers treat "no filters" as "match
+/// every file".
+pub fn to_kernel_predicate(
     filters: &[PartitionFilter],
     table_schema: &StructType,
 ) -> DeltaResult<Predicate> {
@@ -199,60 +340,23 @@ fn filter_to_kernel_predicate(
     filter: &PartitionFilter,
     table_schema: &StructType,
 ) -> DeltaResult<Predicate> {
-    let Some(field) = table_schema.field(&filter.key) else {
-        return Err(DeltaTableError::SchemaMismatch {
-            msg: format!("Field '{}' is not a root table field.", filter.key),
-        });
+    let (op, value) = match &filter.value {
+        PartitionValue::Equal(v) => ("=", FilterValue::Scalar(v)),
+        PartitionValue::NotEqual(v) => ("!=", FilterValue::Scalar(v)),
+        PartitionValue::GreaterThan(v) => (">", FilterValue::Scalar(v)),
+        PartitionValue::GreaterThanOrEqual(v) => (">=", FilterValue::Scalar(v)),
+        PartitionValue::LessThan(v) => ("<", FilterValue::Scalar(v)),
+        PartitionValue::LessThanOrEqual(v) => ("<=", FilterValue::Scalar(v)),
+        PartitionValue::In(vs) => (
+            "in",
+            FilterValue::Set(vs.iter().map(String::as_str).collect()),
+        ),
+        PartitionValue::NotIn(vs) => (
+            "not in",
+            FilterValue::Set(vs.iter().map(String::as_str).collect()),
+        ),
     };
-    let Some(dt) = field.data_type().as_primitive_opt() else {
-        return Err(DeltaTableError::SchemaMismatch {
-            msg: format!("Field '{}' is not a primitive type", field.name()),
-        });
-    };
-
-    let column = Expression::column([field.name()]);
-    Ok(match &filter.value {
-        // NOTE: In SQL NULL is not equal to anything, including itself. However when specifying partition filters
-        // we have allowed to equality against null. So here we have to handle null values explicitly by using
-        // is_null and is_not_null methods directly.
-        PartitionValue::Equal(raw) => {
-            let scalar = dt.parse_scalar(raw)?;
-            if scalar.is_null() {
-                column.is_null()
-            } else {
-                column.eq(scalar)
-            }
-        }
-        PartitionValue::NotEqual(raw) => {
-            let scalar = dt.parse_scalar(raw)?;
-            if scalar.is_null() {
-                column.is_not_null()
-            } else {
-                column.ne(scalar)
-            }
-        }
-        PartitionValue::LessThan(raw) => column.lt(dt.parse_scalar(raw)?),
-        PartitionValue::LessThanOrEqual(raw) => column.le(dt.parse_scalar(raw)?),
-        PartitionValue::GreaterThan(raw) => column.gt(dt.parse_scalar(raw)?),
-        PartitionValue::GreaterThanOrEqual(raw) => column.ge(dt.parse_scalar(raw)?),
-        op @ PartitionValue::In(raw_values) | op @ PartitionValue::NotIn(raw_values) => {
-            let values = raw_values
-                .iter()
-                .map(|v| dt.parse_scalar(v))
-                .collect::<Result<Vec<_>, _>>()?;
-            let (expr, operator): (Box<dyn Fn(Scalar) -> Predicate>, _) = match op {
-                PartitionValue::In(_) => {
-                    (Box::new(|v| column.clone().eq(v)), JunctionPredicateOp::Or)
-                }
-                PartitionValue::NotIn(_) => {
-                    (Box::new(|v| column.clone().ne(v)), JunctionPredicateOp::And)
-                }
-                _ => unreachable!(),
-            };
-            let predicates = values.into_iter().map(expr).collect::<Vec<_>>();
-            Predicate::junction(operator, predicates)
-        }
-    })
+    literal_to_kernel_predicate(&(filter.key.as_str(), op, value), table_schema)
 }
 
 #[cfg(test)]
@@ -585,6 +689,88 @@ mod tests {
             value: PartitionValue::LessThan("3.14".to_string()),
         };
         assert!(filter_to_kernel_predicate(&filter, &schema).is_ok());
+    }
+
+    fn dnf_test_schema() -> StructType {
+        StructType::try_new(vec![
+            StructField::new("year", DataType::Primitive(PrimitiveType::Integer), true),
+            StructField::new("month", DataType::Primitive(PrimitiveType::Integer), true),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn test_dnf_to_kernel_predicate_or_of_ands() {
+        let schema = dnf_test_schema();
+        let dnf = vec![
+            vec![
+                ("year", "=", FilterValue::Scalar("2020")),
+                ("month", "=", FilterValue::Scalar("2")),
+            ],
+            vec![("year", "=", FilterValue::Scalar("2021"))],
+        ];
+
+        let predicate = dnf_to_kernel_predicate(&dnf, &schema).unwrap();
+
+        let expected = Predicate::junction(
+            JunctionPredicateOp::Or,
+            vec![
+                Predicate::junction(
+                    JunctionPredicateOp::And,
+                    vec![
+                        Expression::column(["year"]).eq(Scalar::Integer(2020)),
+                        Expression::column(["month"]).eq(Scalar::Integer(2)),
+                    ],
+                ),
+                Expression::column(["year"]).eq(Scalar::Integer(2021)),
+            ],
+        );
+        assert_eq!(predicate, expected);
+    }
+
+    #[test]
+    fn test_dnf_to_kernel_predicate_single_conjunction_unwrapped() {
+        let schema = dnf_test_schema();
+        let literal = ("year", ">=", FilterValue::Scalar("2021"));
+
+        let predicate = dnf_to_kernel_predicate(&[vec![literal.clone()]], &schema).unwrap();
+
+        assert_eq!(
+            predicate,
+            literal_to_kernel_predicate(&literal, &schema).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_dnf_to_kernel_predicate_empty_errors() {
+        let schema = dnf_test_schema();
+        assert!(matches!(
+            dnf_to_kernel_predicate(&[], &schema).unwrap_err(),
+            DeltaTableError::Generic(_)
+        ));
+        assert!(matches!(
+            dnf_to_kernel_predicate(&[vec![]], &schema).unwrap_err(),
+            DeltaTableError::Generic(_)
+        ));
+    }
+
+    #[test]
+    fn test_literal_to_kernel_predicate_invalid_op() {
+        let schema = dnf_test_schema();
+        let result =
+            literal_to_kernel_predicate(&("year", "like", FilterValue::Scalar("2021")), &schema);
+        assert!(matches!(
+            result.unwrap_err(),
+            DeltaTableError::InvalidPartitionFilter { .. }
+        ));
+
+        // scalar ops reject set values and vice versa
+        let result =
+            literal_to_kernel_predicate(&("year", "=", FilterValue::Set(vec!["2021"])), &schema);
+        assert!(result.is_err());
+        let result =
+            literal_to_kernel_predicate(&("year", "in", FilterValue::Scalar("2021")), &schema);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/core/src/kernel/schema/partitions.rs
+++ b/crates/core/src/kernel/schema/partitions.rs
@@ -228,6 +228,9 @@ pub fn literal_to_kernel_predicate(
 
     let col = Expression::column([field.name()]);
     Ok(match (*op, value) {
+        // NOTE: In SQL NULL is not equal to anything, including itself. However when specifying partition filters
+        // we have allowed to equality against null. So here we have to handle null values explicitly by using
+        // is_null and is_not_null methods directly.
         ("=", FilterValue::Scalar(raw)) => {
             let scalar = dt.parse_scalar(raw)?;
             if scalar.is_null() {

--- a/crates/core/src/kernel/snapshot/iterators.rs
+++ b/crates/core/src/kernel/snapshot/iterators.rs
@@ -137,7 +137,7 @@ impl LogicalFileView {
     ///
     /// this tries to parse the file string and if that fails, it will return the string as is.
     // TODO assert consistent handling of the paths encoding when reading log data so this logic can be removed.
-    pub(crate) fn object_store_path(&self) -> Path {
+    pub fn object_store_path(&self) -> Path {
         let path = self.path();
         // Try to preserve percent encoding if possible
         match Path::parse(path.as_ref()) {

--- a/crates/core/src/kernel/snapshot/iterators.rs
+++ b/crates/core/src/kernel/snapshot/iterators.rs
@@ -141,7 +141,7 @@ impl LogicalFileView {
     ///
     /// this tries to parse the file string and if that fails, it will return the string as is.
     // TODO assert consistent handling of the paths encoding when reading log data so this logic can be removed.
-    pub(crate) fn object_store_path(&self) -> Path {
+    pub fn object_store_path(&self) -> Path {
         let path = self.path();
         // Try to preserve percent encoding if possible
         match Path::parse(path.as_ref()) {

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -2602,6 +2602,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_file_views_with_dnf_predicate() -> TestResult {
+        use crate::kernel::schema::partitions::{FilterValue, dnf_to_kernel_predicate};
+
+        let base = TestTables::Delta0_8_0Partitioned
+            .table_builder()?
+            .build_storage()?;
+        let snapshot = Snapshot::try_new(base.as_ref(), Default::default(), None).await?;
+
+        let dnf = vec![
+            vec![
+                ("year", "=", FilterValue::Scalar("2020")),
+                ("month", "=", FilterValue::Scalar("2")),
+            ],
+            vec![
+                ("year", "=", FilterValue::Scalar("2021")),
+                ("month", "=", FilterValue::Scalar("12")),
+            ],
+        ];
+        let predicate = Arc::new(dnf_to_kernel_predicate(&dnf, snapshot.schema().as_ref())?);
+
+        let mut paths: Vec<_> = snapshot
+            .file_views(base.as_ref(), Some(predicate))
+            .map_ok(|view| view.path_raw().to_string())
+            .try_collect()
+            .await?;
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![
+                "year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet".to_string(),
+                "year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet".to_string(),
+                "year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet".to_string(),
+                "year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet".to_string(),
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_partition_values_map_preserves_all_columns_under_narrowing_predicate()
     -> TestResult {
         use std::collections::BTreeSet;

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -3896,6 +3896,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_file_views_with_dnf_predicate() -> TestResult {
+        use crate::kernel::schema::partitions::{FilterValue, dnf_to_kernel_predicate};
+
+        let base = TestTables::Delta0_8_0Partitioned
+            .table_builder()?
+            .build_storage()?;
+        let snapshot = Snapshot::try_new(base.as_ref(), Default::default(), None).await?;
+
+        let dnf = vec![
+            vec![
+                ("year", "=", FilterValue::Scalar("2020")),
+                ("month", "=", FilterValue::Scalar("2")),
+            ],
+            vec![
+                ("year", "=", FilterValue::Scalar("2021")),
+                ("month", "=", FilterValue::Scalar("12")),
+            ],
+        ];
+        let predicate = Arc::new(dnf_to_kernel_predicate(&dnf, snapshot.schema().as_ref())?);
+
+        let mut paths: Vec<_> = snapshot
+            .file_views(base.as_ref(), Some(predicate))
+            .map_ok(|view| view.path_raw().to_string())
+            .try_collect()
+            .await?;
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![
+                "year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet".to_string(),
+                "year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet".to_string(),
+                "year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet".to_string(),
+                "year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet".to_string(),
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_partition_values_map_preserves_all_columns_under_narrowing_predicate()
     -> TestResult {
         use std::collections::BTreeSet;

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -6,6 +6,7 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+use delta_kernel::expressions::PredicateRef;
 use futures::future::ready;
 use futures::stream::{BoxStream, once};
 use futures::{StreamExt, TryStreamExt};
@@ -287,6 +288,24 @@ impl DeltaTable {
         infos.pop().ok_or(DeltaTableError::Generic(
             "Somehow there is nothing in the history!".into(),
         ))
+    }
+
+    /// Stream all logical files matching the provided kernel [`Predicate`](delta_kernel::expressions::Predicate).
+    ///
+    /// Predicates over partition columns select files exactly. Predicates over
+    /// data columns are evaluated against file statistics and select a superset:
+    /// every file that may contain a matching row, including files without
+    /// statistics for the referenced columns.
+    pub fn get_active_add_actions_by_predicate(
+        &self,
+        predicate: Option<PredicateRef>,
+    ) -> BoxStream<'_, DeltaResult<LogicalFileView>> {
+        let Some(state) = self.state.as_ref() else {
+            return Box::pin(futures::stream::once(async {
+                Err(DeltaTableError::NotInitialized)
+            }));
+        };
+        state.snapshot().file_views(&self.log_store, predicate)
     }
 
     /// Stream all logical files matching the provided `PartitionFilter`s.

--- a/docs/how-delta-lake-works/delta-lake-file-skipping.md
+++ b/docs/how-delta-lake-works/delta-lake-file-skipping.md
@@ -72,6 +72,26 @@ pl.scan_delta("tmp/a_table").filter(pl.col("age") < 20).collect()
 
 Polars can use the Delta table metadata to skip the file that does not contain data relevant to the query.
 
+## File skipping with deltalake
+
+The same skipping is exposed directly on `DeltaTable`: file-listing and read
+methods accept a SQL `predicate` (or tuple filters) and prune files against the
+transaction log before any data is read.
+
+```python
+dt = DeltaTable("tmp/a_table")
+
+dt.file_uris(predicate="age < 20")  # only the file that may contain age < 20
+dt.to_pandas(predicate="age < 20", filters=[("age", "<", 20)])
+```
+
+On non-partition columns like `age` the pruning is conservative: a file is
+dropped only when its min/max statistics prove no row can match, so the file
+list is a complete superset of the matching files. Partition-column predicates
+prune exactly. See
+[Querying Delta Tables](../usage/querying-delta-tables.md#selecting-files-with-predicates)
+for details.
+
 ## How Delta Lake implements file skipping
 
 Here’s how engines execute queries on Delta tables:

--- a/docs/how-delta-lake-works/delta-lake-file-skipping.md
+++ b/docs/how-delta-lake-works/delta-lake-file-skipping.md
@@ -81,8 +81,8 @@ transaction log before any data is read.
 ```python
 dt = DeltaTable("tmp/a_table")
 
-dt.file_uris(predicate="age < 20")  # only the file that may contain age < 20
-dt.to_pandas(predicate="age < 20", filters=[("age", "<", 20)])
+dt.file_uris(file_pruning_predicate="age < 20")  # only the file that may contain age < 20
+dt.to_pandas(file_pruning_predicate="age < 20", filters=[("age", "<", 20)])
 ```
 
 On non-partition columns like `age` the pruning is conservative: a file is

--- a/docs/usage/querying-delta-tables.md
+++ b/docs/usage/querying-delta-tables.md
@@ -34,6 +34,47 @@ pyarrow.Table
 value: string
 ```
 
+## Selecting files with predicates
+
+The `partitions` filters shown above are one conjunction: every tuple in the
+list must hold (AND). To express OR, pass a list of such lists -- the filters
+are then evaluated in disjunctive normal form, an OR across the inner AND
+groups -- or pass a SQL predicate string instead:
+
+``` python
+>>> dt.to_pandas(
+...     partitions=[
+...         [("year", "=", "2020"), ("month", "=", "2")],
+...         [("year", "=", "2021"), ("month", "=", "12")],
+...     ],
+... )
+>>> dt.to_pandas(predicate="(year = 2020 AND month = 2) OR (year = 2021 AND month = 12)")
+```
+
+Both forms are accepted everywhere files are selected: `to_pandas`,
+`to_pyarrow_table`, `to_pyarrow_dataset`, `file_uris`, and `partitions`.
+Predicates may reference any column, not just partition columns, and prune
+before any data is read:
+
+- **Partition columns** prune exactly: every returned file matches the
+  predicate, and only matching files are returned.
+- **Other columns** prune conservatively using the per-file min/max statistics
+  in the transaction log: files that provably contain no matching row are
+  dropped, every file that *may* contain one is kept, and files without
+  statistics for a referenced column are always kept. The result is a
+  complete superset of the matching files.
+
+Because file pruning selects whole files, `predicate=` on `to_pandas` and
+`to_pyarrow_table` does not filter rows. Pair it with an equivalent `filters=`
+expression when you need exact rows from a non-partition column:
+
+``` python
+>>> dt.to_pandas(predicate="value >= '5'", filters=[("value", ">=", "5")])
+```
+
+The full syntax for both forms is documented on
+[`DeltaTable.file_uris`](../api/delta_table/index.md).
+
 Converting to a PyArrow Dataset allows you to filter on columns other
 than partition columns and load the result as a stream of batches rather
 than a single table. Convert to a dataset using
@@ -91,10 +132,13 @@ VARCHAR
 ```
 
 Finally, you can always pass the list of file paths to an engine. For
-example, you can pass them to `dask.dataframe.read_parquet`:
+example, you can pass them to `dask.dataframe.read_parquet`. `file_uris`
+accepts the same predicates, so the file list can be pruned before it ever
+reaches the other engine:
 
 ``` python
 >>> import dask.dataframe as dd
+>>> df = dd.read_parquet(dt.file_uris(predicate="year = 2021 OR month = 2"))
 >>> df = dd.read_parquet(dt.file_uris())
 >>> df
 Dask DataFrame Structure:

--- a/docs/usage/querying-delta-tables.md
+++ b/docs/usage/querying-delta-tables.md
@@ -67,7 +67,11 @@ column, not just partition columns:
   in the transaction log: files that provably contain no matching row are
   dropped, every file that *may* contain one is kept, and files without
   statistics for a referenced column are always kept. The result is a
-  complete superset of the matching files.
+  complete superset of the matching files. How much gets pruned depends on the
+  data layout: statistics only rule out files when similar values are
+  colocated, for example by partitioning or z-ordering on the column. See
+  [Delta Lake File Skipping](../how-delta-lake-works/delta-lake-file-skipping.md)
+  for how to lay out tables so predicates prune well.
 
 As the name says, the predicate prunes files, not rows. Pair it with an
 equivalent `filters=` expression when you need exact rows from a

--- a/docs/usage/querying-delta-tables.md
+++ b/docs/usage/querying-delta-tables.md
@@ -42,7 +42,11 @@ is a conjunction (AND); a list of such lists is an OR across the inner AND
 groups:
 
 ``` python
+>>> # SQL string
 >>> dt.to_pandas(file_pruning_predicate="(year = 2020 AND month = 2) OR (year = 2021 AND month = 12)")
+>>> # flat list of tuples: a single conjunction, year = 2020 AND month = 2
+>>> dt.to_pandas(file_pruning_predicate=[("year", "=", "2020"), ("month", "=", "2")])
+>>> # list of lists: OR across the inner AND groups
 >>> dt.to_pandas(
 ...     file_pruning_predicate=[
 ...         [("year", "=", "2020"), ("month", "=", "2")],

--- a/docs/usage/querying-delta-tables.md
+++ b/docs/usage/querying-delta-tables.md
@@ -23,38 +23,39 @@ value: string
 year: string
 month: string
 day: string
->>> dt.to_pandas(partitions=[("year", "=", "2021")], columns=["value"])
+>>> dt.to_pandas(file_pruning_predicate=[("year", "=", "2021")], columns=["value"])
       value
 0     6
 1     7
 2     5
 3     4
->>> dt.to_pyarrow_table(partitions=[("year", "=", "2021")], columns=["value"])
+>>> dt.to_pyarrow_table(file_pruning_predicate="year = 2021", columns=["value"])
 pyarrow.Table
 value: string
 ```
 
-## Selecting files with predicates
+## Selecting files with a pruning predicate
 
-The `partitions` filters shown above are one conjunction: every tuple in the
-list must hold (AND). To express OR, pass a list of such lists -- the filters
-are then evaluated in disjunctive normal form, an OR across the inner AND
-groups -- or pass a SQL predicate string instead:
+`file_pruning_predicate` selects which files are read, before any data is
+scanned. It takes either a SQL string or tuple filters. A flat list of tuples
+is a conjunction (AND); a list of such lists is an OR across the inner AND
+groups:
 
 ``` python
+>>> dt.to_pandas(file_pruning_predicate="(year = 2020 AND month = 2) OR (year = 2021 AND month = 12)")
 >>> dt.to_pandas(
-...     partitions=[
+...     file_pruning_predicate=[
 ...         [("year", "=", "2020"), ("month", "=", "2")],
 ...         [("year", "=", "2021"), ("month", "=", "12")],
 ...     ],
 ... )
->>> dt.to_pandas(predicate="(year = 2020 AND month = 2) OR (year = 2021 AND month = 12)")
 ```
 
-Both forms are accepted everywhere files are selected: `to_pandas`,
+The parameter is accepted everywhere files are selected: `to_pandas`,
 `to_pyarrow_table`, `to_pyarrow_dataset`, `file_uris`, and `partitions`.
-Predicates may reference any column, not just partition columns, and prune
-before any data is read:
+The older `partitions` and `partition_filters` parameters on these methods
+still work but are deprecated in its favor. The predicate may reference any
+column, not just partition columns:
 
 - **Partition columns** prune exactly: every returned file matches the
   predicate, and only matching files are returned.
@@ -64,12 +65,12 @@ before any data is read:
   statistics for a referenced column are always kept. The result is a
   complete superset of the matching files.
 
-Because file pruning selects whole files, `predicate=` on `to_pandas` and
-`to_pyarrow_table` does not filter rows. Pair it with an equivalent `filters=`
-expression when you need exact rows from a non-partition column:
+As the name says, the predicate prunes files, not rows. Pair it with an
+equivalent `filters=` expression when you need exact rows from a
+non-partition column:
 
 ``` python
->>> dt.to_pandas(predicate="value >= '5'", filters=[("value", ">=", "5")])
+>>> dt.to_pandas(file_pruning_predicate="value >= '5'", filters=[("value", ">=", "5")])
 ```
 
 The full syntax for both forms is documented on
@@ -138,7 +139,7 @@ reaches the other engine:
 
 ``` python
 >>> import dask.dataframe as dd
->>> df = dd.read_parquet(dt.file_uris(predicate="year = 2021 OR month = 2"))
+>>> df = dd.read_parquet(dt.file_uris(file_pruning_predicate="year = 2021 OR month = 2"))
 >>> df = dd.read_parquet(dt.file_uris())
 >>> df
 Dask DataFrame Structure:

--- a/docs/usage/working-with-partitions.md
+++ b/docs/usage/working-with-partitions.md
@@ -55,6 +55,25 @@ print(pdf)
 1    2      b      US
 ```
 
+A flat list of filter tuples is a conjunction: every filter must hold. To
+combine partitions with OR, pass a list of lists (an OR across the inner AND
+groups) or a SQL `predicate` string:
+
+```python
+pdf = dt.to_pandas(partitions=[[("country", "=", "US")], [("country", "=", "CA")]])
+pdf = dt.to_pandas(predicate="country = 'US' OR country = 'CA'")
+```
+
+The same filters work on [DeltaTable.file_uris()](../api/delta_table/index.md#deltalake.DeltaTable.file_uris)
+and [DeltaTable.partitions()](../api/delta_table/index.md#deltalake.DeltaTable.partitions),
+and may reference non-partition columns as well -- see
+[Querying Delta Tables](querying-delta-tables.md#selecting-files-with-predicates)
+for the pruning semantics.
+
+```python
+dt.partitions(predicate="country IN ('US', 'CA')")
+```
+
 ### Partition Columns in Table Metadata
 
 Partition columns can also be inspected via metadata on a `DeltaTable`.

--- a/docs/usage/working-with-partitions.md
+++ b/docs/usage/working-with-partitions.md
@@ -45,7 +45,7 @@ In this example we restrict our query to the `country="US"` partition.
 ```python
 dt = DeltaTable("tmp/partitioned-table")
 
-pdf = dt.to_pandas(partitions=[("country", "=", "US")])
+pdf = dt.to_pandas(file_pruning_predicate=[("country", "=", "US")])
 print(pdf)
 ```
 
@@ -60,8 +60,8 @@ combine partitions with OR, pass a list of lists (an OR across the inner AND
 groups) or a SQL `predicate` string:
 
 ```python
-pdf = dt.to_pandas(partitions=[[("country", "=", "US")], [("country", "=", "CA")]])
-pdf = dt.to_pandas(predicate="country = 'US' OR country = 'CA'")
+pdf = dt.to_pandas(file_pruning_predicate=[[("country", "=", "US")], [("country", "=", "CA")]])
+pdf = dt.to_pandas(file_pruning_predicate="country = 'US' OR country = 'CA'")
 ```
 
 The same filters work on [DeltaTable.file_uris()](../api/delta_table/index.md#deltalake.DeltaTable.file_uris)
@@ -71,7 +71,7 @@ and may reference non-partition columns as well -- see
 for the pruning semantics.
 
 ```python
-dt.partitions(predicate="country IN ('US', 'CA')")
+dt.partitions(file_pruning_predicate="country IN ('US', 'CA')")
 ```
 
 ### Partition Columns in Table Metadata

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -108,8 +108,16 @@ class RawDeltaTable:
     def table_config(self) -> tuple[bool, int, bool]: ...
     def load_version(self, version: int) -> None: ...
     def load_with_datetime(self, ds: str) -> None: ...
-    def files(self, partition_filters: PartitionFilterType | None) -> list[str]: ...
-    def file_uris(self, partition_filters: PartitionFilterType | None) -> list[str]: ...
+    def files(
+        self,
+        partition_filters: PartitionFilterDNFType | None = None,
+        predicate: str | None = None,
+    ) -> list[str]: ...
+    def file_uris(
+        self,
+        partition_filters: PartitionFilterDNFType | None = None,
+        predicate: str | None = None,
+    ) -> list[str]: ...
     def generate(self) -> None: ...
     def vacuum(
         self,
@@ -204,7 +212,8 @@ class RawDeltaTable:
     def dataset_partitions(
         self,
         schema: ArrowSchemaExportable,
-        partition_filters: FilterConjunctionType | None,
+        partition_filters: PartitionFilterDNFType | None = None,
+        predicate: str | None = None,
     ) -> list[Any]: ...
     def create_checkpoint(self) -> None: ...
     def compact_logs(self, starting_version: int, ending_version: int) -> None: ...
@@ -249,7 +258,9 @@ class RawDeltaTable:
     ) -> PyMergeBuilder: ...
     def merge_execute(self, merge_builder: PyMergeBuilder) -> str: ...
     def get_active_partitions(
-        self, partitions_filters: FilterType | None = None
+        self,
+        partitions_filters: PartitionFilterDNFType | None = None,
+        predicate: str | None = None,
     ) -> Any: ...
     def create_write_transaction(
         self,
@@ -1071,6 +1082,7 @@ FilterConjunctionType = list[FilterLiteralType]
 FilterDNFType = list[FilterConjunctionType]
 FilterType = FilterConjunctionType | FilterDNFType
 PartitionFilterType = list[tuple[str, str, str | list[str]]]
+PartitionFilterDNFType = list[PartitionFilterType]
 
 class Transaction:
     app_id: str

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -108,8 +108,16 @@ class RawDeltaTable:
     def table_config(self) -> tuple[bool, int, bool]: ...
     def load_version(self, version: int) -> None: ...
     def load_with_datetime(self, ds: str) -> None: ...
-    def files(self, partition_filters: PartitionFilterType | None) -> list[str]: ...
-    def file_uris(self, partition_filters: PartitionFilterType | None) -> list[str]: ...
+    def files(
+        self,
+        partition_filters: PartitionFilterDNFType | None = None,
+        predicate: str | None = None,
+    ) -> list[str]: ...
+    def file_uris(
+        self,
+        partition_filters: PartitionFilterDNFType | None = None,
+        predicate: str | None = None,
+    ) -> list[str]: ...
     def generate(self) -> None: ...
     def vacuum(
         self,
@@ -210,7 +218,8 @@ class RawDeltaTable:
     def dataset_partitions(
         self,
         schema: ArrowSchemaExportable,
-        partition_filters: FilterConjunctionType | None,
+        partition_filters: PartitionFilterDNFType | None = None,
+        predicate: str | None = None,
     ) -> list[Any]: ...
     def create_checkpoint(self) -> None: ...
     def compact_logs(self, starting_version: int, ending_version: int) -> None: ...
@@ -255,7 +264,9 @@ class RawDeltaTable:
     ) -> PyMergeBuilder: ...
     def merge_execute(self, merge_builder: PyMergeBuilder) -> str: ...
     def get_active_partitions(
-        self, partitions_filters: FilterType | None = None
+        self,
+        partitions_filters: PartitionFilterDNFType | None = None,
+        predicate: str | None = None,
     ) -> Any: ...
     def create_write_transaction(
         self,
@@ -1077,6 +1088,7 @@ FilterConjunctionType = list[FilterLiteralType]
 FilterDNFType = list[FilterConjunctionType]
 FilterType = FilterConjunctionType | FilterDNFType
 PartitionFilterType = list[tuple[str, str, str | list[str]]]
+PartitionFilterDNFType = list[PartitionFilterType]
 
 class Transaction:
     app_id: str

--- a/python/deltalake/_internal.pyi
+++ b/python/deltalake/_internal.pyi
@@ -110,13 +110,11 @@ class RawDeltaTable:
     def load_with_datetime(self, ds: str) -> None: ...
     def files(
         self,
-        partition_filters: PartitionFilterDNFType | None = None,
-        predicate: str | None = None,
+        file_pruning_predicate: str | PartitionFilterDNFType | None = None,
     ) -> list[str]: ...
     def file_uris(
         self,
-        partition_filters: PartitionFilterDNFType | None = None,
-        predicate: str | None = None,
+        file_pruning_predicate: str | PartitionFilterDNFType | None = None,
     ) -> list[str]: ...
     def generate(self) -> None: ...
     def vacuum(
@@ -218,8 +216,7 @@ class RawDeltaTable:
     def dataset_partitions(
         self,
         schema: ArrowSchemaExportable,
-        partition_filters: PartitionFilterDNFType | None = None,
-        predicate: str | None = None,
+        file_pruning_predicate: str | PartitionFilterDNFType | None = None,
     ) -> list[Any]: ...
     def create_checkpoint(self) -> None: ...
     def compact_logs(self, starting_version: int, ending_version: int) -> None: ...
@@ -265,8 +262,7 @@ class RawDeltaTable:
     def merge_execute(self, merge_builder: PyMergeBuilder) -> str: ...
     def get_active_partitions(
         self,
-        partitions_filters: PartitionFilterDNFType | None = None,
-        predicate: str | None = None,
+        file_pruning_predicate: str | PartitionFilterDNFType | None = None,
     ) -> Any: ...
     def create_write_transaction(
         self,

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -78,6 +78,31 @@ FilterType = Union[FilterConjunctionType, FilterDNFType]
 PartitionFilterType = list[tuple[str, str, Union[str, list[str]]]]
 
 
+def _require_exclusive_filter(
+    filters_name: str, filters: FilterType | None, predicate: str | None
+) -> None:
+    if filters is not None and predicate is not None:
+        raise ValueError(
+            f"`{filters_name}` and `predicate` are mutually exclusive; pass only one"
+        )
+
+
+def _encode_filter_conjunction(
+    conjunction: FilterConjunctionType,
+) -> PartitionFilterType:
+    """Encode the values of one conjunction of filter tuples to their partition
+    string form."""
+    encoded: PartitionFilterType = []
+    for field, op, value in conjunction:
+        str_value: str | list[str]
+        if isinstance(value, (list, tuple)):
+            str_value = [encode_partition_value(val) for val in value]
+        else:
+            str_value = encode_partition_value(value)
+        encoded.append((field, op, str_value))
+    return encoded
+
+
 class _KeywordArgDefault:
     """Sentinel that preserves the rendered default while tracking omission."""
 
@@ -340,7 +365,9 @@ class DeltaTable:
 
     def partitions(
         self,
-        partition_filters: list[tuple[str, str, Any]] | None = None,
+        partition_filters: FilterType | None = None,
+        *,
+        predicate: str | None = None,
     ) -> list[dict[str, str]]:
         """
         Returns the partitions as a list of dicts.
@@ -349,12 +376,19 @@ class DeltaTable:
           `[{'month': '1', 'year': '2020', 'day': '1'}, ...]`
 
         Args:
-            partition_filters: The partition filters that will be used for getting the matched partitions, defaults to `None` (no filtering).
+            partition_filters: Tuple filters with the syntax described in `file_uris`,
+                defaults to `None` (no filtering). Mutually exclusive with `predicate`.
+            predicate: A SQL predicate string with the syntax described in `file_uris`.
+
+        When a filter references a non-partition column, the result contains the
+        partitions of every file that may hold matching rows, following the pruning
+        semantics described in `file_uris`.
         """
+        _require_exclusive_filter("partition_filters", partition_filters, predicate)
 
         partitions: list[dict[str, str]] = []
         for partition in self._table.get_active_partitions(
-            self._stringify_partition_values(partition_filters)
+            self._stringify_partition_values(partition_filters), predicate
         ):
             if not partition:
                 continue
@@ -362,7 +396,10 @@ class DeltaTable:
         return partitions
 
     def file_uris(
-        self, partition_filters: FilterConjunctionType | None = None
+        self,
+        partition_filters: FilterType | None = None,
+        *,
+        predicate: str | None = None,
     ) -> list[str]:
         """
         Get the list of files as absolute URIs, including the scheme (e.g. "s3://").
@@ -370,33 +407,58 @@ class DeltaTable:
         Local files will be just plain absolute paths, without a scheme. (That is,
         no 'file://' prefix.)
 
-        Use the partition_filters parameter to retrieve a subset of files that match the
-        given filters.
+        Files can be selected with tuple filters (`partition_filters`) or with a SQL
+        predicate string (`predicate`); the two parameters are mutually exclusive.
 
-        Args:
-            partition_filters: the partition filters that will be used for getting the matched files
+        **Tuple filters.** Each filter is a `(column, op, value)` tuple. A flat list
+        is a conjunction (AND) of its filters. A list of such lists is interpreted in
+        disjunctive normal form: an OR across the inner AND groups.
 
-        Returns:
-            list of the .parquet files with an absolute URI referenced for the current version of the DeltaTable
+        ```python
+        dt.file_uris([("year", "=", "2021"), ("month", "=", "12")])
+        # year = 2021 AND month = 12
 
-        Filters are a conjunction (AND) of predicates, each expressed as a
-        `(key, op, value)` tuple comparing a partition column against a value.
+        dt.file_uris([
+            [("year", "=", "2021")],
+            [("year", "=", "2020"), ("month", ">=", "10")],
+        ])
+        # year = 2021 OR (year = 2020 AND month >= 10)
+        ```
 
         The supported ops are `=`, `!=`, `<`, `<=`, `>`, `>=`, `in`, and `not in`.
         For `in` and `not in`, the value must be a collection such as a list, a set
-        or a tuple. Values are compared as partition-encoded strings; use the empty
-        string `''` for a null partition value.
+        or a tuple. Values may be Python primitives (str, int, float, bool, date,
+        datetime); each is encoded to its partition string form and parsed against
+        the column's type. Comparisons follow that type: on a string column,
+        `("month", ">=", 12)` compares lexicographically, so `"4" >= "12"`. Use
+        the empty string `''` to match a null partition value, or a `predicate`
+        with `IS NULL`.
 
-        Example:
-            ```
-            ("x", "=", "a")
-            ("x", "!=", "a")
-            ("y", "in", ["a", "b", "c"])
-            ("z", "not in", ["a", "b"])
-            ```
+        **SQL predicates.** Any boolean SQL expression built from column comparisons
+        (`=`, `!=`, `<`, `<=`, `>`, `>=`), `IS [NOT] NULL`, `[NOT] IN`,
+        `[NOT] BETWEEN`, `NOT`, `AND` and `OR`:
+
+        ```python
+        dt.file_uris(predicate="year = 2021 AND (month = 1 OR day > 15)")
+        ```
+
+        **Pruning semantics.** Filters on partition columns select files exactly.
+        Filters on other columns are evaluated against per-file min/max statistics
+        and select a superset: every file that may contain a matching row is
+        returned, files that provably contain none are dropped, and files without
+        statistics for a referenced column are always retained. Filter the rows
+        after reading when you need exact results.
+
+        Args:
+            partition_filters: tuple filters as described above
+            predicate: a SQL predicate string as described above
+
+        Returns:
+            list of the .parquet files with an absolute URI referenced for the current version of the DeltaTable
         """
+        _require_exclusive_filter("partition_filters", partition_filters, predicate)
         return self._table.file_uris(
-            self._stringify_partition_values(partition_filters)
+            self._stringify_partition_values(partition_filters), predicate
         )
 
     def load_as_version(self, version: int | str | datetime) -> None:
@@ -939,17 +1001,19 @@ class DeltaTable:
 
     def to_pyarrow_dataset(
         self,
-        partitions: FilterConjunctionType | None = None,
+        partitions: FilterType | None = None,
         filesystem: str | pa_fs.FileSystem | None = None,
         parquet_read_options: ParquetReadOptions | None = None,
         schema: pyarrow.Schema | None = None,
         as_large_types: bool = False,
+        predicate: str | None = None,
     ) -> "pyarrow.dataset.Dataset":
         """
         Build a PyArrow Dataset using data from the DeltaTable.
 
         Args:
-            partitions: A list of partition filters; see the `file_uris` docstring for filter syntax
+            partitions: Tuple filters selecting the files to include; see the `file_uris`
+                docstring for the syntax and pruning semantics. Mutually exclusive with `predicate`
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
             parquet_read_options: Optional read options for Parquet. Use this to handle INT96 to timestamp conversion for edge cases like 0001-01-01 or 9999-12-31
             schema: The schema to use for the dataset. If None, the schema of the DeltaTable will be used. This can be used to force reading of Parquet/Arrow datatypes
@@ -958,6 +1022,8 @@ class DeltaTable:
             as_large_types: get schema with all variable size types (list, binary, string) as large variants (with int64 indices).
                 This is for compatibility with systems like Polars that only support the large versions of Arrow types.
                 If `schema` is passed it takes precedence over this option.
+            predicate: A SQL predicate string selecting the files to include; see the
+                `file_uris` docstring for the syntax and pruning semantics
 
          More info on [pyarrow dataset ParquetReadOptions](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.ParquetReadOptions.html).
 
@@ -980,6 +1046,7 @@ class DeltaTable:
         Returns:
             the PyArrow dataset in PyArrow
         """
+        _require_exclusive_filter("partitions", partitions, predicate)
         try:
             from pyarrow.dataset import (
                 FileSystemDataset,
@@ -1058,7 +1125,7 @@ class DeltaTable:
                 self.schema().to_arrow(as_large_types=as_large_types)
             )
 
-        partitions = self._stringify_partition_values(partitions)
+        encoded_partitions = self._stringify_partition_values(partitions)
 
         fragments = [
             format.make_fragment(
@@ -1067,7 +1134,7 @@ class DeltaTable:
                 partition_expression=part_expression,
             )
             for file, part_expression in self._table.dataset_partitions(
-                schema, partitions
+                schema, encoded_partitions, predicate
             )
         ]
 
@@ -1084,19 +1151,31 @@ class DeltaTable:
 
     def to_pyarrow_table(
         self,
-        partitions: list[tuple[str, str, Any]] | None = None,
+        partitions: FilterType | None = None,
         columns: list[str] | None = None,
         filesystem: str | pa_fs.FileSystem | None = None,
         filters: FilterType | Expression | None = None,
+        predicate: str | None = None,
     ) -> "pyarrow.Table":
         """
         Build a PyArrow Table using data from the DeltaTable.
 
+        `partitions` and `predicate` select which *files* are read, pruning at the
+        file level before any data is scanned; see the `file_uris` docstring for
+        their syntax and pruning semantics. `filters` filters *rows* while scanning.
+        A predicate on a non-partition column selects a superset of files, so pair
+        it with an equivalent `filters` expression when you need exact rows:
+
+        ```python
+        dt.to_pyarrow_table(predicate="value >= 100", filters=[("value", ">=", 100)])
+        ```
+
         Args:
-            partitions: A list of partition filters; see the `file_uris` docstring for filter syntax
+            partitions: Tuple filters selecting the files to read; mutually exclusive with `predicate`
             columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
-            filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression. If you pass a filter you do not need to pass ``partitions``
+            filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression
+            predicate: A SQL predicate string selecting the files to read
         """
         try:
             from pyarrow.parquet import filters_to_expression  # pyarrow >= 10.0.0
@@ -1108,31 +1187,45 @@ class DeltaTable:
         if filters is not None:
             filters = filters_to_expression(filters)
         return self.to_pyarrow_dataset(
-            partitions=partitions, filesystem=filesystem
+            partitions=partitions, filesystem=filesystem, predicate=predicate
         ).to_table(columns=columns, filter=filters)
 
     def to_pandas(
         self,
-        partitions: list[tuple[str, str, Any]] | None = None,
+        partitions: FilterType | None = None,
         columns: list[str] | None = None,
         filesystem: str | pa_fs.FileSystem | None = None,
         filters: FilterType | Expression | None = None,
         types_mapper: Callable[[pyarrow.DataType], Any] | None = None,
+        predicate: str | None = None,
     ) -> "pd.DataFrame":
         """
         Build a pandas dataframe using data from the DeltaTable.
 
+        `partitions` and `predicate` select which *files* are read, pruning at the
+        file level before any data is scanned; see the `file_uris` docstring for
+        their syntax and pruning semantics. `filters` filters *rows* while scanning.
+        A predicate on a non-partition column selects a superset of files, so pair
+        it with an equivalent `filters` expression when you need exact rows:
+
+        ```python
+        dt.to_pandas(predicate="value >= 100", filters=[("value", ">=", 100)])
+        ```
+
         Args:
-            partitions: A list of partition filters; see the `file_uris` docstring for filter syntax
+            partitions: Tuple filters selecting the files to read; mutually exclusive with `predicate`
             columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
-            filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression. If you pass a filter you do not need to pass ``partitions``
+            filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression
+            types_mapper: A function mapping a pyarrow DataType to a pandas ExtensionDtype
+            predicate: A SQL predicate string selecting the files to read
         """
         return self.to_pyarrow_table(
             partitions=partitions,
             columns=columns,
             filesystem=filesystem,
             filters=filters,
+            predicate=predicate,
         ).to_pandas(types_mapper=types_mapper)
 
     def update_incremental(self) -> None:
@@ -1162,19 +1255,28 @@ class DeltaTable:
         self._table.cleanup_metadata()
 
     def _stringify_partition_values(
-        self, partition_filters: FilterConjunctionType | None
-    ) -> PartitionFilterType | None:
-        if partition_filters is None:
-            return partition_filters
-        out = []
-        for field, op, value in partition_filters:
-            str_value: str | list[str]
-            if isinstance(value, (list, tuple)):
-                str_value = [encode_partition_value(val) for val in value]
-            else:
-                str_value = encode_partition_value(value)
-            out.append((field, op, str_value))
-        return out
+        self, partition_filters: FilterType | None
+    ) -> list[PartitionFilterType] | None:
+        """Normalize tuple filters to disjunctive normal form -- a list of
+        conjunctions -- and encode every value to its partition string form."""
+        if not partition_filters:
+            return None
+        conjunctions: FilterDNFType
+        if all(isinstance(conjunction, list) for conjunction in partition_filters):
+            conjunctions = cast(FilterDNFType, partition_filters)
+        elif all(isinstance(literal, tuple) for literal in partition_filters):
+            conjunctions = [cast(FilterConjunctionType, partition_filters)]
+        else:
+            raise ValueError(
+                "filters must be a list of (column, op, value) tuples (a conjunction), "
+                "or a list of such lists (an OR across conjunctions), not a mix of both"
+            )
+        for conjunction in conjunctions:
+            if not conjunction:
+                raise ValueError(
+                    "empty conjunction in filters; pass no filter to match all files"
+                )
+        return [_encode_filter_conjunction(conjunction) for conjunction in conjunctions]
 
     def get_add_actions(self, flatten: bool = False) -> Table:
         """Return an Arrow table describing every file currently in the table.
@@ -2269,7 +2371,9 @@ class TableOptimizer:
             min_commit_interval = int(min_commit_interval.total_seconds())
 
         metrics = self.table._table.compact_optimize(
-            self.table._stringify_partition_values(partition_filters),
+            _encode_filter_conjunction(partition_filters)
+            if partition_filters
+            else None,
             target_size,
             max_concurrent_tasks,
             max_spill_size,
@@ -2352,7 +2456,9 @@ class TableOptimizer:
 
         metrics = self.table._table.z_order_optimize(
             list(columns),
-            self.table._stringify_partition_values(partition_filters),
+            _encode_filter_conjunction(partition_filters)
+            if partition_filters
+            else None,
             target_size,
             max_concurrent_tasks,
             max_spill_size,

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -377,31 +377,25 @@ class DeltaTable:
         Returns:
             list of the .parquet files with an absolute URI referenced for the current version of the DeltaTable
 
-        Predicates are expressed in disjunctive normal form (DNF), like `[("x", "=", "a"), ...]`.
-        DNF allows arbitrary boolean logical combinations of single partition predicates.
-        The innermost tuples each describe a single partition predicate. The list of inner
-        predicates is interpreted as a conjunction (AND), forming a more selective and
-        multiple partition predicates.
+        Filters are a conjunction (AND) of predicates, each expressed as a
+        `(key, op, value)` tuple comparing a partition column against a value.
 
-        Each tuple has format: `(key, op, value)` and compares the key with the value.
-
-        The supported op are: `=`, `!=`, `in`, and `not in`. If the op is `in` or `not in`,
-        the value must be a collection such as a list, a set or a tuple.
-        The supported type for value is `str`. Use empty string `''` for Null partition value.
+        The supported ops are `=`, `!=`, `<`, `<=`, `>`, `>=`, `in`, and `not in`.
+        For `in` and `not in`, the value must be a collection such as a list, a set
+        or a tuple. Values are compared as partition-encoded strings; use the empty
+        string `''` for a null partition value.
 
         Example:
             ```
             ("x", "=", "a")
             ("x", "!=", "a")
             ("y", "in", ["a", "b", "c"])
-            ("z", "not in", ["a","b"])
+            ("z", "not in", ["a", "b"])
             ```
         """
         return self._table.file_uris(
             self._stringify_partition_values(partition_filters)
         )
-
-    file_uris.__doc__ = ""
 
     def load_as_version(self, version: int | str | datetime) -> None:
         """
@@ -953,7 +947,7 @@ class DeltaTable:
         Build a PyArrow Dataset using data from the DeltaTable.
 
         Args:
-            partitions: A list of partition filters, see help(DeltaTable.files_by_partitions) for filter syntax
+            partitions: A list of partition filters; see the `file_uris` docstring for filter syntax
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
             parquet_read_options: Optional read options for Parquet. Use this to handle INT96 to timestamp conversion for edge cases like 0001-01-01 or 9999-12-31
             schema: The schema to use for the dataset. If None, the schema of the DeltaTable will be used. This can be used to force reading of Parquet/Arrow datatypes
@@ -1097,7 +1091,7 @@ class DeltaTable:
         Build a PyArrow Table using data from the DeltaTable.
 
         Args:
-            partitions: A list of partition filters, see help(DeltaTable.files_by_partitions) for filter syntax
+            partitions: A list of partition filters; see the `file_uris` docstring for filter syntax
             columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
             filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression. If you pass a filter you do not need to pass ``partitions``
@@ -1127,7 +1121,7 @@ class DeltaTable:
         Build a pandas dataframe using data from the DeltaTable.
 
         Args:
-            partitions: A list of partition filters, see help(DeltaTable.files_by_partitions) for filter syntax
+            partitions: A list of partition filters; see the `file_uris` docstring for filter syntax
             columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
             filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression. If you pass a filter you do not need to pass ``partitions``

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -353,7 +353,9 @@ class DeltaTable:
         """
 
         partitions: list[dict[str, str]] = []
-        for partition in self._table.get_active_partitions(partition_filters):
+        for partition in self._table.get_active_partitions(
+            self._stringify_partition_values(partition_filters)
+        ):
             if not partition:
                 continue
             partitions.append({k: v for (k, v) in partition})

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -90,6 +90,12 @@ def _merge_deprecated_filters(
         raise ValueError(
             f"`{deprecated_name}` is deprecated; pass only `file_pruning_predicate`"
         )
+    warnings.warn(
+        f"`{deprecated_name}` is deprecated; pass the filters to "
+        "`file_pruning_predicate` instead",
+        DeprecationWarning,
+        stacklevel=3,
+    )
     return deprecated_value
 
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -78,6 +78,31 @@ FilterType = Union[FilterConjunctionType, FilterDNFType]
 PartitionFilterType = list[tuple[str, str, Union[str, list[str]]]]
 
 
+def _require_exclusive_filter(
+    filters_name: str, filters: FilterType | None, predicate: str | None
+) -> None:
+    if filters is not None and predicate is not None:
+        raise ValueError(
+            f"`{filters_name}` and `predicate` are mutually exclusive; pass only one"
+        )
+
+
+def _encode_filter_conjunction(
+    conjunction: FilterConjunctionType,
+) -> PartitionFilterType:
+    """Encode the values of one conjunction of filter tuples to their partition
+    string form."""
+    encoded: PartitionFilterType = []
+    for field, op, value in conjunction:
+        str_value: str | list[str]
+        if isinstance(value, (list, tuple)):
+            str_value = [encode_partition_value(val) for val in value]
+        else:
+            str_value = encode_partition_value(value)
+        encoded.append((field, op, str_value))
+    return encoded
+
+
 class _KeywordArgDefault:
     """Sentinel that preserves the rendered default while tracking omission."""
 
@@ -340,7 +365,9 @@ class DeltaTable:
 
     def partitions(
         self,
-        partition_filters: list[tuple[str, str, Any]] | None = None,
+        partition_filters: FilterType | None = None,
+        *,
+        predicate: str | None = None,
     ) -> list[dict[str, str]]:
         """
         Returns the partitions as a list of dicts.
@@ -349,12 +376,19 @@ class DeltaTable:
           `[{'month': '1', 'year': '2020', 'day': '1'}, ...]`
 
         Args:
-            partition_filters: The partition filters that will be used for getting the matched partitions, defaults to `None` (no filtering).
+            partition_filters: Tuple filters with the syntax described in `file_uris`,
+                defaults to `None` (no filtering). Mutually exclusive with `predicate`.
+            predicate: A SQL predicate string with the syntax described in `file_uris`.
+
+        When a filter references a non-partition column, the result contains the
+        partitions of every file that may hold matching rows, following the pruning
+        semantics described in `file_uris`.
         """
+        _require_exclusive_filter("partition_filters", partition_filters, predicate)
 
         partitions: list[dict[str, str]] = []
         for partition in self._table.get_active_partitions(
-            self._stringify_partition_values(partition_filters)
+            self._stringify_partition_values(partition_filters), predicate
         ):
             if not partition:
                 continue
@@ -362,7 +396,10 @@ class DeltaTable:
         return partitions
 
     def file_uris(
-        self, partition_filters: FilterConjunctionType | None = None
+        self,
+        partition_filters: FilterType | None = None,
+        *,
+        predicate: str | None = None,
     ) -> list[str]:
         """
         Get the list of files as absolute URIs, including the scheme (e.g. "s3://").
@@ -370,33 +407,58 @@ class DeltaTable:
         Local files will be just plain absolute paths, without a scheme. (That is,
         no 'file://' prefix.)
 
-        Use the partition_filters parameter to retrieve a subset of files that match the
-        given filters.
+        Files can be selected with tuple filters (`partition_filters`) or with a SQL
+        predicate string (`predicate`); the two parameters are mutually exclusive.
 
-        Args:
-            partition_filters: the partition filters that will be used for getting the matched files
+        **Tuple filters.** Each filter is a `(column, op, value)` tuple. A flat list
+        is a conjunction (AND) of its filters. A list of such lists is interpreted in
+        disjunctive normal form: an OR across the inner AND groups.
 
-        Returns:
-            list of the .parquet files with an absolute URI referenced for the current version of the DeltaTable
+        ```python
+        dt.file_uris([("year", "=", "2021"), ("month", "=", "12")])
+        # year = 2021 AND month = 12
 
-        Filters are a conjunction (AND) of predicates, each expressed as a
-        `(key, op, value)` tuple comparing a partition column against a value.
+        dt.file_uris([
+            [("year", "=", "2021")],
+            [("year", "=", "2020"), ("month", ">=", "10")],
+        ])
+        # year = 2021 OR (year = 2020 AND month >= 10)
+        ```
 
         The supported ops are `=`, `!=`, `<`, `<=`, `>`, `>=`, `in`, and `not in`.
         For `in` and `not in`, the value must be a collection such as a list, a set
-        or a tuple. Values are compared as partition-encoded strings; use the empty
-        string `''` for a null partition value.
+        or a tuple. Values may be Python primitives (str, int, float, bool, date,
+        datetime); each is encoded to its partition string form and parsed against
+        the column's type. Comparisons follow that type: on a string column,
+        `("month", ">=", 12)` compares lexicographically, so `"4" >= "12"`. Use
+        the empty string `''` to match a null partition value, or a `predicate`
+        with `IS NULL`.
 
-        Example:
-            ```
-            ("x", "=", "a")
-            ("x", "!=", "a")
-            ("y", "in", ["a", "b", "c"])
-            ("z", "not in", ["a", "b"])
-            ```
+        **SQL predicates.** Any boolean SQL expression built from column comparisons
+        (`=`, `!=`, `<`, `<=`, `>`, `>=`), `IS [NOT] NULL`, `[NOT] IN`,
+        `[NOT] BETWEEN`, `NOT`, `AND` and `OR`:
+
+        ```python
+        dt.file_uris(predicate="year = 2021 AND (month = 1 OR day > 15)")
+        ```
+
+        **Pruning semantics.** Filters on partition columns select files exactly.
+        Filters on other columns are evaluated against per-file min/max statistics
+        and select a superset: every file that may contain a matching row is
+        returned, files that provably contain none are dropped, and files without
+        statistics for a referenced column are always retained. Filter the rows
+        after reading when you need exact results.
+
+        Args:
+            partition_filters: tuple filters as described above
+            predicate: a SQL predicate string as described above
+
+        Returns:
+            list of the .parquet files with an absolute URI referenced for the current version of the DeltaTable
         """
+        _require_exclusive_filter("partition_filters", partition_filters, predicate)
         return self._table.file_uris(
-            self._stringify_partition_values(partition_filters)
+            self._stringify_partition_values(partition_filters), predicate
         )
 
     def load_as_version(self, version: int | str | datetime) -> None:
@@ -939,17 +1001,19 @@ class DeltaTable:
 
     def to_pyarrow_dataset(
         self,
-        partitions: FilterConjunctionType | None = None,
+        partitions: FilterType | None = None,
         filesystem: str | pa_fs.FileSystem | None = None,
         parquet_read_options: ParquetReadOptions | None = None,
         schema: pyarrow.Schema | None = None,
         as_large_types: bool = False,
+        predicate: str | None = None,
     ) -> "pyarrow.dataset.Dataset":
         """
         Build a PyArrow Dataset using data from the DeltaTable.
 
         Args:
-            partitions: A list of partition filters; see the `file_uris` docstring for filter syntax
+            partitions: Tuple filters selecting the files to include; see the `file_uris`
+                docstring for the syntax and pruning semantics. Mutually exclusive with `predicate`
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
             parquet_read_options: Optional read options for Parquet. Use this to handle INT96 to timestamp conversion for edge cases like 0001-01-01 or 9999-12-31
             schema: The schema to use for the dataset. If None, the schema of the DeltaTable will be used. This can be used to force reading of Parquet/Arrow datatypes
@@ -958,6 +1022,8 @@ class DeltaTable:
             as_large_types: get schema with all variable size types (list, binary, string) as large variants (with int64 indices).
                 This is for compatibility with systems like Polars that only support the large versions of Arrow types.
                 If `schema` is passed it takes precedence over this option.
+            predicate: A SQL predicate string selecting the files to include; see the
+                `file_uris` docstring for the syntax and pruning semantics
 
          More info on [pyarrow dataset ParquetReadOptions](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.ParquetReadOptions.html).
 
@@ -980,6 +1046,7 @@ class DeltaTable:
         Returns:
             the PyArrow dataset in PyArrow
         """
+        _require_exclusive_filter("partitions", partitions, predicate)
         try:
             from pyarrow.dataset import (
                 FileSystemDataset,
@@ -1058,7 +1125,7 @@ class DeltaTable:
                 self.schema().to_arrow(as_large_types=as_large_types)
             )
 
-        partitions = self._stringify_partition_values(partitions)
+        encoded_partitions = self._stringify_partition_values(partitions)
 
         fragments = [
             format.make_fragment(
@@ -1067,7 +1134,7 @@ class DeltaTable:
                 partition_expression=part_expression,
             )
             for file, part_expression in self._table.dataset_partitions(
-                schema, partitions
+                schema, encoded_partitions, predicate
             )
         ]
 
@@ -1084,19 +1151,31 @@ class DeltaTable:
 
     def to_pyarrow_table(
         self,
-        partitions: list[tuple[str, str, Any]] | None = None,
+        partitions: FilterType | None = None,
         columns: list[str] | None = None,
         filesystem: str | pa_fs.FileSystem | None = None,
         filters: FilterType | Expression | None = None,
+        predicate: str | None = None,
     ) -> "pyarrow.Table":
         """
         Build a PyArrow Table using data from the DeltaTable.
 
+        `partitions` and `predicate` select which *files* are read, pruning at the
+        file level before any data is scanned; see the `file_uris` docstring for
+        their syntax and pruning semantics. `filters` filters *rows* while scanning.
+        A predicate on a non-partition column selects a superset of files, so pair
+        it with an equivalent `filters` expression when you need exact rows:
+
+        ```python
+        dt.to_pyarrow_table(predicate="value >= 100", filters=[("value", ">=", 100)])
+        ```
+
         Args:
-            partitions: A list of partition filters; see the `file_uris` docstring for filter syntax
+            partitions: Tuple filters selecting the files to read; mutually exclusive with `predicate`
             columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
-            filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression. If you pass a filter you do not need to pass ``partitions``
+            filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression
+            predicate: A SQL predicate string selecting the files to read
         """
         try:
             from pyarrow.parquet import filters_to_expression  # pyarrow >= 10.0.0
@@ -1108,31 +1187,45 @@ class DeltaTable:
         if filters is not None:
             filters = filters_to_expression(filters)
         return self.to_pyarrow_dataset(
-            partitions=partitions, filesystem=filesystem
+            partitions=partitions, filesystem=filesystem, predicate=predicate
         ).to_table(columns=columns, filter=filters)
 
     def to_pandas(
         self,
-        partitions: list[tuple[str, str, Any]] | None = None,
+        partitions: FilterType | None = None,
         columns: list[str] | None = None,
         filesystem: str | pa_fs.FileSystem | None = None,
         filters: FilterType | Expression | None = None,
         types_mapper: Callable[[pyarrow.DataType], Any] | None = None,
+        predicate: str | None = None,
     ) -> "pd.DataFrame":
         """
         Build a pandas dataframe using data from the DeltaTable.
 
+        `partitions` and `predicate` select which *files* are read, pruning at the
+        file level before any data is scanned; see the `file_uris` docstring for
+        their syntax and pruning semantics. `filters` filters *rows* while scanning.
+        A predicate on a non-partition column selects a superset of files, so pair
+        it with an equivalent `filters` expression when you need exact rows:
+
+        ```python
+        dt.to_pandas(predicate="value >= 100", filters=[("value", ">=", 100)])
+        ```
+
         Args:
-            partitions: A list of partition filters; see the `file_uris` docstring for filter syntax
+            partitions: Tuple filters selecting the files to read; mutually exclusive with `predicate`
             columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
-            filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression. If you pass a filter you do not need to pass ``partitions``
+            filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression
+            types_mapper: A function mapping a pyarrow DataType to a pandas ExtensionDtype
+            predicate: A SQL predicate string selecting the files to read
         """
         return self.to_pyarrow_table(
             partitions=partitions,
             columns=columns,
             filesystem=filesystem,
             filters=filters,
+            predicate=predicate,
         ).to_pandas(types_mapper=types_mapper)
 
     def update_incremental(self) -> None:
@@ -1162,19 +1255,28 @@ class DeltaTable:
         self._table.cleanup_metadata()
 
     def _stringify_partition_values(
-        self, partition_filters: FilterConjunctionType | None
-    ) -> PartitionFilterType | None:
-        if partition_filters is None:
-            return partition_filters
-        out = []
-        for field, op, value in partition_filters:
-            str_value: str | list[str]
-            if isinstance(value, (list, tuple)):
-                str_value = [encode_partition_value(val) for val in value]
-            else:
-                str_value = encode_partition_value(value)
-            out.append((field, op, str_value))
-        return out
+        self, partition_filters: FilterType | None
+    ) -> list[PartitionFilterType] | None:
+        """Normalize tuple filters to disjunctive normal form -- a list of
+        conjunctions -- and encode every value to its partition string form."""
+        if not partition_filters:
+            return None
+        conjunctions: FilterDNFType
+        if all(isinstance(conjunction, list) for conjunction in partition_filters):
+            conjunctions = cast(FilterDNFType, partition_filters)
+        elif all(isinstance(literal, tuple) for literal in partition_filters):
+            conjunctions = [cast(FilterConjunctionType, partition_filters)]
+        else:
+            raise ValueError(
+                "filters must be a list of (column, op, value) tuples (a conjunction), "
+                "or a list of such lists (an OR across conjunctions), not a mix of both"
+            )
+        for conjunction in conjunctions:
+            if not conjunction:
+                raise ValueError(
+                    "empty conjunction in filters; pass no filter to match all files"
+                )
+        return [_encode_filter_conjunction(conjunction) for conjunction in conjunctions]
 
     def get_add_actions(self, flatten: bool = False) -> Table:
         """Return an Arrow table describing every file currently in the table.
@@ -2299,7 +2401,9 @@ class TableOptimizer:
             min_commit_interval = int(min_commit_interval.total_seconds())
 
         metrics = self.table._table.compact_optimize(
-            self.table._stringify_partition_values(partition_filters),
+            _encode_filter_conjunction(partition_filters)
+            if partition_filters
+            else None,
             target_size,
             max_concurrent_tasks,
             max_spill_size,
@@ -2382,7 +2486,9 @@ class TableOptimizer:
 
         metrics = self.table._table.z_order_optimize(
             list(columns),
-            self.table._stringify_partition_values(partition_filters),
+            _encode_filter_conjunction(partition_filters)
+            if partition_filters
+            else None,
             target_size,
             max_concurrent_tasks,
             max_spill_size,

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -76,15 +76,21 @@ FilterConjunctionType = list[FilterLiteralType]
 FilterDNFType = list[FilterConjunctionType]
 FilterType = Union[FilterConjunctionType, FilterDNFType]
 PartitionFilterType = list[tuple[str, str, Union[str, list[str]]]]
+FilePruningPredicateType = Union[str, FilterType]
 
 
-def _require_exclusive_filter(
-    filters_name: str, filters: FilterType | None, predicate: str | None
-) -> None:
-    if filters is not None and predicate is not None:
+def _merge_deprecated_filters(
+    deprecated_name: str,
+    deprecated_value: FilterType | None,
+    file_pruning_predicate: FilePruningPredicateType | None,
+) -> FilePruningPredicateType | None:
+    if deprecated_value is None:
+        return file_pruning_predicate
+    if file_pruning_predicate is not None:
         raise ValueError(
-            f"`{filters_name}` and `predicate` are mutually exclusive; pass only one"
+            f"`{deprecated_name}` is deprecated; pass only `file_pruning_predicate`"
         )
+    return deprecated_value
 
 
 def _encode_filter_conjunction(
@@ -367,7 +373,7 @@ class DeltaTable:
         self,
         partition_filters: FilterType | None = None,
         *,
-        predicate: str | None = None,
+        file_pruning_predicate: FilePruningPredicateType | None = None,
     ) -> list[dict[str, str]]:
         """
         Returns the partitions as a list of dicts.
@@ -376,19 +382,21 @@ class DeltaTable:
           `[{'month': '1', 'year': '2020', 'day': '1'}, ...]`
 
         Args:
-            partition_filters: Tuple filters with the syntax described in `file_uris`,
-                defaults to `None` (no filtering). Mutually exclusive with `predicate`.
-            predicate: A SQL predicate string with the syntax described in `file_uris`.
+            partition_filters: Deprecated. Pass tuple filters to `file_pruning_predicate` instead.
+            file_pruning_predicate: A SQL predicate string or tuple filters; syntax and
+                pruning semantics are described in `file_uris`.
 
         When a filter references a non-partition column, the result contains the
         partitions of every file that may hold matching rows, following the pruning
         semantics described in `file_uris`.
         """
-        _require_exclusive_filter("partition_filters", partition_filters, predicate)
+        file_pruning_predicate = _merge_deprecated_filters(
+            "partition_filters", partition_filters, file_pruning_predicate
+        )
 
         partitions: list[dict[str, str]] = []
         for partition in self._table.get_active_partitions(
-            self._stringify_partition_values(partition_filters), predicate
+            self._encode_file_pruning_predicate(file_pruning_predicate)
         ):
             if not partition:
                 continue
@@ -399,7 +407,7 @@ class DeltaTable:
         self,
         partition_filters: FilterType | None = None,
         *,
-        predicate: str | None = None,
+        file_pruning_predicate: FilePruningPredicateType | None = None,
     ) -> list[str]:
         """
         Get the list of files as absolute URIs, including the scheme (e.g. "s3://").
@@ -407,18 +415,26 @@ class DeltaTable:
         Local files will be just plain absolute paths, without a scheme. (That is,
         no 'file://' prefix.)
 
-        Files can be selected with tuple filters (`partition_filters`) or with a SQL
-        predicate string (`predicate`); the two parameters are mutually exclusive.
+        Files are selected with `file_pruning_predicate`, which takes either a SQL
+        predicate string or tuple filters.
+
+        **SQL predicates.** Any boolean SQL expression built from column comparisons
+        (`=`, `!=`, `<`, `<=`, `>`, `>=`), `IS [NOT] NULL`, `[NOT] IN`,
+        `[NOT] BETWEEN`, `NOT`, `AND` and `OR`:
+
+        ```python
+        dt.file_uris(file_pruning_predicate="year = 2021 AND (month = 1 OR day > 15)")
+        ```
 
         **Tuple filters.** Each filter is a `(column, op, value)` tuple. A flat list
         is a conjunction (AND) of its filters. A list of such lists is interpreted in
         disjunctive normal form: an OR across the inner AND groups.
 
         ```python
-        dt.file_uris([("year", "=", "2021"), ("month", "=", "12")])
+        dt.file_uris(file_pruning_predicate=[("year", "=", "2021"), ("month", "=", "12")])
         # year = 2021 AND month = 12
 
-        dt.file_uris([
+        dt.file_uris(file_pruning_predicate=[
             [("year", "=", "2021")],
             [("year", "=", "2020"), ("month", ">=", "10")],
         ])
@@ -431,34 +447,29 @@ class DeltaTable:
         datetime); each is encoded to its partition string form and parsed against
         the column's type. Comparisons follow that type: on a string column,
         `("month", ">=", 12)` compares lexicographically, so `"4" >= "12"`. Use
-        the empty string `''` to match a null partition value, or a `predicate`
+        the empty string `''` to match a null partition value, or a SQL predicate
         with `IS NULL`.
 
-        **SQL predicates.** Any boolean SQL expression built from column comparisons
-        (`=`, `!=`, `<`, `<=`, `>`, `>=`), `IS [NOT] NULL`, `[NOT] IN`,
-        `[NOT] BETWEEN`, `NOT`, `AND` and `OR`:
-
-        ```python
-        dt.file_uris(predicate="year = 2021 AND (month = 1 OR day > 15)")
-        ```
-
-        **Pruning semantics.** Filters on partition columns select files exactly.
-        Filters on other columns are evaluated against per-file min/max statistics
-        and select a superset: every file that may contain a matching row is
-        returned, files that provably contain none are dropped, and files without
-        statistics for a referenced column are always retained. Filter the rows
-        after reading when you need exact results.
+        **Pruning semantics.** The predicate prunes files, not rows. Filters on
+        partition columns select files exactly. Filters on other columns are
+        evaluated against per-file min/max statistics and select a superset: every
+        file that may contain a matching row is returned, files that provably
+        contain none are dropped, and files without statistics for a referenced
+        column are always retained. Filter the rows after reading when you need
+        exact results.
 
         Args:
-            partition_filters: tuple filters as described above
-            predicate: a SQL predicate string as described above
+            partition_filters: Deprecated. Pass tuple filters to `file_pruning_predicate` instead.
+            file_pruning_predicate: a SQL predicate string or tuple filters as described above
 
         Returns:
             list of the .parquet files with an absolute URI referenced for the current version of the DeltaTable
         """
-        _require_exclusive_filter("partition_filters", partition_filters, predicate)
+        file_pruning_predicate = _merge_deprecated_filters(
+            "partition_filters", partition_filters, file_pruning_predicate
+        )
         return self._table.file_uris(
-            self._stringify_partition_values(partition_filters), predicate
+            self._encode_file_pruning_predicate(file_pruning_predicate)
         )
 
     def load_as_version(self, version: int | str | datetime) -> None:
@@ -1006,14 +1017,13 @@ class DeltaTable:
         parquet_read_options: ParquetReadOptions | None = None,
         schema: pyarrow.Schema | None = None,
         as_large_types: bool = False,
-        predicate: str | None = None,
+        file_pruning_predicate: FilePruningPredicateType | None = None,
     ) -> "pyarrow.dataset.Dataset":
         """
         Build a PyArrow Dataset using data from the DeltaTable.
 
         Args:
-            partitions: Tuple filters selecting the files to include; see the `file_uris`
-                docstring for the syntax and pruning semantics. Mutually exclusive with `predicate`
+            partitions: Deprecated. Pass tuple filters to `file_pruning_predicate` instead
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
             parquet_read_options: Optional read options for Parquet. Use this to handle INT96 to timestamp conversion for edge cases like 0001-01-01 or 9999-12-31
             schema: The schema to use for the dataset. If None, the schema of the DeltaTable will be used. This can be used to force reading of Parquet/Arrow datatypes
@@ -1022,8 +1032,9 @@ class DeltaTable:
             as_large_types: get schema with all variable size types (list, binary, string) as large variants (with int64 indices).
                 This is for compatibility with systems like Polars that only support the large versions of Arrow types.
                 If `schema` is passed it takes precedence over this option.
-            predicate: A SQL predicate string selecting the files to include; see the
-                `file_uris` docstring for the syntax and pruning semantics
+            file_pruning_predicate: A SQL predicate string or tuple filters selecting the
+                files to include; see the `file_uris` docstring for the syntax and
+                pruning semantics
 
          More info on [pyarrow dataset ParquetReadOptions](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.ParquetReadOptions.html).
 
@@ -1046,7 +1057,9 @@ class DeltaTable:
         Returns:
             the PyArrow dataset in PyArrow
         """
-        _require_exclusive_filter("partitions", partitions, predicate)
+        file_pruning_predicate = _merge_deprecated_filters(
+            "partitions", partitions, file_pruning_predicate
+        )
         try:
             from pyarrow.dataset import (
                 FileSystemDataset,
@@ -1125,8 +1138,6 @@ class DeltaTable:
                 self.schema().to_arrow(as_large_types=as_large_types)
             )
 
-        encoded_partitions = self._stringify_partition_values(partitions)
-
         fragments = [
             format.make_fragment(
                 file,
@@ -1134,7 +1145,7 @@ class DeltaTable:
                 partition_expression=part_expression,
             )
             for file, part_expression in self._table.dataset_partitions(
-                schema, encoded_partitions, predicate
+                schema, self._encode_file_pruning_predicate(file_pruning_predicate)
             )
         ]
 
@@ -1155,27 +1166,29 @@ class DeltaTable:
         columns: list[str] | None = None,
         filesystem: str | pa_fs.FileSystem | None = None,
         filters: FilterType | Expression | None = None,
-        predicate: str | None = None,
+        file_pruning_predicate: FilePruningPredicateType | None = None,
     ) -> "pyarrow.Table":
         """
         Build a PyArrow Table using data from the DeltaTable.
 
-        `partitions` and `predicate` select which *files* are read, pruning at the
+        `file_pruning_predicate` selects which *files* are read, pruning at the
         file level before any data is scanned; see the `file_uris` docstring for
-        their syntax and pruning semantics. `filters` filters *rows* while scanning.
-        A predicate on a non-partition column selects a superset of files, so pair
-        it with an equivalent `filters` expression when you need exact rows:
+        its syntax and pruning semantics. `filters` filters *rows* while scanning.
+        A pruning predicate on a non-partition column selects a superset of files,
+        so pair it with an equivalent `filters` expression when you need exact rows:
 
         ```python
-        dt.to_pyarrow_table(predicate="value >= 100", filters=[("value", ">=", 100)])
+        dt.to_pyarrow_table(
+            file_pruning_predicate="value >= 100", filters=[("value", ">=", 100)]
+        )
         ```
 
         Args:
-            partitions: Tuple filters selecting the files to read; mutually exclusive with `predicate`
+            partitions: Deprecated. Pass tuple filters to `file_pruning_predicate` instead
             columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
             filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression
-            predicate: A SQL predicate string selecting the files to read
+            file_pruning_predicate: A SQL predicate string or tuple filters selecting the files to read
         """
         try:
             from pyarrow.parquet import filters_to_expression  # pyarrow >= 10.0.0
@@ -1187,7 +1200,9 @@ class DeltaTable:
         if filters is not None:
             filters = filters_to_expression(filters)
         return self.to_pyarrow_dataset(
-            partitions=partitions, filesystem=filesystem, predicate=predicate
+            partitions=partitions,
+            filesystem=filesystem,
+            file_pruning_predicate=file_pruning_predicate,
         ).to_table(columns=columns, filter=filters)
 
     def to_pandas(
@@ -1197,35 +1212,35 @@ class DeltaTable:
         filesystem: str | pa_fs.FileSystem | None = None,
         filters: FilterType | Expression | None = None,
         types_mapper: Callable[[pyarrow.DataType], Any] | None = None,
-        predicate: str | None = None,
+        file_pruning_predicate: FilePruningPredicateType | None = None,
     ) -> "pd.DataFrame":
         """
         Build a pandas dataframe using data from the DeltaTable.
 
-        `partitions` and `predicate` select which *files* are read, pruning at the
+        `file_pruning_predicate` selects which *files* are read, pruning at the
         file level before any data is scanned; see the `file_uris` docstring for
-        their syntax and pruning semantics. `filters` filters *rows* while scanning.
-        A predicate on a non-partition column selects a superset of files, so pair
-        it with an equivalent `filters` expression when you need exact rows:
+        its syntax and pruning semantics. `filters` filters *rows* while scanning.
+        A pruning predicate on a non-partition column selects a superset of files,
+        so pair it with an equivalent `filters` expression when you need exact rows:
 
         ```python
-        dt.to_pandas(predicate="value >= 100", filters=[("value", ">=", 100)])
+        dt.to_pandas(file_pruning_predicate="value >= 100", filters=[("value", ">=", 100)])
         ```
 
         Args:
-            partitions: Tuple filters selecting the files to read; mutually exclusive with `predicate`
+            partitions: Deprecated. Pass tuple filters to `file_pruning_predicate` instead
             columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
             filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression
             types_mapper: A function mapping a pyarrow DataType to a pandas ExtensionDtype
-            predicate: A SQL predicate string selecting the files to read
+            file_pruning_predicate: A SQL predicate string or tuple filters selecting the files to read
         """
         return self.to_pyarrow_table(
             partitions=partitions,
             columns=columns,
             filesystem=filesystem,
             filters=filters,
-            predicate=predicate,
+            file_pruning_predicate=file_pruning_predicate,
         ).to_pandas(types_mapper=types_mapper)
 
     def update_incremental(self) -> None:
@@ -1253,6 +1268,14 @@ class DeltaTable:
         the `delta.logRetentionDuration` value, 30 days by default.
         """
         self._table.cleanup_metadata()
+
+    def _encode_file_pruning_predicate(
+        self, predicate: FilePruningPredicateType | None
+    ) -> str | list[PartitionFilterType] | None:
+        """Pass SQL strings through; normalize and encode tuple filters."""
+        if predicate is None or isinstance(predicate, str):
+            return predicate
+        return self._stringify_partition_values(predicate)
 
     def _stringify_partition_values(
         self, partition_filters: FilterType | None

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -456,7 +456,11 @@ class DeltaTable:
         file that may contain a matching row is returned, files that provably
         contain none are dropped, and files without statistics for a referenced
         column are always retained. Filter the rows after reading when you need
-        exact results.
+        exact results. How much a data-column filter actually prunes depends on
+        the data layout: min/max statistics only rule out files when similar
+        values are colocated, so tables partitioned or z-ordered on the
+        referenced column prune well, while uniformly distributed values may
+        prune nothing.
 
         Args:
             partition_filters: Deprecated. Pass tuple filters to `file_pruning_predicate` instead.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -13,7 +13,7 @@ mod writer;
 use arrow_schema::{ArrowError, SchemaRef};
 use chrono::{DateTime, Duration, FixedOffset, Utc};
 use datafusion_ffi::table_provider::FFI_TableProvider;
-use delta_kernel::expressions::Scalar;
+use delta_kernel::expressions::{PredicateRef, Scalar};
 use delta_kernel::schema::{MetadataValue, StructField};
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use deltalake::arrow::{
@@ -35,6 +35,7 @@ use deltalake::arrow::array::{
     ArrayRef, BooleanBuilder, LargeStringBuilder, ListBuilder, RecordBatchIterator,
 };
 use deltalake::delta_datafusion::create_session_state_with_spill_config;
+use deltalake::delta_datafusion::expr::parse_sql_predicate_to_kernel;
 use deltalake::errors::DeltaTableError;
 use deltalake::kernel::scalars::ScalarExt;
 use deltalake::kernel::transaction::{CommitBuilder, CommitProperties, TableReference};
@@ -54,7 +55,9 @@ use deltalake::operations::write::WriteBuilder;
 use deltalake::parquet::basic::{Compression, Encoding};
 use deltalake::parquet::errors::ParquetError;
 use deltalake::parquet::file::properties::{EnabledStatistics, WriterProperties};
-use deltalake::partitions::PartitionFilter;
+use deltalake::partitions::{
+    FilterLiteral, FilterValue, PartitionFilter, dnf_to_kernel_predicate, to_kernel_predicate,
+};
 use deltalake::protocol::log_compaction::compact_logs;
 use deltalake::protocol::{DeltaOperation, SaveMode};
 use deltalake::table::config::TablePropertiesExt as _;
@@ -117,6 +120,11 @@ enum PartitionFilterValue {
     Single(PyBackedStr),
     Multiple(Vec<PyBackedStr>),
 }
+
+/// One conjunction (AND group) of `(column, op, value)` filter tuples. The
+/// Python side always sends filters as a list of these, i.e. in disjunctive
+/// normal form; a lone conjunction arrives as a single-element list.
+type PyFilterConjunction = Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>;
 
 #[pyclass(module = "deltalake._internal", frozen)]
 struct RawDeltaTable {
@@ -291,6 +299,42 @@ impl RawDeltaTable {
                 .map_err(PythonError::from)
                 .map_err(PyErr::from)
         })
+    }
+
+    /// Resolve the mutually exclusive tuple-filter and SQL-predicate parameters
+    /// of the file listing APIs into one kernel predicate.
+    fn resolve_files_predicate(
+        &self,
+        partition_filters: Option<Vec<PyFilterConjunction>>,
+        predicate: Option<String>,
+    ) -> PyResult<Option<PredicateRef>> {
+        let partition_filters = partition_filters.filter(|filters| !filters.is_empty());
+        let resolved = match (partition_filters, predicate) {
+            (Some(_), Some(_)) => {
+                return Err(PyValueError::new_err(
+                    "partition_filters and predicate are mutually exclusive; pass only one",
+                ));
+            }
+            (None, None) => return Ok(None),
+            (Some(filters), None) => {
+                kernel_dnf_predicate(&filters, self.snapshot_schema()?.as_ref())
+                    .map_err(PythonError::from)?
+            }
+            (None, Some(predicate)) => {
+                let session = SessionContext::new();
+                parse_sql_predicate_to_kernel(
+                    &predicate,
+                    self.snapshot_schema()?.as_ref(),
+                    &session.state(),
+                )
+                .map_err(PythonError::from)?
+            }
+        };
+        Ok(Some(Arc::new(resolved)))
+    }
+
+    fn snapshot_schema(&self) -> PyResult<delta_kernel::schema::SchemaRef> {
+        self.with_table(|t| Ok(t.snapshot().map_err(PythonError::from)?.schema().clone()))
     }
 
     /// Clone both the table handle and its snapshot state under a single lock acquisition.
@@ -561,30 +605,29 @@ impl RawDeltaTable {
         })
     }
 
-    #[pyo3(signature = (partition_filters=None))]
+    #[pyo3(signature = (partition_filters=None, predicate=None))]
     pub fn files(
         &self,
         py: Python,
-        partition_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partition_filters: Option<Vec<PyFilterConjunction>>,
+        predicate: Option<String>,
     ) -> PyResult<Vec<String>> {
         if !self.has_files()? {
             return Err(DeltaError::new_err("Table is instantiated without files."));
         }
+        let filter = self.resolve_files_predicate(partition_filters, predicate)?;
         py.detach(|| {
-            if let Some(filters) = partition_filters {
-                let filters = convert_partition_filters(filters).map_err(PythonError::from)?;
-                Ok(self
-                    .with_table(|t| {
-                        rt().block_on(async {
-                            t.get_files_by_partitions(&filters)
-                                .await
-                                .map_err(PythonError::from)
-                                .map_err(PyErr::from)
-                        })
-                    })?
-                    .into_iter()
-                    .map(|p| p.to_string())
-                    .collect())
+            if let Some(filter) = filter {
+                self.with_table(|t| {
+                    rt().block_on(async {
+                        t.get_active_add_actions_by_predicate(Some(filter.clone()))
+                            .map_ok(|view| view.object_store_path().to_string())
+                            .try_collect()
+                            .await
+                            .map_err(PythonError::from)
+                            .map_err(PyErr::from)
+                    })
+                })
             } else {
                 match self._table.lock() {
                     Ok(table) => Ok(table
@@ -598,23 +641,30 @@ impl RawDeltaTable {
         })
     }
 
-    #[pyo3(signature = (partition_filters=None))]
+    #[pyo3(signature = (partition_filters=None, predicate=None))]
     pub fn file_uris(
         &self,
-        partition_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partition_filters: Option<Vec<PyFilterConjunction>>,
+        predicate: Option<String>,
     ) -> PyResult<Vec<String>> {
         if !self.with_table(|t| Ok(t.config.require_files))? {
             return Err(DeltaError::new_err("Table is initiated without files."));
         }
 
-        if let Some(filters) = partition_filters {
-            let filters = convert_partition_filters(filters).map_err(PythonError::from)?;
+        let filter = self.resolve_files_predicate(partition_filters, predicate)?;
+        if let Some(filter) = filter {
             self.with_table(|t| {
                 rt().block_on(async {
-                    t.get_file_uris_by_partitions(&filters)
+                    let paths: Vec<_> = t
+                        .get_active_add_actions_by_predicate(Some(filter.clone()))
+                        .map_ok(|view| view.object_store_path())
+                        .try_collect()
                         .await
-                        .map_err(PythonError::from)
-                        .map_err(PyErr::from)
+                        .map_err(PythonError::from)?;
+                    Ok(paths
+                        .iter()
+                        .map(|path| t.log_store().to_uri(path))
+                        .collect())
                 })
             })
         } else {
@@ -772,7 +822,7 @@ impl RawDeltaTable {
     pub fn compact_optimize(
         &self,
         py: Python,
-        partition_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partition_filters: Option<PyFilterConjunction>,
         target_size: Option<u64>,
         max_concurrent_tasks: Option<usize>,
         max_spill_size: Option<usize>,
@@ -848,7 +898,7 @@ impl RawDeltaTable {
         &self,
         py: Python,
         z_order_columns: Vec<String>,
-        partition_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partition_filters: Option<PyFilterConjunction>,
         target_size: Option<u64>,
         max_concurrent_tasks: Option<usize>,
         max_spill_size: Option<usize>,
@@ -1351,18 +1401,22 @@ impl RawDeltaTable {
         })
     }
 
-    #[pyo3(signature = (schema, partition_filters=None))]
+    #[pyo3(signature = (schema, partition_filters=None, predicate=None))]
     pub fn dataset_partitions<'py>(
         &self,
         py: Python<'py>,
         schema: PyArrowSchema,
-        partition_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partition_filters: Option<Vec<PyFilterConjunction>>,
+        predicate: Option<String>,
     ) -> PyResult<Vec<(String, Option<Bound<'py, PyAny>>)>> {
-        let path_set = match partition_filters {
-            Some(filters) => Some(HashSet::<_>::from_iter(
-                self.files(py, Some(filters))?.iter().cloned(),
-            )),
-            None => None,
+        let path_set = if partition_filters.is_some() || predicate.is_some() {
+            Some(HashSet::<_>::from_iter(
+                self.files(py, partition_filters, predicate)?
+                    .iter()
+                    .cloned(),
+            ))
+        } else {
+            None
         };
         let stats_cols = self.get_stats_columns()?;
         let num_index_cols = self.get_num_index_cols()?;
@@ -1407,10 +1461,11 @@ impl RawDeltaTable {
             .collect()
     }
 
-    #[pyo3(signature = (partitions_filters=None))]
+    #[pyo3(signature = (partitions_filters=None, predicate=None))]
     fn get_active_partitions<'py>(
         &self,
-        partitions_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partitions_filters: Option<Vec<PyFilterConjunction>>,
+        predicate: Option<String>,
         py: Python<'py>,
     ) -> PyResult<Bound<'py, PyFrozenSet>> {
         let schema = self.with_table(|t| {
@@ -1438,6 +1493,7 @@ impl RawDeltaTable {
         if let Some(filters) = &partitions_filters {
             let unknown_columns: Vec<&PyBackedStr> = filters
                 .iter()
+                .flatten()
                 .map(|(column_name, _, _)| column_name)
                 .filter(|column_name| {
                     let column_name: &'_ str = column_name.as_ref();
@@ -1449,25 +1505,9 @@ impl RawDeltaTable {
                     "Filters include columns that are not in table schema: {unknown_columns:?}"
                 )));
             }
-
-            let non_partition_columns: Vec<&PyBackedStr> = filters
-                .iter()
-                .map(|(column_name, _, _)| column_name)
-                .filter(|column_name| {
-                    let column_name: &'_ str = column_name.as_ref();
-                    !partition_columns.contains(column_name)
-                })
-                .collect();
-
-            if !non_partition_columns.is_empty() {
-                return Err(PyValueError::new_err(format!(
-                    "Filters include columns that are not partition columns: {non_partition_columns:?}"
-                )));
-            }
         }
 
-        let converted_filters = convert_partition_filters(partitions_filters.unwrap_or_default())
-            .map_err(PythonError::from)?;
+        let filter = self.resolve_files_predicate(partitions_filters, predicate)?;
 
         let partition_columns: Vec<&str> = partition_columns.into_iter().collect();
         let partition_column_keys: Vec<(&str, String)> = partition_columns
@@ -1492,13 +1532,7 @@ impl RawDeltaTable {
         let state = self.cloned_state()?;
         let log_store = self.log_store()?;
         let adds: Vec<_> = rt()
-            .block_on(async {
-                #[allow(deprecated)]
-                state
-                    .file_views_by_partitions(&log_store, &converted_filters)
-                    .try_collect()
-                    .await
-            })
+            .block_on(async { state.file_views(&log_store, filter).try_collect().await })
             .map_err(PythonError::from)?;
         let active_partitions: HashSet<Vec<(&str, Option<String>)>> = adds
             .iter()
@@ -1546,7 +1580,7 @@ impl RawDeltaTable {
         mode: &str,
         partition_by: Vec<String>,
         schema: PyRef<PySchema>,
-        partitions_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partitions_filters: Option<PyFilterConjunction>,
         commit_properties: Option<PyCommitProperties>,
         post_commithook_properties: Option<PyPostCommitHookProperties>,
     ) -> PyResult<()> {
@@ -1572,13 +1606,17 @@ impl RawDeltaTable {
 
                     let state = self.cloned_state()?;
                     let log_store = self.log_store()?;
+                    let filter = if converted_filters.is_empty() {
+                        None
+                    } else {
+                        Some(Arc::new(
+                            to_kernel_predicate(&converted_filters, state.schema().as_ref())
+                                .map_err(PythonError::from)?,
+                        ) as PredicateRef)
+                    };
                     let add_actions: Vec<_> = rt()
                         .block_on(async {
-                            #[allow(deprecated)]
-                            state
-                                .file_views_by_partitions(&log_store, &converted_filters)
-                                .try_collect()
-                                .await
+                            state.file_views(&log_store, filter).try_collect().await
                         })
                         .map_err(PythonError::from)?;
 
@@ -2354,6 +2392,32 @@ fn set_writer_properties(writer_properties: PyWriterProperties) -> DeltaResult<W
         }
     }
     Ok(properties.build())
+}
+
+/// Translate DNF filter tuples into a kernel predicate, without materializing
+/// `PartitionFilter`s along the way.
+fn kernel_dnf_predicate(
+    dnf: &[PyFilterConjunction],
+    table_schema: &delta_kernel::schema::StructType,
+) -> Result<delta_kernel::expressions::Predicate, DeltaTableError> {
+    let dnf: Vec<Vec<FilterLiteral<'_>>> = dnf
+        .iter()
+        .map(|conjunction| {
+            conjunction
+                .iter()
+                .map(|(column, op, value)| {
+                    let value = match value {
+                        PartitionFilterValue::Single(v) => FilterValue::Scalar(v.as_ref()),
+                        PartitionFilterValue::Multiple(vs) => {
+                            FilterValue::Set(vs.iter().map(|v| v.as_ref()).collect())
+                        }
+                    };
+                    (column.as_ref(), op.as_ref(), value)
+                })
+                .collect()
+        })
+        .collect();
+    dnf_to_kernel_predicate(&dnf, table_schema)
 }
 
 fn convert_partition_filters(

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -13,7 +13,7 @@ mod writer;
 use arrow_schema::{ArrowError, SchemaRef};
 use chrono::{DateTime, Duration, FixedOffset, Utc};
 use datafusion_ffi::table_provider::FFI_TableProvider;
-use delta_kernel::expressions::Scalar;
+use delta_kernel::expressions::{PredicateRef, Scalar};
 use delta_kernel::schema::{MetadataValue, StructField};
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use deltalake::arrow::{
@@ -35,6 +35,7 @@ use deltalake::arrow::array::{
     ArrayRef, BooleanBuilder, LargeStringBuilder, ListBuilder, RecordBatchIterator,
 };
 use deltalake::delta_datafusion::create_session_state_with_spill_config;
+use deltalake::delta_datafusion::expr::parse_sql_predicate_to_kernel;
 use deltalake::errors::DeltaTableError;
 use deltalake::kernel::scalars::ScalarExt;
 use deltalake::kernel::transaction::{CommitBuilder, CommitProperties, TableReference};
@@ -54,7 +55,9 @@ use deltalake::operations::write::WriteBuilder;
 use deltalake::parquet::basic::{Compression, Encoding};
 use deltalake::parquet::errors::ParquetError;
 use deltalake::parquet::file::properties::{EnabledStatistics, WriterProperties};
-use deltalake::partitions::PartitionFilter;
+use deltalake::partitions::{
+    FilterLiteral, FilterValue, PartitionFilter, dnf_to_kernel_predicate, to_kernel_predicate,
+};
 use deltalake::protocol::log_compaction::compact_logs;
 use deltalake::protocol::{DeltaOperation, SaveMode};
 use deltalake::table::config::TablePropertiesExt as _;
@@ -117,6 +120,11 @@ enum PartitionFilterValue {
     Single(PyBackedStr),
     Multiple(Vec<PyBackedStr>),
 }
+
+/// One conjunction (AND group) of `(column, op, value)` filter tuples. The
+/// Python side always sends filters as a list of these, i.e. in disjunctive
+/// normal form; a lone conjunction arrives as a single-element list.
+type PyFilterConjunction = Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>;
 
 #[pyclass(module = "deltalake._internal", frozen)]
 struct RawDeltaTable {
@@ -291,6 +299,42 @@ impl RawDeltaTable {
                 .map_err(PythonError::from)
                 .map_err(PyErr::from)
         })
+    }
+
+    /// Resolve the mutually exclusive tuple-filter and SQL-predicate parameters
+    /// of the file listing APIs into one kernel predicate.
+    fn resolve_files_predicate(
+        &self,
+        partition_filters: Option<Vec<PyFilterConjunction>>,
+        predicate: Option<String>,
+    ) -> PyResult<Option<PredicateRef>> {
+        let partition_filters = partition_filters.filter(|filters| !filters.is_empty());
+        let resolved = match (partition_filters, predicate) {
+            (Some(_), Some(_)) => {
+                return Err(PyValueError::new_err(
+                    "partition_filters and predicate are mutually exclusive; pass only one",
+                ));
+            }
+            (None, None) => return Ok(None),
+            (Some(filters), None) => {
+                kernel_dnf_predicate(&filters, self.snapshot_schema()?.as_ref())
+                    .map_err(PythonError::from)?
+            }
+            (None, Some(predicate)) => {
+                let session = SessionContext::new();
+                parse_sql_predicate_to_kernel(
+                    &predicate,
+                    self.snapshot_schema()?.as_ref(),
+                    &session.state(),
+                )
+                .map_err(PythonError::from)?
+            }
+        };
+        Ok(Some(Arc::new(resolved)))
+    }
+
+    fn snapshot_schema(&self) -> PyResult<delta_kernel::schema::SchemaRef> {
+        self.with_table(|t| Ok(t.snapshot().map_err(PythonError::from)?.schema().clone()))
     }
 
     /// Clone both the table handle and its snapshot state under a single lock acquisition.
@@ -561,30 +605,29 @@ impl RawDeltaTable {
         })
     }
 
-    #[pyo3(signature = (partition_filters=None))]
+    #[pyo3(signature = (partition_filters=None, predicate=None))]
     pub fn files(
         &self,
         py: Python,
-        partition_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partition_filters: Option<Vec<PyFilterConjunction>>,
+        predicate: Option<String>,
     ) -> PyResult<Vec<String>> {
         if !self.has_files()? {
             return Err(DeltaError::new_err("Table is instantiated without files."));
         }
+        let filter = self.resolve_files_predicate(partition_filters, predicate)?;
         py.detach(|| {
-            if let Some(filters) = partition_filters {
-                let filters = convert_partition_filters(filters).map_err(PythonError::from)?;
-                Ok(self
-                    .with_table(|t| {
-                        rt().block_on(async {
-                            t.get_files_by_partitions(&filters)
-                                .await
-                                .map_err(PythonError::from)
-                                .map_err(PyErr::from)
-                        })
-                    })?
-                    .into_iter()
-                    .map(|p| p.to_string())
-                    .collect())
+            if let Some(filter) = filter {
+                self.with_table(|t| {
+                    rt().block_on(async {
+                        t.get_active_add_actions_by_predicate(Some(filter.clone()))
+                            .map_ok(|view| view.object_store_path().to_string())
+                            .try_collect()
+                            .await
+                            .map_err(PythonError::from)
+                            .map_err(PyErr::from)
+                    })
+                })
             } else {
                 match self._table.lock() {
                     Ok(table) => Ok(table
@@ -598,23 +641,30 @@ impl RawDeltaTable {
         })
     }
 
-    #[pyo3(signature = (partition_filters=None))]
+    #[pyo3(signature = (partition_filters=None, predicate=None))]
     pub fn file_uris(
         &self,
-        partition_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partition_filters: Option<Vec<PyFilterConjunction>>,
+        predicate: Option<String>,
     ) -> PyResult<Vec<String>> {
         if !self.with_table(|t| Ok(t.config.require_files))? {
             return Err(DeltaError::new_err("Table is initiated without files."));
         }
 
-        if let Some(filters) = partition_filters {
-            let filters = convert_partition_filters(filters).map_err(PythonError::from)?;
+        let filter = self.resolve_files_predicate(partition_filters, predicate)?;
+        if let Some(filter) = filter {
             self.with_table(|t| {
                 rt().block_on(async {
-                    t.get_file_uris_by_partitions(&filters)
+                    let paths: Vec<_> = t
+                        .get_active_add_actions_by_predicate(Some(filter.clone()))
+                        .map_ok(|view| view.object_store_path())
+                        .try_collect()
                         .await
-                        .map_err(PythonError::from)
-                        .map_err(PyErr::from)
+                        .map_err(PythonError::from)?;
+                    Ok(paths
+                        .iter()
+                        .map(|path| t.log_store().to_uri(path))
+                        .collect())
                 })
             })
         } else {
@@ -772,7 +822,7 @@ impl RawDeltaTable {
     pub fn compact_optimize(
         &self,
         py: Python,
-        partition_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partition_filters: Option<PyFilterConjunction>,
         target_size: Option<u64>,
         max_concurrent_tasks: Option<usize>,
         max_spill_size: Option<usize>,
@@ -848,7 +898,7 @@ impl RawDeltaTable {
         &self,
         py: Python,
         z_order_columns: Vec<String>,
-        partition_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partition_filters: Option<PyFilterConjunction>,
         target_size: Option<u64>,
         max_concurrent_tasks: Option<usize>,
         max_spill_size: Option<usize>,
@@ -1381,18 +1431,22 @@ impl RawDeltaTable {
         })
     }
 
-    #[pyo3(signature = (schema, partition_filters=None))]
+    #[pyo3(signature = (schema, partition_filters=None, predicate=None))]
     pub fn dataset_partitions<'py>(
         &self,
         py: Python<'py>,
         schema: PyArrowSchema,
-        partition_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partition_filters: Option<Vec<PyFilterConjunction>>,
+        predicate: Option<String>,
     ) -> PyResult<Vec<(String, Option<Bound<'py, PyAny>>)>> {
-        let path_set = match partition_filters {
-            Some(filters) => Some(HashSet::<_>::from_iter(
-                self.files(py, Some(filters))?.iter().cloned(),
-            )),
-            None => None,
+        let path_set = if partition_filters.is_some() || predicate.is_some() {
+            Some(HashSet::<_>::from_iter(
+                self.files(py, partition_filters, predicate)?
+                    .iter()
+                    .cloned(),
+            ))
+        } else {
+            None
         };
         let stats_cols = self.get_stats_columns()?;
         let num_index_cols = self.get_num_index_cols()?;
@@ -1437,10 +1491,11 @@ impl RawDeltaTable {
             .collect()
     }
 
-    #[pyo3(signature = (partitions_filters=None))]
+    #[pyo3(signature = (partitions_filters=None, predicate=None))]
     fn get_active_partitions<'py>(
         &self,
-        partitions_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partitions_filters: Option<Vec<PyFilterConjunction>>,
+        predicate: Option<String>,
         py: Python<'py>,
     ) -> PyResult<Bound<'py, PyFrozenSet>> {
         let schema = self.with_table(|t| {
@@ -1468,6 +1523,7 @@ impl RawDeltaTable {
         if let Some(filters) = &partitions_filters {
             let unknown_columns: Vec<&PyBackedStr> = filters
                 .iter()
+                .flatten()
                 .map(|(column_name, _, _)| column_name)
                 .filter(|column_name| {
                     let column_name: &'_ str = column_name.as_ref();
@@ -1479,25 +1535,9 @@ impl RawDeltaTable {
                     "Filters include columns that are not in table schema: {unknown_columns:?}"
                 )));
             }
-
-            let non_partition_columns: Vec<&PyBackedStr> = filters
-                .iter()
-                .map(|(column_name, _, _)| column_name)
-                .filter(|column_name| {
-                    let column_name: &'_ str = column_name.as_ref();
-                    !partition_columns.contains(column_name)
-                })
-                .collect();
-
-            if !non_partition_columns.is_empty() {
-                return Err(PyValueError::new_err(format!(
-                    "Filters include columns that are not partition columns: {non_partition_columns:?}"
-                )));
-            }
         }
 
-        let converted_filters = convert_partition_filters(partitions_filters.unwrap_or_default())
-            .map_err(PythonError::from)?;
+        let filter = self.resolve_files_predicate(partitions_filters, predicate)?;
 
         let partition_columns: Vec<&str> = partition_columns.into_iter().collect();
         let partition_column_keys: Vec<(&str, String)> = partition_columns
@@ -1522,13 +1562,7 @@ impl RawDeltaTable {
         let state = self.cloned_state()?;
         let log_store = self.log_store()?;
         let adds: Vec<_> = rt()
-            .block_on(async {
-                #[allow(deprecated)]
-                state
-                    .file_views_by_partitions(&log_store, &converted_filters)
-                    .try_collect()
-                    .await
-            })
+            .block_on(async { state.file_views(&log_store, filter).try_collect().await })
             .map_err(PythonError::from)?;
         let active_partitions: HashSet<Vec<(&str, Option<String>)>> = adds
             .iter()
@@ -1576,7 +1610,7 @@ impl RawDeltaTable {
         mode: &str,
         partition_by: Vec<String>,
         schema: PyRef<PySchema>,
-        partitions_filters: Option<Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>>,
+        partitions_filters: Option<PyFilterConjunction>,
         commit_properties: Option<PyCommitProperties>,
         post_commithook_properties: Option<PyPostCommitHookProperties>,
     ) -> PyResult<()> {
@@ -1602,13 +1636,17 @@ impl RawDeltaTable {
 
                     let state = self.cloned_state()?;
                     let log_store = self.log_store()?;
+                    let filter = if converted_filters.is_empty() {
+                        None
+                    } else {
+                        Some(Arc::new(
+                            to_kernel_predicate(&converted_filters, state.schema().as_ref())
+                                .map_err(PythonError::from)?,
+                        ) as PredicateRef)
+                    };
                     let add_actions: Vec<_> = rt()
                         .block_on(async {
-                            #[allow(deprecated)]
-                            state
-                                .file_views_by_partitions(&log_store, &converted_filters)
-                                .try_collect()
-                                .await
+                            state.file_views(&log_store, filter).try_collect().await
                         })
                         .map_err(PythonError::from)?;
 
@@ -2384,6 +2422,32 @@ fn set_writer_properties(writer_properties: PyWriterProperties) -> DeltaResult<W
         }
     }
     Ok(properties.build())
+}
+
+/// Translate DNF filter tuples into a kernel predicate, without materializing
+/// `PartitionFilter`s along the way.
+fn kernel_dnf_predicate(
+    dnf: &[PyFilterConjunction],
+    table_schema: &delta_kernel::schema::StructType,
+) -> Result<delta_kernel::expressions::Predicate, DeltaTableError> {
+    let dnf: Vec<Vec<FilterLiteral<'_>>> = dnf
+        .iter()
+        .map(|conjunction| {
+            conjunction
+                .iter()
+                .map(|(column, op, value)| {
+                    let value = match value {
+                        PartitionFilterValue::Single(v) => FilterValue::Scalar(v.as_ref()),
+                        PartitionFilterValue::Multiple(vs) => {
+                            FilterValue::Set(vs.iter().map(|v| v.as_ref()).collect())
+                        }
+                    };
+                    (column.as_ref(), op.as_ref(), value)
+                })
+                .collect()
+        })
+        .collect();
+    dnf_to_kernel_predicate(&dnf, table_schema)
 }
 
 fn convert_partition_filters(

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -126,6 +126,14 @@ enum PartitionFilterValue {
 /// normal form; a lone conjunction arrives as a single-element list.
 type PyFilterConjunction = Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>;
 
+/// The file pruning predicate of the listing APIs: a SQL string, or tuple
+/// filters in disjunctive normal form.
+#[derive(FromPyObject)]
+enum PyFilePruningPredicate {
+    Sql(String),
+    Dnf(Vec<PyFilterConjunction>),
+}
+
 #[pyclass(module = "deltalake._internal", frozen)]
 struct RawDeltaTable {
     /// The internal reference to the table is guarded by a Mutex to allow for re-using the same
@@ -301,29 +309,23 @@ impl RawDeltaTable {
         })
     }
 
-    /// Resolve the mutually exclusive tuple-filter and SQL-predicate parameters
-    /// of the file listing APIs into one kernel predicate.
+    /// Resolve the file pruning predicate of the listing APIs into a kernel
+    /// predicate.
     fn resolve_files_predicate(
         &self,
-        partition_filters: Option<Vec<PyFilterConjunction>>,
-        predicate: Option<String>,
+        predicate: Option<PyFilePruningPredicate>,
     ) -> PyResult<Option<PredicateRef>> {
-        let partition_filters = partition_filters.filter(|filters| !filters.is_empty());
-        let resolved = match (partition_filters, predicate) {
-            (Some(_), Some(_)) => {
-                return Err(PyValueError::new_err(
-                    "partition_filters and predicate are mutually exclusive; pass only one",
-                ));
-            }
-            (None, None) => return Ok(None),
-            (Some(filters), None) => {
+        let resolved = match predicate {
+            None => return Ok(None),
+            Some(PyFilePruningPredicate::Dnf(filters)) if filters.is_empty() => return Ok(None),
+            Some(PyFilePruningPredicate::Dnf(filters)) => {
                 kernel_dnf_predicate(&filters, self.snapshot_schema()?.as_ref())
                     .map_err(PythonError::from)?
             }
-            (None, Some(predicate)) => {
+            Some(PyFilePruningPredicate::Sql(sql)) => {
                 let session = SessionContext::new();
                 parse_sql_predicate_to_kernel(
-                    &predicate,
+                    &sql,
                     self.snapshot_schema()?.as_ref(),
                     &session.state(),
                 )
@@ -605,17 +607,16 @@ impl RawDeltaTable {
         })
     }
 
-    #[pyo3(signature = (partition_filters=None, predicate=None))]
+    #[pyo3(signature = (file_pruning_predicate=None))]
     pub fn files(
         &self,
         py: Python,
-        partition_filters: Option<Vec<PyFilterConjunction>>,
-        predicate: Option<String>,
+        file_pruning_predicate: Option<PyFilePruningPredicate>,
     ) -> PyResult<Vec<String>> {
         if !self.has_files()? {
             return Err(DeltaError::new_err("Table is instantiated without files."));
         }
-        let filter = self.resolve_files_predicate(partition_filters, predicate)?;
+        let filter = self.resolve_files_predicate(file_pruning_predicate)?;
         py.detach(|| {
             if let Some(filter) = filter {
                 self.with_table(|t| {
@@ -641,17 +642,16 @@ impl RawDeltaTable {
         })
     }
 
-    #[pyo3(signature = (partition_filters=None, predicate=None))]
+    #[pyo3(signature = (file_pruning_predicate=None))]
     pub fn file_uris(
         &self,
-        partition_filters: Option<Vec<PyFilterConjunction>>,
-        predicate: Option<String>,
+        file_pruning_predicate: Option<PyFilePruningPredicate>,
     ) -> PyResult<Vec<String>> {
         if !self.with_table(|t| Ok(t.config.require_files))? {
             return Err(DeltaError::new_err("Table is initiated without files."));
         }
 
-        let filter = self.resolve_files_predicate(partition_filters, predicate)?;
+        let filter = self.resolve_files_predicate(file_pruning_predicate)?;
         if let Some(filter) = filter {
             self.with_table(|t| {
                 rt().block_on(async {
@@ -1431,19 +1431,16 @@ impl RawDeltaTable {
         })
     }
 
-    #[pyo3(signature = (schema, partition_filters=None, predicate=None))]
+    #[pyo3(signature = (schema, file_pruning_predicate=None))]
     pub fn dataset_partitions<'py>(
         &self,
         py: Python<'py>,
         schema: PyArrowSchema,
-        partition_filters: Option<Vec<PyFilterConjunction>>,
-        predicate: Option<String>,
+        file_pruning_predicate: Option<PyFilePruningPredicate>,
     ) -> PyResult<Vec<(String, Option<Bound<'py, PyAny>>)>> {
-        let path_set = if partition_filters.is_some() || predicate.is_some() {
+        let path_set = if file_pruning_predicate.is_some() {
             Some(HashSet::<_>::from_iter(
-                self.files(py, partition_filters, predicate)?
-                    .iter()
-                    .cloned(),
+                self.files(py, file_pruning_predicate)?.iter().cloned(),
             ))
         } else {
             None
@@ -1491,11 +1488,10 @@ impl RawDeltaTable {
             .collect()
     }
 
-    #[pyo3(signature = (partitions_filters=None, predicate=None))]
+    #[pyo3(signature = (file_pruning_predicate=None))]
     fn get_active_partitions<'py>(
         &self,
-        partitions_filters: Option<Vec<PyFilterConjunction>>,
-        predicate: Option<String>,
+        file_pruning_predicate: Option<PyFilePruningPredicate>,
         py: Python<'py>,
     ) -> PyResult<Bound<'py, PyFrozenSet>> {
         let schema = self.with_table(|t| {
@@ -1520,7 +1516,7 @@ impl RawDeltaTable {
             .map(|col| col.as_str())
             .collect();
 
-        if let Some(filters) = &partitions_filters {
+        if let Some(PyFilePruningPredicate::Dnf(filters)) = &file_pruning_predicate {
             let unknown_columns: Vec<&PyBackedStr> = filters
                 .iter()
                 .flatten()
@@ -1537,7 +1533,7 @@ impl RawDeltaTable {
             }
         }
 
-        let filter = self.resolve_files_predicate(partitions_filters, predicate)?;
+        let filter = self.resolve_files_predicate(file_pruning_predicate)?;
 
         let partition_columns: Vec<&str> = partition_columns.into_iter().collect();
         let partition_column_keys: Vec<(&str, String)> = partition_columns

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -672,6 +672,225 @@ def test_get_files_partitioned_table():
     )
 
 
+PARTITIONED_TABLE_PATHS = {
+    (2020, 1, 1): (
+        "year=2020/month=1/day=1/part-00000-8eafa330-3be9-4a39-ad78-fd13c2027c7e.c000.snappy.parquet"
+    ),
+    (2020, 2, 3): (
+        "year=2020/month=2/day=3/part-00000-94d16827-f2fd-42cd-a060-f67ccc63ced9.c000.snappy.parquet"
+    ),
+    (2020, 2, 5): (
+        "year=2020/month=2/day=5/part-00000-89cdd4c8-2af7-4add-8ea3-3990b2f027b5.c000.snappy.parquet"
+    ),
+    (2021, 4, 5): (
+        "year=2021/month=4/day=5/part-00000-c5856301-3439-4032-a6fc-22b7bc92bebb.c000.snappy.parquet"
+    ),
+    (2021, 12, 4): (
+        "year=2021/month=12/day=4/part-00000-6dc763c0-3e8b-4d52-b19e-1f92af3fbb25.c000.snappy.parquet"
+    ),
+    (2021, 12, 20): (
+        "year=2021/month=12/day=20/part-00000-9275fdf4-3961-4184-baa0-1c8a2bb98104.c000.snappy.parquet"
+    ),
+}
+
+
+def _partitioned_table_uris(*keys: tuple[int, int, int]) -> set[str]:
+    root = Path.cwd().parent / "crates/test/tests/data/delta-0.8.0-partitioned"
+    return {(root / PARTITIONED_TABLE_PATHS[key]).as_posix() for key in keys}
+
+
+def test_file_uris_dnf_filters():
+    dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
+
+    # a flat conjunction and its single-element DNF spelling are equivalent
+    flat = dt.file_uris([("day", "=", "3")])
+    nested = dt.file_uris([[("day", "=", "3")]])
+    assert flat == nested
+    assert set(flat) == _partitioned_table_uris((2020, 2, 3))
+
+    dnf = [
+        [("year", "=", "2020"), ("month", "=", "2")],
+        [("year", "=", "2021"), ("month", "=", "12")],
+    ]
+    assert set(dt.file_uris(dnf)) == _partitioned_table_uris(
+        (2020, 2, 3), (2020, 2, 5), (2021, 12, 4), (2021, 12, 20)
+    )
+
+    # primitive values work in DNF form too
+    dnf = [[("year", "=", 2020)], [("month", "=", 12)]]
+    assert set(dt.file_uris(dnf)) == _partitioned_table_uris(
+        (2020, 1, 1), (2020, 2, 3), (2020, 2, 5), (2021, 12, 4), (2021, 12, 20)
+    )
+
+
+def test_file_uris_predicate_equals_dnf():
+    dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
+
+    dnf = [
+        [("year", "=", "2020"), ("month", "=", "2")],
+        [("year", "=", "2021"), ("month", "=", "12")],
+    ]
+    predicate = "(year = 2020 AND month = 2) OR (year = 2021 AND month = 12)"
+    assert set(dt.file_uris(predicate=predicate)) == set(dt.file_uris(dnf))
+    assert set(dt.file_uris(predicate=predicate)) == _partitioned_table_uris(
+        (2020, 2, 3), (2020, 2, 5), (2021, 12, 4), (2021, 12, 20)
+    )
+
+
+def test_file_uris_predicate_operators():
+    dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
+
+    for predicate, filters in [
+        ("year >= 2021", [("year", ">=", "2021")]),
+        ("day != 3", [("day", "!=", "3")]),
+        ("day IN (3, 20)", [("day", "in", ["3", "20"])]),
+        ("day NOT IN (3, 20)", [("day", "not in", ["3", "20"])]),
+    ]:
+        assert set(dt.file_uris(predicate=predicate)) == set(dt.file_uris(filters)), (
+            predicate
+        )
+
+    assert set(dt.file_uris(predicate="month BETWEEN 2 AND 4")) == set(
+        dt.file_uris([("month", ">=", "2"), ("month", "<=", "4")])
+    )
+    assert set(dt.file_uris(predicate="NOT (year = 2020)")) == set(
+        dt.file_uris([("year", "!=", "2020")])
+    )
+
+
+def test_file_uris_filter_errors():
+    dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        dt.file_uris([("year", "=", "2020")], predicate="year = 2020")
+
+    with pytest.raises(ValueError, match="empty conjunction"):
+        dt.file_uris([[("year", "=", "2020")], []])
+
+    with pytest.raises(ValueError, match="not a mix"):
+        dt.file_uris([("year", "=", "2020"), [("month", "=", "2")]])
+
+    with pytest.raises(Exception, match="nope"):
+        dt.file_uris(predicate="nope = 1")
+
+    with pytest.raises(Exception, match="file skipping"):
+        dt.file_uris(predicate="year LIKE '20%'")
+
+
+def test_partitions_predicate():
+    dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
+
+    expected = [
+        {"day": "5", "month": "4", "year": "2021"},
+        {"day": "20", "month": "12", "year": "2021"},
+        {"day": "4", "month": "12", "year": "2021"},
+    ]
+    actual = dt.partitions(predicate="year >= 2021")
+    assert len(actual) == len(expected)
+    for partition in expected:
+        assert partition in actual
+
+    dnf = [[("year", "=", "2020")], [("month", "=", "12")]]
+    by_dnf = dt.partitions(dnf)
+    by_predicate = dt.partitions(predicate="year = 2020 OR month = 12")
+    assert len(by_dnf) == len(by_predicate) == 5
+    for partition in by_dnf:
+        assert partition in by_predicate
+
+
+@pytest.mark.pyarrow
+def test_data_column_predicate_superset(tmp_path: Path):
+    import pyarrow as pa
+
+    write_deltalake(tmp_path, pa.table({"value": [1, 5, 10]}))
+    write_deltalake(tmp_path, pa.table({"value": [100, 200, 300]}), mode="append")
+    dt = DeltaTable(tmp_path)
+
+    all_files = set(dt.file_uris())
+    assert len(all_files) == 2
+    low_files = set(dt.file_uris(predicate="value <= 10"))
+    high_files = set(dt.file_uris(predicate="value >= 100"))
+    assert len(low_files) == len(high_files) == 1
+    assert low_files | high_files == all_files
+
+    # tuple filters work on data columns too
+    assert set(dt.file_uris([("value", ">=", 100)])) == high_files
+
+    # a predicate straddling both files' ranges retains both
+    assert set(dt.file_uris(predicate="value > 5")) == all_files
+
+    # stats can only prove absence: no row equals 7, but the file whose
+    # min/max range covers 7 is still returned
+    assert set(dt.file_uris(predicate="value = 7")) == low_files
+    # ...while a value outside every range prunes everything
+    assert dt.file_uris(predicate="value > 1000") == []
+
+
+@pytest.mark.pandas
+@pytest.mark.pyarrow
+def test_to_pandas_predicate_with_filters_exact(tmp_path: Path):
+    import pyarrow as pa
+
+    write_deltalake(tmp_path, pa.table({"value": [1, 5, 10]}))
+    write_deltalake(tmp_path, pa.table({"value": [100, 200, 300]}), mode="append")
+    dt = DeltaTable(tmp_path)
+
+    # predicate alone prunes files, so whole surviving files come back
+    superset = dt.to_pandas(predicate="value >= 150")
+    assert sorted(superset["value"]) == [100, 200, 300]
+
+    # pairing it with a row filter gives exact rows
+    exact = dt.to_pandas(predicate="value >= 150", filters=[("value", ">=", 150)])
+    assert sorted(exact["value"]) == [200, 300]
+
+
+@pytest.mark.pyarrow
+def test_dataset_predicate_prunes_fragments():
+    dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
+
+    dataset = dt.to_pyarrow_dataset(predicate="year = 2021")
+    assert len(dataset.files) == 3
+    assert dataset.to_table().num_rows == 4
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        dt.to_pyarrow_dataset(
+            partitions=[("year", "=", "2021")], predicate="year = 2021"
+        )
+
+
+@pytest.mark.pyarrow
+def test_predicate_no_stats_table(tmp_path: Path):
+    import pyarrow as pa
+
+    config = {"delta.dataSkippingNumIndexedCols": "0"}
+    write_deltalake(tmp_path, pa.table({"value": [1, 5, 10]}), configuration=config)
+    write_deltalake(tmp_path, pa.table({"value": [100, 200, 300]}), mode="append")
+    dt = DeltaTable(tmp_path)
+
+    # without stats nothing can be proven absent, so every file is retained
+    assert len(dt.file_uris(predicate="value >= 100")) == 2
+
+
+def test_predicate_column_mapped_table():
+    # Spark-written name-mode fixture: partitioned by "Company Very Short",
+    # stats and partition values stored under physical col-<uuid> names.
+    dt = DeltaTable("../crates/test/tests/data/table_with_column_mapping")
+
+    assert len(dt.file_uris()) == 2
+    by_predicate = dt.file_uris(predicate="\"Company Very Short\" = 'BME'")
+    by_filters = dt.file_uris([("Company Very Short", "=", "BME")])
+    assert len(by_predicate) == 1
+    assert by_predicate == by_filters
+
+    # stats-based skipping resolves the mapping too: only the BME file's
+    # min/max range covers this value
+    assert dt.file_uris(predicate="\"Super Name\" = 'Timothy Lamb'") == by_predicate
+
+    assert dt.partitions(predicate="\"Company Very Short\" = 'BME'") == [
+        {"Company Very Short": "BME"}
+    ]
+
+
 @pytest.mark.pandas
 @pytest.mark.pyarrow
 def test_delta_table_to_pandas():

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -1031,6 +1031,27 @@ def test_partitions_filtering_partitioned_table():
         partition in actual
 
 
+def test_partitions_filtering_with_primitive_values():
+    table_path = "../crates/test/tests/data/partition-type-primitives"
+    dt = DeltaTable(table_path)
+
+    def partition_set(filters):
+        return {frozenset(p.items()) for p in dt.partitions(filters)}
+
+    by_int = partition_set([("year", "=", 2020)])
+    assert by_int
+    assert by_int == partition_set([("year", "=", "2020")])
+    assert all(dict(p)["year"] == "2020" for p in by_int)
+
+    by_bool = partition_set([("is_active", "=", True)])
+    assert by_bool
+    assert by_bool == partition_set([("is_active", "=", "true")])
+
+    by_date = partition_set([("event_date", "=", date(2023, 1, 1))])
+    assert by_date
+    assert by_date == partition_set([("event_date", "=", "2023-01-01")])
+
+
 @pytest.mark.pyarrow
 def test_partitions_date_partitioned_table(tmp_path: Path):
     import pyarrow as pa

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -763,6 +763,25 @@ def test_file_uris_predicate_operators():
     )
 
 
+def test_legacy_filter_params_warn():
+    dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
+
+    with pytest.warns(DeprecationWarning, match="partition_filters"):
+        legacy = dt.file_uris([("year", "=", "2021")])
+    assert legacy == dt.file_uris(file_pruning_predicate=[("year", "=", "2021")])
+
+    with pytest.warns(DeprecationWarning, match="partition_filters"):
+        dt.partitions(partition_filters=[("year", "=", "2021")])
+
+
+@pytest.mark.pyarrow
+def test_legacy_dataset_partitions_param_warns():
+    dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
+
+    with pytest.warns(DeprecationWarning, match="partitions"):
+        dt.to_pyarrow_dataset(partitions=[("year", "=", "2021")])
+
+
 def test_file_uris_filter_errors():
     dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
 

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -722,6 +722,9 @@ def test_file_uris_dnf_filters():
         (2020, 1, 1), (2020, 2, 3), (2020, 2, 5), (2021, 12, 4), (2021, 12, 20)
     )
 
+    # tuple filters via the new parameter match the deprecated positional form
+    assert dt.file_uris(file_pruning_predicate=dnf) == dt.file_uris(dnf)
+
 
 def test_file_uris_predicate_equals_dnf():
     dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
@@ -731,8 +734,10 @@ def test_file_uris_predicate_equals_dnf():
         [("year", "=", "2021"), ("month", "=", "12")],
     ]
     predicate = "(year = 2020 AND month = 2) OR (year = 2021 AND month = 12)"
-    assert set(dt.file_uris(predicate=predicate)) == set(dt.file_uris(dnf))
-    assert set(dt.file_uris(predicate=predicate)) == _partitioned_table_uris(
+    assert set(dt.file_uris(file_pruning_predicate=predicate)) == set(dt.file_uris(dnf))
+    assert set(
+        dt.file_uris(file_pruning_predicate=predicate)
+    ) == _partitioned_table_uris(
         (2020, 2, 3), (2020, 2, 5), (2021, 12, 4), (2021, 12, 20)
     )
 
@@ -746,14 +751,14 @@ def test_file_uris_predicate_operators():
         ("day IN (3, 20)", [("day", "in", ["3", "20"])]),
         ("day NOT IN (3, 20)", [("day", "not in", ["3", "20"])]),
     ]:
-        assert set(dt.file_uris(predicate=predicate)) == set(dt.file_uris(filters)), (
-            predicate
-        )
+        assert set(dt.file_uris(file_pruning_predicate=predicate)) == set(
+            dt.file_uris(filters)
+        ), predicate
 
-    assert set(dt.file_uris(predicate="month BETWEEN 2 AND 4")) == set(
+    assert set(dt.file_uris(file_pruning_predicate="month BETWEEN 2 AND 4")) == set(
         dt.file_uris([("month", ">=", "2"), ("month", "<=", "4")])
     )
-    assert set(dt.file_uris(predicate="NOT (year = 2020)")) == set(
+    assert set(dt.file_uris(file_pruning_predicate="NOT (year = 2020)")) == set(
         dt.file_uris([("year", "!=", "2020")])
     )
 
@@ -761,8 +766,8 @@ def test_file_uris_predicate_operators():
 def test_file_uris_filter_errors():
     dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
 
-    with pytest.raises(ValueError, match="mutually exclusive"):
-        dt.file_uris([("year", "=", "2020")], predicate="year = 2020")
+    with pytest.raises(ValueError, match="deprecated"):
+        dt.file_uris([("year", "=", "2020")], file_pruning_predicate="year = 2020")
 
     with pytest.raises(ValueError, match="empty conjunction"):
         dt.file_uris([[("year", "=", "2020")], []])
@@ -771,10 +776,10 @@ def test_file_uris_filter_errors():
         dt.file_uris([("year", "=", "2020"), [("month", "=", "2")]])
 
     with pytest.raises(Exception, match="nope"):
-        dt.file_uris(predicate="nope = 1")
+        dt.file_uris(file_pruning_predicate="nope = 1")
 
     with pytest.raises(Exception, match="file skipping"):
-        dt.file_uris(predicate="year LIKE '20%'")
+        dt.file_uris(file_pruning_predicate="year LIKE '20%'")
 
 
 def test_partitions_predicate():
@@ -785,14 +790,14 @@ def test_partitions_predicate():
         {"day": "20", "month": "12", "year": "2021"},
         {"day": "4", "month": "12", "year": "2021"},
     ]
-    actual = dt.partitions(predicate="year >= 2021")
+    actual = dt.partitions(file_pruning_predicate="year >= 2021")
     assert len(actual) == len(expected)
     for partition in expected:
         assert partition in actual
 
     dnf = [[("year", "=", "2020")], [("month", "=", "12")]]
     by_dnf = dt.partitions(dnf)
-    by_predicate = dt.partitions(predicate="year = 2020 OR month = 12")
+    by_predicate = dt.partitions(file_pruning_predicate="year = 2020 OR month = 12")
     assert len(by_dnf) == len(by_predicate) == 5
     for partition in by_dnf:
         assert partition in by_predicate
@@ -808,8 +813,8 @@ def test_data_column_predicate_superset(tmp_path: Path):
 
     all_files = set(dt.file_uris())
     assert len(all_files) == 2
-    low_files = set(dt.file_uris(predicate="value <= 10"))
-    high_files = set(dt.file_uris(predicate="value >= 100"))
+    low_files = set(dt.file_uris(file_pruning_predicate="value <= 10"))
+    high_files = set(dt.file_uris(file_pruning_predicate="value >= 100"))
     assert len(low_files) == len(high_files) == 1
     assert low_files | high_files == all_files
 
@@ -817,13 +822,13 @@ def test_data_column_predicate_superset(tmp_path: Path):
     assert set(dt.file_uris([("value", ">=", 100)])) == high_files
 
     # a predicate straddling both files' ranges retains both
-    assert set(dt.file_uris(predicate="value > 5")) == all_files
+    assert set(dt.file_uris(file_pruning_predicate="value > 5")) == all_files
 
     # stats can only prove absence: no row equals 7, but the file whose
     # min/max range covers 7 is still returned
-    assert set(dt.file_uris(predicate="value = 7")) == low_files
+    assert set(dt.file_uris(file_pruning_predicate="value = 7")) == low_files
     # ...while a value outside every range prunes everything
-    assert dt.file_uris(predicate="value > 1000") == []
+    assert dt.file_uris(file_pruning_predicate="value > 1000") == []
 
 
 @pytest.mark.pandas
@@ -836,11 +841,13 @@ def test_to_pandas_predicate_with_filters_exact(tmp_path: Path):
     dt = DeltaTable(tmp_path)
 
     # predicate alone prunes files, so whole surviving files come back
-    superset = dt.to_pandas(predicate="value >= 150")
+    superset = dt.to_pandas(file_pruning_predicate="value >= 150")
     assert sorted(superset["value"]) == [100, 200, 300]
 
     # pairing it with a row filter gives exact rows
-    exact = dt.to_pandas(predicate="value >= 150", filters=[("value", ">=", 150)])
+    exact = dt.to_pandas(
+        file_pruning_predicate="value >= 150", filters=[("value", ">=", 150)]
+    )
     assert sorted(exact["value"]) == [200, 300]
 
 
@@ -848,13 +855,13 @@ def test_to_pandas_predicate_with_filters_exact(tmp_path: Path):
 def test_dataset_predicate_prunes_fragments():
     dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
 
-    dataset = dt.to_pyarrow_dataset(predicate="year = 2021")
+    dataset = dt.to_pyarrow_dataset(file_pruning_predicate="year = 2021")
     assert len(dataset.files) == 3
     assert dataset.to_table().num_rows == 4
 
-    with pytest.raises(ValueError, match="mutually exclusive"):
+    with pytest.raises(ValueError, match="deprecated"):
         dt.to_pyarrow_dataset(
-            partitions=[("year", "=", "2021")], predicate="year = 2021"
+            partitions=[("year", "=", "2021")], file_pruning_predicate="year = 2021"
         )
 
 
@@ -868,7 +875,7 @@ def test_predicate_no_stats_table(tmp_path: Path):
     dt = DeltaTable(tmp_path)
 
     # without stats nothing can be proven absent, so every file is retained
-    assert len(dt.file_uris(predicate="value >= 100")) == 2
+    assert len(dt.file_uris(file_pruning_predicate="value >= 100")) == 2
 
 
 def test_predicate_column_mapped_table():
@@ -877,16 +884,19 @@ def test_predicate_column_mapped_table():
     dt = DeltaTable("../crates/test/tests/data/table_with_column_mapping")
 
     assert len(dt.file_uris()) == 2
-    by_predicate = dt.file_uris(predicate="\"Company Very Short\" = 'BME'")
+    by_predicate = dt.file_uris(file_pruning_predicate="\"Company Very Short\" = 'BME'")
     by_filters = dt.file_uris([("Company Very Short", "=", "BME")])
     assert len(by_predicate) == 1
     assert by_predicate == by_filters
 
     # stats-based skipping resolves the mapping too: only the BME file's
     # min/max range covers this value
-    assert dt.file_uris(predicate="\"Super Name\" = 'Timothy Lamb'") == by_predicate
+    assert (
+        dt.file_uris(file_pruning_predicate="\"Super Name\" = 'Timothy Lamb'")
+        == by_predicate
+    )
 
-    assert dt.partitions(predicate="\"Company Very Short\" = 'BME'") == [
+    assert dt.partitions(file_pruning_predicate="\"Company Very Short\" = 'BME'") == [
         {"Company Very Short": "BME"}
     ]
 


### PR DESCRIPTION
# Description

The tuple partition filters on `file_uris()`, `partitions()`, `to_pyarrow_dataset()`, `to_pyarrow_table()` and `to_pandas()` only ever supported AND, while the docstrings claimed full DNF, and the `file_uris` docstring was wiped at runtime by a leftover `__doc__ = ""` besides. This closes the gap, building on the kernel file skipping from #3669.

One new parameter, `file_pruning_predicate`, on the listing APIs. It takes three forms:

```python
# SQL string, same dialect delete/update/merge already take
dt.file_uris(file_pruning_predicate="year = 2021 OR (year = 2020 AND month >= 10)")

# flat list of tuples: one conjunction (AND), same meaning as the old params
dt.file_uris(file_pruning_predicate=[("year", "=", "2020"), ("month", ">=", "10")])

# list of lists: true DNF, an OR across the inner AND groups
dt.file_uris(file_pruning_predicate=[
    [("year", "=", "2021")],
    [("year", "=", "2020"), ("month", ">=", "10")],
])
```

The old `partition_filters`/`partitions` params keep working and are documented as deprecated (no runtime warning yet).

Both forms turn into a kernel `Predicate` and prune during log replay. Any column is allowed, not just partition columns:

- Partition columns prune exactly.
- Other columns prune on file-level min/max stats: files that provably contain no matching row are dropped, anything that might match is kept, files without stats for a referenced column are always kept. A complete superset, never a miss. How much actually prunes depends on layout (partitioning, z-ordering); documented on `file_uris` and in the user guide.

Following roeap's suggestion in #1923, tuples translate directly to kernel predicates (`literal/conjunction/dnf_to_kernel_predicate` in `partitions.rs`); the old `PartitionFilter` translation is a shim over that path. The SQL path (`parse_sql_predicate_to_kernel`) reuses the delete/update parse/coerce/simplify pipeline. The last two uses of the deprecated `EagerSnapshot::file_views_by_partitions` are removed.

Bugs fixed while in here:

- `coerce_predicate_literals` didn't coerce IN lists: `year IN (2020)` handed the kernel an Int64 literal against an Int32 column.
- `DeltaTable.partitions([("year", "=", 2021)])` failed on the int while the same filter worked on `file_uris`.
- The docstring rot above, three dead `files_by_partitions` references, an op list missing four of the eight supported ops.

## The stack

Follow-ups are built, not filed. They live on my fork because a PR's base must be a branch in the target repo; each retargets to main after this merges.

- **delta-io/delta-rs#4585** — this PR
  - **FrankPortman/delta-rs#1** — drop `file_pruning_predicate` from `to_pandas`/`to_pyarrow_table`, where `filters` already prunes files via fragment stats and then filters rows exactly. Lands with this PR before a release, or closes.
  - **FrankPortman/delta-rs#3** — delete `PartitionFilter`, add a typed `FilterOp`. Standalone; operationParameters serialization byte-identical.
  - **FrankPortman/delta-rs#2** — QueryBuilder path for `to_pandas`/`to_pyarrow_table` (ion's suggestion). Reads columnMapping and DV tables today; adds a second read path until the chain below completes.
    - **FrankPortman/delta-rs#4** — deprecate the pyarrow fallbacks; `to_pyarrow_dataset` becomes the explicit pyarrow interop surface.
      - **FrankPortman/delta-rs#5** — dataframe methods run only through QueryBuilder. Removes released API (`filesystem=`, `Expression` filters), so it ships a release after FrankPortman/delta-rs#4's warnings unless maintainers prefer one breaking release.

Preferred sequencing: this PR + #1 + #3 before the next release, #2 + #4 with it or next, #5 one release later. Every piece is separable; #1 keeps the pruning param off the dataframe methods even if the chain stalls.

## Decision table

Open rows are defaults with defensible alternatives; object per row and I'll change it here.

| # | Boundary | Status |
|---|---|---|
| 1 | Param count | **Resolved (review):** single `file_pruning_predicate`, SQL string or tuples |
| 2 | Both params passed | **Moot:** one param. Old deprecated params error if combined with the new one |
| 3 | Column scope | Any column, no flag. roeap called data-column skipping the point of kernel predicates (#1923); rename carries the disambiguation. Open to restricting if blocking |
| 4 | `get_active_partitions` validation | Non-partition-column error removed (error, now results) |
| 5 | Superset semantics | Data columns prune to a documented stats-based superset |
| 6 | Flat-list back-compat | Kept, flat means one conjunction |
| 7 | `''` for null | Kept, documented; SQL `IS NULL` is the unambiguous spelling |
| 8 | Unconvertible SQL (`LIKE`, functions) | Hard error listing what is supported |
| 9 | Dataframe-method pruning | **Resolved by the stack:** FrankPortman/delta-rs#1 now, #2/#4/#5 as the direction |
| 10 | Empty inner conjunction `[[]]` | Error |
| 11 | optimize / create_write_transaction | Out of scope; migrated off deprecated APIs only |
| 12 | `PartitionFilter` | **Built:** deleted in FrankPortman/delta-rs#3 |
| 13 | Session for SQL parsing | Throwaway `SessionContext::new()` per call, same as `load_cdf` |
| 14 | Op typing | **Built:** typed `FilterOp` in FrankPortman/delta-rs#3 |
| 15 | Core API shape | New `get_active_add_actions_by_predicate(Option<PredicateRef>)` next to the `_by_partitions` variant |

## Tradeoffs kept

- IN is lowered in two places (tuple path in `partitions.rs`, SQL path in `to_kernel.rs`); a parity test asserts identical predicates, so drift fails CI.
- `dataset_partitions` keeps its two-pass shape; single-pass touches the pyarrow fragment plumbing and belongs in its own change.
- Null handling differs between forms for legacy reasons: tuple `("col", "=", "")` means IS NULL, SQL `col = ''` means empty string. Documented.
- Ordering ops on string columns compare lexicographically (`("month", ">=", 12)` matches `"4"`). Documented on `file_uris`.

# Related Issue(s)

- closes #1923
- follow up to #1316 and #3669

# Documentation

- `docs/usage/querying-delta-tables.md`: selecting files with a pruning predicate, all three forms, exact vs superset rules, layout note
- `docs/usage/working-with-partitions.md`: OR across partitions in both forms
- `docs/how-delta-lake-works/delta-lake-file-skipping.md`: connects the concept page to the API
- API reference regenerates from the rewritten docstrings
