### PR TITLE
fix: speed up full vacuum listing on multi-level partitions (#4634)

### DIFF
--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -10,10 +10,14 @@ edition = "2021"
 publish = false
 
 [dependencies]
+async-trait = { workspace = true }
 clap = { version = "4", features = ["derive", "env"] }
-tokio = { workspace = true, features = ["fs", "macros", "rt", "io-util"] }
+tokio = { workspace = true, features = ["fs", "macros", "rt", "io-util", "time"] }
 url = { workspace = true }
 tempfile = { workspace = true }
+chrono = { workspace = true, default-features = false, features = ["clock"] }
+futures = { workspace = true }
+object_store = { workspace = true }
 anyhow = "1"
 
 [dependencies.deltalake-core]
@@ -34,4 +38,8 @@ harness = false
 
 [[bench]]
 name = "tpcds"
+harness = false
+
+[[bench]]
+name = "vacuum"
 harness = false

--- a/crates/benchmarks/README.md
+++ b/crates/benchmarks/README.md
@@ -79,3 +79,122 @@ cargo install samply --locked
 cargo build --profile profiling -p delta-benchmarks
 samply record ./target/profiling/delta-benchmarks merge upsert
 ```
+
+## Vacuum full-scan listing
+
+Compares full-mode vacuum dry-run listing cost (plan/scan only; no deletes):
+
+- **parallel** — multi-level prefix expansion + concurrent leaf `list(prefix)`
+- **flat** — `.disable_parallel_scan()` → single recursive `list(None)`
+
+CLI and Divan use the **same flag names**:
+
+| Flag | Env fallback | Meaning |
+|------|----------------|---------|
+| `--fixture <PATH>` | `VACUUM_BENCH_FIXTURE` | Fixture table directory |
+| `--list-latency-ms <MS>` | `VACUUM_BENCH_LIST_LATENCY_MS` | Artificial LIST latency (cloud RTT sim) |
+| `--sample-count <N>` | Divan: also `DIVAN_SAMPLE_COUNT` | Timed runs / Divan samples (default CLI **1**, Divan **100**) |
+
+On local FS with high `--scan-concurrency`, raise open-file limits if you hit
+`Too many open files (os error 24)`:
+
+```bash
+ulimit -n 10240
+```
+
+### Prep once, then measure
+
+```bash
+# 1) Prepare fixture once (skips if already present at default path)
+cargo run --release -p delta-benchmarks -- generate-vacuum-fixture
+
+# 2) Divan bench (flat + parallel at default concurrency)
+cargo bench -p delta-benchmarks --bench vacuum
+```
+
+Default fixture: ~30 days × 500 groups ≈ **15k leaf partitions**, one commit per
+day, partitions `date` + `group`, under
+`crates/benchmarks/data/vacuum_bench/d30_g500`.
+
+Custom / larger fixture:
+
+```bash
+cargo run --release -p delta-benchmarks -- generate-vacuum-fixture \
+  --out crates/benchmarks/data/vacuum_bench/custom \
+  --days 90 --groups 2000 --force
+
+cargo bench -p delta-benchmarks --bench vacuum -- \
+  --fixture crates/benchmarks/data/vacuum_bench/custom \
+  --list-latency-ms 100 \
+  --sample-count 2
+```
+
+### Divan benches
+
+- `full_dry_run_flat` — flat scan
+- `full_dry_run_parallel` — parallel scan with library default LIST concurrency
+  (`None` → env / default **10**)
+
+```bash
+# Both benches, 2 samples each (simple A/B)
+ulimit -n 10240
+cargo bench -p delta-benchmarks --bench vacuum -- \
+  --fixture crates/benchmarks/data/vacuum_bench/d1095_g5001 \
+  --list-latency-ms 100 \
+  --sample-count 2
+
+# Parallel only
+cargo bench -p delta-benchmarks --bench vacuum -- \
+  --fixture crates/benchmarks/data/vacuum_bench/d1095_g5001 \
+  --list-latency-ms 100 \
+  --sample-count 2 \
+  full_dry_run_parallel
+
+# Flat only
+cargo bench -p delta-benchmarks --bench vacuum -- \
+  --fixture crates/benchmarks/data/vacuum_bench/d1095_g5001 \
+  --list-latency-ms 100 \
+  --sample-count 2 \
+  full_dry_run_flat
+```
+
+`--list-latency-ms` delays every LIST / `list_with_delimiter`; flat `list`
+streams are also delayed every 1000 keys (simulated S3 page size).
+
+Env vars still work as fallbacks if you prefer not to pass flags:
+
+```bash
+VACUUM_BENCH_FIXTURE=crates/benchmarks/data/vacuum_bench/custom \
+VACUUM_BENCH_LIST_LATENCY_MS=100 \
+  cargo bench -p delta-benchmarks --bench vacuum -- --sample-count 1
+```
+
+### Ad-hoc / profiling CLI
+
+Same flags as Divan (`--fixture`, `--list-latency-ms`, `--sample-count`), plus
+scan controls:
+
+```bash
+# Optional: --generate builds the default fixture if missing
+cargo run --release -p delta-benchmarks -- vacuum \
+  --generate --scan parallel --sample-count 5
+
+cargo run --release -p delta-benchmarks -- vacuum \
+  --scan flat --sample-count 5
+
+cargo run --release -p delta-benchmarks -- vacuum \
+  --scan parallel --scan-concurrency 20
+
+# Local "cloud-like" LIST latency
+cargo run --release -p delta-benchmarks -- vacuum \
+  --fixture crates/benchmarks/data/vacuum_bench/d1095_g5001 \
+  --scan parallel --scan-concurrency 32 \
+  --list-latency-ms 100 --sample-count 1
+
+cargo run --release -p delta-benchmarks -- vacuum \
+  --fixture crates/benchmarks/data/vacuum_bench/d1095_g5001 \
+  --scan flat --list-latency-ms 100 --sample-count 1
+```
+
+CLI also accepts `VACUUM_BENCH_FIXTURE` / `VACUUM_BENCH_LIST_LATENCY_MS` as env
+aliases for those flags.

--- a/crates/benchmarks/benches/vacuum.rs
+++ b/crates/benchmarks/benches/vacuum.rs
@@ -1,0 +1,207 @@
+//! Full-mode vacuum listing bench (parallel vs flat).
+//!
+//! **Prep once, then measure only** (fixture is never built inside timed samples).
+//!
+//! If the fixture path is missing, the bench exits and tells you to generate it.
+//!
+//! ## Generate fixture
+//!
+//! ```bash
+//! # Default: crates/benchmarks/data/vacuum_bench/d30_g500 (~30 days × 500 groups)
+//! cargo run --release -p delta-benchmarks -- generate-vacuum-fixture
+//!
+//! # Larger / custom path
+//! cargo run --release -p delta-benchmarks -- generate-vacuum-fixture \
+//!   --out path/to/fixture --days 90 --groups 2000
+//! ```
+//!
+//! ## Run this vacuum bench
+//!
+//! ```bash
+//! cargo bench -p delta-benchmarks --bench vacuum -- \
+//!   --fixture path/to/fixture \
+//!   --list-latency-ms 100 \
+//!   --sample-count 2
+//! ```
+//!
+//! Benches that will be run: `full_dry_run_flat`, `full_dry_run_parallel`.
+//!
+//! Same flags also work on the one-shot CLI:
+//! `cargo run -p delta-benchmarks -- vacuum --scan flat|parallel ...`
+//!
+//! Env aliases: `VACUUM_BENCH_FIXTURE`, `VACUUM_BENCH_LIST_LATENCY_MS`.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use delta_benchmarks::{
+    default_fixture_dir, fixture_exists, open_vacuum_fixture_with_list_latency,
+    run_vacuum_full_dry_run, VacuumScanMode,
+};
+use deltalake_core::DeltaTable;
+use divan::{AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+/// Shared with CLI: `--fixture` / `VACUUM_BENCH_FIXTURE`,
+/// `--list-latency-ms` / `VACUUM_BENCH_LIST_LATENCY_MS`.
+struct BenchConfig {
+    fixture: PathBuf,
+    list_latency_ms: u64,
+}
+
+static CONFIG: OnceLock<BenchConfig> = OnceLock::new();
+
+fn config() -> &'static BenchConfig {
+    CONFIG.get().expect("bench config initialized in main")
+}
+
+fn main() {
+    let cfg = parse_config_and_maybe_reexec();
+    let _ = CONFIG.set(cfg);
+
+    let cfg = config();
+    if !fixture_exists(&cfg.fixture) {
+        eprintln!(
+            "vacuum bench fixture not found at {}\n\n\
+             Prepare it once, then re-run the bench:\n\n\
+             cargo run --release -p delta-benchmarks -- generate-vacuum-fixture\n\n\
+             Or point at an existing fixture (same flags as the vacuum CLI):\n\n\
+             cargo bench -p delta-benchmarks --bench vacuum -- \\\n\
+               --fixture /path/to/fixture --list-latency-ms 100\n",
+            cfg.fixture.display()
+        );
+        std::process::exit(1);
+    }
+
+    divan::main();
+}
+
+/// Read `--fixture` / `--list-latency-ms` (CLI-compatible). If present on argv,
+/// strip them and re-exec so Divan only sees its own flags/filters.
+fn parse_config_and_maybe_reexec() -> BenchConfig {
+    let mut fixture = std::env::var_os("VACUUM_BENCH_FIXTURE")
+        .map(PathBuf::from)
+        .unwrap_or_else(default_fixture_dir);
+    let mut list_latency_ms = std::env::var("VACUUM_BENCH_LIST_LATENCY_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    let args: Vec<String> = std::env::args().collect();
+    let mut stripped = Vec::with_capacity(args.len());
+    stripped.push(args[0].clone());
+    let mut i = 1;
+    let mut saw_ours = false;
+
+    while i < args.len() {
+        let a = &args[i];
+        if a == "--fixture" {
+            let v = args
+                .get(i + 1)
+                .unwrap_or_else(|| usage_exit("--fixture needs a value"));
+            fixture = PathBuf::from(v);
+            saw_ours = true;
+            i += 2;
+        } else if let Some(v) = a.strip_prefix("--fixture=") {
+            fixture = PathBuf::from(v);
+            saw_ours = true;
+            i += 1;
+        } else if a == "--list-latency-ms" {
+            let v = args
+                .get(i + 1)
+                .unwrap_or_else(|| usage_exit("--list-latency-ms needs a value"));
+            list_latency_ms = v
+                .parse()
+                .unwrap_or_else(|_| usage_exit("--list-latency-ms needs an integer"));
+            saw_ours = true;
+            i += 2;
+        } else if let Some(v) = a.strip_prefix("--list-latency-ms=") {
+            list_latency_ms = v
+                .parse()
+                .unwrap_or_else(|_| usage_exit("--list-latency-ms needs an integer"));
+            saw_ours = true;
+            i += 1;
+        } else if a == "--help" || a == "-h" {
+            eprint_our_flags();
+            stripped.push(a.clone());
+            i += 1;
+        } else {
+            stripped.push(a.clone());
+            i += 1;
+        }
+    }
+
+    if saw_ours {
+        // Re-exec without our flags; pass config via the same env names as CLI.
+        let status = Command::new(&stripped[0])
+            .args(&stripped[1..])
+            .env("VACUUM_BENCH_FIXTURE", &fixture)
+            .env("VACUUM_BENCH_LIST_LATENCY_MS", list_latency_ms.to_string())
+            .status()
+            .expect("re-exec vacuum bench");
+        std::process::exit(status.code().unwrap_or(1));
+    }
+
+    BenchConfig {
+        fixture,
+        list_latency_ms,
+    }
+}
+
+fn eprint_our_flags() {
+    eprintln!(
+        "Vacuum bench options (same as `delta-benchmarks vacuum` CLI):\n\
+         \n\
+         \t--fixture <PATH>           Fixture directory [env: VACUUM_BENCH_FIXTURE]\n\
+         \t--list-latency-ms <MS>     Artificial LIST latency [env: VACUUM_BENCH_LIST_LATENCY_MS]\n"
+    );
+}
+
+fn usage_exit(msg: &str) -> ! {
+    eprintln!("error: {msg}");
+    eprint_our_flags();
+    std::process::exit(2);
+}
+
+fn shared_table() -> &'static DeltaTable {
+    static TABLE: OnceLock<DeltaTable> = OnceLock::new();
+    TABLE.get_or_init(|| {
+        let cfg = config();
+        let list_latency = Duration::from_millis(cfg.list_latency_ms);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            open_vacuum_fixture_with_list_latency(&cfg.fixture, list_latency)
+                .await
+                .expect("open vacuum fixture")
+        })
+    })
+}
+
+fn bench_vacuum(bencher: Bencher, mode: VacuumScanMode, scan_concurrency: Option<usize>) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let table = shared_table();
+    bencher.bench_local(|| {
+        rt.block_on(async {
+            let result = run_vacuum_full_dry_run(table, mode, scan_concurrency)
+                .await
+                .expect("vacuum dry-run");
+            divan::black_box(result);
+        });
+    });
+}
+
+/// Flat full scan (concurrency N/A).
+#[divan::bench]
+fn full_dry_run_flat(bencher: Bencher) {
+    bench_vacuum(bencher, VacuumScanMode::Flat, None);
+}
+
+/// Parallel full scan with default scan concurrency.
+#[divan::bench]
+fn full_dry_run_parallel(bencher: Bencher) {
+    bench_vacuum(bencher, VacuumScanMode::Parallel, None);
+}

--- a/crates/benchmarks/src/latency_store.rs
+++ b/crates/benchmarks/src/latency_store.rs
@@ -1,0 +1,184 @@
+//! Object-store wrapper that injects delay on LIST operations.
+//!
+//! Used by vacuum listing benches to simulate high-latency cloud LIST on a
+//! local filesystem table. Only `list` / `list_with_offset` /
+//! `list_with_delimiter` are delayed; reads/writes pass through.
+//!
+//! Flat `list()` streams are delayed **per page** (default 1000 keys) to mimic
+//! S3-style pagination. A single delay-at-start would under-penalize flat LIST
+//! on local disk (one stream, all keys) versus many parallel prefix LISTs.
+
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use object_store::path::Path;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions, Result as OSResult,
+};
+
+/// Default keys per simulated LIST page (S3 ListObjects max-keys default).
+const DEFAULT_LIST_PAGE_SIZE: usize = 1000;
+
+/// Wraps an [`ObjectStore`] and sleeps on LIST-family APIs.
+#[derive(Debug)]
+pub struct LatencyStore {
+    inner: Arc<dyn ObjectStore>,
+    list_delay: Duration,
+    /// Simulated page size for `list` / `list_with_offset` streams.
+    page_size: usize,
+}
+
+impl LatencyStore {
+    pub fn new(inner: Arc<dyn ObjectStore>, list_delay: Duration) -> Self {
+        Self {
+            inner,
+            list_delay,
+            page_size: DEFAULT_LIST_PAGE_SIZE,
+        }
+    }
+
+    pub fn list_delay(&self) -> Duration {
+        self.list_delay
+    }
+
+    async fn delay(&self) {
+        if !self.list_delay.is_zero() {
+            tokio::time::sleep(self.list_delay).await;
+        }
+    }
+}
+
+impl fmt::Display for LatencyStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "LatencyStore(list_delay={:?}, page_size={}, inner={})",
+            self.list_delay, self.page_size, self.inner
+        )
+    }
+}
+
+fn delayed_list_stream(
+    inner: Arc<dyn ObjectStore>,
+    prefix: Option<Path>,
+    offset: Option<Path>,
+    delay: Duration,
+    page_size: usize,
+) -> BoxStream<'static, OSResult<ObjectMeta>> {
+    let page_size = page_size.max(1);
+    async_stream_list(inner, prefix, offset, delay, page_size)
+}
+
+fn async_stream_list(
+    inner: Arc<dyn ObjectStore>,
+    prefix: Option<Path>,
+    offset: Option<Path>,
+    delay: Duration,
+    page_size: usize,
+) -> BoxStream<'static, OSResult<ObjectMeta>> {
+    // Use unfold over the inner stream so we can sleep every `page_size` yields
+    // without pulling in the async-stream crate.
+    let inner_stream = match offset {
+        Some(offset) => inner.list_with_offset(prefix.as_ref(), &offset),
+        None => inner.list(prefix.as_ref()),
+    };
+
+    futures::stream::try_unfold(
+        (inner_stream, 0usize, true),
+        move |(mut s, mut in_page, first)| async move {
+            if first && !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+            match s.next().await {
+                None => Ok(None),
+                Some(Err(e)) => Err(e),
+                Some(Ok(item)) => {
+                    in_page += 1;
+                    // After finishing a page, sleep before the next key (next "RPC").
+                    let at_page_boundary = in_page >= page_size;
+                    if at_page_boundary {
+                        in_page = 0;
+                        if !delay.is_zero() {
+                            tokio::time::sleep(delay).await;
+                        }
+                    }
+                    Ok(Some((item, (s, in_page, false))))
+                }
+            }
+        },
+    )
+    .boxed()
+}
+
+#[async_trait]
+impl ObjectStore for LatencyStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> OSResult<PutResult> {
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> OSResult<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OSResult<Path>>,
+    ) -> BoxStream<'static, OSResult<Path>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        delayed_list_stream(
+            Arc::clone(&self.inner),
+            prefix.cloned(),
+            None,
+            self.list_delay,
+            self.page_size,
+        )
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        delayed_list_stream(
+            Arc::clone(&self.inner),
+            prefix.cloned(),
+            Some(offset.clone()),
+            self.list_delay,
+            self.page_size,
+        )
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+        self.delay().await;
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> OSResult<()> {
+        self.inner.copy_opts(from, to, options).await
+    }
+
+    async fn rename_opts(&self, from: &Path, to: &Path, options: RenameOptions) -> OSResult<()> {
+        self.inner.rename_opts(from, to, options).await
+    }
+}

--- a/crates/benchmarks/src/lib.rs
+++ b/crates/benchmarks/src/lib.rs
@@ -1,7 +1,10 @@
+pub mod latency_store;
 pub mod merge;
 pub mod smoke;
 pub mod tpcds_queries;
+pub mod vacuum;
 
+pub use latency_store::LatencyStore;
 pub use merge::{
     delete_only_cases, insert_only_cases, merge_case_by_name, merge_case_names, merge_delete,
     merge_insert, merge_noop_heavy_upsert, merge_test_cases, merge_upsert, noop_heavy_upsert_cases,
@@ -10,4 +13,9 @@ pub use merge::{
 pub use smoke::{run_smoke_once, SmokeParams};
 pub use tpcds_queries::{
     register_tpcds_tables, tpcds_queries, tpcds_query, tpcds_query_names, TPCDS_TABLE_NAMES,
+};
+pub use vacuum::{
+    default_fixture_dir, fixture_exists, generate_vacuum_fixture, open_vacuum_fixture,
+    open_vacuum_fixture_with_list_latency, run_vacuum_full_dry_run, VacuumFixtureParams,
+    VacuumScanMode,
 };

--- a/crates/benchmarks/src/main.rs
+++ b/crates/benchmarks/src/main.rs
@@ -1,14 +1,16 @@
 use std::{
     path::{Path, PathBuf},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use clap::{Parser, Subcommand, ValueEnum};
 
 use delta_benchmarks::{
-    merge_case_by_name, merge_case_names, merge_delete, merge_insert, merge_noop_heavy_upsert,
-    merge_upsert, prepare_source_and_table, register_tpcds_tables, run_smoke_once, tpcds_queries,
-    tpcds_query, MergeOp, MergePerfParams, MergeTestCase, SmokeParams,
+    default_fixture_dir, generate_vacuum_fixture, merge_case_by_name, merge_case_names,
+    merge_delete, merge_insert, merge_noop_heavy_upsert, merge_upsert,
+    open_vacuum_fixture_with_list_latency, prepare_source_and_table, register_tpcds_tables,
+    run_smoke_once, run_vacuum_full_dry_run, tpcds_queries, tpcds_query, MergeOp, MergePerfParams,
+    MergeTestCase, SmokeParams, VacuumFixtureParams, VacuumScanMode,
 };
 use deltalake_core::ensure_table_uri;
 
@@ -18,6 +20,21 @@ enum OpKind {
     NoopHeavyUpsert,
     Delete,
     Insert,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum VacuumScanCli {
+    Parallel,
+    Flat,
+}
+
+impl From<VacuumScanCli> for VacuumScanMode {
+    fn from(value: VacuumScanCli) -> Self {
+        match value {
+            VacuumScanCli::Parallel => VacuumScanMode::Parallel,
+            VacuumScanCli::Flat => VacuumScanMode::Flat,
+        }
+    }
 }
 
 #[derive(Parser, Debug)]
@@ -80,6 +97,60 @@ enum Command {
         /// Run the query and measure execution time
         #[arg(long, conflicts_with = "list", requires = "case")]
         run: bool,
+    },
+
+    /// Generate a multi-level vacuum listing fixture (once) for reuse by benches
+    GenerateVacuumFixture {
+        /// Output directory for the Delta table fixture
+        #[arg(long, default_value_os_t = default_fixture_dir())]
+        out: PathBuf,
+
+        /// Number of day partitions (one commit per day)
+        #[arg(long, default_value_t = VacuumFixtureParams::default().days)]
+        days: usize,
+
+        /// Number of group values per day
+        #[arg(long, default_value_t = VacuumFixtureParams::default().groups)]
+        groups: usize,
+
+        /// Rows per (date, group) partition
+        #[arg(long, default_value_t = VacuumFixtureParams::default().rows_per_partition)]
+        rows_per_partition: usize,
+
+        /// Rebuild even if a fixture already exists at --out
+        #[arg(long, default_value_t = false)]
+        force: bool,
+    },
+
+    /// Dry-run full vacuum against a generated fixture (for profiling / sanity)
+    Vacuum {
+        /// Fixture directory (must already exist unless --generate is set)
+        #[arg(
+            long,
+            env = "VACUUM_BENCH_FIXTURE",
+            default_value_os_t = default_fixture_dir()
+        )]
+        fixture: PathBuf,
+
+        /// Scan strategy
+        #[arg(long, value_enum, default_value_t = VacuumScanCli::Parallel)]
+        scan: VacuumScanCli,
+
+        /// Optional LIST concurrency override (parallel path)
+        #[arg(long)]
+        scan_concurrency: Option<usize>,
+
+        /// Artificial LIST latency in milliseconds (simulates cloud RTT on local FS)
+        #[arg(long, env = "VACUUM_BENCH_LIST_LATENCY_MS", default_value_t = 0)]
+        list_latency_ms: u64,
+
+        /// Generate the default-sized fixture at --fixture if missing
+        #[arg(long, default_value_t = false)]
+        generate: bool,
+
+        /// Number of timed dry-run samples after open (same name as Divan `--sample-count`)
+        #[arg(long = "sample-count", default_value_t = 1)]
+        sample_count: usize,
     },
 }
 
@@ -170,6 +241,58 @@ async fn main() -> anyhow::Result<()> {
                 }
             } else {
                 anyhow::bail!("specify --case <id> or --list");
+            }
+        }
+        Command::GenerateVacuumFixture {
+            out,
+            days,
+            groups,
+            rows_per_partition,
+            force,
+        } => {
+            let params = VacuumFixtureParams {
+                days,
+                groups,
+                rows_per_partition,
+            };
+            let start = Instant::now();
+            let path = generate_vacuum_fixture(&out, &params, force).await?;
+            println!(
+                "vacuum_fixture_path={} days={} groups={} partitions_approx={} generate_duration_ms={}",
+                path.display(),
+                params.days,
+                params.groups,
+                params.days.saturating_mul(params.groups),
+                start.elapsed().as_millis()
+            );
+        }
+        Command::Vacuum {
+            fixture,
+            scan,
+            scan_concurrency,
+            list_latency_ms,
+            generate,
+            sample_count,
+        } => {
+            if generate {
+                let params = VacuumFixtureParams::default();
+                generate_vacuum_fixture(&fixture, &params, false).await?;
+            }
+            let list_latency = Duration::from_millis(list_latency_ms);
+            let table = open_vacuum_fixture_with_list_latency(&fixture, list_latency).await?;
+            let mode = VacuumScanMode::from(scan);
+            for i in 0..sample_count {
+                let start = Instant::now();
+                let (_table, metrics) =
+                    run_vacuum_full_dry_run(&table, mode, scan_concurrency).await?;
+                println!(
+                    "sample={} scan={} list_latency_ms={} vacuum_duration_ms={} files_deleted={}",
+                    i,
+                    mode.name(),
+                    list_latency_ms,
+                    start.elapsed().as_millis(),
+                    metrics.files_deleted.len()
+                );
             }
         }
     }

--- a/crates/benchmarks/src/vacuum.rs
+++ b/crates/benchmarks/src/vacuum.rs
@@ -229,7 +229,7 @@ pub async fn run_vacuum_full_dry_run(
         builder = builder.with_scan_concurrency(n);
     }
     if mode == VacuumScanMode::Flat {
-        builder = builder.disable_parallel_scan();
+        builder = builder.parallel_scan(false);
     }
 
     builder.await

--- a/crates/benchmarks/src/vacuum.rs
+++ b/crates/benchmarks/src/vacuum.rs
@@ -1,0 +1,338 @@
+//! Full-mode vacuum listing benchmarks.
+//!
+//! Fixture strategy: generate a multi-level partitioned Delta table **once**,
+//! then dry-run full vacuum many times (parallel vs flat). Dry-run does not
+//! delete, so the same table can be reused across samples.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use chrono::Duration as ChronoDuration;
+use deltalake_core::arrow;
+use deltalake_core::kernel::{DataType, PrimitiveType, StructField, StructType};
+use deltalake_core::operations::vacuum::{VacuumMetrics, VacuumMode};
+use deltalake_core::protocol::SaveMode;
+use deltalake_core::{DeltaResult, DeltaTable, DeltaTableBuilder, DeltaTableError};
+use object_store::local::LocalFileSystem;
+use url::Url;
+
+use crate::latency_store::LatencyStore;
+
+/// Parameters for the multi-level vacuum fixture.
+///
+/// Layout: partitions `date` (string YYYY-MM-DD) and `group` (string).
+#[derive(Debug, Clone, Copy)]
+pub struct VacuumFixtureParams {
+    /// Number of distinct `date` partition values (one commit per day).
+    pub days: usize,
+    /// Number of distinct `group` values per day (`0..groups`).
+    pub groups: usize,
+    /// Rows written per (date, group) partition.
+    pub rows_per_partition: usize,
+}
+
+impl Default for VacuumFixtureParams {
+    fn default() -> Self {
+        // ~30 * 500 = 15k leaf partitions — enough to exercise listing without
+        // multi-hour generation.
+        Self {
+            days: 30,
+            groups: 500,
+            rows_per_partition: 1,
+        }
+    }
+}
+
+/// Whether full-mode vacuum uses the parallel multi-level scan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VacuumScanMode {
+    /// Default: parallel prefix expansion when the table has >1 partition cols.
+    Parallel,
+    /// Force flat `list(None)` via [`VacuumBuilder::disable_parallel_scan`].
+    Flat,
+}
+
+impl VacuumScanMode {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Parallel => "parallel",
+            Self::Flat => "flat",
+        }
+    }
+}
+
+impl std::fmt::Display for VacuumScanMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+/// Marker file written next to a generated fixture for resume/skip.
+const FIXTURE_META: &str = "vacuum_fixture_meta.txt";
+
+/// True if `dir` already looks like a complete vacuum fixture.
+pub fn fixture_exists(dir: &Path) -> bool {
+    dir.join(FIXTURE_META).is_file() && dir.join("_delta_log").is_dir()
+}
+
+/// Generate (or skip if present) a multi-level partitioned table at `dir`.
+///
+/// This is partitioned by `date` and `group`.
+/// One commit per day containing all groups for that day.
+///
+/// Depending on the size of dataset it may take a long time (hours).
+/// For example: for 1095 days (`date`) and 5001 groups (`group`)
+/// it will take 1 to 2 hours depending on the machine it's executed.
+pub async fn generate_vacuum_fixture(
+    dir: &Path,
+    params: &VacuumFixtureParams,
+    force: bool,
+) -> DeltaResult<PathBuf> {
+    if !force && fixture_exists(dir) {
+        return Ok(fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf()));
+    }
+
+    if dir.exists() {
+        fs::remove_dir_all(dir).map_err(|e| {
+            DeltaTableError::generic(format!(
+                "failed to clear fixture dir {}: {e}",
+                dir.display()
+            ))
+        })?;
+    }
+    fs::create_dir_all(dir).map_err(|e| {
+        DeltaTableError::generic(format!(
+            "failed to create fixture dir {}: {e}",
+            dir.display()
+        ))
+    })?;
+
+    // Url::from_directory_path requires an absolute path; --out is often relative.
+    let dir = fs::canonicalize(dir)
+        .map_err(|e| DeltaTableError::generic(format!("canonicalize {}: {e}", dir.display())))?;
+
+    let table_url = Url::from_directory_path(&dir)
+        .map_err(|_| DeltaTableError::generic(format!("invalid table path: {}", dir.display())))?;
+
+    let schema = StructType::try_new(vec![
+        StructField::new("date", DataType::Primitive(PrimitiveType::String), false),
+        StructField::new("group", DataType::Primitive(PrimitiveType::String), false),
+        StructField::new("id", DataType::Primitive(PrimitiveType::Long), false),
+        StructField::new("value", DataType::Primitive(PrimitiveType::String), true),
+    ])?;
+
+    let mut table = DeltaTable::try_from_url(table_url)
+        .await?
+        .create()
+        .with_columns(schema.fields().cloned())
+        .with_partition_columns(["date", "group"])
+        .await?;
+
+    let start_day = days_ago_ymd(params.days.saturating_sub(1) as i64);
+    let mut global_id: i64 = 0;
+
+    for day_idx in 0..params.days {
+        let date = add_days(&start_day, day_idx as i64);
+        let batch = day_batch(
+            &date,
+            params.groups,
+            params.rows_per_partition,
+            &mut global_id,
+        )?;
+        table = table
+            .write(vec![batch])
+            .with_save_mode(SaveMode::Append)
+            .with_partition_columns(["date", "group"])
+            .await?;
+
+        if day_idx == 0 || day_idx + 1 == params.days || (day_idx + 1) % 10 == 0 {
+            eprintln!(
+                "vacuum fixture: committed day {}/{} ({date})",
+                day_idx + 1,
+                params.days
+            );
+        }
+    }
+
+    let meta = format!(
+        "days={}\ngroups={}\nrows_per_partition={}\npartitions_approx={}\n",
+        params.days,
+        params.groups,
+        params.rows_per_partition,
+        params.days.saturating_mul(params.groups)
+    );
+    fs::write(dir.join(FIXTURE_META), meta)
+        .map_err(|e| DeltaTableError::generic(format!("failed to write fixture meta: {e}")))?;
+
+    Ok(dir)
+}
+
+/// Open a previously generated fixture from the local filesystem.
+pub async fn open_vacuum_fixture(dir: &Path) -> DeltaResult<DeltaTable> {
+    open_vacuum_fixture_with_list_latency(dir, Duration::ZERO).await
+}
+
+/// Open a fixture, optionally wrapping the store so every LIST sleeps
+/// `list_latency` (simulates cloud LIST RTT on local disk).
+pub async fn open_vacuum_fixture_with_list_latency(
+    dir: &Path,
+    list_latency: Duration,
+) -> DeltaResult<DeltaTable> {
+    if !fixture_exists(dir) {
+        return Err(DeltaTableError::generic(format!(
+            "vacuum fixture not found at {} — run generate first",
+            dir.display()
+        )));
+    }
+    let dir = fs::canonicalize(dir)
+        .map_err(|e| DeltaTableError::generic(format!("canonicalize {}: {e}", dir.display())))?;
+    let table_url = Url::from_directory_path(&dir)
+        .map_err(|_| DeltaTableError::generic(format!("invalid table path: {}", dir.display())))?;
+
+    if list_latency.is_zero() {
+        return DeltaTableBuilder::from_url(table_url)?.load().await;
+    }
+
+    // Root-level local FS (not prefix-stripped). Table location in the URL
+    // selects the table path; LatencyStore only delays LIST-family calls.
+    let store = Arc::new(LatencyStore::new(
+        Arc::new(LocalFileSystem::new()),
+        list_latency,
+    ));
+    DeltaTableBuilder::from_url(table_url.clone())?
+        .with_storage_backend(store, table_url)
+        .load()
+        .await
+}
+
+/// Dry-run full vacuum once
+///
+/// Note: Clones `table` so the shared fixture can be reused across iterations.
+pub async fn run_vacuum_full_dry_run(
+    table: &DeltaTable,
+    mode: VacuumScanMode,
+    scan_concurrency: Option<usize>,
+) -> DeltaResult<(DeltaTable, VacuumMetrics)> {
+    let mut builder = table
+        .clone()
+        .vacuum()
+        .with_mode(VacuumMode::Full)
+        .with_dry_run(true)
+        .with_enforce_retention_duration(false)
+        // Listing-cost bench: retention 0. Live add files stay referenced so the
+        // delete set should be empty on a clean fixture (no planted orphans).
+        .with_retention_period(ChronoDuration::seconds(0));
+
+    if let Some(n) = scan_concurrency {
+        builder = builder.with_scan_concurrency(n);
+    }
+    if mode == VacuumScanMode::Flat {
+        builder = builder.disable_parallel_scan();
+    }
+
+    builder.await
+}
+
+fn day_batch(
+    date: &str,
+    groups: usize,
+    rows_per_partition: usize,
+    global_id: &mut i64,
+) -> DeltaResult<arrow::record_batch::RecordBatch> {
+    let n = groups.saturating_mul(rows_per_partition);
+    let mut dates = Vec::with_capacity(n);
+    let mut group_vals = Vec::with_capacity(n);
+    let mut ids = Vec::with_capacity(n);
+    let mut values = Vec::with_capacity(n);
+
+    for g in 0..groups {
+        let group = g.to_string();
+        for r in 0..rows_per_partition {
+            dates.push(date.to_string());
+            group_vals.push(group.clone());
+            ids.push(*global_id);
+            values.push(format!("v-{date}-{g}-{r}"));
+            *global_id += 1;
+        }
+    }
+
+    let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+        arrow::datatypes::Field::new("date", arrow::datatypes::DataType::Utf8, false),
+        arrow::datatypes::Field::new("group", arrow::datatypes::DataType::Utf8, false),
+        arrow::datatypes::Field::new("id", arrow::datatypes::DataType::Int64, false),
+        arrow::datatypes::Field::new("value", arrow::datatypes::DataType::Utf8, true),
+    ]));
+
+    Ok(arrow::record_batch::RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(arrow::array::StringArray::from(dates)),
+            Arc::new(arrow::array::StringArray::from(group_vals)),
+            Arc::new(arrow::array::Int64Array::from(ids)),
+            Arc::new(arrow::array::StringArray::from(values)),
+        ],
+    )?)
+}
+
+/// Calendar day string `YYYY-MM-DD` for `days_ago` days before today (UTC).
+fn days_ago_ymd(days_ago: i64) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    let secs = now - days_ago.saturating_mul(86_400);
+    format_utc_ymd(secs)
+}
+
+fn add_days(start_ymd: &str, days: i64) -> String {
+    let start_secs = parse_utc_ymd(start_ymd).unwrap_or(0);
+    format_utc_ymd(start_secs + days.saturating_mul(86_400))
+}
+
+fn parse_utc_ymd(s: &str) -> Option<i64> {
+    let mut parts = s.split('-');
+    let y: i32 = parts.next()?.parse().ok()?;
+    let m: u32 = parts.next()?.parse().ok()?;
+    let d: u32 = parts.next()?.parse().ok()?;
+    Some(ymd_to_unix_days(y, m, d).saturating_mul(86_400))
+}
+
+fn format_utc_ymd(unix_secs: i64) -> String {
+    let days = unix_secs.div_euclid(86_400);
+    let (y, m, d) = unix_days_to_ymd(days);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+fn ymd_to_unix_days(y: i32, m: u32, d: u32) -> i64 {
+    let y = y as i64;
+    let m = m as i64;
+    let d = d as i64;
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = y.div_euclid(400);
+    let yoe = y.rem_euclid(400);
+    let mp = if m > 2 { m - 3 } else { m + 9 };
+    let doy = (153 * mp + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+fn unix_days_to_ymd(days: i64) -> (i32, u32, u32) {
+    let z = days + 719468;
+    let era = z.div_euclid(146097);
+    let doe = z.rem_euclid(146097);
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as i32, m as u32, d as u32)
+}
+
+/// Default fixture directory under the benchmarks crate data folder.
+pub fn default_fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data/vacuum_bench/d30_g500")
+}

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -451,9 +451,10 @@ impl VacuumBuilder {
                         let tombstone_path_sets = Arc::clone(&tombstone_path_sets);
                         let partition_columns = Arc::clone(&partition_columns);
                         let scanned = Arc::clone(&leaf_scanned);
-                        async move {
-                            let prefix = prefix_res?;
-                            Ok::<_, DeltaTableError>(list_orphans_under_prefix(
+                        // Lazy leaf-list stream per prefix. LIST runs on poll;
+                        // concurrency comes from try_flatten_unordered below.
+                        prefix_res.map(|prefix| {
+                            list_orphans_under_prefix(
                                 store,
                                 prefix,
                                 valid_files,
@@ -463,11 +464,10 @@ impl VacuumBuilder {
                                 now_millis,
                                 retention_millis,
                                 scanned,
-                            ))
-                        }
+                            )
+                        })
                     })
-                    .buffer_unordered(scan_concurrency)
-                    .try_flatten()
+                    .try_flatten_unordered(scan_concurrency)
                     .try_for_each(|(path, size)| {
                         files_to_delete.push(path);
                         file_sizes.push(size);

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -23,11 +23,11 @@
 
 use std::collections::HashSet;
 use std::fmt::Debug;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use chrono::{Duration, Utc};
 use futures::future::{BoxFuture, ready};
-use futures::{StreamExt, TryStreamExt};
+use futures::{StreamExt, TryStreamExt, stream};
 use object_store::{Error, ObjectStore, path::Path};
 use serde::Serialize;
 use tracing::*;
@@ -43,6 +43,19 @@ use crate::protocol::DeltaOperation;
 use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 use crate::{DeltaTable, DeltaTableConfig};
+
+const DEFAULT_VACUUM_LIST_CONCURRENCY: usize = 256;
+
+fn vacuum_list_concurrency() -> usize {
+    static LIST_CONCURRENCY: OnceLock<usize> = OnceLock::new();
+    *LIST_CONCURRENCY.get_or_init(|| {
+        std::env::var("DELTARS_VACUUM_LIST_CONCURRENCY")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|&value| value > 0)
+            .unwrap_or(DEFAULT_VACUUM_LIST_CONCURRENCY)
+    })
+}
 
 /// Errors that can occur during vacuum
 #[derive(thiserror::Error, Debug)]
@@ -336,61 +349,100 @@ impl VacuumBuilder {
         if self.mode == VacuumMode::Full {
             let object_store = self.log_store.object_store(None);
 
-            let list_span = info_span!("list_files", operation = "vacuum");
-            let mut all_files = list_span.in_scope(|| object_store.list(None));
+            if should_try_parallel_vacuum(partition_columns) {
+                let valid_files = Arc::new(valid_files);
+                let keep_files = Arc::new(keep_files);
+                let tombstone_path_sets = Arc::new(tombstone_path_sets);
+                let partition_columns: Arc<Vec<String>> = Arc::new(partition_columns.to_vec());
+                let retention_millis = retention_period.num_milliseconds();
+                // Stop before the last partition column so leaf LIST targets are
+                // prefix paths of depth n-1 (e.g. date=…/), not the final fan-out
+                // (e.g. date=…/part=…/).
+                let partition_depth = partition_columns.len() - 1;
 
-            while let Some(obj_meta) = all_files.next().await {
-                // TODO should we allow NotFound here in case we have a temporary commit file in the list
-                let obj_meta = obj_meta.map_err(DeltaTableError::from)?;
-                if tombstone_path_sets
-                    .expired_tombstone_paths
-                    .contains(&obj_meta.location)
-                {
-                    debug!(
-                        "The file {:?} is already queued as an expired tombstone",
-                        &obj_meta.location,
-                    );
-                    continue;
+                let parallel_span =
+                    info_span!("list_files_parallel", operation = "vacuum", partition_depth,);
+                async {
+                    // Walk n-1 delimiter levels. Leaf list(prefix) then covers
+                    // the last partition column in bulk under each prefix.
+                    // Objects found at intermediate levels are considered immediately.
+                    let (leaf_prefixes, intermediate_orphans, intermediate_scanned) =
+                        expand_partition_prefixes(
+                            object_store.as_ref(),
+                            partition_depth,
+                            &valid_files,
+                            &keep_files,
+                            &partition_columns,
+                            &tombstone_path_sets,
+                            now_millis,
+                            retention_millis,
+                        )
+                        .await?;
+
+                    file_count += intermediate_scanned;
+                    for (path, size) in intermediate_orphans {
+                        files_to_delete.push(path);
+                        file_sizes.push(size);
+                    }
+
+                    let listed: Vec<(Vec<(Path, i64)>, usize)> = stream::iter(leaf_prefixes)
+                        .map(|prefix| {
+                            let store = object_store.clone();
+                            let valid_files = Arc::clone(&valid_files);
+                            let keep_files = Arc::clone(&keep_files);
+                            let tombstone_path_sets = Arc::clone(&tombstone_path_sets);
+                            let partition_columns = Arc::clone(&partition_columns);
+                            async move {
+                                list_orphans_under_prefix(
+                                    store.as_ref(),
+                                    Some(&prefix),
+                                    &valid_files,
+                                    &keep_files,
+                                    &partition_columns,
+                                    &tombstone_path_sets,
+                                    now_millis,
+                                    retention_millis,
+                                )
+                                .await
+                            }
+                        })
+                        .buffer_unordered(vacuum_list_concurrency())
+                        .try_collect()
+                        .await?;
+
+                    for (orphans, scanned) in listed {
+                        file_count += scanned;
+                        for (path, size) in orphans {
+                            files_to_delete.push(path);
+                            file_sizes.push(size);
+                        }
+                    }
+
+                    Ok::<_, VacuumError>(())
                 }
+                .instrument(parallel_span)
+                .await?;
+            } else {
+                let list_span = info_span!("list_files", operation = "vacuum");
+                let mut all_files = list_span.in_scope(|| object_store.list(None));
 
-                if !ok_to_delete(
-                    &obj_meta.location,
-                    &valid_files,
-                    &keep_files,
-                    partition_columns,
-                )? {
-                    continue;
+                while let Some(obj_meta) = all_files.next().await {
+                    // TODO should we allow NotFound here in case we have a temporary commit file in the list
+                    let obj_meta = obj_meta.map_err(DeltaTableError::from)?;
+                    if let Some((path, size)) = consider_orphan_for_deletion(
+                        &obj_meta,
+                        &valid_files,
+                        &keep_files,
+                        partition_columns,
+                        &tombstone_path_sets,
+                        now_millis,
+                        retention_period.num_milliseconds(),
+                    )? {
+                        files_to_delete.push(path);
+                        file_sizes.push(size);
+                        file_count += 1;
+                    }
                 }
-
-                if tombstone_path_sets
-                    .all_tombstone_paths
-                    .contains(&obj_meta.location)
-                {
-                    debug!(
-                        "The file {:?} has a recent tombstone, keeping it until tombstone retention expires",
-                        &obj_meta.location,
-                    );
-                    continue;
-                }
-
-                // At this point the path is untracked by the Delta log, so full mode falls back
-                // to physical object age to protect recent concurrent-writer output.
-                let file_age_millis = now_millis - obj_meta.last_modified.timestamp_millis();
-                if file_age_millis < retention_period.num_milliseconds() {
-                    debug!(
-                        "The file {:?} is an untracked recent file, protecting it from vacuum",
-                        &obj_meta.location,
-                    );
-                    continue;
-                }
-
-                debug!(
-                    "The file {:?} is an untracked stale orphan and will be vacuumed in full mode",
-                    &obj_meta.location
-                );
-                files_to_delete.push(obj_meta.location);
-                file_sizes.push(obj_meta.size as i64);
-                file_count += 1;
             }
         }
         info!(
@@ -605,6 +657,203 @@ fn ok_to_delete(
     )
 }
 
+/// Decide whether a listed object is an orphan eligible for full-mode vacuum.
+///
+/// Returns `Some((path, size))` when the object should be deleted, or `None`
+/// when it is still referenced, kept, hidden, recently tombstoned, or too new.
+fn consider_orphan_for_deletion(
+    obj_meta: &object_store::ObjectMeta,
+    valid_files: &HashSet<Path>,
+    keep_files: &HashSet<String>,
+    partition_columns: &[String],
+    tombstone_path_sets: &TombstonePathSets,
+    now_millis: i64,
+    retention_millis: i64,
+) -> Result<Option<(Path, i64)>, DeltaTableError> {
+    if tombstone_path_sets
+        .expired_tombstone_paths
+        .contains(&obj_meta.location)
+    {
+        debug!(
+            "The file {:?} is already queued as an expired tombstone",
+            &obj_meta.location,
+        );
+        return Ok(None);
+    }
+
+    if !ok_to_delete(
+        &obj_meta.location,
+        valid_files,
+        keep_files,
+        partition_columns,
+    )? {
+        return Ok(None);
+    }
+
+    if tombstone_path_sets
+        .all_tombstone_paths
+        .contains(&obj_meta.location)
+    {
+        debug!(
+            "The file {:?} has a recent tombstone, keeping it until tombstone retention expires",
+            &obj_meta.location,
+        );
+        return Ok(None);
+    }
+
+    // At this point the path is untracked by the Delta log, so full mode falls back
+    // to physical object age to protect recent concurrent-writer output.
+    let file_age_millis = now_millis - obj_meta.last_modified.timestamp_millis();
+    if file_age_millis < retention_millis {
+        debug!(
+            "The file {:?} is an untracked recent file, protecting it from vacuum",
+            &obj_meta.location,
+        );
+        return Ok(None);
+    }
+
+    debug!(
+        "The file {:?} is an untracked stale orphan and will be vacuumed in full mode",
+        &obj_meta.location
+    );
+    Ok(Some((obj_meta.location.clone(), obj_meta.size as i64)))
+}
+
+/// Root prefixes that should not be expanded during full-mode partition walks.
+fn is_skippable_root_prefix(path: &Path) -> bool {
+    let path_name = path.to_string();
+    path_name == "_delta_log" || path_name.starts_with("_delta_log/") || path_name.starts_with('.')
+}
+
+/// Walk `partition_depth` delimiter levels and collect leaf partition prefixes.
+///
+/// Objects found at intermediate levels are evaluated immediately. Returns
+/// `(leaf_prefixes, intermediate_orphans, intermediate_files_scanned)`.
+async fn expand_partition_prefixes(
+    store: &dyn ObjectStore,
+    partition_depth: usize,
+    valid_files: &HashSet<Path>,
+    keep_files: &HashSet<String>,
+    partition_columns: &[String],
+    tombstone_path_sets: &TombstonePathSets,
+    now_millis: i64,
+    retention_millis: i64,
+) -> Result<(Vec<Path>, Vec<(Path, i64)>, usize), DeltaTableError> {
+    let mut orphans = Vec::new();
+    let mut scanned = 0usize;
+    let mut to_expand: Vec<Option<Path>> = vec![None];
+
+    for level in 0..partition_depth {
+        let listings = stream::iter(to_expand)
+            .map(|prefix| {
+                let prefix_label = prefix
+                    .as_ref()
+                    .map(|p| p.as_ref())
+                    .unwrap_or("")
+                    .to_string();
+                async move {
+                    let listing = async {
+                        store
+                            .list_with_delimiter(prefix.as_ref())
+                            .await
+                            .map_err(DeltaTableError::from)
+                    }
+                    .instrument(info_span!(
+                        "list_with_delimiter",
+                        operation = "vacuum",
+                        level,
+                        prefix = prefix_label,
+                    ))
+                    .await?;
+
+                    Ok::<_, DeltaTableError>(listing)
+                }
+            })
+            .buffer_unordered(vacuum_list_concurrency())
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let mut next_frontier = Vec::new();
+        for listing in listings {
+            // Collect orphans at this level if any objects are found
+            // although there should be none
+            for obj_meta in listing.objects {
+                scanned += 1;
+                if let Some(entry) = consider_orphan_for_deletion(
+                    &obj_meta,
+                    valid_files,
+                    keep_files,
+                    partition_columns,
+                    tombstone_path_sets,
+                    now_millis,
+                    retention_millis,
+                )? {
+                    orphans.push(entry);
+                }
+            }
+
+            for child in listing.common_prefixes {
+                if level == 0 && is_skippable_root_prefix(&child) {
+                    continue;
+                }
+                next_frontier.push(Some(child));
+            }
+        }
+
+        to_expand = next_frontier;
+    }
+
+    let leaf_prefixes = to_expand.into_iter().flatten().collect();
+    Ok((leaf_prefixes, orphans, scanned))
+}
+
+/// Recursively list `prefix` and return orphans eligible for full-mode vacuum.
+///
+/// Returns `(orphans, files_scanned)`.
+async fn list_orphans_under_prefix(
+    store: &dyn ObjectStore,
+    prefix: Option<&Path>,
+    valid_files: &HashSet<Path>,
+    keep_files: &HashSet<String>,
+    partition_columns: &[String],
+    tombstone_path_sets: &TombstonePathSets,
+    now_millis: i64,
+    retention_millis: i64,
+) -> Result<(Vec<(Path, i64)>, usize), DeltaTableError> {
+    let prefix_label = prefix.map(|p| p.as_ref()).unwrap_or("");
+    async {
+        let mut files = store.list(prefix);
+        let mut orphans = Vec::new();
+        let mut scanned = 0usize;
+
+        while let Some(obj_meta) = files.next().await {
+            // TODO should we allow NotFound here in case we have a temporary commit file in the list
+            let obj_meta = obj_meta.map_err(DeltaTableError::from)?;
+            scanned += 1;
+            if let Some(entry) = consider_orphan_for_deletion(
+                &obj_meta,
+                valid_files,
+                keep_files,
+                partition_columns,
+                tombstone_path_sets,
+                now_millis,
+                retention_millis,
+            )? {
+                orphans.push(entry);
+            }
+        }
+
+        Ok((orphans, scanned))
+    }
+    .instrument(info_span!(
+        "list_files",
+        operation = "vacuum",
+        mode = "parallel",
+        prefix = prefix_label,
+    ))
+    .await
+}
+
 async fn collect_full_mode_tombstones(
     snapshot: &EagerSnapshot,
     tombstone_retention_timestamp: i64,
@@ -651,6 +900,12 @@ async fn get_stale_files(
 
 fn is_tombstone_expired(tombstone: &TombstoneView, tombstone_retention_timestamp: i64) -> bool {
     tombstone.deletion_timestamp().unwrap_or(0) < tombstone_retention_timestamp
+}
+
+fn should_try_parallel_vacuum(partition_columns: &[String]) -> bool {
+    // Single-level partitions: flat list(None) is cheaper than expand-to-leaves
+    // when cardinality is high and leaves are tiny. Multi-level: expand to n-1.
+    partition_columns.len() > 1
 }
 
 #[cfg(test)]

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -136,6 +136,9 @@ pub struct VacuumBuilder {
     ///
     /// `None` uses [`default_vacuum_list_concurrency`] (env or built-in default).
     scan_concurrency: Option<usize>,
+    /// When true, force the flat `list(None)` full-mode scan even for multi-level
+    /// partitioned tables (disables the default parallel prefix-expansion path).
+    disable_parallel_scan: bool,
     /// Override the source of time
     clock: Option<Arc<dyn Clock>>,
     /// Additional information to add to the commit
@@ -194,6 +197,7 @@ impl VacuumBuilder {
             dry_run: false,
             mode: VacuumMode::Lite,
             scan_concurrency: None,
+            disable_parallel_scan: false,
             clock: None,
             commit_properties: CommitProperties::default(),
             custom_execute_handler: None,
@@ -220,6 +224,17 @@ impl VacuumBuilder {
     /// Values of `0` are ignored and fall back to that default resolution.
     pub fn with_scan_concurrency(mut self, concurrency: usize) -> Self {
         self.scan_concurrency = Some(concurrency);
+        self
+    }
+
+    /// Disable the parallel multi-level partition scan used by full-mode vacuum.
+    ///
+    /// By default, tables with more than one partition column use hierarchical
+    /// prefix expansion and concurrent leaf LIST calls. Calling this forces the
+    /// flat `list(None)` scan path instead (useful for comparison, debugging, or
+    /// working around store rate limits).
+    pub fn disable_parallel_scan(mut self) -> Self {
+        self.disable_parallel_scan = true;
         self
     }
 
@@ -382,7 +397,7 @@ impl VacuumBuilder {
         if self.mode == VacuumMode::Full {
             let object_store = self.log_store.object_store(None);
 
-            if should_try_parallel_vacuum(partition_columns) {
+            if !self.disable_parallel_scan && should_try_parallel_vacuum(partition_columns) {
                 let valid_files = Arc::new(valid_files);
                 let keep_files = Arc::new(keep_files);
                 let tombstone_path_sets = Arc::new(tombstone_path_sets);
@@ -1623,6 +1638,33 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_disable_parallel_scan_builder() -> DeltaResult<()> {
+        let table_path = std::path::Path::new("../test/tests/data/simple_commit");
+        let table_uri =
+            Url::from_directory_path(std::fs::canonicalize(table_path).unwrap()).unwrap();
+        let table = open_table(table_uri).await?;
+
+        let multi_level = ["date".to_string(), "group".to_string()];
+        assert!(should_try_parallel_vacuum(&multi_level));
+
+        let builder =
+            VacuumBuilder::new(table.log_store(), Some(table.snapshot()?.snapshot.clone()));
+        // Parallel scan is enabled by default for multi-level tables.
+        assert!(!builder.disable_parallel_scan);
+        let use_parallel =
+            !builder.disable_parallel_scan && should_try_parallel_vacuum(&multi_level);
+        assert!(use_parallel);
+
+        let builder = builder.disable_parallel_scan();
+        assert!(builder.disable_parallel_scan);
+        let use_parallel =
+            !builder.disable_parallel_scan && should_try_parallel_vacuum(&multi_level);
+        assert!(!use_parallel);
+
+        Ok(())
+    }
+
     fn make_object_meta(
         path: &str,
         last_modified_millis: i64,
@@ -2042,13 +2084,18 @@ mod tests {
         Ok(())
     }
 
-    /// Exercises the hierarchical parallel-listing path used for multi-level
-    /// partitioned tables (`should_try_parallel_vacuum` / `expand_partition_prefixes`
-    /// / `list_orphans_under_prefix`), covering orphans found at the table root
-    /// (intermediate level), directly under the first partition level, and nested
-    /// under the leaf partition directory.
-    #[tokio::test]
-    async fn test_vacuum_full_parallel_multi_level_partitions() -> DeltaResult<()> {
+    /// Shared multi-level full-vacuum fixture: 2 partition columns, tracked data
+    /// file, stale orphans at root/mid/leaf, and one recent protected orphan.
+    async fn multi_level_full_vacuum_fixture() -> DeltaResult<(
+        tempfile::TempDir,
+        crate::DeltaTable,
+        i64,
+        Vec<String>,
+        String,
+        String,
+        String,
+        String,
+    )> {
         let temp_dir = tempfile::tempdir().unwrap();
         let table_path = temp_dir.path().to_str().unwrap();
         let partition_cols = vec!["modified".to_string(), "id".to_string()];
@@ -2076,30 +2123,87 @@ mod tests {
             .collect();
         assert_eq!(valid_paths.len(), 1);
 
-        // Orphan directly at the table root: exercises the "intermediate orphan"
-        // branch inside expand_partition_prefixes.
-        let root_orphan = "orphan-root.parquet";
-        std::fs::write(temp_dir.path().join(root_orphan), b"root orphan").unwrap();
-        set_last_modified(&temp_dir.path().join(root_orphan), stale_time);
+        let root_orphan = "orphan-root.parquet".to_string();
+        std::fs::write(temp_dir.path().join(&root_orphan), b"root orphan").unwrap();
+        set_last_modified(&temp_dir.path().join(&root_orphan), stale_time);
 
-        // Orphan directly under the first (non-final) partition level: exercises
-        // list_orphans_under_prefix recursing under a leaf prefix.
         let modified_prefix = "modified=2021-02-01";
         let mid_orphan = format!("{modified_prefix}/orphan-mid.parquet");
         std::fs::write(temp_dir.path().join(&mid_orphan), b"mid orphan").unwrap();
         set_last_modified(&temp_dir.path().join(&mid_orphan), stale_time);
 
-        // Orphan nested under the leaf (final) partition directory.
         let deep_dir = format!("{modified_prefix}/id=A");
         let deep_orphan = format!("{deep_dir}/orphan-deep.parquet");
         std::fs::write(temp_dir.path().join(&deep_orphan), b"deep orphan").unwrap();
         set_last_modified(&temp_dir.path().join(&deep_orphan), stale_time);
 
-        // Recent orphan that must be protected because it is younger than the
-        // retention period.
         let recent_orphan = format!("{deep_dir}/orphan-recent.parquet");
         std::fs::write(temp_dir.path().join(&recent_orphan), b"recent orphan").unwrap();
         set_last_modified(&temp_dir.path().join(&recent_orphan), recent_time);
+
+        Ok((
+            temp_dir,
+            table,
+            current_time_millis,
+            valid_paths,
+            root_orphan,
+            mid_orphan,
+            deep_orphan,
+            recent_orphan,
+        ))
+    }
+
+    fn assert_multi_level_vacuum_result(
+        result: &VacuumMetrics,
+        root_orphan: &str,
+        mid_orphan: &str,
+        deep_orphan: &str,
+        recent_orphan: &str,
+        valid_paths: &[String],
+    ) {
+        for expected in [root_orphan, mid_orphan, deep_orphan] {
+            assert!(
+                result.files_deleted.contains(&expected.to_string()),
+                "expected {expected} to be vacuumed: {:?}",
+                result.files_deleted
+            );
+        }
+        assert!(
+            !result.files_deleted.contains(&recent_orphan.to_string()),
+            "recent orphan should be protected: {:?}",
+            result.files_deleted
+        );
+        for valid in valid_paths {
+            assert!(
+                !result.files_deleted.contains(valid),
+                "valid tracked file should never be vacuumed: {valid}"
+            );
+        }
+    }
+
+    /// Exercises the hierarchical parallel-listing path used for multi-level
+    /// partitioned tables (`should_try_parallel_vacuum` / `expand_partition_prefixes`
+    /// / `list_orphans_under_prefix`), covering orphans found at the table root
+    /// (intermediate level), directly under the first partition level, and nested
+    /// under the leaf partition directory.
+    #[tokio::test]
+    async fn test_vacuum_full_parallel_multi_level_partitions() -> DeltaResult<()> {
+        let (
+            _temp_dir,
+            table,
+            current_time_millis,
+            valid_paths,
+            root_orphan,
+            mid_orphan,
+            deep_orphan,
+            recent_orphan,
+        ) = multi_level_full_vacuum_fixture().await?;
+
+        assert!(!should_try_parallel_vacuum(&[]));
+        assert!(should_try_parallel_vacuum(&[
+            "modified".to_string(),
+            "id".to_string()
+        ]));
 
         let (_table, result) =
             VacuumBuilder::new(table.log_store(), Some(table.snapshot()?.snapshot.clone()))
@@ -2110,29 +2214,99 @@ mod tests {
                 .with_clock(Arc::new(MockClock::new(current_time_millis)))
                 .await?;
 
-        for expected in [
-            root_orphan.to_string(),
-            mid_orphan.clone(),
-            deep_orphan.clone(),
-        ] {
-            assert!(
-                result.files_deleted.contains(&expected),
-                "expected {expected} to be vacuumed: {:?}",
-                result.files_deleted
-            );
-        }
-        assert!(
-            !result.files_deleted.contains(&recent_orphan),
-            "recent orphan should be protected: {:?}",
-            result.files_deleted
+        assert_multi_level_vacuum_result(
+            &result,
+            &root_orphan,
+            &mid_orphan,
+            &deep_orphan,
+            &recent_orphan,
+            &valid_paths,
         );
-        for valid in &valid_paths {
-            assert!(
-                !result.files_deleted.contains(valid),
-                "valid tracked file should never be vacuumed: {valid}"
-            );
-        }
+        Ok(())
+    }
 
+    /// Same multi-level fixture as the parallel test, but with
+    /// [`VacuumBuilder::disable_parallel_scan`] forcing the flat `list(None)`
+    /// path. Results must match the parallel path.
+    #[tokio::test]
+    async fn test_vacuum_full_flat_scan_with_disable_parallel_scan() -> DeltaResult<()> {
+        let (
+            _temp_dir,
+            table,
+            current_time_millis,
+            valid_paths,
+            root_orphan,
+            mid_orphan,
+            deep_orphan,
+            recent_orphan,
+        ) = multi_level_full_vacuum_fixture().await?;
+
+        let builder =
+            VacuumBuilder::new(table.log_store(), Some(table.snapshot()?.snapshot.clone()))
+                .with_retention_period(Duration::seconds(5))
+                .with_dry_run(true)
+                .with_mode(VacuumMode::Full)
+                .with_enforce_retention_duration(false)
+                .disable_parallel_scan()
+                .with_clock(Arc::new(MockClock::new(current_time_millis)));
+        assert!(builder.disable_parallel_scan);
+
+        let (_table, result) = builder.await?;
+
+        assert_multi_level_vacuum_result(
+            &result,
+            &root_orphan,
+            &mid_orphan,
+            &deep_orphan,
+            &recent_orphan,
+            &valid_paths,
+        );
+        Ok(())
+    }
+
+    /// Parallel and flat full-mode scans on the same multi-level table must
+    /// select the same delete set.
+    #[tokio::test]
+    async fn test_vacuum_full_parallel_and_flat_agree() -> DeltaResult<()> {
+        let (
+            _temp_dir,
+            table,
+            current_time_millis,
+            _valid_paths,
+            _root_orphan,
+            _mid_orphan,
+            _deep_orphan,
+            _recent_orphan,
+        ) = multi_level_full_vacuum_fixture().await?;
+
+        let clock: Arc<dyn Clock> = Arc::new(MockClock::new(current_time_millis));
+        let snapshot = table.snapshot()?.snapshot.clone();
+
+        let (_t1, parallel) = VacuumBuilder::new(table.log_store(), Some(snapshot.clone()))
+            .with_retention_period(Duration::seconds(5))
+            .with_dry_run(true)
+            .with_mode(VacuumMode::Full)
+            .with_enforce_retention_duration(false)
+            .with_clock(Arc::clone(&clock))
+            .await?;
+
+        let (_t2, flat) = VacuumBuilder::new(table.log_store(), Some(snapshot))
+            .with_retention_period(Duration::seconds(5))
+            .with_dry_run(true)
+            .with_mode(VacuumMode::Full)
+            .with_enforce_retention_duration(false)
+            .disable_parallel_scan()
+            .with_clock(clock)
+            .await?;
+
+        let mut parallel_files = parallel.files_deleted;
+        let mut flat_files = flat.files_deleted;
+        parallel_files.sort();
+        flat_files.sort();
+        assert_eq!(
+            parallel_files, flat_files,
+            "parallel and flat full scans must agree on delete set"
+        );
         Ok(())
     }
 }

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -85,6 +85,10 @@ enum VacuumError {
     /// Error returned
     #[error(transparent)]
     DeltaTable(#[from] DeltaTableError),
+
+    /// Failed while collecting orphaned files during the full-mode scan.
+    #[error("Failed to scan for orphaned files: {0}")]
+    OrphanScanError(String),
 }
 
 impl From<VacuumError> for DeltaTableError {
@@ -136,9 +140,10 @@ pub struct VacuumBuilder {
     ///
     /// `None` uses [`default_vacuum_list_concurrency`] (env or built-in default).
     scan_concurrency: Option<usize>,
-    /// When true, force the flat `list(None)` full-mode scan even for multi-level
-    /// partitioned tables (disables the default parallel prefix-expansion path).
-    disable_parallel_scan: bool,
+    /// By default, true. If true, it will scan the files parallelizing
+    /// through prefix-expansion path, otherwise, if false it will use
+    /// flat `list(None)` full-mode scan.
+    parallel_scan: bool,
     /// Override the source of time
     clock: Option<Arc<dyn Clock>>,
     /// Additional information to add to the commit
@@ -197,7 +202,7 @@ impl VacuumBuilder {
             dry_run: false,
             mode: VacuumMode::Lite,
             scan_concurrency: None,
-            disable_parallel_scan: false,
+            parallel_scan: true,
             clock: None,
             commit_properties: CommitProperties::default(),
             custom_execute_handler: None,
@@ -227,14 +232,13 @@ impl VacuumBuilder {
         self
     }
 
-    /// Disable the parallel multi-level partition scan used by full-mode vacuum.
+    /// Flag to enable/disable the parallel multi-level partition scan used by full-mode vacuum.
     ///
     /// By default, tables with more than one partition column use hierarchical
-    /// prefix expansion and concurrent leaf LIST calls. Calling this forces the
-    /// flat `list(None)` scan path instead (useful for comparison, debugging, or
-    /// working around store rate limits).
-    pub fn disable_parallel_scan(mut self) -> Self {
-        self.disable_parallel_scan = true;
+    /// prefix expansion and concurrent leaf LIST calls. Calling this with `false` forces the
+    /// flat `list(None)` scan path instead.
+    pub fn parallel_scan(mut self, parallel_scan: bool) -> Self {
+        self.parallel_scan = parallel_scan;
         self
     }
 
@@ -397,7 +401,7 @@ impl VacuumBuilder {
         if self.mode == VacuumMode::Full {
             let object_store = self.log_store.object_store(None);
 
-            if !self.disable_parallel_scan && should_try_parallel_vacuum(partition_columns) {
+            if self.parallel_scan && should_try_parallel_vacuum(partition_columns) {
                 let valid_files = Arc::new(valid_files);
                 let keep_files = Arc::new(keep_files);
                 let tombstone_path_sets = Arc::new(tombstone_path_sets);
@@ -441,7 +445,13 @@ impl VacuumBuilder {
                         Arc::clone(&expand_scanned),
                         scan_concurrency,
                         move |path, size| {
-                            intermediate_orphans_cb.lock().unwrap().push((path, size));
+                            intermediate_orphans_cb
+                                .lock()
+                                .map_err(|_| {
+                                    VacuumError::OrphanScanError("Failed to lock mutex".to_string())
+                                })?
+                                .push((path, size));
+                            Ok(())
                         },
                     )
                     .map(|prefix_res| {
@@ -475,7 +485,11 @@ impl VacuumBuilder {
                     })
                     .await?;
 
-                    for (path, size) in intermediate_orphans.lock().unwrap().drain(..) {
+                    let mut intermediate = intermediate_orphans.lock().map_err(|_| {
+                        VacuumError::OrphanScanError("Failed to lock mutex".to_string())
+                    })?;
+
+                    for (path, size) in intermediate.drain(..) {
                         files_to_delete.push(path);
                         file_sizes.push(size);
                     }
@@ -697,7 +711,7 @@ impl TombstonePathSets {
 /// deleted even if they'd normally be hidden. The _db_index directory contains (bloom filter)
 /// indexes and these must be deleted when the data they are tied to is deleted.
 fn is_hidden_directory(partition_columns: &[String], path: &Path) -> Result<bool, DeltaTableError> {
-    let path_name = path.to_string();
+    let path_name = path.as_ref();
     Ok((path_name.starts_with('.') || path_name.starts_with('_'))
         && !path_name.starts_with("_delta_index")
         && !path_name.starts_with("_change_data")
@@ -786,7 +800,7 @@ fn consider_orphan_for_deletion(
 
 /// Root prefixes that should not be expanded during full-mode partition walks.
 fn is_skippable_root_prefix(path: &Path) -> bool {
-    let path_name = path.to_string();
+    let path_name = path.as_ref();
     path_name == "_delta_log" || path_name.starts_with("_delta_log/") || path_name.starts_with('.')
 }
 
@@ -808,7 +822,7 @@ fn expand_partition_prefixes(
     retention_millis: i64,
     scanned: Arc<AtomicUsize>,
     scan_concurrency: usize,
-    mut on_intermediate_orphan: impl FnMut(Path, i64) + Send + 'static,
+    mut on_intermediate_orphan: impl FnMut(Path, i64) -> Result<(), DeltaTableError> + Send + 'static,
 ) -> impl Stream<Item = Result<Path, DeltaTableError>> {
     let (mut tx, rx) = mpsc::channel(scan_concurrency.saturating_mul(4).max(16));
 
@@ -857,7 +871,12 @@ fn expand_partition_prefixes(
                                 now_millis,
                                 retention_millis,
                             ) {
-                                Ok(Some((path, size))) => on_intermediate_orphan(path, size),
+                                Ok(Some((path, size))) => {
+                                    if let Err(e) = on_intermediate_orphan(path, size) {
+                                        let _ = tx.send(Err(e)).await;
+                                        return;
+                                    }
+                                }
                                 Ok(None) => {}
                                 Err(e) => {
                                     let _ = tx.send(Err(e)).await;
@@ -1639,7 +1658,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_disable_parallel_scan_builder() -> DeltaResult<()> {
+    async fn test_parallel_scan_builder() -> DeltaResult<()> {
         let table_path = std::path::Path::new("../test/tests/data/simple_commit");
         let table_uri =
             Url::from_directory_path(std::fs::canonicalize(table_path).unwrap()).unwrap();
@@ -1651,15 +1670,13 @@ mod tests {
         let builder =
             VacuumBuilder::new(table.log_store(), Some(table.snapshot()?.snapshot.clone()));
         // Parallel scan is enabled by default for multi-level tables.
-        assert!(!builder.disable_parallel_scan);
-        let use_parallel =
-            !builder.disable_parallel_scan && should_try_parallel_vacuum(&multi_level);
+        assert!(builder.parallel_scan);
+        let use_parallel = builder.parallel_scan && should_try_parallel_vacuum(&multi_level);
         assert!(use_parallel);
 
-        let builder = builder.disable_parallel_scan();
-        assert!(builder.disable_parallel_scan);
-        let use_parallel =
-            !builder.disable_parallel_scan && should_try_parallel_vacuum(&multi_level);
+        let builder = builder.parallel_scan(false);
+        assert!(!builder.parallel_scan);
+        let use_parallel = builder.parallel_scan && should_try_parallel_vacuum(&multi_level);
         assert!(!use_parallel);
 
         Ok(())
@@ -1876,7 +1893,10 @@ mod tests {
             0,
             Arc::clone(&scanned),
             DEFAULT_VACUUM_LIST_CONCURRENCY,
-            move |path, size| orphans_cb.lock().unwrap().push((path, size)),
+            move |path, size| {
+                orphans_cb.lock().unwrap().push((path, size));
+                Ok(())
+            },
         )
         .try_collect::<Vec<_>>()
         .await?;
@@ -1945,7 +1965,10 @@ mod tests {
             0,
             Arc::clone(&scanned),
             DEFAULT_VACUUM_LIST_CONCURRENCY,
-            move |path, size| orphans_cb.lock().unwrap().push((path, size)),
+            move |path, size| {
+                orphans_cb.lock().unwrap().push((path, size));
+                Ok(())
+            },
         )
         .try_collect::<Vec<_>>()
         .await?;
@@ -2226,7 +2249,7 @@ mod tests {
     }
 
     /// Same multi-level fixture as the parallel test, but with
-    /// [`VacuumBuilder::disable_parallel_scan`] forcing the flat `list(None)`
+    /// [`VacuumBuilder::parallel_scan`] forcing the flat `list(None)`
     /// path. Results must match the parallel path.
     #[tokio::test]
     async fn test_vacuum_full_flat_scan_with_disable_parallel_scan() -> DeltaResult<()> {
@@ -2247,9 +2270,9 @@ mod tests {
                 .with_dry_run(true)
                 .with_mode(VacuumMode::Full)
                 .with_enforce_retention_duration(false)
-                .disable_parallel_scan()
+                .parallel_scan(false)
                 .with_clock(Arc::new(MockClock::new(current_time_millis)));
-        assert!(builder.disable_parallel_scan);
+        assert!(!builder.parallel_scan);
 
         let (_table, result) = builder.await?;
 
@@ -2295,7 +2318,7 @@ mod tests {
             .with_dry_run(true)
             .with_mode(VacuumMode::Full)
             .with_enforce_retention_duration(false)
-            .disable_parallel_scan()
+            .parallel_scan(false)
             .with_clock(clock)
             .await?;
 

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -23,11 +23,13 @@
 
 use std::collections::HashSet;
 use std::fmt::Debug;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use chrono::{Duration, Utc};
+use futures::channel::mpsc;
 use futures::future::{BoxFuture, ready};
-use futures::{StreamExt, TryStreamExt, stream};
+use futures::{SinkExt, Stream, StreamExt, TryStreamExt, stream};
 use object_store::{Error, ObjectStore, path::Path};
 use serde::Serialize;
 use tracing::*;
@@ -44,9 +46,12 @@ use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 use crate::{DeltaTable, DeltaTableConfig};
 
-const DEFAULT_VACUUM_LIST_CONCURRENCY: usize = 256;
+const DEFAULT_VACUUM_LIST_CONCURRENCY: usize = 10;
 
-fn vacuum_list_concurrency() -> usize {
+/// Default scan concurrency from env (`DELTARS_VACUUM_LIST_CONCURRENCY`) or built-in default.
+///
+/// Cached process-wide. Prefer [`VacuumBuilder::with_scan_concurrency`] for per-operation control.
+fn default_vacuum_list_concurrency() -> usize {
     static LIST_CONCURRENCY: OnceLock<usize> = OnceLock::new();
     *LIST_CONCURRENCY.get_or_init(|| {
         std::env::var("DELTARS_VACUUM_LIST_CONCURRENCY")
@@ -55,6 +60,12 @@ fn vacuum_list_concurrency() -> usize {
             .filter(|&value| value > 0)
             .unwrap_or(DEFAULT_VACUUM_LIST_CONCURRENCY)
     })
+}
+
+fn resolve_scan_concurrency(override_value: Option<usize>) -> usize {
+    override_value
+        .filter(|&value| value > 0)
+        .unwrap_or_else(default_vacuum_list_concurrency)
 }
 
 /// Errors that can occur during vacuum
@@ -121,6 +132,10 @@ pub struct VacuumBuilder {
     dry_run: bool,
     /// Mode of vacuum that should be run
     mode: VacuumMode,
+    /// Max concurrent object-store LIST operations during full-mode scan.
+    ///
+    /// `None` uses [`default_vacuum_list_concurrency`] (env or built-in default).
+    scan_concurrency: Option<usize>,
     /// Override the source of time
     clock: Option<Arc<dyn Clock>>,
     /// Additional information to add to the commit
@@ -178,6 +193,7 @@ impl VacuumBuilder {
             keep_versions: None,
             dry_run: false,
             mode: VacuumMode::Lite,
+            scan_concurrency: None,
             clock: None,
             commit_properties: CommitProperties::default(),
             custom_execute_handler: None,
@@ -187,6 +203,23 @@ impl VacuumBuilder {
     /// Override the default retention period for which files are deleted.
     pub fn with_retention_period(mut self, retention_period: Duration) -> Self {
         self.retention_period = Some(retention_period);
+        self
+    }
+
+    /// Set the maximum number of concurrent object-store LIST operations used
+    /// during full-mode vacuum scanning (partition prefix expansion and leaf
+    /// orphan listing).
+    ///
+    /// Higher values can speed up scans on high-latency object stores but may
+    /// trigger throttling (e.g. HTTP 429/503). LIST retries/backoff are handled
+    /// by the underlying object store's [`object_store::RetryConfig`], not by
+    /// vacuum itself—if a LIST ultimately fails, the vacuum operation fails.
+    ///
+    /// When unset, concurrency is taken from the `DELTARS_VACUUM_LIST_CONCURRENCY`
+    /// environment variable if set to a positive integer, otherwise defaults to 10.
+    /// Values of `0` are ignored and fall back to that default resolution.
+    pub fn with_scan_concurrency(mut self, concurrency: usize) -> Self {
+        self.scan_concurrency = Some(concurrency);
         self
     }
 
@@ -355,68 +388,85 @@ impl VacuumBuilder {
                 let tombstone_path_sets = Arc::new(tombstone_path_sets);
                 let partition_columns: Arc<Vec<String>> = Arc::new(partition_columns.to_vec());
                 let retention_millis = retention_period.num_milliseconds();
+                let scan_concurrency = resolve_scan_concurrency(self.scan_concurrency);
                 // Stop before the last partition column so leaf LIST targets are
                 // prefix paths of depth n-1 (e.g. date=…/), not the final fan-out
                 // (e.g. date=…/part=…/).
                 let partition_depth = partition_columns.len() - 1;
 
-                let parallel_span =
-                    info_span!("list_files_parallel", operation = "vacuum", partition_depth,);
+                let parallel_span = info_span!(
+                    "list_files_parallel",
+                    operation = "vacuum",
+                    partition_depth,
+                    scan_concurrency,
+                );
                 async {
-                    // Walk n-1 delimiter levels. Leaf list(prefix) then covers
-                    // the last partition column in bulk under each prefix.
-                    // Objects found at intermediate levels are considered immediately.
-                    let (leaf_prefixes, intermediate_orphans, intermediate_scanned) =
-                        expand_partition_prefixes(
-                            object_store.as_ref(),
-                            partition_depth,
-                            &valid_files,
-                            &keep_files,
-                            &partition_columns,
-                            &tombstone_path_sets,
-                            now_millis,
-                            retention_millis,
-                        )
-                        .await?;
+                    // Walk n-1 delimiter levels, streaming leaf prefixes as they
+                    // are discovered so leaf LIST can start before the full
+                    // prefix set is materialised. Intermediate-level objects are
+                    // reported via callback.
+                    let expand_scanned = Arc::new(AtomicUsize::new(0));
+                    let leaf_scanned = Arc::new(AtomicUsize::new(0));
 
-                    file_count += intermediate_scanned;
-                    for (path, size) in intermediate_orphans {
+                    // Expand runs in a spawned task; buffer intermediate orphans
+                    // until the leaf pipeline finishes (usually few/none).
+                    let intermediate_orphans =
+                        Arc::new(std::sync::Mutex::new(Vec::<(Path, i64)>::new()));
+                    let intermediate_orphans_cb = Arc::clone(&intermediate_orphans);
+
+                    expand_partition_prefixes(
+                        object_store.clone(),
+                        partition_depth,
+                        Arc::clone(&valid_files),
+                        Arc::clone(&keep_files),
+                        Arc::clone(&partition_columns),
+                        Arc::clone(&tombstone_path_sets),
+                        now_millis,
+                        retention_millis,
+                        Arc::clone(&expand_scanned),
+                        scan_concurrency,
+                        move |path, size| {
+                            intermediate_orphans_cb.lock().unwrap().push((path, size));
+                        },
+                    )
+                    .map(|prefix_res| {
+                        let store = object_store.clone();
+                        let valid_files = Arc::clone(&valid_files);
+                        let keep_files = Arc::clone(&keep_files);
+                        let tombstone_path_sets = Arc::clone(&tombstone_path_sets);
+                        let partition_columns = Arc::clone(&partition_columns);
+                        let scanned = Arc::clone(&leaf_scanned);
+                        async move {
+                            let prefix = prefix_res?;
+                            Ok::<_, DeltaTableError>(list_orphans_under_prefix(
+                                store,
+                                prefix,
+                                valid_files,
+                                keep_files,
+                                partition_columns,
+                                tombstone_path_sets,
+                                now_millis,
+                                retention_millis,
+                                scanned,
+                            ))
+                        }
+                    })
+                    .buffer_unordered(scan_concurrency)
+                    .try_flatten()
+                    .try_for_each(|(path, size)| {
+                        files_to_delete.push(path);
+                        file_sizes.push(size);
+                        ready(Ok::<_, DeltaTableError>(()))
+                    })
+                    .await?;
+
+                    for (path, size) in intermediate_orphans.lock().unwrap().drain(..) {
                         files_to_delete.push(path);
                         file_sizes.push(size);
                     }
 
-                    let listed: Vec<(Vec<(Path, i64)>, usize)> = stream::iter(leaf_prefixes)
-                        .map(|prefix| {
-                            let store = object_store.clone();
-                            let valid_files = Arc::clone(&valid_files);
-                            let keep_files = Arc::clone(&keep_files);
-                            let tombstone_path_sets = Arc::clone(&tombstone_path_sets);
-                            let partition_columns = Arc::clone(&partition_columns);
-                            async move {
-                                list_orphans_under_prefix(
-                                    store.as_ref(),
-                                    Some(&prefix),
-                                    &valid_files,
-                                    &keep_files,
-                                    &partition_columns,
-                                    &tombstone_path_sets,
-                                    now_millis,
-                                    retention_millis,
-                                )
-                                .await
-                            }
-                        })
-                        .buffer_unordered(vacuum_list_concurrency())
-                        .try_collect()
-                        .await?;
-
-                    for (orphans, scanned) in listed {
-                        file_count += scanned;
-                        for (path, size) in orphans {
-                            files_to_delete.push(path);
-                            file_sizes.push(size);
-                        }
-                    }
+                    file_count += expand_scanned.load(Ordering::Relaxed);
+                    file_count += leaf_scanned.load(Ordering::Relaxed);
 
                     Ok::<_, VacuumError>(())
                 }
@@ -725,133 +775,152 @@ fn is_skippable_root_prefix(path: &Path) -> bool {
     path_name == "_delta_log" || path_name.starts_with("_delta_log/") || path_name.starts_with('.')
 }
 
-/// Walk `partition_depth` delimiter levels and collect leaf partition prefixes.
+/// Walk `partition_depth` delimiter levels and stream leaf partition prefixes.
 ///
-/// Objects found at intermediate levels are evaluated immediately. Returns
-/// `(leaf_prefixes, intermediate_orphans, intermediate_files_scanned)`.
-async fn expand_partition_prefixes(
-    store: &dyn ObjectStore,
+/// Non-final levels still keep an in-memory prefix frontier (required for BFS).
+/// Delimiter results are folded as they complete (no per-level `Vec<ListResult>`).
+/// At the final level each child prefix is yielded immediately.
+/// Intermediate-level orphans are reported via `on_intermediate_orphan`.
+/// Every listed object increments `scanned`.
+fn expand_partition_prefixes(
+    store: Arc<dyn ObjectStore>,
     partition_depth: usize,
-    valid_files: &HashSet<Path>,
-    keep_files: &HashSet<String>,
-    partition_columns: &[String],
-    tombstone_path_sets: &TombstonePathSets,
+    valid_files: Arc<HashSet<Path>>,
+    keep_files: Arc<HashSet<String>>,
+    partition_columns: Arc<Vec<String>>,
+    tombstone_path_sets: Arc<TombstonePathSets>,
     now_millis: i64,
     retention_millis: i64,
-) -> Result<(Vec<Path>, Vec<(Path, i64)>, usize), DeltaTableError> {
-    let mut orphans = Vec::new();
-    let mut scanned = 0usize;
-    let mut to_expand: Vec<Option<Path>> = vec![None];
+    scanned: Arc<AtomicUsize>,
+    scan_concurrency: usize,
+    mut on_intermediate_orphan: impl FnMut(Path, i64) + Send + 'static,
+) -> impl Stream<Item = Result<Path, DeltaTableError>> {
+    let (mut tx, rx) = mpsc::channel(scan_concurrency.saturating_mul(4).max(16));
 
-    for level in 0..partition_depth {
-        let listings = stream::iter(to_expand)
-            .map(|prefix| {
-                let prefix_label = prefix
-                    .as_ref()
-                    .map(|p| p.as_ref())
-                    .unwrap_or("")
-                    .to_string();
-                async move {
-                    let listing = async {
+    tokio::spawn(async move {
+        let mut frontier: Vec<Option<Path>> = vec![None];
+
+        for level in 0..partition_depth {
+            let is_final_level = level + 1 == partition_depth;
+            let current = std::mem::take(&mut frontier);
+            let mut next_frontier = Vec::new();
+
+            let mut listings = stream::iter(current)
+                .map(|prefix| {
+                    let store = store.clone();
+                    let prefix_label = prefix
+                        .as_ref()
+                        .map(|p| p.as_ref())
+                        .unwrap_or("")
+                        .to_string();
+                    async move {
                         store
                             .list_with_delimiter(prefix.as_ref())
+                            .instrument(info_span!(
+                                "list_with_delimiter",
+                                operation = "vacuum",
+                                level,
+                                prefix = prefix_label,
+                            ))
                             .await
                             .map_err(DeltaTableError::from)
                     }
-                    .instrument(info_span!(
-                        "list_with_delimiter",
-                        operation = "vacuum",
-                        level,
-                        prefix = prefix_label,
-                    ))
-                    .await?;
+                })
+                .buffer_unordered(scan_concurrency);
 
-                    Ok::<_, DeltaTableError>(listing)
-                }
-            })
-            .buffer_unordered(vacuum_list_concurrency())
-            .try_collect::<Vec<_>>()
-            .await?;
+            loop {
+                match listings.try_next().await {
+                    Ok(Some(listing)) => {
+                        for obj_meta in listing.objects {
+                            scanned.fetch_add(1, Ordering::Relaxed);
+                            match consider_orphan_for_deletion(
+                                &obj_meta,
+                                valid_files.as_ref(),
+                                keep_files.as_ref(),
+                                partition_columns.as_ref(),
+                                tombstone_path_sets.as_ref(),
+                                now_millis,
+                                retention_millis,
+                            ) {
+                                Ok(Some((path, size))) => on_intermediate_orphan(path, size),
+                                Ok(None) => {}
+                                Err(e) => {
+                                    let _ = tx.send(Err(e)).await;
+                                    return;
+                                }
+                            }
+                        }
 
-        let mut next_frontier = Vec::new();
-        for listing in listings {
-            // Collect orphans at this level if any objects are found
-            // although there should be none
-            for obj_meta in listing.objects {
-                scanned += 1;
-                if let Some(entry) = consider_orphan_for_deletion(
-                    &obj_meta,
-                    valid_files,
-                    keep_files,
-                    partition_columns,
-                    tombstone_path_sets,
-                    now_millis,
-                    retention_millis,
-                )? {
-                    orphans.push(entry);
+                        for child in listing.common_prefixes {
+                            if level == 0 && is_skippable_root_prefix(&child) {
+                                continue;
+                            }
+                            if is_final_level {
+                                if tx.send(Ok(child)).await.is_err() {
+                                    return; // consumer dropped
+                                }
+                            } else {
+                                next_frontier.push(Some(child));
+                            }
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        let _ = tx.send(Err(e)).await;
+                        return;
+                    }
                 }
             }
 
-            for child in listing.common_prefixes {
-                if level == 0 && is_skippable_root_prefix(&child) {
-                    continue;
-                }
-                next_frontier.push(Some(child));
-            }
+            frontier = next_frontier;
         }
+    });
 
-        to_expand = next_frontier;
-    }
-
-    let leaf_prefixes = to_expand.into_iter().flatten().collect();
-    Ok((leaf_prefixes, orphans, scanned))
+    rx
 }
 
-/// Recursively list `prefix` and return orphans eligible for full-mode vacuum.
+/// List `prefix` and yield orphans eligible for full-mode vacuum.
 ///
-/// Returns `(orphans, files_scanned)`.
-async fn list_orphans_under_prefix(
-    store: &dyn ObjectStore,
-    prefix: Option<&Path>,
-    valid_files: &HashSet<Path>,
-    keep_files: &HashSet<String>,
-    partition_columns: &[String],
-    tombstone_path_sets: &TombstonePathSets,
+/// Each successfully listed object increments `scanned` (objects observed,
+/// not just orphans). Only objects that pass `consider_orphan_for_deletion`
+/// are yielded. Inputs are owned/`Arc` so the stream is `'static` and can be
+/// driven from concurrent `buffer_unordered` tasks.
+fn list_orphans_under_prefix(
+    store: Arc<dyn ObjectStore>,
+    prefix: Path,
+    valid_files: Arc<HashSet<Path>>,
+    keep_files: Arc<HashSet<String>>,
+    partition_columns: Arc<Vec<String>>,
+    tombstone_path_sets: Arc<TombstonePathSets>,
     now_millis: i64,
     retention_millis: i64,
-) -> Result<(Vec<(Path, i64)>, usize), DeltaTableError> {
-    let prefix_label = prefix.map(|p| p.as_ref()).unwrap_or("");
-    async {
-        let mut files = store.list(prefix);
-        let mut orphans = Vec::new();
-        let mut scanned = 0usize;
-
-        while let Some(obj_meta) = files.next().await {
-            // TODO should we allow NotFound here in case we have a temporary commit file in the list
-            let obj_meta = obj_meta.map_err(DeltaTableError::from)?;
-            scanned += 1;
-            if let Some(entry) = consider_orphan_for_deletion(
-                &obj_meta,
-                valid_files,
-                keep_files,
-                partition_columns,
-                tombstone_path_sets,
-                now_millis,
-                retention_millis,
-            )? {
-                orphans.push(entry);
-            }
-        }
-
-        Ok((orphans, scanned))
-    }
-    .instrument(info_span!(
+    scanned: Arc<AtomicUsize>,
+) -> impl Stream<Item = Result<(Path, i64), DeltaTableError>> {
+    let span = info_span!(
         "list_files",
         operation = "vacuum",
         mode = "parallel",
-        prefix = prefix_label,
-    ))
-    .await
+        prefix = prefix.to_string(),
+    );
+    store
+        .list(Some(&prefix))
+        .map_err(DeltaTableError::from)
+        .try_filter_map(move |obj_meta| {
+            let _guard = span.enter();
+            // Count every listed object for progress diagnostics.
+            scanned.fetch_add(1, Ordering::Relaxed);
+            // TODO should we allow NotFound here in case we have a temporary commit file in the list
+            let result = consider_orphan_for_deletion(
+                &obj_meta,
+                valid_files.as_ref(),
+                keep_files.as_ref(),
+                partition_columns.as_ref(),
+                tombstone_path_sets.as_ref(),
+                now_millis,
+                retention_millis,
+            );
+            ready(result)
+        })
 }
 
 async fn collect_full_mode_tombstones(
@@ -921,6 +990,7 @@ mod tests {
     use crate::writer::{DeltaWriter, JsonWriter};
     use crate::{ensure_table_uri, open_table};
     use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::{
         fs::{FileTimes, OpenOptions},
         io::Read,
@@ -1492,11 +1562,65 @@ mod tests {
     /// (regardless of ordering) is guaranteed to resolve to the built-in
     /// default, which is what this test asserts.
     #[test]
-    fn test_vacuum_list_concurrency_default() {
+    fn test_default_vacuum_list_concurrency() {
         assert!(std::env::var("DELTARS_VACUUM_LIST_CONCURRENCY").is_err());
-        assert_eq!(vacuum_list_concurrency(), DEFAULT_VACUUM_LIST_CONCURRENCY);
+        assert_eq!(
+            default_vacuum_list_concurrency(),
+            DEFAULT_VACUUM_LIST_CONCURRENCY
+        );
         // Calling it again must return the same cached value.
-        assert_eq!(vacuum_list_concurrency(), vacuum_list_concurrency());
+        assert_eq!(
+            default_vacuum_list_concurrency(),
+            default_vacuum_list_concurrency()
+        );
+    }
+
+    #[test]
+    fn test_resolve_scan_concurrency() {
+        // Explicit positive overrides win.
+        assert_eq!(resolve_scan_concurrency(Some(1)), 1);
+        assert_eq!(resolve_scan_concurrency(Some(7)), 7);
+        assert_eq!(resolve_scan_concurrency(Some(1000)), 1000);
+
+        // None and zero fall back to the process default.
+        assert_eq!(
+            resolve_scan_concurrency(None),
+            default_vacuum_list_concurrency()
+        );
+        assert_eq!(
+            resolve_scan_concurrency(Some(0)),
+            default_vacuum_list_concurrency()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_with_scan_concurrency_builder() -> DeltaResult<()> {
+        let table_path = std::path::Path::new("../test/tests/data/simple_commit");
+        let table_uri =
+            Url::from_directory_path(std::fs::canonicalize(table_path).unwrap()).unwrap();
+        let table = open_table(table_uri).await?;
+
+        let builder =
+            VacuumBuilder::new(table.log_store(), Some(table.snapshot()?.snapshot.clone()));
+        assert_eq!(builder.scan_concurrency, None);
+        assert_eq!(
+            resolve_scan_concurrency(builder.scan_concurrency),
+            default_vacuum_list_concurrency()
+        );
+
+        let builder = builder.with_scan_concurrency(25);
+        assert_eq!(builder.scan_concurrency, Some(25));
+        assert_eq!(resolve_scan_concurrency(builder.scan_concurrency), 25);
+
+        // Zero is stored but ignored at resolve time.
+        let builder = builder.with_scan_concurrency(0);
+        assert_eq!(builder.scan_concurrency, Some(0));
+        assert_eq!(
+            resolve_scan_concurrency(builder.scan_concurrency),
+            default_vacuum_list_concurrency()
+        );
+
+        Ok(())
     }
 
     fn make_object_meta(
@@ -1695,16 +1819,24 @@ mod tests {
         let partition_columns = vec!["a".to_string(), "b".to_string()];
         let tombstone_path_sets = TombstonePathSets::default();
 
-        let (mut leaf_prefixes, orphans, scanned) = expand_partition_prefixes(
-            &store,
+        let scanned = Arc::new(AtomicUsize::new(0));
+        let orphans = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let orphans_cb = Arc::clone(&orphans);
+
+        let mut leaf_prefixes = expand_partition_prefixes(
+            Arc::new(store),
             1,
-            &valid_files,
-            &keep_files,
-            &partition_columns,
-            &tombstone_path_sets,
+            Arc::new(valid_files),
+            Arc::new(keep_files),
+            Arc::new(partition_columns),
+            Arc::new(tombstone_path_sets),
             i64::MAX / 2,
             0,
+            Arc::clone(&scanned),
+            DEFAULT_VACUUM_LIST_CONCURRENCY,
+            move |path, size| orphans_cb.lock().unwrap().push((path, size)),
         )
+        .try_collect::<Vec<_>>()
         .await?;
 
         leaf_prefixes.sort();
@@ -1716,12 +1848,12 @@ mod tests {
             ]
         );
         assert_eq!(
-            orphans,
+            orphans.lock().unwrap().clone(),
             vec![(object_store::path::Path::from("orphan-root.parquet"), 11)]
         );
         // Only the root-level object is scanned by this function; nested
         // objects under "a=1/" and "a=2/" are left for the leaf listing step.
-        assert_eq!(scanned, 1);
+        assert_eq!(scanned.load(Ordering::Relaxed), 1);
 
         Ok(())
     }
@@ -1756,16 +1888,24 @@ mod tests {
         let partition_columns = vec!["a".to_string(), "b".to_string(), "c".to_string()];
         let tombstone_path_sets = TombstonePathSets::default();
 
-        let (mut leaf_prefixes, orphans, _scanned) = expand_partition_prefixes(
-            &store,
+        let scanned = Arc::new(AtomicUsize::new(0));
+        let orphans = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let orphans_cb = Arc::clone(&orphans);
+
+        let mut leaf_prefixes = expand_partition_prefixes(
+            Arc::new(store),
             2,
-            &valid_files,
-            &keep_files,
-            &partition_columns,
-            &tombstone_path_sets,
+            Arc::new(valid_files),
+            Arc::new(keep_files),
+            Arc::new(partition_columns),
+            Arc::new(tombstone_path_sets),
             i64::MAX / 2,
             0,
+            Arc::clone(&scanned),
+            DEFAULT_VACUUM_LIST_CONCURRENCY,
+            move |path, size| orphans_cb.lock().unwrap().push((path, size)),
         )
+        .try_collect::<Vec<_>>()
         .await?;
 
         leaf_prefixes.sort();
@@ -1777,7 +1917,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            orphans,
+            orphans.lock().unwrap().clone(),
             vec![(object_store::path::Path::from("a=1/orphan-mid.parquet"), 10)]
         );
 
@@ -1826,20 +1966,22 @@ mod tests {
         );
 
         // retention_millis = 0 so the untracked orphan is always considered stale.
-        let (orphans, scanned) = list_orphans_under_prefix(
-            &store,
-            Some(&object_store::path::Path::from("leaf")),
-            &valid_files,
-            &keep_files,
-            &partition_columns,
-            &tombstone_path_sets,
+        let scanned = Arc::new(AtomicUsize::new(0));
+        let mut orphans = list_orphans_under_prefix(
+            Arc::new(store),
+            object_store::path::Path::from("leaf"),
+            Arc::new(valid_files),
+            Arc::new(keep_files),
+            Arc::new(partition_columns),
+            Arc::new(tombstone_path_sets),
             i64::MAX / 2,
             0,
+            Arc::clone(&scanned),
         )
+        .try_collect::<Vec<_>>()
         .await?;
 
-        assert_eq!(scanned, 6);
-        let mut orphans = orphans;
+        assert_eq!(scanned.load(Ordering::Relaxed), 6);
         orphans.sort();
         assert_eq!(
             orphans,
@@ -1876,19 +2018,22 @@ mod tests {
         // Retention far larger than any possible elapsed time since the put above.
         let retention_millis = 24 * 60 * 60 * 1000;
 
-        let (orphans, scanned) = list_orphans_under_prefix(
-            &store,
-            Some(&object_store::path::Path::from("leaf")),
-            &valid_files,
-            &keep_files,
-            &partition_columns,
-            &tombstone_path_sets,
+        let scanned = Arc::new(AtomicUsize::new(0));
+        let orphans = list_orphans_under_prefix(
+            Arc::new(store),
+            object_store::path::Path::from("leaf"),
+            Arc::new(valid_files),
+            Arc::new(keep_files),
+            Arc::new(partition_columns),
+            Arc::new(tombstone_path_sets),
             now_millis,
             retention_millis,
+            Arc::clone(&scanned),
         )
+        .try_collect::<Vec<_>>()
         .await?;
 
-        assert_eq!(scanned, 1);
+        assert_eq!(scanned.load(Ordering::Relaxed), 1);
         assert!(
             orphans.is_empty(),
             "recent untracked file should be protected: {orphans:?}"

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -1436,4 +1436,558 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_should_try_parallel_vacuum() {
+        assert!(!should_try_parallel_vacuum(&[]));
+        assert!(!should_try_parallel_vacuum(&["modified".to_string()]));
+        assert!(should_try_parallel_vacuum(&[
+            "modified".to_string(),
+            "id".to_string()
+        ]));
+        assert!(should_try_parallel_vacuum(&[
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string()
+        ]));
+    }
+
+    #[test]
+    fn test_is_skippable_root_prefix() {
+        assert!(is_skippable_root_prefix(&object_store::path::Path::from(
+            "_delta_log"
+        )));
+        assert!(is_skippable_root_prefix(&object_store::path::Path::from(
+            "_delta_log/00000000000000000000.json"
+        )));
+        assert!(is_skippable_root_prefix(&object_store::path::Path::from(
+            ".hidden"
+        )));
+        assert!(!is_skippable_root_prefix(&object_store::path::Path::from(
+            "modified=2021-02-01"
+        )));
+        assert!(!is_skippable_root_prefix(&object_store::path::Path::from(
+            "regular_folder"
+        )));
+    }
+
+    #[test]
+    fn test_tombstone_path_sets_record() {
+        let mut sets = TombstonePathSets::default();
+        let expired_path = object_store::path::Path::from("expired.parquet");
+        let recent_path = object_store::path::Path::from("recent.parquet");
+
+        sets.record(expired_path.clone(), true);
+        sets.record(recent_path.clone(), false);
+
+        assert!(sets.expired_tombstone_paths.contains(&expired_path));
+        assert!(!sets.expired_tombstone_paths.contains(&recent_path));
+        assert!(sets.all_tombstone_paths.contains(&expired_path));
+        assert!(sets.all_tombstone_paths.contains(&recent_path));
+    }
+
+    /// The `DELTARS_VACUUM_LIST_CONCURRENCY` env var is only read once, on the
+    /// first call, because the value is cached in a process-wide `OnceLock`.
+    /// Since no other test sets this env var, every call in this test binary
+    /// (regardless of ordering) is guaranteed to resolve to the built-in
+    /// default, which is what this test asserts.
+    #[test]
+    fn test_vacuum_list_concurrency_default() {
+        assert!(std::env::var("DELTARS_VACUUM_LIST_CONCURRENCY").is_err());
+        assert_eq!(vacuum_list_concurrency(), DEFAULT_VACUUM_LIST_CONCURRENCY);
+        // Calling it again must return the same cached value.
+        assert_eq!(vacuum_list_concurrency(), vacuum_list_concurrency());
+    }
+
+    fn make_object_meta(
+        path: &str,
+        last_modified_millis: i64,
+        size: u64,
+    ) -> object_store::ObjectMeta {
+        object_store::ObjectMeta {
+            location: object_store::path::Path::from(path),
+            last_modified: chrono::DateTime::from_timestamp_millis(last_modified_millis).unwrap(),
+            size,
+            e_tag: None,
+            version: None,
+        }
+    }
+
+    /// Directly exercises every branch of `consider_orphan_for_deletion` with
+    /// hand-crafted inputs, independent of any full vacuum run.
+    #[test]
+    fn test_consider_orphan_for_deletion_branches() {
+        let partition_columns = vec!["modified".to_string()];
+        let now_millis: i64 = 1_000_000;
+        let retention_millis: i64 = 1_000;
+
+        let valid_files: HashSet<object_store::path::Path> =
+            [object_store::path::Path::from("valid.parquet")]
+                .into_iter()
+                .collect();
+        let keep_files: HashSet<String> = ["kept.parquet".to_string()].into_iter().collect();
+
+        let mut tombstone_path_sets = TombstonePathSets::default();
+        tombstone_path_sets.record(
+            object_store::path::Path::from("expired-tombstone.parquet"),
+            true,
+        );
+        tombstone_path_sets.record(
+            object_store::path::Path::from("recent-tombstone.parquet"),
+            false,
+        );
+
+        // 1. Already queued as an expired tombstone -> None, regardless of age.
+        let meta = make_object_meta("expired-tombstone.parquet", now_millis, 10);
+        assert_eq!(
+            consider_orphan_for_deletion(
+                &meta,
+                &valid_files,
+                &keep_files,
+                &partition_columns,
+                &tombstone_path_sets,
+                now_millis,
+                retention_millis,
+            )
+            .unwrap(),
+            None
+        );
+
+        // 2. Still tracked as a valid file -> not ok to delete -> None.
+        let meta = make_object_meta("valid.parquet", 0, 10);
+        assert_eq!(
+            consider_orphan_for_deletion(
+                &meta,
+                &valid_files,
+                &keep_files,
+                &partition_columns,
+                &tombstone_path_sets,
+                now_millis,
+                retention_millis,
+            )
+            .unwrap(),
+            None
+        );
+
+        // 3. Associated with a version being kept -> not ok to delete -> None.
+        let meta = make_object_meta("kept.parquet", 0, 10);
+        assert_eq!(
+            consider_orphan_for_deletion(
+                &meta,
+                &valid_files,
+                &keep_files,
+                &partition_columns,
+                &tombstone_path_sets,
+                now_millis,
+                retention_millis,
+            )
+            .unwrap(),
+            None
+        );
+
+        // 4. Hidden directory entry (not a partition column, not _delta_index /
+        //    _change_data) -> not ok to delete -> None.
+        let meta = make_object_meta("_staging/file.parquet", 0, 10);
+        assert_eq!(
+            consider_orphan_for_deletion(
+                &meta,
+                &valid_files,
+                &keep_files,
+                &partition_columns,
+                &tombstone_path_sets,
+                now_millis,
+                retention_millis,
+            )
+            .unwrap(),
+            None
+        );
+
+        // 5. Has a recent (non-expired) tombstone -> keep until it expires -> None.
+        let meta = make_object_meta("recent-tombstone.parquet", 0, 10);
+        assert_eq!(
+            consider_orphan_for_deletion(
+                &meta,
+                &valid_files,
+                &keep_files,
+                &partition_columns,
+                &tombstone_path_sets,
+                now_millis,
+                retention_millis,
+            )
+            .unwrap(),
+            None
+        );
+
+        // 6. Untracked but too recent (age < retention) -> protected -> None.
+        let meta = make_object_meta(
+            "recent-orphan.parquet",
+            now_millis - retention_millis + 1,
+            10,
+        );
+        assert_eq!(
+            consider_orphan_for_deletion(
+                &meta,
+                &valid_files,
+                &keep_files,
+                &partition_columns,
+                &tombstone_path_sets,
+                now_millis,
+                retention_millis,
+            )
+            .unwrap(),
+            None
+        );
+
+        // 7. Untracked and stale -> eligible for deletion -> Some((path, size)).
+        let meta = make_object_meta(
+            "stale-orphan.parquet",
+            now_millis - retention_millis - 1,
+            42,
+        );
+        assert_eq!(
+            consider_orphan_for_deletion(
+                &meta,
+                &valid_files,
+                &keep_files,
+                &partition_columns,
+                &tombstone_path_sets,
+                now_millis,
+                retention_millis,
+            )
+            .unwrap(),
+            Some((object_store::path::Path::from("stale-orphan.parquet"), 42))
+        );
+    }
+
+    /// Directly exercises `expand_partition_prefixes` at depth 1: root-level
+    /// orphans are collected immediately, `_delta_log` is skipped, and the
+    /// remaining top-level partition directories are returned as leaf prefixes.
+    #[tokio::test]
+    async fn test_expand_partition_prefixes_root_orphans_and_skips() -> DeltaResult<()> {
+        let store = InMemory::new();
+        store
+            .put(
+                &object_store::path::Path::from("orphan-root.parquet"),
+                PutPayload::from_static(b"root orphan"),
+            )
+            .await?;
+        store
+            .put(
+                &object_store::path::Path::from("_delta_log/00000000000000000000.json"),
+                PutPayload::from_static(b"{}"),
+            )
+            .await?;
+        store
+            .put(
+                &object_store::path::Path::from("a=1/file.parquet"),
+                PutPayload::from_static(b"a1"),
+            )
+            .await?;
+        store
+            .put(
+                &object_store::path::Path::from("a=2/file.parquet"),
+                PutPayload::from_static(b"a2"),
+            )
+            .await?;
+
+        let valid_files = HashSet::new();
+        let keep_files = HashSet::new();
+        let partition_columns = vec!["a".to_string(), "b".to_string()];
+        let tombstone_path_sets = TombstonePathSets::default();
+
+        let (mut leaf_prefixes, orphans, scanned) = expand_partition_prefixes(
+            &store,
+            1,
+            &valid_files,
+            &keep_files,
+            &partition_columns,
+            &tombstone_path_sets,
+            i64::MAX / 2,
+            0,
+        )
+        .await?;
+
+        leaf_prefixes.sort();
+        assert_eq!(
+            leaf_prefixes,
+            vec![
+                object_store::path::Path::from("a=1"),
+                object_store::path::Path::from("a=2"),
+            ]
+        );
+        assert_eq!(
+            orphans,
+            vec![(object_store::path::Path::from("orphan-root.parquet"), 11)]
+        );
+        // Only the root-level object is scanned by this function; nested
+        // objects under "a=1/" and "a=2/" are left for the leaf listing step.
+        assert_eq!(scanned, 1);
+
+        Ok(())
+    }
+
+    /// Directly exercises `expand_partition_prefixes` recursing across two
+    /// delimiter levels (depth 2), including an orphan found at the
+    /// intermediate ("a=1/") level.
+    #[tokio::test]
+    async fn test_expand_partition_prefixes_recurses_multiple_levels() -> DeltaResult<()> {
+        let store = InMemory::new();
+        store
+            .put(
+                &object_store::path::Path::from("a=1/orphan-mid.parquet"),
+                PutPayload::from_static(b"mid orphan"),
+            )
+            .await?;
+        store
+            .put(
+                &object_store::path::Path::from("a=1/b=1/file.parquet"),
+                PutPayload::from_static(b"leaf"),
+            )
+            .await?;
+        store
+            .put(
+                &object_store::path::Path::from("a=2/b=1/file.parquet"),
+                PutPayload::from_static(b"leaf"),
+            )
+            .await?;
+
+        let valid_files = HashSet::new();
+        let keep_files = HashSet::new();
+        let partition_columns = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let tombstone_path_sets = TombstonePathSets::default();
+
+        let (mut leaf_prefixes, orphans, _scanned) = expand_partition_prefixes(
+            &store,
+            2,
+            &valid_files,
+            &keep_files,
+            &partition_columns,
+            &tombstone_path_sets,
+            i64::MAX / 2,
+            0,
+        )
+        .await?;
+
+        leaf_prefixes.sort();
+        assert_eq!(
+            leaf_prefixes,
+            vec![
+                object_store::path::Path::from("a=1/b=1"),
+                object_store::path::Path::from("a=2/b=1"),
+            ]
+        );
+        assert_eq!(
+            orphans,
+            vec![(object_store::path::Path::from("a=1/orphan-mid.parquet"), 10)]
+        );
+
+        Ok(())
+    }
+
+    /// Directly exercises `list_orphans_under_prefix`, verifying that valid,
+    /// kept, and tombstoned files are excluded while untracked files --
+    /// including one nested under a `_`-prefixed subdirectory, which
+    /// `is_hidden_directory` does not special-case for non-root locations --
+    /// are returned as orphans.
+    #[tokio::test]
+    async fn test_list_orphans_under_prefix_orphan_detection() -> DeltaResult<()> {
+        let store = InMemory::new();
+        for (path, contents) in [
+            ("leaf/valid.parquet", "valid"),
+            ("leaf/kept.parquet", "kept"),
+            ("leaf/_hidden/file.parquet", "hidden"),
+            ("leaf/expired-tombstone.parquet", "expired"),
+            ("leaf/recent-tombstone.parquet", "recent"),
+            ("leaf/orphan.parquet", "orphan!"),
+        ] {
+            store
+                .put(
+                    &object_store::path::Path::from(path),
+                    PutPayload::from_bytes(bytes::Bytes::from_static(contents.as_bytes())),
+                )
+                .await?;
+        }
+
+        let valid_files: HashSet<object_store::path::Path> =
+            [object_store::path::Path::from("leaf/valid.parquet")]
+                .into_iter()
+                .collect();
+        let keep_files: HashSet<String> = ["leaf/kept.parquet".to_string()].into_iter().collect();
+        let partition_columns = vec!["modified".to_string()];
+
+        let mut tombstone_path_sets = TombstonePathSets::default();
+        tombstone_path_sets.record(
+            object_store::path::Path::from("leaf/expired-tombstone.parquet"),
+            true,
+        );
+        tombstone_path_sets.record(
+            object_store::path::Path::from("leaf/recent-tombstone.parquet"),
+            false,
+        );
+
+        // retention_millis = 0 so the untracked orphan is always considered stale.
+        let (orphans, scanned) = list_orphans_under_prefix(
+            &store,
+            Some(&object_store::path::Path::from("leaf")),
+            &valid_files,
+            &keep_files,
+            &partition_columns,
+            &tombstone_path_sets,
+            i64::MAX / 2,
+            0,
+        )
+        .await?;
+
+        assert_eq!(scanned, 6);
+        let mut orphans = orphans;
+        orphans.sort();
+        assert_eq!(
+            orphans,
+            vec![
+                (
+                    object_store::path::Path::from("leaf/_hidden/file.parquet"),
+                    6
+                ),
+                (object_store::path::Path::from("leaf/orphan.parquet"), 7),
+            ]
+        );
+
+        Ok(())
+    }
+
+    /// Directly exercises `list_orphans_under_prefix` protecting an untracked
+    /// file that is younger than the retention period.
+    #[tokio::test]
+    async fn test_list_orphans_under_prefix_protects_recent_files() -> DeltaResult<()> {
+        let store = InMemory::new();
+        store
+            .put(
+                &object_store::path::Path::from("leaf/recent-orphan.parquet"),
+                PutPayload::from_static(b"recent"),
+            )
+            .await?;
+
+        let valid_files = HashSet::new();
+        let keep_files = HashSet::new();
+        let partition_columns = vec!["modified".to_string()];
+        let tombstone_path_sets = TombstonePathSets::default();
+
+        let now_millis = Utc::now().timestamp_millis();
+        // Retention far larger than any possible elapsed time since the put above.
+        let retention_millis = 24 * 60 * 60 * 1000;
+
+        let (orphans, scanned) = list_orphans_under_prefix(
+            &store,
+            Some(&object_store::path::Path::from("leaf")),
+            &valid_files,
+            &keep_files,
+            &partition_columns,
+            &tombstone_path_sets,
+            now_millis,
+            retention_millis,
+        )
+        .await?;
+
+        assert_eq!(scanned, 1);
+        assert!(
+            orphans.is_empty(),
+            "recent untracked file should be protected: {orphans:?}"
+        );
+
+        Ok(())
+    }
+
+    /// Exercises the hierarchical parallel-listing path used for multi-level
+    /// partitioned tables (`should_try_parallel_vacuum` / `expand_partition_prefixes`
+    /// / `list_orphans_under_prefix`), covering orphans found at the table root
+    /// (intermediate level), directly under the first partition level, and nested
+    /// under the leaf partition directory.
+    #[tokio::test]
+    async fn test_vacuum_full_parallel_multi_level_partitions() -> DeltaResult<()> {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let table_path = temp_dir.path().to_str().unwrap();
+        let partition_cols = vec!["modified".to_string(), "id".to_string()];
+        let mut table = create_initialized_table(table_path, &partition_cols).await;
+
+        let current_time = SystemTime::now();
+        let current_time_millis =
+            current_time.duration_since(UNIX_EPOCH).unwrap().as_millis() as i64;
+        let stale_time = current_time - StdDuration::from_secs(10);
+        let recent_time = current_time - StdDuration::from_secs(1);
+
+        let mut writer = JsonWriter::for_table(&table)?;
+        writer
+            .write(vec![
+                json!({"id": "A", "value": 1, "modified": "2021-02-01"}),
+            ])
+            .await?;
+        writer.flush_and_commit(&mut table).await?;
+
+        let valid_paths: Vec<String> = table
+            .snapshot()?
+            .log_data()
+            .into_iter()
+            .map(|add| add.object_store_path().to_string())
+            .collect();
+        assert_eq!(valid_paths.len(), 1);
+
+        // Orphan directly at the table root: exercises the "intermediate orphan"
+        // branch inside expand_partition_prefixes.
+        let root_orphan = "orphan-root.parquet";
+        std::fs::write(temp_dir.path().join(root_orphan), b"root orphan").unwrap();
+        set_last_modified(&temp_dir.path().join(root_orphan), stale_time);
+
+        // Orphan directly under the first (non-final) partition level: exercises
+        // list_orphans_under_prefix recursing under a leaf prefix.
+        let modified_prefix = "modified=2021-02-01";
+        let mid_orphan = format!("{modified_prefix}/orphan-mid.parquet");
+        std::fs::write(temp_dir.path().join(&mid_orphan), b"mid orphan").unwrap();
+        set_last_modified(&temp_dir.path().join(&mid_orphan), stale_time);
+
+        // Orphan nested under the leaf (final) partition directory.
+        let deep_dir = format!("{modified_prefix}/id=A");
+        let deep_orphan = format!("{deep_dir}/orphan-deep.parquet");
+        std::fs::write(temp_dir.path().join(&deep_orphan), b"deep orphan").unwrap();
+        set_last_modified(&temp_dir.path().join(&deep_orphan), stale_time);
+
+        // Recent orphan that must be protected because it is younger than the
+        // retention period.
+        let recent_orphan = format!("{deep_dir}/orphan-recent.parquet");
+        std::fs::write(temp_dir.path().join(&recent_orphan), b"recent orphan").unwrap();
+        set_last_modified(&temp_dir.path().join(&recent_orphan), recent_time);
+
+        let (_table, result) =
+            VacuumBuilder::new(table.log_store(), Some(table.snapshot()?.snapshot.clone()))
+                .with_retention_period(Duration::seconds(5))
+                .with_dry_run(true)
+                .with_mode(VacuumMode::Full)
+                .with_enforce_retention_duration(false)
+                .with_clock(Arc::new(MockClock::new(current_time_millis)))
+                .await?;
+
+        for expected in [
+            root_orphan.to_string(),
+            mid_orphan.clone(),
+            deep_orphan.clone(),
+        ] {
+            assert!(
+                result.files_deleted.contains(&expected),
+                "expected {expected} to be vacuumed: {:?}",
+                result.files_deleted
+            );
+        }
+        assert!(
+            !result.files_deleted.contains(&recent_orphan),
+            "recent orphan should be protected: {:?}",
+            result.files_deleted
+        );
+        for valid in &valid_paths {
+            assert!(
+                !result.files_deleted.contains(valid),
+                "valid tracked file should never be vacuumed: {valid}"
+            );
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
# Description

Full-mode vacuum used a single sequential object-store list over the table root. On large multi-level partitioned tables that is correct but serial, so wall time is dominated by `LIST` round-trips.

This change switches multi-level tables (`n > 1` partition columns) to a parallel listings:

- expand only to depth `n-1` with `list_with_delimiter`
- list each resulting prefix in parallel
- leave the last partition column unexpanded so files under it are returned in bulk (avoids millions of tiny per-leaf `LIST` calls when the final column has high fan-out)

Single-level and unpartitioned tables keep the flat `list(None)` path, which is cheaper when expanding the only column would create many sparse leaves.

`LIST` concurrency defaults to 10 and can be overridden with `DELTARS_VACUUM_LIST_CONCURRENCY` but from my tests `10` gives some of the best results. 

# Benchmarks

### Summary

In short, this approach is 🚀 **`8 times`** 🚀 faster.

Here is a quick comparison between the old way of scanning and the parallel way in regards to duration:

|                       | fastest | slowest | median  | mean    | samples | iters |
| --------------------- | ------- | ------- | ------- | ------- | ------- | ----- |
| dry_run_flat (original)     | 17.88 m | 19.6 m  | 18.74 m | 18.74 m | 2       | 2     |
| dry_run_parallel (new) | 2.256 m | 2.297 m | 2.277 m | 2.277 m | 2       | 2     |

### By store latency

Here is a comparison with different storage latencies:

| store latency | dry_run_parallel | dry_run_flat | times faster | time reduction |
|---------------|----------|-----------------|--------------|----------------|
| 1 s           | 13.45 m  | 1.79 h          | 7.98 x       | 87.47 %        |
| 500 ms        | 7.938 m  | 59.01 m         | 7.43 x       | 86.54 %        |
| 300 ms        | 5.479 m  | 39.4 m          | 7.19 x       | 86.09 %        |
| 200 ms        | 4.23 m   | 30.23 m         | 7.15 x       | 86.01 %        |
| 100 ms        | 2.35 m   | 19.91 m         | 8.47 x       | 88.19 %        |
| 50 ms         | 2.099 m  | 13.54 m         | 6.45 x       | 84.50 %        |
| 10 ms         | 2.073 m  | 8.706 m         | 4.20 x       | 76.19 %        |
| 1 ms          | 2.107 m  | 7.75 m          | 3.68 x       | 72.81 %        |

### CPU load

Here is another comparison between the two modes this time in terms of CPU load:

|      | dry_run_flat | dry_run_parallel |
|--------|--------|--------|
| Wall time | ~1181 s (~19.7 min) | ~149 s (~2.5 min) |
| Total CPU time (all threads summed) | ~403 s (~6.7 min) | ~546 s (~9.1 min) |
| Avg CPU load | ~0.34 cores busy | ~3.67 cores busy |
| Avg as % of one core | ~34% | ~367% |
| Equivalent machine utilization (if 32 cores) | ~1% of all cores | ~12% of all cores |
| Threads | 171 | 227 |
| CPU time | ~403 s | ~546 s |
| Avg cores busy | 0.34 | 3.69 |
| Median | 0.33 | 3.85 |
| p95 | 0.37 | 4.81 |
| Max | 1.55 | 6.42 |
| Seconds with ≥ 0.5 cores | 1.3% | 99.3% |
| Seconds with ≥ 1.0 cores | 0.8% | 96.6% |
| Seconds with ≥ 2.0 cores | 0% | 89.9% |
| Seconds with ≥ 4.0 cores | 0% | 22.3% |

### Details

The fixture (aka the big 5.5 million partition dataset) was created once and multiple dry-run vacuums were executed on top of it to gather some valuable numbers.

I did use this command to generate it and it took at least `1h`:

```bash
cargo run --release -p delta-benchmarks -- generate-vacuum-fixture \
  --out ./crates/benchmarks/data/vacuum_bench/d1095_g5001 \
  --days 1095 \
  --groups 5001 \
  --force
```

Then I used the following command with a synthetic latency of `100ms` trying to mimic an object store.

```bash
cargo bench -p delta-benchmarks --bench vacuum -- \
--fixture ./crates/benchmarks/data/vacuum_bench/d1095_g5001 \
--list-latency-ms 100 \
--sample-count 2
```

# Real Life Example

I have multiple production dataset with tens of millions of files spread in two Hive partition columns. I'll give the one of my findings on such a dataset: first partition has a cardinality of approx `5000` and the second partition columns has a cardinality of approx `10000`. Current approach does listing sequentially the `5000 * 10000` object, page by page with `1000` objects per page and is very slow. 

# Related Issue(s)

- closes #4634

# Documentation

<!---
Share links to useful documentation
--->
