### PR TITLE
chore: upgrade our build to 1.94.1 which is now required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 
 [workspace.package]
 authors = ["Qingping Hou <dave2008713@gmail.com>", "R Tyler Croy <rtyler@brokenco.de>"]
-rust-version = "1.91.1"
+rust-version = "1.94.1"
 keywords = ["deltalake", "delta", "datalake"]
 readme = "README.md"
 edition = "2024"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,5 +16,5 @@
 # under the License.
 
 [toolchain]
-channel = "1.91.1"
+channel = "1.94.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
The AWS crates bumped their MSRV and thus so do we -_-
