### PR TITLE
fix: fix typos in DeltaTable

### DIFF
--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -39,9 +39,9 @@ pub use columns::*;
 
 /// In memory representation of a Delta Table
 ///
-/// A DeltaTable is a purely logical concept that represents a dataset that can ewvolve over time.
+/// A DeltaTable is a purely logical concept that represents a dataset that can evolve over time.
 /// To attain concrete information about a table a snapshot need to be loaded.
-/// Most commonly this is the latest state of the tablem but may also loaded for a specific
+/// Most commonly this is the latest state of the table, but may also loaded for a specific
 /// version or point in time.
 #[derive(Clone)]
 pub struct DeltaTable {


### PR DESCRIPTION
# Description

Two small typos fixed in the docs for DeltaTable:

- `ewvolve` → `evolve`
- `tablem`→ `table,`

# Documentation

The compiled documentation can be seen here:
https://docs.rs/deltalake-core/0.32.4/deltalake_core/table/struct.DeltaTable.html

This change would fix the two typos visible in the description of the `DeltaTable` struct.