### PR TITLE
fix: dont compare nested fields to partition_cols in map_fields since they are not partition candidates

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/plan.rs
@@ -431,7 +431,7 @@ impl DeltaScanConfig {
             DataType::Struct(fields) => {
                 let new_fields = fields
                     .iter()
-                    .map(|f| self.map_field(f.clone(), partition_cols))
+                    .map(|f| self.map_field(f.clone(), &[]))
                     .collect();
                 field
                     .as_ref()
@@ -442,23 +442,17 @@ impl DeltaScanConfig {
             DataType::List(inner) => field
                 .as_ref()
                 .clone()
-                .with_data_type(DataType::List(
-                    self.map_field(inner.clone(), partition_cols),
-                ))
+                .with_data_type(DataType::List(self.map_field(inner.clone(), &[])))
                 .into(),
             DataType::LargeList(inner) => field
                 .as_ref()
                 .clone()
-                .with_data_type(DataType::LargeList(
-                    self.map_field(inner.clone(), partition_cols),
-                ))
+                .with_data_type(DataType::LargeList(self.map_field(inner.clone(), &[])))
                 .into(),
             DataType::ListView(inner) => field
                 .as_ref()
                 .clone()
-                .with_data_type(DataType::ListView(
-                    self.map_field(inner.clone(), partition_cols),
-                ))
+                .with_data_type(DataType::ListView(self.map_field(inner.clone(), &[])))
                 .into(),
             _ => field,
         }

--- a/python/tests/test_optimize.py
+++ b/python/tests/test_optimize.py
@@ -499,6 +499,66 @@ def test_optimize_schema_evolved_3185(tmp_path):
     assert last_action["operation"] == "OPTIMIZE"
 
 
+@pytest.mark.pyarrow
+def test_optimize_nested_field_named_like_partition_column(tmp_path: pathlib.Path):
+    """A nested field sharing a partition column's name must not break OPTIMIZE.
+
+    Partition columns are always top level, so a name match inside a struct is a false
+    positive. Dictionary-encoding the nested field made the Parquet read schema disagree
+    with the file, failing compaction with "Incorrect datatype. Expected string, got
+    Dictionary(UInt16, Utf8)".
+    """
+    import pyarrow as pa
+
+    schema = pa.schema(
+        [
+            pa.field("date", pa.string()),
+            pa.field("someOtherField", pa.string()),
+            pa.field("properties", pa.struct([pa.field("date", pa.string())])),
+        ]
+    )
+
+    first_write = pa.Table.from_pylist(
+        [
+            {
+                "date": "2026-08-18",
+                "someOtherField": "abc123",
+                "properties": {"date": "2026-08-18"},
+            }
+        ],
+        schema=schema,
+    )
+    second_write = pa.Table.from_pylist(
+        [
+            {
+                "date": "2026-08-18",
+                "someOtherField": "abc456",
+                "properties": {"date": "2026-08-18"},
+            }
+        ],
+        schema=schema,
+    )
+
+    write_deltalake(tmp_path, first_write, partition_by=["date"], mode="append")
+    write_deltalake(tmp_path, second_write, partition_by=["date"], mode="append")
+
+    dt = DeltaTable(tmp_path)
+    metrics = dt.optimize.compact()
+
+    assert metrics["numFilesAdded"] == 1
+    assert metrics["numFilesRemoved"] == 2
+
+    assert dt.version() == 2
+    last_action = dt.history(1)[0]
+    assert last_action["operation"] == "OPTIMIZE"
+
+    # The nested field keeps its type and its values through the rewrite.
+    table = dt.to_pyarrow_table()
+    assert table.schema.field("properties").type.field(0).type == pa.string()
+    assert table.num_rows == 2
+    assert table.column("properties").to_pylist() == [{"date": "2026-08-18"}] * 2
+
+
 def test_compact_with_spill_parameters(
     tmp_path: pathlib.Path,
     sample_table: Table,


### PR DESCRIPTION
# Description
Currently when an optimize (either compact or z_order) scans physical parquet files, the `map_field` recursive fn walks and determines if a column is a partition column. The issue is that this is done even on nested fields (which aren't partition column candidates to begin with) and fails when a nested column collides with the name of a top-level partition column, e.g. `date` vs `properties.date`.

The proposed solution is to still allow map_field to walk the columns tree, but to not check complex field types (structs and lists) to the list of partition cols since they should never be partition candidates to begin with.

Added a new unit test with a schema that follows this pattern, confirmed working locally with the fix, and was failing before the fix.

# Related Issue(s)

closes #4652 

# Documentation
