### PR TITLE
fix: vacuum percent-encoded partition paths

### DIFF
--- a/crates/core/src/kernel/snapshot/iterators/tombstones.rs
+++ b/crates/core/src/kernel/snapshot/iterators/tombstones.rs
@@ -5,7 +5,7 @@ use arrow::{
     datatypes::Int64Type,
 };
 use delta_kernel::{actions::Remove, schema::ToSchema};
-use object_store::path::Path;
+use object_store::path::{Path, PathPart};
 use percent_encoding::percent_decode_str;
 
 use crate::kernel::snapshot::iterators::get_string_value;
@@ -38,10 +38,10 @@ impl TombstoneView {
     /// Returns an object store path using the same decoded representation as logical files.
     pub(crate) fn object_store_path(&self) -> Path {
         let path = self.path();
-        match Path::parse(path.as_ref()) {
-            Ok(path) => path,
-            Err(_) => Path::from(path.as_ref()),
-        }
+        path.as_ref()
+            .split('/')
+            .map(|segment| PathPart::parse(segment).unwrap_or_else(|_| PathPart::from(segment)))
+            .collect()
     }
 
     /// Returns the deletion timestamp (milliseconds since epoch), if recorded.
@@ -94,8 +94,7 @@ mod tests {
     use delta_kernel::scan::scan_row_schema;
     use std::sync::Arc;
 
-    #[test]
-    fn object_store_path_matches_logical_file_view() {
+    fn tombstone_view(raw_path: &str) -> TombstoneView {
         let kernel_schema = Remove::to_schema();
         let schema: Schema = (&kernel_schema).try_into_arrow().unwrap();
         let mut columns: Vec<ArrayRef> = schema
@@ -103,14 +102,19 @@ mod tests {
             .iter()
             .map(|field| new_null_array(field.data_type(), 1))
             .collect();
-        let raw_path = "part=a%20b/file.parquet";
         columns[schema.index_of("path").unwrap()] =
             Arc::new(StringArray::from(vec![Some(raw_path)]));
         columns[schema.index_of("dataChange").unwrap()] =
             Arc::new(BooleanArray::from(vec![Some(true)]));
 
         let batch = RecordBatch::try_new(Arc::new(schema), columns).unwrap();
-        let view = TombstoneView::new(batch, 0);
+        TombstoneView::new(batch, 0)
+    }
+
+    #[test]
+    fn object_store_path_matches_logical_file_view() {
+        let raw_path = "part=a%20b/file.parquet";
+        let view = tombstone_view(raw_path);
 
         assert_eq!(view.path(), "part=a b/file.parquet");
         let expected = Path::parse(view.path().as_ref()).unwrap();
@@ -134,5 +138,24 @@ mod tests {
         let logical_view =
             crate::kernel::snapshot::iterators::LogicalFileView::new(logical_batch, 0);
         assert_eq!(view.object_store_path(), logical_view.object_store_path());
+    }
+
+    #[test]
+    fn object_store_path_falls_back_for_invalid_path() {
+        let view = tombstone_view("valid/../file.parquet");
+
+        assert!(Path::parse(view.path().as_ref()).is_err());
+        assert_eq!(
+            view.object_store_path().as_ref(),
+            "valid/%2E%2E/file.parquet"
+        );
+    }
+
+    #[test]
+    fn object_store_path_preserves_percent_encoding() {
+        let view = tombstone_view("part=a%2520b/file.parquet");
+
+        assert_eq!(view.path(), "part=a%20b/file.parquet");
+        assert_eq!(view.object_store_path().as_ref(), "part=a%20b/file.parquet");
     }
 }

--- a/crates/core/src/kernel/snapshot/iterators/tombstones.rs
+++ b/crates/core/src/kernel/snapshot/iterators/tombstones.rs
@@ -5,6 +5,7 @@ use arrow::{
     datatypes::Int64Type,
 };
 use delta_kernel::{actions::Remove, schema::ToSchema};
+use object_store::path::Path;
 use percent_encoding::percent_decode_str;
 
 use crate::kernel::snapshot::iterators::get_string_value;
@@ -32,6 +33,15 @@ impl TombstoneView {
         let raw = get_string_value(self.data.column(*FIELD_INDEX), self.index)
             .expect("valid string field");
         percent_decode_str(raw).decode_utf8_lossy()
+    }
+
+    /// Returns an object store path using the same decoded representation as logical files.
+    pub(crate) fn object_store_path(&self) -> Path {
+        let path = self.path();
+        match Path::parse(path.as_ref()) {
+            Ok(path) => path,
+            Err(_) => Path::from(path.as_ref()),
+        }
     }
 
     /// Returns the deletion timestamp (milliseconds since epoch), if recorded.
@@ -70,5 +80,59 @@ impl TombstoneView {
             .column(*FIELD_INDEX)
             .as_primitive_opt::<Int64Type>()
             .map(|a| a.value(self.index))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::{
+        array::{ArrayRef, BooleanArray, StringArray, new_null_array},
+        datatypes::Schema,
+    };
+    use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+    use delta_kernel::scan::scan_row_schema;
+    use std::sync::Arc;
+
+    #[test]
+    fn object_store_path_matches_logical_file_view() {
+        let kernel_schema = Remove::to_schema();
+        let schema: Schema = (&kernel_schema).try_into_arrow().unwrap();
+        let mut columns: Vec<ArrayRef> = schema
+            .fields()
+            .iter()
+            .map(|field| new_null_array(field.data_type(), 1))
+            .collect();
+        let raw_path = "part=a%20b/file.parquet";
+        columns[schema.index_of("path").unwrap()] =
+            Arc::new(StringArray::from(vec![Some(raw_path)]));
+        columns[schema.index_of("dataChange").unwrap()] =
+            Arc::new(BooleanArray::from(vec![Some(true)]));
+
+        let batch = RecordBatch::try_new(Arc::new(schema), columns).unwrap();
+        let view = TombstoneView::new(batch, 0);
+
+        assert_eq!(view.path(), "part=a b/file.parquet");
+        let expected = Path::parse(view.path().as_ref()).unwrap();
+        assert_eq!(view.object_store_path(), expected);
+        assert_eq!(view.object_store_path().as_ref(), "part=a b/file.parquet");
+
+        let logical_schema: Schema = scan_row_schema().as_ref().try_into_arrow().unwrap();
+        let mut logical_columns: Vec<ArrayRef> = logical_schema
+            .fields()
+            .iter()
+            .map(|field| new_null_array(field.data_type(), 1))
+            .collect();
+        logical_columns[logical_schema.index_of("path").unwrap()] =
+            Arc::new(StringArray::from(vec![Some(raw_path)]));
+        logical_columns[logical_schema.index_of("size").unwrap()] =
+            Arc::new(arrow::array::Int64Array::from(vec![Some(1)]));
+        logical_columns[logical_schema.index_of("modificationTime").unwrap()] =
+            Arc::new(arrow::array::Int64Array::from(vec![Some(1)]));
+        let logical_batch =
+            RecordBatch::try_new(Arc::new(logical_schema), logical_columns).unwrap();
+        let logical_view =
+            crate::kernel::snapshot::iterators::LogicalFileView::new(logical_batch, 0);
+        assert_eq!(view.object_store_path(), logical_view.object_store_path());
     }
 }

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -326,7 +326,7 @@ impl VacuumBuilder {
         // VacuumMode::Lite file set
         // Expired tombstones are *always deleted (*unless in keep list)
         for tombs in expired_tombstones.iter() {
-            let path = Path::from(tombs.path().to_string());
+            let path = tombs.object_store_path();
             if ok_to_delete(&path, &valid_files, &keep_files, partition_columns)? {
                 files_to_delete.push(path);
                 file_sizes.push(tombs.size().unwrap_or(0));
@@ -617,7 +617,7 @@ async fn collect_full_mode_tombstones(
             (Vec::new(), TombstonePathSets::default()),
             |(mut expired_tombstones, mut tombstone_path_sets), tombstone| {
                 let is_expired = is_tombstone_expired(&tombstone, tombstone_retention_timestamp);
-                let path = Path::from(tombstone.path().to_string());
+                let path = tombstone.object_store_path();
                 tombstone_path_sets.record(path, is_expired);
                 if is_expired {
                     expired_tombstones.push(tombstone);
@@ -712,6 +712,84 @@ mod tests {
                 "part-00001-4327c977-2734-4477-9507-7ccf67924649-c000.snappy.parquet",
             ]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_vacuum_lite_deletes_percent_encoded_partition_path() -> DeltaResult<()> {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let table_path = temp_dir.path().to_str().unwrap();
+        let partition_columns = vec!["modified".to_string()];
+        let mut table = create_initialized_table(table_path, &partition_columns).await;
+
+        let mut writer = JsonWriter::for_table(&table)?;
+        writer
+            .write(vec![json!({
+                "id": "A",
+                "value": 1,
+                "modified": "a b"
+            })])
+            .await?;
+        writer.flush_and_commit(&mut table).await?;
+
+        let old_path = table
+            .snapshot()?
+            .log_data()
+            .into_iter()
+            .next()
+            .unwrap()
+            .object_store_path()
+            .to_string();
+        let old_file = temp_dir.path().join(&old_path);
+        assert!(old_file.exists(), "expected written file at {old_path}");
+
+        let remove_actions = table
+            .snapshot()?
+            .snapshot()
+            .file_views(&table.log_store(), None)
+            .map_ok(|file| {
+                let mut remove = file.remove_action(true);
+                remove.deletion_timestamp = Some(0);
+                Action::Remove(remove)
+            })
+            .try_collect::<Vec<_>>()
+            .await?;
+        let mut overwrite_writer = JsonWriter::for_table(&table)?;
+        overwrite_writer
+            .write(vec![json!({
+                "id": "B",
+                "value": 2,
+                "modified": "a b"
+            })])
+            .await?;
+        let add_actions = overwrite_writer.flush().await?.into_iter().map(Action::Add);
+        let mut actions = remove_actions;
+        actions.extend(add_actions);
+
+        CommitBuilder::default()
+            .with_actions(actions)
+            .build(
+                Some(table.snapshot()?),
+                table.log_store().clone(),
+                DeltaOperation::Write {
+                    mode: SaveMode::Overwrite,
+                    partition_by: Some(partition_columns),
+                    predicate: None,
+                },
+            )
+            .await?;
+        table.update_state().await?;
+
+        let (_table, result) =
+            VacuumBuilder::new(table.log_store(), Some(table.snapshot()?.snapshot.clone()))
+                .with_retention_period(Duration::hours(0))
+                .with_dry_run(false)
+                .with_mode(VacuumMode::Lite)
+                .with_enforce_retention_duration(false)
+                .await?;
+
+        assert!(result.files_deleted.contains(&old_path));
+        assert!(!old_file.exists());
         Ok(())
     }
 

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -325,11 +325,10 @@ impl VacuumBuilder {
 
         // VacuumMode::Lite file set
         // Expired tombstones are *always deleted (*unless in keep list)
-        for tombs in expired_tombstones.iter() {
-            let path = tombs.object_store_path();
+        for (tombstone, path) in expired_tombstones {
             if ok_to_delete(&path, &valid_files, &keep_files, partition_columns)? {
                 files_to_delete.push(path);
-                file_sizes.push(tombs.size().unwrap_or(0));
+                file_sizes.push(tombstone.size().unwrap_or(0));
             }
         }
 
@@ -609,7 +608,7 @@ async fn collect_full_mode_tombstones(
     snapshot: &EagerSnapshot,
     tombstone_retention_timestamp: i64,
     store: &dyn LogStore,
-) -> DeltaResult<(Vec<TombstoneView>, TombstonePathSets)> {
+) -> DeltaResult<(Vec<(TombstoneView, Path)>, TombstonePathSets)> {
     snapshot
         .snapshot()
         .active_tombstones(store)
@@ -618,9 +617,9 @@ async fn collect_full_mode_tombstones(
             |(mut expired_tombstones, mut tombstone_path_sets), tombstone| {
                 let is_expired = is_tombstone_expired(&tombstone, tombstone_retention_timestamp);
                 let path = tombstone.object_store_path();
-                tombstone_path_sets.record(path, is_expired);
+                tombstone_path_sets.record(path.clone(), is_expired);
                 if is_expired {
-                    expired_tombstones.push(tombstone);
+                    expired_tombstones.push((tombstone, path));
                 }
                 ready(Ok((expired_tombstones, tombstone_path_sets)))
             },
@@ -634,7 +633,7 @@ async fn get_stale_files(
     retention_period: Duration,
     now_timestamp_millis: i64,
     store: &dyn LogStore,
-) -> DeltaResult<Vec<TombstoneView>> {
+) -> DeltaResult<Vec<(TombstoneView, Path)>> {
     let tombstone_retention_timestamp = now_timestamp_millis - retention_period.num_milliseconds();
     snapshot
         .snapshot()
@@ -644,6 +643,10 @@ async fn get_stale_files(
                 tombstone,
                 tombstone_retention_timestamp,
             ))
+        })
+        .map_ok(|tombstone| {
+            let path = tombstone.object_store_path();
+            (tombstone, path)
         })
         .try_collect::<Vec<_>>()
         .await


### PR DESCRIPTION
# Description

Vacuum rebuilt decoded tombstone paths with `Path::from`, which re-encoded
percent-escaped partition names. It could therefore report a deletion while
leaving the original file in place.

This constructs tombstone object-store paths the same way as active files and
uses them in both lite and full vacuum modes. A local regression test verifies
that lite vacuum deletes a superseded file under an escaped partition path.

# Related Issue(s)

- Closes #4646

# Documentation

Not applicable.

# Testing

- Regression fails with the old vacuum path conversion and passes with this fix
- `cargo check -p deltalake-core --lib --no-default-features --features rustls`
- `git diff --check`

# AI assistance

OpenAI Codex helped draft the patch and tests. I reviewed the path semantics and
verified the regression and final diff.
