### PR TITLE
chore: datafusion 55 upgrade and some related fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,35 +19,35 @@ repository = "https://github.com/delta-io/delta.rs"
 #delta_kernel = { package = "buoyant_kernel", path = "../delta-kernel-rs/kernel", features = [
 #delta_kernel = { package = "buoyant_kernel", git = "https://github.com/buoyant-data/delta-kernel-rs", branch = "buoyant/main", features = [
 delta_kernel = { package = "buoyant_kernel", version = "0.25.0,<0.25.100", features = [
-    "arrow-58",
+    "arrow-59",
     "internal-api",
 ] }
 #delta_kernel_default_engine = {  package = "buoyant_kernel_engine",  path = "../delta-kernel-rs/default-engine", features = ["arrow-58", "rustls"], default-features = false }
 #delta_kernel_default_engine = {  package = "buoyant_kernel_engine",  git = "https://github.com/buoyant-data/delta-kernel-rs", branch = "buoyant/main", features = ["arrow-58", "rustls"], default-features = false }
-delta_kernel_default_engine = {  package = "buoyant_kernel_engine",  version = "0.25.0,<0.25.100", features = ["arrow-58", "rustls"], default-features = false }
+delta_kernel_default_engine = {  package = "buoyant_kernel_engine",  version = "0.25.0,<0.25.100", features = ["arrow-59", "rustls"], default-features = false }
 
 
 # arrow
-arrow = { version = "58" }
-arrow-arith = { version = "58" }
-arrow-array = { version = "58", features = ["chrono-tz"] }
-arrow-buffer = { version = "58" }
-arrow-cast = { version = "58" }
-arrow-ipc = { version = "58" }
-arrow-json = { version = "58" }
-arrow-ord = { version = "58" }
-arrow-row = { version = "58" }
-arrow-schema = { version = "58" }
-arrow-select = { version = "58" }
+arrow = { version = "59" }
+arrow-arith = { version = "59" }
+arrow-array = { version = "59", features = ["chrono-tz"] }
+arrow-buffer = { version = "59" }
+arrow-cast = { version = "59" }
+arrow-ipc = { version = "59" }
+arrow-json = { version = "59" }
+arrow-ord = { version = "59" }
+arrow-row = { version = "59" }
+arrow-schema = { version = "59" }
+arrow-select = { version = "59" }
 object_store = { version = "0.13.2" }
-parquet = { version = "58" }
+parquet = { version = "59" }
 
 # datafusion 54
-datafusion = { version = "54.1.0" }
-datafusion-datasource = { version = "54.1.0" }
-datafusion-physical-expr-adapter = { version = "54.1.0" }
-datafusion-ffi = { version = "54.1.0" }
-datafusion-proto = { version = "54.1.0" }
+datafusion = { version = "55" }
+datafusion-datasource = { version = "55" }
+datafusion-physical-expr-adapter = { version = "55" }
+datafusion-ffi = { version = "55" }
+datafusion-proto = { version = "55" }
 
 # serde
 serde = { version = "1.0.194", features = ["derive"] }

--- a/crates/core/src/delta_datafusion/column_mapping.rs
+++ b/crates/core/src/delta_datafusion/column_mapping.rs
@@ -17,11 +17,14 @@ use std::task::{Context, Poll};
 use arrow::array::{Array, ArrayData, ArrayRef, RecordBatch, make_array};
 use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
 use datafusion::common::Statistics;
+use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::CardinalityEffect;
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, PlanProperties,
+};
 use delta_kernel::schema::{
     DataType as KernelDataType, SchemaRef as KernelSchemaRef, StructField, StructType,
 };
@@ -216,6 +219,17 @@ impl ExecutionPlan for ColumnMappingExec {
 
     fn cardinality_effect(&self) -> CardinalityEffect {
         CardinalityEffect::Equal
+    }
+
+    fn apply_expressions(
+        &self,
+        expr_rewriter: &mut dyn FnMut(
+            &Arc<dyn PhysicalExpr>,
+        ) -> Result<TreeNodeRecursion, DataFusionError>,
+    ) -> Result<TreeNodeRecursion, DataFusionError> {
+        // Traverse child execution plan with the expression rewriter
+        self.input.apply_expressions(expr_rewriter)?;
+        Ok(TreeNodeRecursion::Continue)
     }
 }
 

--- a/crates/core/src/delta_datafusion/column_mapping.rs
+++ b/crates/core/src/delta_datafusion/column_mapping.rs
@@ -22,6 +22,7 @@ use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::CardinalityEffect;
+use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, PlanProperties,
 };
@@ -209,8 +210,20 @@ impl ExecutionPlan for ColumnMappingExec {
         }))
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
-        self.input.partition_statistics(partition)
+    fn child_stats_requests(&self, partition: Option<usize>) -> Vec<ChildStats> {
+        vec![ChildStats::At(partition)]
+    }
+
+    fn statistics_from_inputs(
+        &self,
+        input_stats: &[Arc<Statistics>],
+        _args: &StatisticsArgs,
+    ) -> Result<Arc<Statistics>> {
+        input_stats.first().map(Arc::clone).ok_or_else(|| {
+            DataFusionError::Internal(
+                "ColumnMappingExec expects statistics for exactly one child".to_string(),
+            )
+        })
     }
 
     fn maintains_input_order(&self) -> Vec<bool> {

--- a/crates/core/src/delta_datafusion/data_validation.rs
+++ b/crates/core/src/delta_datafusion/data_validation.rs
@@ -27,6 +27,7 @@ use datafusion::optimizer::simplify_expressions::simplify_predicates;
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::CardinalityEffect;
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
+use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, PlanProperties,
 };
@@ -486,8 +487,20 @@ impl ExecutionPlan for DataValidationExec {
         )))
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
-        self.input.partition_statistics(partition)
+    fn child_stats_requests(&self, partition: Option<usize>) -> Vec<ChildStats> {
+        vec![ChildStats::At(partition)]
+    }
+
+    fn statistics_from_inputs(
+        &self,
+        input_stats: &[Arc<Statistics>],
+        _args: &StatisticsArgs,
+    ) -> Result<Arc<Statistics>> {
+        input_stats.first().map(Arc::clone).ok_or_else(|| {
+            DataFusionError::Internal(
+                "DataValidationExec expects statistics for exactly one child".to_string(),
+            )
+        })
     }
 
     fn maintains_input_order(&self) -> Vec<bool> {

--- a/crates/core/src/delta_datafusion/data_validation.rs
+++ b/crates/core/src/delta_datafusion/data_validation.rs
@@ -16,9 +16,8 @@ use datafusion::common::{
 };
 use datafusion::config::ConfigOptions;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::execution::{
-    RecordBatchStream, SendableRecordBatchStream, SessionState, TaskContext,
-};
+use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
+use datafusion::logical_expr::physical_planning_context::PhysicalPlanningContext;
 use datafusion::logical_expr::utils::conjunction;
 use datafusion::logical_expr::{
     ColumnarValue, ExprSchemable as _, LogicalPlan, Operator, UserDefinedLogicalNode,
@@ -216,8 +215,9 @@ impl ExtensionPlanner for DataValidationExtensionPlanner {
         node: &dyn UserDefinedLogicalNode,
         _logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
-        session_state: &SessionState,
-    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        session_state: &dyn Session,
+        _planning_ctx: &PhysicalPlanningContext,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>, DataFusionError> {
         if let Some(node) = node.as_any().downcast_ref::<DataValidation>() {
             if physical_inputs.len() != 1 {
                 return plan_err!(
@@ -534,6 +534,17 @@ impl ExecutionPlan for DataValidationExec {
         _config: &ConfigOptions,
     ) -> Result<FilterDescription> {
         FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn apply_expressions(
+        &self,
+        expr_rewriter: &mut dyn FnMut(
+            &Arc<dyn PhysicalExpr>,
+        ) -> Result<TreeNodeRecursion, DataFusionError>,
+    ) -> Result<TreeNodeRecursion, DataFusionError> {
+        // Traverse child execution plan with the expression rewriter
+        self.input.apply_expressions(expr_rewriter)?;
+        Ok(TreeNodeRecursion::Continue)
     }
 }
 

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -48,7 +48,7 @@ use datafusion::logical_expr::{Expr, Extension, LogicalPlan};
 use datafusion::physical_optimizer::pruning::PruningPredicate;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_proto::logical_plan::LogicalExtensionCodec;
-use datafusion_proto::physical_plan::PhysicalExtensionCodec;
+use datafusion_proto::physical_plan::{PhysicalExtensionCodec, PhysicalProtoConverterExtension};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use either::Either;
 
@@ -461,6 +461,7 @@ impl PhysicalExtensionCodec for DeltaPhysicalCodec {
         buf: &[u8],
         inputs: &[Arc<dyn ExecutionPlan>],
         _registry: &TaskContext,
+        _converter: &dyn PhysicalProtoConverterExtension,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let wire: DeltaScanWire = serde_json::from_reader(buf)
             .map_err(|_| DataFusionError::Internal("Unable to decode DeltaScan".to_string()))?;
@@ -472,6 +473,7 @@ impl PhysicalExtensionCodec for DeltaPhysicalCodec {
         &self,
         node: Arc<dyn ExecutionPlan>,
         buf: &mut Vec<u8>,
+        _converter: &dyn PhysicalProtoConverterExtension,
     ) -> Result<(), DataFusionError> {
         let delta_scan = node
             .downcast_ref::<DeltaScan>()
@@ -540,11 +542,15 @@ impl TableProviderFactory for DeltaTableFactory {
         ctx: &dyn Session,
         cmd: &CreateExternalTable,
     ) -> datafusion::error::Result<Arc<dyn TableProvider>> {
+        let location = cmd
+            .locations
+            .get(0)
+            .expect("The command should have at least one location!");
         let table = if cmd.options.is_empty() {
-            let table_url = ensure_table_uri(&cmd.to_owned().location)?;
+            let table_url = ensure_table_uri(&location)?;
             open_table(table_url).await?
         } else {
-            let table_url = ensure_table_uri(&cmd.to_owned().location)?;
+            let table_url = ensure_table_uri(&location)?;
             open_table_with_storage_options(table_url, cmd.to_owned().options).await?
         };
         let table_uri = table.log_store().root_url().clone();

--- a/crates/core/src/delta_datafusion/physical.rs
+++ b/crates/core/src/delta_datafusion/physical.rs
@@ -8,6 +8,7 @@ use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::error::DataFusionError;
 use datafusion::error::Result as DataFusionResult;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
     DisplayAs, ExecutionPlan, PhysicalExpr, RecordBatchStream, SendableRecordBatchStream,
 };
@@ -106,11 +107,20 @@ impl ExecutionPlan for MetricObserverExec {
         }))
     }
 
-    fn partition_statistics(
+    fn child_stats_requests(&self, partition: Option<usize>) -> Vec<ChildStats> {
+        vec![ChildStats::At(partition)]
+    }
+
+    fn statistics_from_inputs(
         &self,
-        partition: Option<usize>,
+        input_stats: &[Arc<Statistics>],
+        _args: &StatisticsArgs,
     ) -> datafusion::common::Result<Arc<Statistics>> {
-        self.parent.partition_statistics(partition)
+        input_stats.first().map(Arc::clone).ok_or_else(|| {
+            DataFusionError::Internal(
+                "MetricObserverExec expects statistics for exactly one child".to_string(),
+            )
+        })
     }
 
     fn with_new_children(

--- a/crates/core/src/delta_datafusion/physical.rs
+++ b/crates/core/src/delta_datafusion/physical.rs
@@ -4,10 +4,12 @@ use std::sync::Arc;
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
 use datafusion::common::Statistics;
+use datafusion::common::tree_node::TreeNodeRecursion;
+use datafusion::error::DataFusionError;
 use datafusion::error::Result as DataFusionResult;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::{
-    DisplayAs, ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
+    DisplayAs, ExecutionPlan, PhysicalExpr, RecordBatchStream, SendableRecordBatchStream,
 };
 use futures::{Stream, StreamExt};
 
@@ -120,6 +122,17 @@ impl ExecutionPlan for MetricObserverExec {
 
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
+    }
+
+    fn apply_expressions(
+        &self,
+        expr_rewriter: &mut dyn FnMut(
+            &Arc<dyn PhysicalExpr>,
+        ) -> Result<TreeNodeRecursion, DataFusionError>,
+    ) -> Result<TreeNodeRecursion, DataFusionError> {
+        // Traverse child execution plan with the expression rewriter
+        self.parent.apply_expressions(expr_rewriter)?;
+        Ok(TreeNodeRecursion::Continue)
     }
 }
 

--- a/crates/core/src/delta_datafusion/planner.rs
+++ b/crates/core/src/delta_datafusion/planner.rs
@@ -25,10 +25,12 @@
 use std::sync::{Arc, LazyLock};
 
 use async_trait::async_trait;
+use datafusion::logical_expr::physical_planning_context::PhysicalPlanningContext;
 use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
 use datafusion::physical_planner::PhysicalPlanner;
 use datafusion::{
-    execution::{context::QueryPlanner, session_state::SessionState},
+    catalog::Session,
+    execution::context::QueryPlanner,
     physical_plan::ExecutionPlan,
     physical_planner::{DefaultPhysicalPlanner, ExtensionPlanner},
 };
@@ -72,14 +74,12 @@ impl QueryPlanner for DeltaPlanner {
     async fn create_physical_plan(
         &self,
         logical_plan: &LogicalPlan,
-        session_state: &SessionState,
+        session: &dyn Session,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let planner = Arc::new(Box::new(DefaultPhysicalPlanner::with_extension_planners(
             vec![DeltaExtensionPlanner::new()],
         )));
-        planner
-            .create_physical_plan(logical_plan, session_state)
-            .await
+        planner.create_physical_plan(logical_plan, session).await
     }
 }
 
@@ -102,7 +102,8 @@ impl ExtensionPlanner for DeltaExtensionPlanner {
         node: &dyn UserDefinedLogicalNode,
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
-        session_state: &SessionState,
+        session_state: &dyn Session,
+        planning_ctx: &PhysicalPlanningContext,
     ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
         for ext_planner in DELTA_EXTENSION_PLANNERS.iter() {
             if let Some(plan) = ext_planner
@@ -112,6 +113,7 @@ impl ExtensionPlanner for DeltaExtensionPlanner {
                     logical_inputs,
                     physical_inputs,
                     session_state,
+                    planning_ctx,
                 )
                 .await?
             {

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -12,6 +12,7 @@ use datafusion::logical_expr::simplify::SimplifyContext;
 use datafusion::optimizer::simplify_expressions::ExprSimplifier;
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, PlanProperties,
 };
@@ -654,8 +655,20 @@ impl ExecutionPlan for DeltaScan {
         Some(self.metrics.clone_inner())
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
-        self.parquet_scan.partition_statistics(partition)
+    fn child_stats_requests(&self, partition: Option<usize>) -> Vec<ChildStats> {
+        vec![ChildStats::At(partition)]
+    }
+
+    fn statistics_from_inputs(
+        &self,
+        input_stats: &[Arc<Statistics>],
+        _args: &StatisticsArgs,
+    ) -> Result<Arc<Statistics>> {
+        input_stats.first().map(Arc::clone).ok_or_else(|| {
+            DataFusionError::Internal(
+                "DeltaScan expects statistics for exactly one child".to_string(),
+            )
+        })
     }
 
     fn gather_filters_for_pushdown(

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::{Schema, SchemaRef};
 use datafusion::catalog::TableProvider;
-use datafusion::common::tree_node::TreeNode;
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::common::{DFSchemaRef, Result, Statistics};
 use datafusion::config::ConfigOptions;
 use datafusion::error::DataFusionError;
@@ -665,6 +665,17 @@ impl ExecutionPlan for DeltaScan {
         _config: &ConfigOptions,
     ) -> Result<FilterDescription> {
         FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn apply_expressions(
+        &self,
+        expr_rewriter: &mut dyn FnMut(
+            &Arc<dyn PhysicalExpr>,
+        ) -> Result<TreeNodeRecursion, DataFusionError>,
+    ) -> Result<TreeNodeRecursion, DataFusionError> {
+        // Traverse child execution plan with the expression rewriter
+        self.parquet_scan.apply_expressions(expr_rewriter)?;
+        Ok(TreeNodeRecursion::Continue)
     }
 }
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -27,6 +27,7 @@ use datafusion::physical_expr::{Distribution, EquivalenceProperties};
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, PlanProperties};
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, Statistics,
 };
@@ -398,10 +399,21 @@ impl ExecutionPlan for DeltaScanExec {
         Some(Arc::new(new_plan))
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
-        let stats = self.input.partition_statistics(partition)?;
-        self.map_statistics(Arc::unwrap_or_clone(stats))
-            .map(Arc::new)
+    fn child_stats_requests(&self, partition: Option<usize>) -> Vec<ChildStats> {
+        // We remap the child's column statistics onto the logical output schema in
+        // `map_statistics`, so we need the child's statistics resolved.
+        vec![ChildStats::At(partition)]
+    }
+
+    fn statistics_from_inputs(
+        &self,
+        input_stats: &[Arc<Statistics>],
+        _args: &StatisticsArgs,
+    ) -> Result<Arc<Statistics>> {
+        let stats = input_stats.first().ok_or_else(|| {
+            internal_datafusion_err!("DeltaScanExec expects statistics for exactly one child")
+        })?;
+        self.map_statistics(Statistics::clone(stats)).map(Arc::new)
     }
 
     fn gather_filters_for_pushdown(
@@ -809,6 +821,7 @@ mod tests {
             PhysicalExpr, collect, collect_partitioned,
             filter_pushdown::{FilterPushdownPhase, PushedDown},
             repartition::RepartitionExec,
+            statistics::StatisticsContext,
         },
         prelude::{col, lit},
         scalar::ScalarValue,
@@ -1478,7 +1491,8 @@ mod tests {
         // for scans without prodicates, we gather only top level statistic
         // and omit collecting column level statistics
         let scan = provider.scan(&session.state(), None, &[], None).await?;
-        let statistics = scan.partition_statistics(None)?;
+        let statistics =
+            StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
         assert_eq!(statistics.num_rows, Precision::Exact(5));
         assert_eq!(statistics.total_byte_size, Precision::Inexact(3240));
         for col_stat in statistics.column_statistics.iter() {
@@ -1497,7 +1511,8 @@ mod tests {
         let scan = provider
             .scan(&session.state(), None, &predicates, None)
             .await?;
-        let statistics = scan.partition_statistics(None)?;
+        let statistics =
+            StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
         for (col_stat, field) in statistics
             .column_statistics
             .iter()
@@ -1537,7 +1552,8 @@ mod tests {
         let scan = provider
             .scan(&session.state(), None, &predicates, None)
             .await?;
-        let statistics = scan.partition_statistics(None)?;
+        let statistics =
+            StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
         assert_eq!(
             statistics.column_statistics.len(),
             provider.schema().fields().len()
@@ -1569,7 +1585,8 @@ mod tests {
         let scan = provider
             .scan(&session.state(), None, &predicates, None)
             .await?;
-        let statistics = scan.partition_statistics(None)?;
+        let statistics =
+            StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
         for (col_stat, _field) in statistics
             .column_statistics
             .iter()

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -16,6 +16,7 @@ use arrow_array::{Array, ArrayRef, BooleanArray, UInt64Array};
 use dashmap::DashMap;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::error::{DataFusionError, Result};
+use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::common::{
     ColumnStatistics, HashMap, internal_datafusion_err, internal_err, plan_err,
 };
@@ -456,6 +457,17 @@ impl ExecutionPlan for DeltaScanExec {
                 &self.children(),
             )),
         }
+    }
+
+    fn apply_expressions(
+        &self,
+        expr_rewriter: &mut dyn FnMut(
+            &Arc<dyn PhysicalExpr>,
+        ) -> Result<TreeNodeRecursion, DataFusionError>,
+    ) -> Result<TreeNodeRecursion, DataFusionError> {
+        // Apply expressions to the input execution plan
+        self.input.apply_expressions(expr_rewriter)?;
+        Ok(TreeNodeRecursion::Continue)
     }
 }
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -1403,10 +1403,17 @@ mod tests {
         assert!(batches[0].schema().column_with_name("filename").is_some());
 
         // Verify each group has a valid parquet filename
-        let filename_col = batches[0]
-            .column_by_name("filename")
-            .unwrap()
-            .as_string_view();
+        //
+        // DataFusion 55 changed `reverse()`'s signature from
+        // `Signature::uniform(1, vec![Utf8View, Utf8, LargeUtf8])` to
+        // `Signature::coercible(Native(logical_string()))` (apache/datafusion#23930).
+        // The old uniform signature widened our dictionary-encoded `file_id` column to
+        // `Utf8View` (first entry in the list); the new coercible signature preserves the
+        // origin string type instead, so this expression now yields `Utf8` rather than
+        // `Utf8View`. Normalize before asserting so the test is encoding-agnostic.
+        let filename_raw = batches[0].column_by_name("filename").unwrap();
+        let filename_flat = arrow::compute::cast(filename_raw, &DataType::Utf8View)?;
+        let filename_col = filename_flat.as_string_view();
 
         for i in 0..filename_col.len() {
             let filename = filename_col.value(i);

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -1491,8 +1491,7 @@ mod tests {
         // for scans without prodicates, we gather only top level statistic
         // and omit collecting column level statistics
         let scan = provider.scan(&session.state(), None, &[], None).await?;
-        let statistics =
-            StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
+        let statistics = StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
         assert_eq!(statistics.num_rows, Precision::Exact(5));
         assert_eq!(statistics.total_byte_size, Precision::Inexact(3240));
         for col_stat in statistics.column_statistics.iter() {
@@ -1511,8 +1510,7 @@ mod tests {
         let scan = provider
             .scan(&session.state(), None, &predicates, None)
             .await?;
-        let statistics =
-            StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
+        let statistics = StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
         for (col_stat, field) in statistics
             .column_statistics
             .iter()
@@ -1552,8 +1550,7 @@ mod tests {
         let scan = provider
             .scan(&session.state(), None, &predicates, None)
             .await?;
-        let statistics =
-            StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
+        let statistics = StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
         assert_eq!(
             statistics.column_statistics.len(),
             provider.schema().fields().len()
@@ -1585,8 +1582,7 @@ mod tests {
         let scan = provider
             .scan(&session.state(), None, &predicates, None)
             .await?;
-        let statistics =
-            StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
+        let statistics = StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
         for (col_stat, _field) in statistics
             .column_statistics
             .iter()

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -27,7 +27,7 @@ use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdo
 use datafusion::physical_plan::metrics::{
     BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
 };
-use datafusion::physical_plan::statistics::{StatisticsArgs, StatisticsContext};
+use datafusion::physical_plan::statistics::StatisticsArgs;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PhysicalExpr, Statistics,
 };
@@ -515,6 +515,7 @@ mod tests {
         common::stats::Precision,
         physical_plan::collect_partitioned,
         physical_plan::displayable,
+        physical_plan::statistics::StatisticsContext,
         prelude::{col, lit},
     };
     use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -27,6 +27,7 @@ use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdo
 use datafusion::physical_plan::metrics::{
     BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
 };
+use datafusion::physical_plan::statistics::{StatisticsArgs, StatisticsContext};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PhysicalExpr, Statistics,
 };
@@ -291,9 +292,15 @@ impl ExecutionPlan for DeltaScanMetaExec {
         None
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
+    fn statistics_from_inputs(
+        &self,
+        _input_stats: &[Arc<Statistics>],
+        args: &StatisticsArgs,
+    ) -> Result<Arc<Statistics>> {
+        // Metadata-only scans synthesize statistics from the Delta log, so the default
+        // `child_stats_requests` (skip every child) is correct here.
         Ok(Arc::new(Statistics {
-            num_rows: Precision::Exact(self.exact_num_rows(partition)?),
+            num_rows: Precision::Exact(self.exact_num_rows(args.partition())?),
             total_byte_size: Precision::Absent,
             column_statistics: Statistics::unknown_column(self.schema().as_ref()),
         }))
@@ -700,7 +707,9 @@ mod tests {
             "expected metadata-only scan\n{diagnostics}"
         );
         assert_eq!(
-            scan.partition_statistics(None)?.num_rows,
+            StatisticsContext::new()
+                .compute(scan.as_ref(), &StatisticsArgs::new())?
+                .num_rows,
             Precision::Exact(expected_row_count),
             "metadata-only scan reported the wrong row count\n{diagnostics}"
         );
@@ -1169,15 +1178,27 @@ mod tests {
             .expect("expected repartitioned DeltaScanMetaExec");
         assert_eq!(repartitioned.input.len(), 2);
         assert_eq!(
-            repartitioned.partition_statistics(Some(0))?.num_rows,
+            StatisticsContext::new()
+                .compute(
+                    repartitioned,
+                    &StatisticsArgs::new().with_partition(Some(0))
+                )?
+                .num_rows,
             Precision::Exact(12)
         );
         assert_eq!(
-            repartitioned.partition_statistics(Some(1))?.num_rows,
+            StatisticsContext::new()
+                .compute(
+                    repartitioned,
+                    &StatisticsArgs::new().with_partition(Some(1))
+                )?
+                .num_rows,
             Precision::Exact(8)
         );
         assert_eq!(
-            repartitioned.partition_statistics(None)?.num_rows,
+            StatisticsContext::new()
+                .compute(repartitioned, &StatisticsArgs::new())?
+                .num_rows,
             Precision::Exact(20)
         );
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -16,6 +16,7 @@ use arrow_schema::{FieldRef, Fields, Schema};
 use dashmap::DashMap;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::error::{DataFusionError, Result};
+use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::common::{HashMap, internal_datafusion_err, stats::Precision};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
@@ -308,6 +309,17 @@ impl ExecutionPlan for DeltaScanMetaExec {
         // since the default methods determines this based on existence of columns in child
         // schemas. In the case of column mapping all columns will have a different name.
         FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn apply_expressions(
+        &self,
+        expr_rewriter: &mut dyn FnMut(
+            &Arc<dyn PhysicalExpr>,
+        ) -> Result<TreeNodeRecursion, DataFusionError>,
+    ) -> Result<TreeNodeRecursion, DataFusionError> {
+        // DeltaScanMetaExec has no children execution plans to traverse
+        // Just continue the recursion
+        Ok(TreeNodeRecursion::Continue)
     }
 }
 

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -44,7 +44,7 @@ use datafusion::catalog::Session;
 use datafusion::common::tree_node::TreeNode;
 use datafusion::common::{ToDFSchema as _, exec_datafusion_err};
 use datafusion::error::Result as DataFusionResult;
-use datafusion::execution::context::SessionState;
+use datafusion::logical_expr::physical_planning_context::PhysicalPlanningContext;
 use datafusion::logical_expr::utils::{conjunction, split_conjunction_owned};
 use datafusion::logical_expr::{Extension, LogicalPlan, UserDefinedLogicalNode, lit};
 use datafusion::optimizer::simplify_expressions::simplify_predicates;
@@ -393,7 +393,8 @@ impl ExtensionPlanner for DeleteMetricExtensionPlanner {
         node: &dyn UserDefinedLogicalNode,
         _logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
-        _session_state: &SessionState,
+        _session: &dyn Session,
+        _planning_ctx: &PhysicalPlanningContext,
     ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
         if let Some(metric_observer) = node.as_any().downcast_ref::<MetricObserver>()
             && (metric_observer.id.eq(SOURCE_COUNT_ID) || metric_observer.id.eq(RESCUED_COUNT_ID))

--- a/crates/core/src/operations/load_cdf.rs
+++ b/crates/core/src/operations/load_cdf.rs
@@ -31,7 +31,7 @@ use datafusion::datasource::memory::DataSourceExec;
 use datafusion::datasource::physical_plan::parquet::CachedParquetFileReaderFactory;
 use datafusion::datasource::physical_plan::{FileGroup, FileScanConfigBuilder, ParquetSource};
 use datafusion::datasource::table_schema::TableSchema;
-use datafusion::execution::cache::DefaultFilesMetadataCache;
+use datafusion::execution::cache::default_cache::DefaultCache;
 use datafusion::logical_expr::Expr;
 use datafusion::physical_expr::{PhysicalExpr, expressions};
 use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
@@ -92,7 +92,7 @@ impl CdfLoadBuilder {
     pub(crate) fn new(log_store: LogStoreRef, snapshot: Option<EagerSnapshot>) -> Self {
         let parquet_metadata_cache = Arc::new(CachedParquetFileReaderFactory::new(
             log_store.object_store(None),
-            Arc::new(DefaultFilesMetadataCache::new(METADATA_CACHE_SIZE)),
+            Arc::new(DefaultCache::new(METADATA_CACHE_SIZE)),
         ));
         Self {
             snapshot,

--- a/crates/core/src/operations/merge/barrier.rs
+++ b/crates/core/src/operations/merge/barrier.rs
@@ -19,6 +19,7 @@ use std::{
 use arrow::array::{Array, ArrayRef, RecordBatch, builder::UInt64Builder};
 use arrow::datatypes::SchemaRef;
 use dashmap::DashSet;
+use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::common::{DataFusionError, Result as DataFusionResult};
 use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 use datafusion::physical_expr::{Distribution, PhysicalExpr};
@@ -116,6 +117,17 @@ impl ExecutionPlan for MergeBarrierExec {
             self.survivors.clone(),
             self.file_column.clone(),
         )))
+    }
+
+    fn apply_expressions(
+        &self,
+        expr_rewriter: &mut dyn FnMut(
+            &Arc<dyn PhysicalExpr>,
+        ) -> Result<TreeNodeRecursion, DataFusionError>,
+    ) -> Result<TreeNodeRecursion, DataFusionError> {
+        // Traverse child execution plan with the expression rewriter
+        self.input.apply_expressions(expr_rewriter)?;
+        Ok(TreeNodeRecursion::Continue)
     }
 }
 

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1547,13 +1547,17 @@ async fn execute(
                 "__delta_rs_update_expanded",
                 when(
                     col(CDC_COLUMN_NAME).eq(lit("update")),
+                    // `new_list` takes the *element* type, not the list type. DataFusion 54
+                    // ignored this argument for non-empty values; 55 casts the values to it
+                    // (apache/datafusion `ScalarValue::new_list`), so passing a list type here
+                    // yields List(List(Utf8)) and unnest leaves a list behind.
                     lit(ScalarValue::List(ScalarValue::new_list(
                         &[
                             ScalarValue::Utf8(Some("update_preimage".into())),
                             ScalarValue::Utf8(Some("update_postimage".into())),
                         ],
-                        &DataType::List(Field::new("element", DataType::Utf8, false).into()),
-                        true,
+                        &DataType::Utf8,
+                        false,
                     ))),
                 )
                 .end()?,

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -44,6 +44,7 @@ use datafusion::datasource::provider_as_source;
 use datafusion::error::Result as DataFusionResult;
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::logical_expr::build_join_schema;
+use datafusion::logical_expr::physical_planning_context::PhysicalPlanningContext;
 use datafusion::logical_expr::simplify::SimplifyContext;
 use datafusion::logical_expr::utils::split_conjunction_owned;
 use datafusion::logical_expr::{
@@ -719,7 +720,8 @@ impl ExtensionPlanner for MergeMetricExtensionPlanner {
         node: &dyn UserDefinedLogicalNode,
         _logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
-        session_state: &SessionState,
+        session_state: &dyn Session,
+        planning_ctx: &PhysicalPlanningContext,
     ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
         if let Some(metric_observer) = node.as_any().downcast_ref::<MetricObserver>() {
             if metric_observer.id.eq(SOURCE_COUNT_ID) {
@@ -796,7 +798,12 @@ impl ExtensionPlanner for MergeMetricExtensionPlanner {
             let schema = validation.input.schema();
             return Ok(Some(Arc::new(MergeValidationExec::new(
                 physical_inputs.first().unwrap().clone(),
-                planner.create_physical_expr(&validation.file_expr, schema, session_state)?,
+                planner.create_physical_expr(
+                    &validation.file_expr,
+                    schema,
+                    session_state,
+                    planning_ctx,
+                )?,
                 Arc::clone(&validation.file_column),
                 Arc::clone(&validation.row_ordinal_column),
             ))));
@@ -810,7 +817,7 @@ impl ExtensionPlanner for MergeMetricExtensionPlanner {
             return Ok(Some(Arc::new(MergeBarrierExec::new(
                 physical_inputs.first().unwrap().clone(),
                 barrier.file_column.clone(),
-                planner.create_physical_expr(&barrier.expr, schema, session_state)?,
+                planner.create_physical_expr(&barrier.expr, schema, session_state, planning_ctx)?,
             ))));
         }
 

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -33,7 +33,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Instant;
 
-use arrow_schema::{DataType, Field, SchemaBuilder};
+use arrow_schema::{DataType, SchemaBuilder};
 use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::common::tree_node::{Transformed, TreeNode};

--- a/crates/core/src/operations/merge/validation.rs
+++ b/crates/core/src/operations/merge/validation.rs
@@ -6,6 +6,7 @@ use std::task::{Context, Poll};
 use arrow::array::{Array, ArrayRef, BooleanArray, Int32Array, RecordBatch, UInt64Array};
 use arrow::compute::{filter_record_batch, take};
 use arrow::datatypes::SchemaRef;
+use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::common::{Column, DataFusionError, Result as DataFusionResult};
 use datafusion::execution::context::SessionState;
 use datafusion::logical_expr::{
@@ -101,6 +102,17 @@ impl ExecutionPlan for MergeValidationExec {
             Arc::clone(&self.file_column),
             Arc::clone(&self.row_ordinal_column),
         )))
+    }
+
+    fn apply_expressions(
+        &self,
+        expr_rewriter: &mut dyn FnMut(
+            &Arc<dyn PhysicalExpr>,
+        ) -> Result<TreeNodeRecursion, DataFusionError>,
+    ) -> Result<TreeNodeRecursion, DataFusionError> {
+        // Traverse child execution plan with the expression rewriter
+        self.input.apply_expressions(expr_rewriter)?;
+        Ok(TreeNodeRecursion::Continue)
     }
 }
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -18,15 +18,18 @@
 //!     .await?;
 //! ````
 
+use futures::future::BoxFuture;
+use futures::prelude::*;
+use itertools::Itertools;
 use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use async_trait::async_trait;
 use datafusion::error::Result as DataFusionResult;
+use datafusion::logical_expr::physical_planning_context::PhysicalPlanningContext;
 use datafusion::{
     catalog::Session,
     common::{Column, ScalarValue, ToDFSchema as _, exec_datafusion_err},
     error::DataFusionError,
-    execution::context::SessionState,
     logical_expr::{
         ExprSchemable as _, Extension, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNode,
         case, cast, col, lit, try_cast, when,
@@ -35,8 +38,6 @@ use datafusion::{
     physical_planner::{ExtensionPlanner, PhysicalPlanner},
     prelude::Expr,
 };
-use futures::{StreamExt as _, TryStreamExt as _, future::BoxFuture, stream};
-use itertools::Itertools as _;
 use parquet::file::properties::WriterProperties;
 use serde::Serialize;
 use tracing::log::*;
@@ -236,7 +237,8 @@ impl ExtensionPlanner for UpdateMetricExtensionPlanner {
         node: &dyn UserDefinedLogicalNode,
         _logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
-        _session_state: &SessionState,
+        _session: &dyn Session,
+        _planning_ctx: &PhysicalPlanningContext,
     ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
         if let Some(metric_observer) = node.as_any().downcast_ref::<MetricObserver>()
             && metric_observer.id.eq(UPDATE_COUNT_ID)

--- a/crates/core/src/operations/write/metrics.rs
+++ b/crates/core/src/operations/write/metrics.rs
@@ -2,11 +2,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use datafusion::common::Result as DataFusionResult;
+use datafusion::logical_expr::physical_planning_context::PhysicalPlanningContext;
 use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
 use datafusion::physical_plan::{ExecutionPlan, metrics::MetricBuilder};
 use datafusion::{
-    execution::SessionState,
+    catalog::Session,
     physical_planner::{ExtensionPlanner, PhysicalPlanner},
+    prelude::Expr,
 };
 
 use crate::delta_datafusion::{logical::MetricObserver, physical::MetricObserverExec};
@@ -31,7 +33,8 @@ impl ExtensionPlanner for WriteMetricExtensionPlanner {
         node: &dyn UserDefinedLogicalNode,
         _logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
-        _session_state: &SessionState,
+        _session_state: &dyn Session,
+        _planning_ctx: &PhysicalPlanningContext,
     ) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
         if let Some(metric_observer) = node.as_any().downcast_ref::<MetricObserver>()
             && metric_observer.id.eq(SOURCE_COUNT_ID)

--- a/crates/core/src/test_utils/datafusion.rs
+++ b/crates/core/src/test_utils/datafusion.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::catalog::Session as DataFusionSession;
+use datafusion::catalog::CatalogProviderList;
+use datafusion::catalog::{EmptyCatalogProviderList, Session as DataFusionSession};
 use datafusion::common::{DFSchema, DataFusionError, ScalarValue};
 use datafusion::config::TableOptions;
 use datafusion::error::Result as DataFusionResult;
@@ -78,6 +79,10 @@ impl WrapperSession {
 
 #[async_trait]
 impl DataFusionSession for WrapperSession {
+    fn catalog_list(&self) -> Arc<dyn CatalogProviderList> {
+        Arc::new(EmptyCatalogProviderList)
+    }
+
     fn session_id(&self) -> &str {
         DataFusionSession::session_id(&self.inner)
     }

--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -11,7 +11,7 @@ use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use parquet::basic::Type;
-use parquet::basic::{ConvertedType, LogicalType};
+use parquet::basic::{ConvertedType, DecimalType, IntType, LogicalType, TimestampType};
 use parquet::file::metadata::ParquetMetaData;
 use parquet::schema::types::{ColumnDescriptor, SchemaDescriptor};
 use parquet::{
@@ -302,25 +302,19 @@ impl StatsScalar {
                 let date = epoch_start + chrono::Duration::days(get_stat!(v) as i64);
                 Ok(Self::Date(date))
             }
-            (Statistics::Int32(v), Some(LogicalType::Decimal { scale, .. })) => {
-                let val = get_stat!(v) as f64 / 10.0_f64.powi(*scale);
+            (Statistics::Int32(v), Some(LogicalType::Decimal(decimal_type))) => {
+                let val = get_stat!(v) as f64 / 10.0_f64.powi(decimal_type.scale);
                 // Spark serializes these as numbers
                 Ok(Self::Decimal {
                     value: val,
-                    scale: *scale,
+                    scale: decimal_type.scale,
                 })
             }
             (Statistics::Int32(v), _) => Ok(Self::Int32(get_stat!(v))),
             // Int64 can be timestamp, decimal, or integer
-            (
-                Statistics::Int64(v),
-                Some(LogicalType::Timestamp {
-                    is_adjusted_to_u_t_c,
-                    unit,
-                }),
-            ) => {
+            (Statistics::Int64(v), Some(LogicalType::Timestamp(timestamp_type))) => {
                 let v = get_stat!(v);
-                let timestamp = match unit {
+                let timestamp = match timestamp_type.unit {
                     TimeUnit::MILLIS => chrono::DateTime::from_timestamp_millis(v),
                     TimeUnit::MICROS => chrono::DateTime::from_timestamp_micros(v),
                     TimeUnit::NANOS => {
@@ -333,18 +327,18 @@ impl StatsScalar {
                     debug_value: v.to_string(),
                     logical_type: logical_type.cloned(),
                 })?;
-                if *is_adjusted_to_u_t_c {
+                if timestamp_type.is_adjusted_to_u_t_c {
                     Ok(Self::Timestamp(timestamp.naive_utc()))
                 } else {
                     Ok(Self::TimestampNtz(timestamp.naive_utc()))
                 }
             }
-            (Statistics::Int64(v), Some(LogicalType::Decimal { scale, .. })) => {
-                let val = get_stat!(v) as f64 / 10.0_f64.powi(*scale);
+            (Statistics::Int64(v), Some(LogicalType::Decimal(decimal_type))) => {
+                let val = get_stat!(v) as f64 / 10.0_f64.powi(decimal_type.scale);
                 // Spark serializes these as numbers
                 Ok(Self::Decimal {
                     value: val,
-                    scale: *scale,
+                    scale: decimal_type.scale,
                 })
             }
             (Statistics::Int64(v), _) => Ok(Self::Int64(get_stat!(v))),
@@ -373,7 +367,7 @@ impl StatsScalar {
                     }),
                 }
             }
-            (Statistics::FixedLenByteArray(v), Some(LogicalType::Decimal { scale, precision })) => {
+            (Statistics::FixedLenByteArray(v), Some(LogicalType::Decimal(decimal_type))) => {
                 let val = if use_min {
                     v.min_bytes_opt()
                 } else {
@@ -386,17 +380,18 @@ impl StatsScalar {
                 } else {
                     return Err(DeltaWriterError::StatsParsingFailed {
                         debug_value: format!("{val:?}"),
-                        logical_type: Some(LogicalType::Decimal {
-                            scale: *scale,
-                            precision: *precision,
-                        }),
+                        logical_type: Some(LogicalType::Decimal(DecimalType {
+                            scale: decimal_type.scale,
+                            precision: decimal_type.precision,
+                        })),
                     });
                 };
 
-                let mut val = val / 10.0_f64.powi(*scale);
+                let mut val = val / 10.0_f64.powi(decimal_type.scale);
 
                 if val.is_normal()
-                    && (val.trunc() as i128).to_string().len() > (precision - scale) as usize
+                    && (val.trunc() as i128).to_string().len()
+                        > (decimal_type.precision - decimal_type.scale) as usize
                 {
                     // For normal values with integer parts that get rounded to a number beyond
                     // the precision - scale range take the next smaller (by magnitude) value
@@ -405,7 +400,7 @@ impl StatsScalar {
 
                 Ok(Self::Decimal {
                     value: val,
-                    scale: *scale,
+                    scale: decimal_type.scale,
                 })
             }
             (Statistics::FixedLenByteArray(v), Some(LogicalType::Uuid)) => {
@@ -674,42 +669,42 @@ mod tests {
         let cases = &[
             (
                 simple_parquet_stat!(Statistics::Boolean, true),
-                Some(LogicalType::Integer {
+                Some(LogicalType::Integer(IntType {
                     bit_width: 1,
                     is_signed: true,
-                }),
+                })),
                 Value::Bool(true),
             ),
             (
                 simple_parquet_stat!(Statistics::Int32, 1),
-                Some(LogicalType::Integer {
+                Some(LogicalType::Integer(IntType {
                     bit_width: 32,
                     is_signed: true,
-                }),
+                })),
                 Value::from(1),
             ),
             (
                 simple_parquet_stat!(Statistics::Int32, 1234),
-                Some(LogicalType::Decimal {
+                Some(LogicalType::Decimal(DecimalType {
                     scale: 3,
                     precision: 4,
-                }),
+                })),
                 Value::from(1.234),
             ),
             (
                 simple_parquet_stat!(Statistics::Int32, 1234),
-                Some(LogicalType::Decimal {
+                Some(LogicalType::Decimal(DecimalType {
                     scale: -1,
                     precision: 4,
-                }),
+                })),
                 Value::from(12340.0),
             ),
             (
                 simple_parquet_stat!(Statistics::Int32, 1234),
-                Some(LogicalType::Decimal {
+                Some(LogicalType::Decimal(DecimalType {
                     scale: 0,
                     precision: 4,
-                }),
+                })),
                 Value::from(1234),
             ),
             (
@@ -719,50 +714,50 @@ mod tests {
             ),
             (
                 simple_parquet_stat!(Statistics::Int64, 1641040496789123456),
-                Some(LogicalType::Timestamp {
+                Some(LogicalType::Timestamp(TimestampType {
                     is_adjusted_to_u_t_c: true,
                     unit: parquet::basic::TimeUnit::NANOS,
-                }),
+                })),
                 Value::from("2022-01-01T12:34:56.789123456Z"),
             ),
             (
                 simple_parquet_stat!(Statistics::Int64, 1641040496789123),
-                Some(LogicalType::Timestamp {
+                Some(LogicalType::Timestamp(TimestampType {
                     is_adjusted_to_u_t_c: true,
                     unit: parquet::basic::TimeUnit::MICROS,
-                }),
+                })),
                 Value::from("2022-01-01T12:34:56.789123Z"),
             ),
             (
                 simple_parquet_stat!(Statistics::Int64, 1641040496789),
-                Some(LogicalType::Timestamp {
+                Some(LogicalType::Timestamp(TimestampType {
                     is_adjusted_to_u_t_c: true,
                     unit: parquet::basic::TimeUnit::MILLIS,
-                }),
+                })),
                 Value::from("2022-01-01T12:34:56.789Z"),
             ),
             (
                 simple_parquet_stat!(Statistics::Int64, 1234),
-                Some(LogicalType::Decimal {
+                Some(LogicalType::Decimal(DecimalType {
                     scale: 3,
                     precision: 4,
-                }),
+                })),
                 Value::from(1.234),
             ),
             (
                 simple_parquet_stat!(Statistics::Int64, 1234),
-                Some(LogicalType::Decimal {
+                Some(LogicalType::Decimal(DecimalType {
                     scale: -1,
                     precision: 4,
-                }),
+                })),
                 Value::from(12340.0),
             ),
             (
                 simple_parquet_stat!(Statistics::Int64, 1234),
-                Some(LogicalType::Decimal {
+                Some(LogicalType::Decimal(DecimalType {
                     scale: 0,
                     precision: 4,
-                }),
+                })),
                 Value::from(1234),
             ),
             (
@@ -785,10 +780,10 @@ mod tests {
                     Statistics::FixedLenByteArray,
                     FixedLenByteArray::from(1243124142314423i128.to_be_bytes().to_vec())
                 ),
-                Some(LogicalType::Decimal {
+                Some(LogicalType::Decimal(DecimalType {
                     scale: 3,
                     precision: 16,
-                }),
+                })),
                 Value::from(1243124142314.423),
             ),
             (
@@ -796,10 +791,10 @@ mod tests {
                     Statistics::FixedLenByteArray,
                     FixedLenByteArray::from(vec![0, 39, 16])
                 ),
-                Some(LogicalType::Decimal {
+                Some(LogicalType::Decimal(DecimalType {
                     scale: 3,
                     precision: 5,
-                }),
+                })),
                 Value::from(10.0),
             ),
             (
@@ -807,10 +802,10 @@ mod tests {
                     Statistics::FixedLenByteArray,
                     FixedLenByteArray::from(1234i128.to_be_bytes().to_vec())
                 ),
-                Some(LogicalType::Decimal {
+                Some(LogicalType::Decimal(DecimalType {
                     scale: 0,
                     precision: 4,
-                }),
+                })),
                 Value::from(1234),
             ),
             (
@@ -820,10 +815,10 @@ mod tests {
                         75, 59, 76, 168, 90, 134, 196, 122, 9, 138, 34, 63, 255, 255, 255, 255
                     ])
                 ),
-                Some(LogicalType::Decimal {
+                Some(LogicalType::Decimal(DecimalType {
                     scale: 6,
                     precision: 38,
-                }),
+                })),
                 Value::from(9.999999999999999e31),
             ),
             (
@@ -833,10 +828,10 @@ mod tests {
                         180, 196, 179, 87, 165, 121, 59, 133, 246, 117, 221, 192, 0, 0, 0, 1
                     ])
                 ),
-                Some(LogicalType::Decimal {
+                Some(LogicalType::Decimal(DecimalType {
                     scale: 6,
                     precision: 38,
-                }),
+                })),
                 Value::from(-9.999999999999999e31),
             ),
             (

--- a/crates/core/tests/it_datafusion/integration_datafusion.rs
+++ b/crates/core/tests/it_datafusion/integration_datafusion.rs
@@ -18,6 +18,7 @@ use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::{Expr, col};
 use datafusion::physical_plan::metrics::Label;
+use datafusion::physical_plan::statistics::{StatisticsArgs, StatisticsContext};
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanVisitor, visit_execution_plan};
 use datafusion::prelude::SessionConfig;
 use datafusion_proto::bytes::{
@@ -685,7 +686,9 @@ mod local {
         let scan = provider
             .scan(&ctx.state(), None, &[col("value").is_not_null()], None)
             .await?;
-        let statistics = scan.partition_statistics(None).unwrap();
+        let statistics = StatisticsContext::new()
+            .compute(scan.as_ref(), &StatisticsArgs::new())
+            .unwrap();
 
         assert_eq!(statistics.num_rows, Precision::Inexact(4));
 
@@ -724,7 +727,9 @@ mod local {
         let table = open_fs_path("../test/tests/data/delta-0.2.0");
         let provider = table.table_provider().await.unwrap();
         let scan = provider.scan(&ctx.state(), None, &[], None).await?;
-        let statistics = scan.partition_statistics(None).unwrap();
+        let statistics = StatisticsContext::new()
+            .compute(scan.as_ref(), &StatisticsArgs::new())
+            .unwrap();
 
         assert_eq!(statistics.num_rows, Precision::Absent);
 
@@ -2784,7 +2789,7 @@ mod insert_into_tests {
 
         let provider = final_table.table_provider().await?;
         let scan = provider.scan(&ctx.state(), None, &[], None).await?;
-        if let Ok(stats) = scan.partition_statistics(None)
+        if let Ok(stats) = StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())
             && let Precision::Exact(num_rows) = stats.num_rows
         {
             assert_eq!(

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -24,7 +24,7 @@ ignored = ["deltalake-catalog-unity"]
 delta_kernel.workspace = true
 url.workspace = true
 
-pyo3-arrow = { version = "0.17.0", default-features = false }
+pyo3-arrow = { version = "0.19.0", default-features = false }
 
 # arrow
 arrow-schema = { workspace = true, features = ["serde"] }
@@ -32,7 +32,7 @@ arrow-cast = { workspace = true }
 
 # datafusion
 datafusion-ffi = { workspace = true }
-datafusion-execution = { version = "54.0.0" }
+datafusion-execution = { version = "55" }
 
 # serde
 serde = { workspace = true }
@@ -89,7 +89,7 @@ tikv-jemallocator = { version = "0.7.0", features = [
 tikv-jemallocator = { version = "0.7.0", features = ["disable_initial_exec_tls"] }
 
 [dependencies.pyo3]
-version = "0.28"
+version = "0.29"
 features = ["extension-module", "abi3", "abi3-py310"]
 
 [dependencies.deltalake]

--- a/python/src/datafusion.rs
+++ b/python/src/datafusion.rs
@@ -14,6 +14,7 @@ use deltalake::datafusion::catalog::{Session, TableProvider};
 use deltalake::datafusion::common::{Column, DFSchema, Result as DataFusionResult};
 use deltalake::datafusion::datasource::TableType;
 use deltalake::datafusion::execution::object_store::ObjectStoreUrl;
+use deltalake::datafusion::logical_expr::physical_planning_context::PhysicalPlanningContext;
 use deltalake::datafusion::logical_expr::{LogicalPlan, TableProviderFilterPushDown};
 use deltalake::datafusion::prelude::Expr;
 use deltalake::delta_datafusion::DeltaScanNext;
@@ -71,8 +72,12 @@ impl TableProvider for LazyTableProvider {
         let df_schema: DFSchema = plan.schema().try_into()?;
 
         if let Some(filter_expr) = conjunction(filters.iter().cloned()) {
-            let physical_expr =
-                create_physical_expr(&filter_expr, &df_schema, &ExecutionProps::new())?;
+            let physical_expr = create_physical_expr(
+                &filter_expr,
+                &df_schema,
+                &ExecutionProps::new(),
+                &PhysicalPlanningContext::default(),
+            )?;
             plan = Arc::new(FilterExec::try_new(physical_expr, plan)?);
         }
 
@@ -88,6 +93,7 @@ impl TableProvider for LazyTableProvider {
                             &Expr::Column(Column::from((table_ref, field))),
                             &df_schema,
                             execution_props,
+                            &PhysicalPlanningContext::default(),
                         )
                         .map(|expr| (expr, field.name().clone()))
                         .map_err(DeltaTableError::from)


### PR DESCRIPTION
This change contains the datafusion 55 upgrade which had some API changes that needed addressing. Of particular note for code review were changes needed to pass some of the table provider statistics tests around partition handling.

