### PR TITLE
fix: optimize on Spark written table fails (#4586)

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -29,14 +29,13 @@ use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSe
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, Statistics,
 };
-use datafusion_physical_expr_adapter::{
-    DefaultPhysicalExprAdapterFactory, PhysicalExprAdapterFactory,
-};
+use datafusion_physical_expr_adapter::PhysicalExprAdapterFactory;
 use delta_kernel::schema::DataType as KernelDataType;
 use delta_kernel::table_features::TableFeature;
 use delta_kernel::{EvaluationHandler, ExpressionRef};
 use futures::stream::{Stream, StreamExt};
 
+use super::expr_adapter::DeltaPhysicalExprAdapterFactory;
 use super::plan::KernelScanPlan;
 use crate::delta_datafusion::file_id::file_id_field;
 use crate::kernel::ARROW_HANDLER;
@@ -425,7 +424,7 @@ impl ExecutionPlan for DeltaScanExec {
             ));
         }
 
-        let adapter_factory = DefaultPhysicalExprAdapterFactory {};
+        let adapter_factory = DeltaPhysicalExprAdapterFactory;
         let adapted_filters = adapter_factory
             .create(
                 Arc::clone(&self.scan_plan.contract.result_schema),

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/expr_adapter.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/expr_adapter.rs
@@ -1,0 +1,221 @@
+//! Delta-aware physical expression adaptation for parquet scans.
+
+use std::sync::Arc;
+
+use arrow_schema::{DataType, Field, FieldRef, Fields, Schema, SchemaRef};
+use datafusion::common::Result;
+use datafusion_physical_expr_adapter::{
+    DefaultPhysicalExprAdapterFactory, PhysicalExprAdapter, PhysicalExprAdapterFactory,
+};
+
+/// A [`PhysicalExprAdapterFactory`] that relaxes nested-field nullability on the
+/// logical (table) schema before delegating to DataFusion's default adapter.
+///
+/// In Delta, `nullable = false` is a write-time invariant: engines such as Spark
+/// write parquet files whose nested fields are physically optional even when the
+/// table schema declares them non-nullable. DataFusion's default adapter rejects
+/// nullable -> non-nullable nested struct field casts at plan time, so we hand it
+/// a nullability-relaxed target schema instead. The data is guaranteed non-null
+/// by the writer, and the logical output schema is restored above the parquet
+/// scan by [`DeltaScanExec`](super::DeltaScanExec)'s transforms.
+#[derive(Debug)]
+pub(crate) struct DeltaPhysicalExprAdapterFactory;
+
+impl PhysicalExprAdapterFactory for DeltaPhysicalExprAdapterFactory {
+    fn create(
+        &self,
+        logical_file_schema: SchemaRef,
+        physical_file_schema: SchemaRef,
+    ) -> Result<Arc<dyn PhysicalExprAdapter>> {
+        DefaultPhysicalExprAdapterFactory.create(
+            Arc::new(relax_schema_nested_nullability(&logical_file_schema)),
+            physical_file_schema,
+        )
+    }
+}
+
+/// Relax nullability of all *nested* fields. Top-level field nullability is kept
+/// as is: the default adapter already tolerates nullable file columns feeding
+/// non-nullable top-level table columns, and keeping it strict preserves the
+/// "non-nullable column missing from file" error for missing top-level columns.
+pub(super) fn relax_schema_nested_nullability(schema: &Schema) -> Schema {
+    let fields: Vec<FieldRef> = schema
+        .fields()
+        .iter()
+        .map(|f| relax_field_type(f.as_ref()))
+        .collect();
+    Schema::new_with_metadata(fields, schema.metadata().clone())
+}
+
+/// Relax nullability within the field's data type, keeping the field's own
+/// nullability unchanged.
+fn relax_field_type(field: &Field) -> FieldRef {
+    Arc::new(
+        field
+            .clone()
+            .with_data_type(relax_nested_nullability(field.data_type())),
+    )
+}
+
+/// Relax nullability within the field's data type and mark the field itself as
+/// nullable.
+fn relax_field(field: &FieldRef) -> FieldRef {
+    Arc::new(relax_field_type(field).as_ref().clone().with_nullable(true))
+}
+
+fn relax_nested_nullability(dt: &DataType) -> DataType {
+    match dt {
+        DataType::Struct(fields) => DataType::Struct(fields.iter().map(relax_field).collect()),
+        DataType::List(f) => DataType::List(relax_field(f)),
+        DataType::LargeList(f) => DataType::LargeList(relax_field(f)),
+        DataType::ListView(f) => DataType::ListView(relax_field(f)),
+        DataType::LargeListView(f) => DataType::LargeListView(relax_field(f)),
+        DataType::FixedSizeList(f, n) => DataType::FixedSizeList(relax_field(f), *n),
+        DataType::Map(entries, sorted) => {
+            // Arrow requires map entries and keys to be non-nullable; only the
+            // value field may be relaxed.
+            let entries_type = match entries.data_type() {
+                DataType::Struct(kv) if kv.len() == 2 => DataType::Struct(Fields::from(vec![
+                    relax_field_type(kv[0].as_ref()),
+                    relax_field(&kv[1]),
+                ])),
+                other => relax_nested_nullability(other),
+            };
+            DataType::Map(
+                Arc::new(entries.as_ref().clone().with_data_type(entries_type)),
+                *sorted,
+            )
+        }
+        DataType::Dictionary(k, v) => {
+            DataType::Dictionary(k.clone(), Box::new(relax_nested_nullability(v)))
+        }
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relax_keeps_top_level_nullability_and_relaxes_nested_fields() {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "meta",
+                DataType::Struct(Fields::from(vec![Field::new(
+                    "int_id",
+                    DataType::Utf8,
+                    false,
+                )])),
+                true,
+            ),
+        ]);
+
+        let relaxed = relax_schema_nested_nullability(&schema);
+
+        // Top-level nullability is preserved.
+        assert!(!relaxed.field(0).is_nullable());
+        assert!(relaxed.field(1).is_nullable());
+
+        // Nested struct field is relaxed to nullable.
+        let DataType::Struct(fields) = relaxed.field(1).data_type() else {
+            panic!("expected struct");
+        };
+        assert!(fields[0].is_nullable());
+    }
+
+    #[test]
+    fn relax_map_keeps_entries_and_key_non_nullable() {
+        let entries = Field::new(
+            "entries",
+            DataType::Struct(Fields::from(vec![
+                Field::new("keys", DataType::Utf8, false),
+                Field::new(
+                    "values",
+                    DataType::Struct(Fields::from(vec![Field::new("v", DataType::Int32, false)])),
+                    false,
+                ),
+            ])),
+            false,
+        );
+        let schema = Schema::new(vec![Field::new(
+            "m",
+            DataType::Map(Arc::new(entries), false),
+            true,
+        )]);
+
+        let relaxed = relax_schema_nested_nullability(&schema);
+        let DataType::Map(entries, _) = relaxed.field(0).data_type() else {
+            panic!("expected map");
+        };
+        assert!(!entries.is_nullable());
+        let DataType::Struct(kv) = entries.data_type() else {
+            panic!("expected struct entries");
+        };
+        assert!(!kv[0].is_nullable(), "map keys must stay non-nullable");
+        assert!(kv[1].is_nullable(), "map values should be relaxed");
+        let DataType::Struct(value_fields) = kv[1].data_type() else {
+            panic!("expected struct values");
+        };
+        assert!(value_fields[0].is_nullable());
+    }
+
+    #[test]
+    fn relax_list_variants_relax_element_nullability() {
+        let elem = Arc::new(Field::new("item", DataType::Int32, false));
+        let schema = Schema::new(vec![
+            Field::new("large", DataType::LargeList(elem.clone()), true),
+            Field::new("view", DataType::ListView(elem.clone()), true),
+            Field::new("large_view", DataType::LargeListView(elem.clone()), true),
+            Field::new("fixed", DataType::FixedSizeList(elem.clone(), 2), true),
+        ]);
+
+        let relaxed = relax_schema_nested_nullability(&schema);
+
+        for field in relaxed.fields() {
+            let inner = match field.data_type() {
+                DataType::LargeList(f) | DataType::ListView(f) | DataType::LargeListView(f) => f,
+                DataType::FixedSizeList(f, n) => {
+                    assert_eq!(*n, 2, "list size must be preserved");
+                    f
+                }
+                other => panic!("unexpected data type: {other:?}"),
+            };
+            assert!(
+                inner.is_nullable(),
+                "element of {} should be relaxed",
+                field.name()
+            );
+        }
+    }
+
+    #[test]
+    fn relax_map_with_non_standard_entries_falls_back_to_generic_relaxation() {
+        // Entries struct with three fields does not match the key/value shape,
+        // so relaxation falls back to the generic nested handling.
+        let entries = Field::new(
+            "entries",
+            DataType::Struct(Fields::from(vec![
+                Field::new("a", DataType::Utf8, false),
+                Field::new("b", DataType::Int32, false),
+                Field::new("c", DataType::Int32, false),
+            ])),
+            false,
+        );
+        let schema = Schema::new(vec![Field::new(
+            "m",
+            DataType::Map(Arc::new(entries), false),
+            true,
+        )]);
+
+        let relaxed = relax_schema_nested_nullability(&schema);
+        let DataType::Map(entries, _) = relaxed.field(0).data_type() else {
+            panic!("expected map");
+        };
+        let DataType::Struct(fields) = entries.data_type() else {
+            panic!("expected struct entries");
+        };
+        assert!(fields.iter().all(|f| f.is_nullable()));
+    }
+}

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -51,8 +51,7 @@ use datafusion_datasource::{
     file_scan_config::FileScanConfigBuilder, source::DataSourceExec,
 };
 use datafusion_physical_expr_adapter::{
-    BatchAdapter, BatchAdapterFactory, DefaultPhysicalExprAdapterFactory,
-    PhysicalExprAdapterFactory,
+    BatchAdapter, BatchAdapterFactory, PhysicalExprAdapterFactory,
 };
 use delta_kernel::{
     Engine, Expression, engine::arrow_data::ArrowEngineData, expressions::StructData,
@@ -66,6 +65,7 @@ use url::Url;
 
 pub use self::exec::DeltaScanExec;
 use self::exec_meta::DeltaScanMetaExec;
+use self::expr_adapter::{DeltaPhysicalExprAdapterFactory, relax_schema_nested_nullability};
 pub(crate) use self::plan::{KernelScanPlan, ProjectedScanContract, supports_filters_pushdown};
 use self::replay::{ScanFileContext, ScanFileStream};
 use super::{FileSelection, ResolvedFileSelection};
@@ -82,6 +82,7 @@ use crate::{
 
 mod exec;
 mod exec_meta;
+mod expr_adapter;
 mod plan;
 mod replay;
 
@@ -657,6 +658,13 @@ async fn get_read_plan(
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut plans = Vec::new();
 
+    // Relax nested-field nullability on the schema handed to the parquet source:
+    // Delta's `nullable = false` is a write-time invariant, and Spark-written files
+    // may mark nested fields optional. The logical schema is restored above the
+    // parquet scan by DeltaScanExec's transforms.
+    let parquet_read_schema = Arc::new(relax_schema_nested_nullability(parquet_read_schema));
+    let parquet_read_schema = &parquet_read_schema;
+
     let pq_options = TableParquetOptions {
         global: state.config().options().execution.parquet.clone(),
         ..Default::default()
@@ -666,7 +674,7 @@ async fn get_read_plan(
     full_read_schema.push(file_id_field.as_ref().clone().with_nullable(true));
     let full_read_schema = Arc::new(full_read_schema.finish());
     let parquet_predicate_df_schema = parquet_predicate_schema.clone().to_dfschema()?;
-    let adapter_factory = Arc::new(DefaultPhysicalExprAdapterFactory {});
+    let adapter_factory = Arc::new(DeltaPhysicalExprAdapterFactory);
 
     for (store_url, files) in files_by_store.into_iter() {
         let reader_factory = Arc::new(CachedParquetFileReaderFactory::new(
@@ -766,7 +774,21 @@ fn finalize_transformed_batch(
     let result = if result.schema_ref().eq(&scan_plan.contract.result_schema) {
         result
     } else {
-        schema_adapter.adapt(result)?
+        let adapted = schema_adapter.adapt(result)?;
+        if adapted.schema_ref().eq(&scan_plan.contract.result_schema) {
+            adapted
+        } else {
+            // The batch adapter targets a nullability-relaxed schema (see
+            // `expr_adapter`). Restamp to the strict logical schema; this
+            // validates actual data nulls rather than declared nullability.
+            crate::kernel::cast_record_batch(
+                &adapted,
+                scan_plan.contract.result_schema.clone(),
+                false,
+                false,
+            )
+            .map_err(|e| DataFusionError::External(Box::new(e)))?
+        }
     };
     if let Some((arr, field)) = file_id_col {
         let arr = if arr.data_type() != field.data_type() {
@@ -804,7 +826,8 @@ struct SchemaAdapter {
 impl SchemaAdapter {
     fn new(target_schema: SchemaRef) -> Self {
         Self {
-            factory: BatchAdapterFactory::new(target_schema),
+            factory: BatchAdapterFactory::new(target_schema)
+                .with_adapter_factory(Arc::new(DeltaPhysicalExprAdapterFactory)),
             cached_source: None,
             cached_adapter: None,
         }
@@ -1540,6 +1563,101 @@ mod tests {
             "+----+--------------------+-----------------------------+",
         ];
         assert_batches_sorted_eq!(&expected, &batches);
+
+        Ok(())
+    }
+
+    /// Reading a file that contains actual null values in a nested field declared
+    /// non-nullable in the table schema must fail: the nullability relaxation in
+    /// the expression adapter only accommodates Spark-style relaxed on-disk
+    /// schemas, while the final `cast_record_batch` in
+    /// `finalize_transformed_batch` validates the actual data.
+    #[tokio::test]
+    async fn test_scan_rejects_actual_nested_nulls() -> TestResult {
+        let store_url = Url::parse("memory:///")?;
+        let log_store =
+            crate::logstore::logstore_for(&store_url, crate::logstore::StorageConfig::default())?;
+
+        // Delta log schema: metadata_col.int_id is NOT nullable.
+        let meta_type = crate::kernel::StructType::try_new(vec![crate::kernel::StructField::new(
+            "int_id",
+            crate::kernel::DataType::Primitive(crate::kernel::PrimitiveType::String),
+            false,
+        )])?;
+        let table = crate::operations::create::CreateBuilder::new()
+            .with_log_store(log_store.clone())
+            .with_columns(vec![crate::kernel::StructField::new(
+                "metadata_col",
+                crate::kernel::DataType::Struct(Box::new(meta_type)),
+                true,
+            )])
+            .await?;
+
+        // Parquet file whose data contains an actual null in int_id, registered
+        // via a raw Add action to bypass the delta-rs writer.
+        let meta_fields = Fields::from(vec![Field::new("int_id", DataType::Utf8, true)]);
+        let file_schema = Arc::new(Schema::new(vec![Field::new(
+            "metadata_col",
+            DataType::Struct(meta_fields.clone()),
+            true,
+        )]));
+        let meta = StructArray::try_new(
+            meta_fields,
+            vec![Arc::new(StringArray::from(vec![Some("t1"), None])) as ArrayRef],
+            None,
+        )?;
+        let batch = RecordBatch::try_new(file_schema.clone(), vec![Arc::new(meta)])?;
+
+        let mut buffer = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buffer, file_schema, None)?;
+        writer.write(&batch)?;
+        writer.close()?;
+        let size = buffer.len() as i64;
+
+        let store = log_store.object_store(None);
+        store
+            .put(&Path::from("part-00000.parquet"), buffer.into())
+            .await?;
+
+        crate::kernel::transaction::CommitBuilder::default()
+            .with_actions(vec![crate::kernel::Action::Add(crate::kernel::Add {
+                path: "part-00000.parquet".to_string(),
+                size,
+                data_change: true,
+                ..Default::default()
+            })])
+            .build(
+                Some(table.snapshot()?),
+                log_store.clone(),
+                crate::protocol::DeltaOperation::Write {
+                    mode: crate::protocol::SaveMode::Append,
+                    partition_by: None,
+                    predicate: None,
+                },
+            )
+            .await?;
+
+        let snapshot = Snapshot::try_new(&log_store, Default::default(), None).await?;
+        let provider = crate::delta_datafusion::table_provider::next::DeltaScan::builder()
+            .with_snapshot(snapshot)
+            .with_log_store(log_store)
+            .await?;
+
+        let session = Arc::new(create_session().into_inner());
+        session
+            .runtime_env()
+            .register_object_store(&store_url, store);
+        session.register_table("delta_table", provider)?;
+
+        let result = session
+            .sql("SELECT * FROM delta_table")
+            .await?
+            .collect()
+            .await;
+        assert!(
+            result.is_err(),
+            "expected error when reading actual nulls in a non-nullable nested field, got: {result:?}"
+        );
 
         Ok(())
     }

--- a/crates/core/tests/it_datafusion/command_optimize.rs
+++ b/crates/core/tests/it_datafusion/command_optimize.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use arrow_array::{Int32Array, Int64Array, RecordBatch, StringArray};
-use arrow_schema::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
+use arrow_schema::{DataType as ArrowDataType, Field, Fields, Schema as ArrowSchema};
 use arrow_select::concat::concat_batches;
 use bytes::Bytes;
 use datafusion::prelude::SessionContext;
@@ -15,7 +15,7 @@ use deltalake_core::delta_datafusion::DeltaSessionContext;
 use deltalake_core::ensure_table_uri;
 use deltalake_core::errors::DeltaTableError;
 use deltalake_core::kernel::transaction::{CommitBuilder, CommitProperties, TransactionError};
-use deltalake_core::kernel::{Action, DataType, PrimitiveType, StructField};
+use deltalake_core::kernel::{Action, Add, DataType, PrimitiveType, StructField, StructType};
 use deltalake_core::logstore::{
     CommitOrBytes, LogStore, LogStoreConfig, LogStoreRef, ObjectStoreRef, get_actions,
 };
@@ -30,8 +30,8 @@ use deltalake_core::{
 };
 use futures::TryStreamExt;
 use object_store::ObjectStoreExt as _;
-use parquet::arrow::ParquetRecordBatchStreamBuilder;
 use parquet::arrow::async_reader::ParquetObjectReader;
+use parquet::arrow::{ArrowWriter, ParquetRecordBatchStreamBuilder};
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use rand::prelude::*;
@@ -2146,6 +2146,133 @@ async fn test_zorder_rejects_invalid_nested_path() -> Result<(), Box<dyn Error>>
             .to_string()
             .contains("\"value\" is not a struct type")
     );
+
+    Ok(())
+}
+
+/// Regression test: optimize must succeed on tables whose parquet files mark a
+/// nested struct field as nullable while the Delta log schema declares it
+/// non-nullable (the on-disk layout produced by Spark). Nullability in the log
+/// schema is a write-time invariant, not a read-time physical constraint.
+#[tokio::test]
+async fn test_optimize_spark_written_nullable_nested_field() -> Result<(), Box<dyn Error>> {
+    let tmp_dir = tempfile::tempdir()?;
+    let table_url = url::Url::from_directory_path(tmp_dir.path()).unwrap();
+
+    // Delta log schema: metadata_col.int_id is NOT nullable.
+    let meta_type = StructType::try_new(vec![StructField::new(
+        "int_id",
+        DataType::Primitive(PrimitiveType::String),
+        false,
+    )])?;
+    DeltaTable::try_from_url(table_url.clone())
+        .await?
+        .create()
+        .with_columns(vec![
+            StructField::new("id", DataType::Primitive(PrimitiveType::Long), false),
+            StructField::new("metadata_col", DataType::Struct(Box::new(meta_type)), true),
+        ])
+        .await?;
+
+    // Parquet files whose arrow schema marks int_id as nullable (mimicking
+    // Spark's writer), registered via raw Add actions to bypass the delta-rs
+    // writer which would cast to the table schema. Two files so optimize bins
+    // them for compaction.
+    let meta_fields = Fields::from(vec![Field::new("int_id", ArrowDataType::Utf8, true)]);
+    let file_schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("id", ArrowDataType::Int64, false),
+        Field::new(
+            "metadata_col",
+            ArrowDataType::Struct(meta_fields.clone()),
+            true,
+        ),
+    ]));
+    for (name, ids, int_ids) in [
+        ("part-00000.parquet", vec![1i64, 2], vec!["t1", "t2"]),
+        ("part-00001.parquet", vec![3i64, 4], vec!["t3", "t4"]),
+    ] {
+        let meta = arrow_array::StructArray::new(
+            meta_fields.clone(),
+            vec![Arc::new(StringArray::from(int_ids)) as arrow_array::ArrayRef],
+            None,
+        );
+        let batch = RecordBatch::try_new(
+            file_schema.clone(),
+            vec![Arc::new(Int64Array::from(ids)), Arc::new(meta)],
+        )?;
+
+        let file_path = tmp_dir.path().join(name);
+        let file = std::fs::File::create(&file_path)?;
+        let mut writer = ArrowWriter::try_new(file, file_schema.clone(), None)?;
+        writer.write(&batch)?;
+        writer.close()?;
+        let size = std::fs::metadata(&file_path)?.len() as i64;
+
+        let table = open_table(table_url.clone()).await?;
+        let add = Add {
+            path: name.to_string(),
+            size,
+            data_change: true,
+            ..Default::default()
+        };
+        CommitBuilder::default()
+            .with_actions(vec![Action::Add(add)])
+            .build(
+                Some(table.snapshot()?),
+                table.log_store(),
+                DeltaOperation::Write {
+                    mode: deltalake_core::protocol::SaveMode::Append,
+                    partition_by: None,
+                    predicate: None,
+                },
+            )
+            .await?;
+    }
+
+    let table = open_table(table_url).await?;
+    assert_eq!(table.snapshot()?.log_data().num_files(), 2);
+
+    let (table, metrics) = table.optimize().await?;
+
+    assert_eq!(metrics.num_files_added, 1);
+    assert_eq!(metrics.num_files_removed, 2);
+    assert_eq!(table.snapshot()?.log_data().num_files(), 1);
+
+    // Verify the compacted file preserved all rows.
+    let file = table.snapshot()?.log_data().into_iter().next().unwrap();
+    let path =
+        Path::parse(file.path().as_ref()).unwrap_or_else(|_| Path::from(file.path().as_ref()));
+    let batch = read_parquet_file(&path, table.object_store()).await?;
+    assert_eq!(batch.num_rows(), 4);
+
+    // Verify strict output schema: int_id must be non-nullable in the compacted file.
+    let batch_schema = batch.schema();
+    let ArrowDataType::Struct(out_meta_fields) =
+        batch_schema.field_with_name("metadata_col")?.data_type()
+    else {
+        panic!("expected struct");
+    };
+    assert!(
+        !out_meta_fields[0].is_nullable(),
+        "compacted file must preserve the strict (non-nullable) schema for int_id"
+    );
+
+    // Verify nested values: all int_id strings are present and correct.
+    let meta_col = batch
+        .column_by_name("metadata_col")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow_array::StructArray>()
+        .unwrap();
+    let int_id_col = meta_col
+        .column_by_name("int_id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow_array::StringArray>()
+        .unwrap();
+    let mut actual: Vec<&str> = int_id_col.iter().map(|v| v.expect("non-null")).collect();
+    actual.sort_unstable();
+    assert_eq!(actual, vec!["t1", "t2", "t3", "t4"]);
 
     Ok(())
 }


### PR DESCRIPTION
# Description

Fixes the failure when running `optimize()` on a table written by Spark, failure that looks like this:
```
Parquet { source: General("Optimize selected-file scan failed while scanning data:
Error during planning: Cannot cast nullable struct field 'int_id' to non-nullable field") }
```

Fixes it by relaxing nested-field nullability while reading physical data, and restore the strict logical schema at the scan output boundary.

- Add `DeltaPhysicalExprAdapterFactory` (scan/expr_adapter.rs): wraps DataFusion's default `PhysicalExprAdapterFactory`, recursively marking nested fields (struct children, list elements, map values) of the logical schema as nullable before expression rewriting. Top-level nullability is untouched, preserving errors for missing columns.
- Use a nullability-relaxed schema for the `ParquetSource` in `get_read_plan`, so the parquet opener accepts files with physically optional nested fields.
- Wire the custom factory into `SchemaAdapter`'s `BatchAdapterFactory` so batch adaptation no longer rejects relaxed batches.
- In `finalize_transformed_batch`, restamp adapted batches to the strict `result_schema` via `kernel::cast_record_batch` when they still carry relaxed nullability. This validates actual data (real nulls still error) rather than declared nullability, and keeps downstream operators (e.g. Z-order) seeing the exact logical schema.

Adds regression test `test_optimize_spark_written_nullable_nested_field` simulating a Spark-written table (parquet nested field optional, Delta schema non-nullable) and asserting `optimize()` succeeds.

# Related Issue(s)

Closes #4586 
