### PR TITLE
chore: bump cargo.toml to 1.6.3

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "1.6.2"
+version = "1.6.3"
 authors = [
     "Qingping Hou <dave2008713@gmail.com>",
     "Will Jones <willjones127@gmail.com>",


### PR DESCRIPTION
# Description
Bumping python/cargo.toml to 1.6.3 for the next release