### PR TITLE
fix: make skip_stats snapshot updates replay safe

### DIFF
--- a/crates/core/src/kernel/snapshot/iterators/scan_row.rs
+++ b/crates/core/src/kernel/snapshot/iterators/scan_row.rs
@@ -164,7 +164,7 @@ fn parse_stats_column_impl(
         if field.name() == FIELD_STATS_PARSED {
             continue;
         }
-        if field.name() == FIELD_STATS && !stats_materialization.preserves_raw_stats() {
+        if field.name() == FIELD_STATS && !stats_materialization.retains_stats_field() {
             continue;
         }
         fields.push(field.clone());

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, LazyLock};
 
 use arrow::array::RecordBatch;
 use arrow::compute::{filter_record_batch, is_not_null};
-use arrow::datatypes::SchemaRef;
+use arrow::datatypes::{DataType as ArrowDataType, SchemaRef};
 use delta_kernel::actions::{Remove, Sidecar};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
@@ -49,6 +49,7 @@ use crate::logstore::{LogStore, LogStoreExt};
 use crate::{DeltaResult, DeltaTableConfig, DeltaTableError, PartitionFilter, to_kernel_predicate};
 
 pub use self::log_data::*;
+use self::stats_projection::FIELD_STATS;
 pub(crate) use self::stats_projection::{
     FIELD_STATS_PARSED, FileStatsMaterialization, StatsProjection,
 };
@@ -1254,6 +1255,19 @@ impl MaterializedFiles {
     }
 
     fn full_table_seed(&self) -> Option<MaterializedFilesSeed> {
+        if self.policy == MaterializedFilesPolicy::FullTableWithoutStats
+            && !self.batches.iter().all(|batch| {
+                batch
+                    .schema_ref()
+                    .field_with_name(FIELD_STATS)
+                    .is_ok_and(|field| {
+                        field.data_type() == &ArrowDataType::Utf8 && field.is_nullable()
+                    })
+            })
+        {
+            return None;
+        }
+
         match self.scope {
             MaterializedFilesScope::FullTable => Some(MaterializedFilesSeed {
                 version: self.identity.version,
@@ -1734,6 +1748,59 @@ mod tests {
         append_test_add_with_stats(&mut table, "part-00000.snappy.parquet", custom_stats).await?;
 
         Ok((table_dir, table))
+    }
+
+    async fn table_with_initial_stats_add() -> DeltaResult<(TempDir, DeltaTable)> {
+        let table_dir = tempfile::tempdir().unwrap();
+        let mut add = make_test_add("part-00000.snappy.parquet", &[], 0);
+        add.size = 1;
+        add.stats = Some(
+            r#"{"numRecords":1,"minValues":{"id":1},"maxValues":{"id":1},"nullCount":{"id":0}}"#
+                .to_string(),
+        );
+        let table = CreateBuilder::new()
+            .with_location(table_dir.path().to_string_lossy())
+            .with_columns([StructField::new(
+                "id",
+                DataType::Primitive(PrimitiveType::Integer),
+                true,
+            )])
+            .with_actions([Action::Add(add)])
+            .await?;
+
+        assert_eq!(table.version(), Some(0));
+        Ok((table_dir, table))
+    }
+
+    fn assert_canonical_no_stats_cache(materialized_files: &MaterializedFiles) {
+        assert_eq!(
+            materialized_files.policy,
+            MaterializedFilesPolicy::FullTableWithoutStats
+        );
+        for batch in materialized_files.batches.iter() {
+            let field = batch
+                .schema_ref()
+                .field_with_name("stats")
+                .expect("cache without statistics must retain the canonical stats field");
+            assert_eq!(field.data_type(), &ArrowDataType::Utf8);
+            assert!(field.is_nullable());
+            let stats = batch
+                .column_by_name("stats")
+                .expect("cache without statistics must retain the canonical stats column");
+            assert_eq!(stats.null_count(), batch.num_rows());
+            assert!(batch.column_by_name("stats_parsed").is_none());
+        }
+    }
+
+    fn without_stats_field(batch: &RecordBatch) -> DeltaResult<RecordBatch> {
+        let projection = batch
+            .schema_ref()
+            .fields()
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, field)| (field.name() != "stats").then_some(idx))
+            .collect::<Vec<_>>();
+        Ok(batch.project(&projection)?)
     }
 
     fn field_count(batch: &RecordBatch, name: &str) -> usize {
@@ -3484,6 +3551,160 @@ mod tests {
             seed.into_iter().collect::<Vec<_>>(),
             materialized_files.batches.as_ref()
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn skip_stats_cache_seeds_update_replay() -> TestResult {
+        let (_table_dir, mut table) = table_with_initial_stats_add().await?;
+        let log_store = table.log_store();
+        let config = DeltaTableConfig {
+            skip_stats: true,
+            ..Default::default()
+        };
+        let mut snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, Some(0)).await?;
+
+        let initial_cache = snapshot
+            .snapshot()
+            .materialized_files()
+            .expect("eager snapshot must contain materialized files");
+        assert_canonical_no_stats_cache(initial_cache);
+        assert!(
+            initial_cache.full_table_seed().is_some(),
+            "new cache without statistics must support replay"
+        );
+
+        append_test_add_with_stats(
+            &mut table,
+            "part-00001.snappy.parquet",
+            r#"{"numRecords":1,"minValues":{"id":2},"maxValues":{"id":2},"nullCount":{"id":0}}"#,
+        )
+        .await?;
+        snapshot.update(log_store.as_ref(), Some(1)).await?;
+
+        assert_eq!(snapshot.version(), 1);
+        let mut files: Vec<_> = snapshot
+            .file_views(log_store.as_ref(), None)
+            .try_collect()
+            .await?;
+        files.sort_by_key(|file| file.path().into_owned());
+        assert_eq!(
+            files.iter().map(|file| file.path()).collect_vec(),
+            ["part-00000.snappy.parquet", "part-00001.snappy.parquet"]
+        );
+        assert!(files.iter().all(|file| file.stats().is_none()));
+
+        let updated_cache = snapshot
+            .snapshot()
+            .materialized_files()
+            .expect("updated eager snapshot must retain materialized files");
+        assert_canonical_no_stats_cache(updated_cache);
+        assert!(
+            updated_cache.full_table_seed().is_some(),
+            "updated cache without statistics must support replay"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_skip_stats_cache_reads_current_files_and_rebuilds_for_update() -> TestResult {
+        let (_table_dir, mut table) = table_with_initial_stats_add().await?;
+        let (log_store, mut operations) = recording_log_store(table.log_store());
+        let config = DeltaTableConfig {
+            skip_stats: true,
+            ..Default::default()
+        };
+        let snapshot = EagerSnapshot::try_new(log_store.as_ref(), config.clone(), Some(0)).await?;
+        let current_cache = snapshot
+            .snapshot()
+            .materialized_files()
+            .expect("eager snapshot must contain materialized files");
+        let mut legacy_cache = current_cache.as_ref().clone();
+        legacy_cache.batches = current_cache
+            .batches
+            .iter()
+            .map(without_stats_field)
+            .collect::<DeltaResult<Vec<_>>>()?
+            .into();
+        assert!(
+            legacy_cache
+                .batches
+                .iter()
+                .any(|batch| batch.num_rows() > 0)
+        );
+        assert!(
+            legacy_cache.full_table_seed().is_none(),
+            "cache without a stats field cannot seed replay"
+        );
+
+        let zero_row_cache = MaterializedFiles {
+            batches: vec![legacy_cache.batches[0].slice(0, 0)].into(),
+            ..legacy_cache.clone()
+        };
+        assert!(
+            zero_row_cache.full_table_seed().is_none(),
+            "empty batch without a stats field cannot seed replay"
+        );
+
+        let empty_table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([StructField::new(
+                "id",
+                DataType::Primitive(PrimitiveType::Integer),
+                true,
+            )])
+            .await?;
+        let empty_snapshot = Snapshot::try_new(
+            empty_table.log_store().as_ref(),
+            config,
+            empty_table.version(),
+        )
+        .await?;
+        let zero_batch_cache = MaterializedFiles::full(&empty_snapshot, vec![]);
+        assert!(
+            zero_batch_cache.full_table_seed().is_some(),
+            "cache with no batches can seed replay"
+        );
+
+        let cached_snapshot = Arc::new(
+            snapshot
+                .snapshot()
+                .with_materialized_files(Some(Arc::new(legacy_cache))),
+        );
+        let mut legacy_snapshot = EagerSnapshot {
+            snapshot: cached_snapshot,
+        };
+        drain_recorded_ops(&mut operations).await;
+
+        let files: Vec<_> = legacy_snapshot
+            .file_views(log_store.as_ref(), None)
+            .try_collect()
+            .await?;
+        let read_ops = drain_recorded_ops(&mut operations).await;
+        assert_eq!(files.len(), 1);
+        assert!(files.iter().all(|file| file.stats().is_none()));
+        assert!(
+            read_ops.iter().all(|op| !op.is_log_replay_read()),
+            "current version read must use the legacy cache; operations: {read_ops:?}"
+        );
+
+        append_test_add_with_stats(
+            &mut table,
+            "part-00001.snappy.parquet",
+            r#"{"numRecords":1,"minValues":{"id":2},"maxValues":{"id":2},"nullCount":{"id":0}}"#,
+        )
+        .await?;
+        legacy_snapshot.update(log_store.as_ref(), Some(1)).await?;
+
+        assert_eq!(legacy_snapshot.version(), 1);
+        let replacement_cache = legacy_snapshot
+            .snapshot()
+            .materialized_files()
+            .expect("full replay must replace the legacy cache");
+        assert_canonical_no_stats_cache(replacement_cache);
+        assert!(replacement_cache.full_table_seed().is_some());
 
         Ok(())
     }

--- a/crates/core/src/kernel/snapshot/scan.rs
+++ b/crates/core/src/kernel/snapshot/scan.rs
@@ -1,4 +1,6 @@
+use std::cell::RefCell;
 use std::pin::Pin;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
@@ -14,9 +16,9 @@ use url::Url;
 
 #[cfg(feature = "datafusion")]
 use super::MaterializedFiles;
-use super::stats_projection::{FileStatsMaterialization, StatsProjection};
-use crate::DeltaResult;
+use super::stats_projection::{FileStatsMaterialization, StatsProjection, StatsSourcePolicy};
 use crate::kernel::{ReceiverStreamBuilder, scan_row_in_eval};
+use crate::{DeltaResult, DeltaTableError};
 
 /// A boxed, `Send`able stream of [`ScanMetadata`] results produced while scanning a snapshot.
 pub type SendableScanMetadataStream = Pin<Box<dyn Stream<Item = DeltaResult<ScanMetadata>> + Send>>;
@@ -77,10 +79,11 @@ impl ScanBuilder {
 
     /// Skip file statistics during kernel log replay.
     ///
-    /// When `true`, min/max/null stats are not parsed and `stats_parsed` in scan output may
-    /// be null. Partition filtering still applies. With a predicate, stats based data skipping
-    /// is disabled. Use `false` when file pruning from statistics is required. Passing `false`
-    /// clears any previous stats materialization override and restores default inference.
+    /// Set `true` to make the kernel skip minimum and maximum values plus null counts.
+    /// The kernel disables predicate pruning, including partition pruning. Scan metadata keeps
+    /// each active file for predicates that depend on file data. Readers must apply the predicate.
+    /// Set `false` to remove a prior override. The builder infers statistics materialization and
+    /// enables kernel pruning.
     pub fn with_skip_stats(mut self, skip_stats: bool) -> Self {
         if skip_stats {
             self.stats_materialization = Some(FileStatsMaterialization::without_stats());
@@ -119,9 +122,6 @@ impl ScanBuilder {
             )?),
         };
 
-        // Modernization: Use kernel's StatsOptions when available
-        // TODO: Add condition to use kernel StatsOptions API once fully integrated
-
         let inner = build_kernel_scan(snapshot, schema, predicate, Some(&stats_materialization))?;
 
         Ok(Scan::new(Arc::new(inner), stats_materialization))
@@ -158,22 +158,19 @@ fn with_kernel_stats_output(
     builder: KernelScanBuilder,
     materialization: &FileStatsMaterialization,
 ) -> KernelScanBuilder {
-    // Modernize to use kernel's StatsOptions API
-    // Map our legacy StatsProjection to kernel's modern StatsOptions
-
-    let stats_opts = match materialization.stats_projection() {
-        StatsProjection::None => delta_kernel::scan::StatsOptions::json_only(),
-        StatsProjection::Full => delta_kernel::scan::StatsOptions::all_struct(),
-        StatsProjection::PredicateColumns(_columns) => {
-            // Use kernel's efficient column-based stats
-            // TODO: Use specific column selection: StructStats::Columns(_columns.iter().cloned().collect())
-            delta_kernel::scan::StatsOptions::all_struct()
-        }
-        StatsProjection::NumRecordsOnly => delta_kernel::scan::StatsOptions::json_only(),
+    let stats_opts = match materialization.stats_source_policy() {
+        StatsSourcePolicy::None => delta_kernel::scan::StatsOptions::none(),
+        StatsSourcePolicy::ParsedWithJsonFallback => match materialization.stats_projection() {
+            StatsProjection::None => delta_kernel::scan::StatsOptions::json_only(),
+            StatsProjection::Full => delta_kernel::scan::StatsOptions::all_struct(),
+            StatsProjection::PredicateColumns(_columns) => {
+                // TODO: Pass the selected columns to `StatsOptions::struct_columns`.
+                delta_kernel::scan::StatsOptions::all_struct()
+            }
+            StatsProjection::NumRecordsOnly => delta_kernel::scan::StatsOptions::json_only(),
+        },
     };
 
-    // Apply the kernel's native stats options
-    // This reuses the kernel's efficient StructStats implementation
     builder.with_stats(stats_opts)
 }
 
@@ -182,12 +179,15 @@ mod tests {
     use delta_kernel::expressions::{ColumnName, Scalar};
     use delta_kernel::schema::{DataType, StructField, StructType};
     use delta_kernel::{Expression, PredicateRef};
+    use futures::TryStreamExt;
 
     use super::super::stats_projection::{
         FileStatsMaterialization, StatsProjection, StatsSourcePolicy,
     };
     use super::*;
-    use crate::DeltaTable;
+    use crate::kernel::Action;
+    use crate::test_utils::make_test_add;
+    use crate::{DeltaTable, kernel::snapshot::Snapshot};
 
     async fn synthetic_snapshot() -> DeltaResult<super::super::Snapshot> {
         let nested = StructType::try_new([
@@ -315,6 +315,68 @@ mod tests {
         );
         assert!(!scan.stats_materialization().preserves_raw_stats());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn scan_builder_skip_stats_disables_partition_pruning() -> DeltaResult<()> {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([
+                StructField::nullable("value", DataType::INTEGER),
+                StructField::nullable("part", DataType::STRING),
+            ])
+            .with_partition_columns(["part"])
+            .with_actions([
+                Action::Add(make_test_add("part=a/part-a.parquet", &[("part", "a")], 0)),
+                Action::Add(make_test_add("part=b/part-b.parquet", &[("part", "b")], 0)),
+            ])
+            .await?;
+        let log_store = table.log_store();
+        let snapshot = Snapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
+        let predicate: PredicateRef =
+            Arc::new(Expression::column(["part"]).eq(Scalar::String("a".to_string())));
+        let scan = snapshot
+            .scan_builder()
+            .with_predicate(predicate)
+            .with_skip_stats(true)
+            .build()?;
+
+        let mut paths = Vec::new();
+        let mut metadata = scan.scan_metadata(log_store.engine(None));
+        while let Some(batch) = metadata.try_next().await? {
+            paths = batch.visit_scan_files(paths, |paths, file| paths.push(file.path))?;
+        }
+        paths.sort();
+
+        assert_eq!(paths, ["part=a/part-a.parquet", "part=b/part-b.parquet"]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn scan_metadata_from_returns_error_for_malformed_cache() -> DeltaResult<()> {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([StructField::nullable("value", DataType::INTEGER)])
+            .await?;
+        let log_store = table.log_store();
+        let snapshot = Snapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
+        let scan = snapshot.scan_builder().build()?;
+        let malformed = RecordBatch::new_empty(Arc::new(arrow_schema::Schema::empty()));
+
+        assert!(
+            scan.scan_metadata_from(
+                log_store.engine(None),
+                snapshot.version(),
+                Box::new(std::iter::once(malformed)),
+                None,
+            )
+            .try_collect::<Vec<_>>()
+            .await
+            .is_err(),
+            "malformed cached data must return an error"
+        );
         Ok(())
     }
 }
@@ -470,27 +532,39 @@ impl Scan {
             Ok(scan_row_in_eval) => scan_row_in_eval,
             Err(err) => return Box::pin(once(ready(Err(err)))),
         };
-        let scan_row_iter = existing_data
-            .map(|batch| Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>)
-            .map(move |b| {
-                evaluator
-                    .evaluate(b.as_ref())
-                    .expect("malformed cached log data")
-            });
-
         // TODO: which capacity to choose?
         let mut builder = ReceiverStreamBuilder::<ScanMetadata>::new(100);
         let tx = builder.tx();
         let scan_inner = move || {
+            let evaluation_error: Rc<RefCell<Option<DeltaTableError>>> =
+                Rc::new(RefCell::new(None));
+            let error_slot = Rc::clone(&evaluation_error);
+            let scan_row_data = existing_data
+                .map(|batch| Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>)
+                .map_while(move |batch| match evaluator.evaluate(batch.as_ref()) {
+                    Ok(data) => Some(data),
+                    Err(err) => {
+                        *error_slot.borrow_mut() = Some(err.into());
+                        None
+                    }
+                })
+                .fuse();
+
             for res in inner.scan_metadata_from(
                 engine.as_ref(),
                 existing_version,
-                Box::new(scan_row_iter),
+                Box::new(scan_row_data),
                 existing_predicate,
             )? {
+                if let Some(err) = evaluation_error.borrow_mut().take() {
+                    return Err(err);
+                }
                 if tx.blocking_send(Ok(res?)).is_err() {
                     break;
                 }
+            }
+            if let Some(err) = evaluation_error.borrow_mut().take() {
+                return Err(err);
             }
             Ok(())
         };

--- a/crates/core/src/kernel/snapshot/stats_projection.rs
+++ b/crates/core/src/kernel/snapshot/stats_projection.rs
@@ -57,16 +57,20 @@ pub(crate) enum StatsSourcePolicy {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RawStatsPolicy {
-    /// Preserve the raw JSON `stats` field in emitted scan rows.
+    /// Keep the raw JSON `stats` payload in scan rows.
     Preserve,
-    /// Omit the raw JSON `stats` field from emitted scan rows.
+    /// Drop the raw JSON `stats` payload from scan rows.
+    ///
+    /// A cache without statistics needs the canonical `stats` slot for replay.
+    /// Materialization fills that slot with null values.
     Omit,
 }
 
 /// Controls file statistics materialization in scan metadata output.
 ///
-/// The policy stores the parsed stats fields to emit, the source for parsed stats,
-/// and whether raw JSON stats remain in the output.
+/// The policy selects parsed statistics and their source. It records whether rows keep the raw
+/// JSON payload. [`FileStatsMaterialization::retains_stats_field`] reports whether emitted batches
+/// keep the canonical `stats` slot.
 ///
 /// Query paths can emit narrow parsed stats and omit raw JSON. Compatibility paths can keep
 /// raw JSON stats for callers that convert file views back to Add actions.
@@ -119,6 +123,10 @@ impl FileStatsMaterialization {
 
     pub(crate) fn preserves_raw_stats(&self) -> bool {
         self.raw_stats_policy == RawStatsPolicy::Preserve
+    }
+
+    pub(crate) fn retains_stats_field(&self) -> bool {
+        self.preserves_raw_stats() || self.stats_source_policy == StatsSourcePolicy::None
     }
 }
 

--- a/crates/core/src/table/builder.rs
+++ b/crates/core/src/table/builder.rs
@@ -53,12 +53,12 @@ pub struct DeltaTableConfig {
     /// when processing record batches.
     pub log_batch_size: usize,
 
-    /// Skip parsing per-file statistics while opening the table.
+    /// Skip parsing file statistics while opening the table.
     /// This defaults to `false`.
     ///
-    /// Use for workflows that never need file pruning (vacuum, filesystem check,
-    /// append-only writes). Any predicated query on this instance will scan every
-    /// file because the cache has no stats. Partition pruning is unaffected.
+    /// Use this option for maintenance and append workflows that do not need file pruning.
+    /// Queries with predicates scan each file because the kernel disables statistics and
+    /// partition pruning.
     #[serde(default)]
     pub skip_stats: bool,
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -183,10 +183,10 @@ class DeltaTable:
                                 This can decrease latency if there are many files in the log since the last checkpoint,
                                 but will also increase memory usage. Possible rate limits of the storage backend should
                                 also be considered for optimal performance. Defaults to 4 * number of cpus.
-            skip_stats: If True, skip parsing per-file statistics while opening the table.
-                                Use for workflows that never need file pruning (vacuum, filesystem check, append-only writes).
-                                Any predicated query on this instance will scan every file because the cache has no stats.
-                                Partition pruning is unaffected. Defaults to False.
+            skip_stats: If True, skip parsing file statistics while opening the table.
+                                Use for maintenance and append workflows that do not need file pruning.
+                                Queries with predicates scan each file because the kernel disables statistics and
+                                partition pruning. Defaults to False.
 
         """
         self._storage_options = storage_options

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -99,6 +99,22 @@ def assert_roundtrips(
 
 
 @pytest.mark.pyarrow
+def test_append_with_skip_stats_table_is_replay_safe(tmp_path: pathlib.Path):
+    import pyarrow as pa
+
+    data = pa.table({"id": [1]})
+    write_deltalake(tmp_path, data)
+
+    table = DeltaTable(tmp_path, skip_stats=True)
+    write_deltalake(table, data, mode="append")
+
+    assert table.version() == 1
+    fresh = DeltaTable(tmp_path)
+    assert fresh.version() == 1
+    assert fresh.to_pyarrow_table().num_rows == 2
+
+
+@pytest.mark.pyarrow
 def test_nanosecond_timestamps_cast_to_microsecond_by_default(tmp_path: pathlib.Path):
     """
     Unless ``enable_nanosecond_timestamps()`` is called, nanosecond timestamps


### PR DESCRIPTION
# Description

Snapshots opened with `skip_stats` could cache file batches without the `stats` field. `EagerSnapshot::update` could not use those batches as replay input, which broke append workflows that reused the loaded table.

This change keeps the nullable `stats` field in new caches while leaving its values null. Current version reads can still use legacy caches that lack the field. Snapshot updates reject those caches as replay seeds and rebuild them through a full log replay.

Cached batch evaluation errors now propagate through the result stream instead of panicking. The `skip_stats` docs now say that predicate pruning including partition pruning is disabled.

# Related Issue(s)

Closes #4649


PR description drafted and completed code review with Codex