### PR TITLE
refactor: use Snapshot for file discovery

### DIFF
--- a/crates/core/src/delta_datafusion/bench_support.rs
+++ b/crates/core/src/delta_datafusion/bench_support.rs
@@ -59,7 +59,7 @@ pub async fn find_files(
     predicate: Option<Expr>,
 ) -> DeltaResult<FindFilesResult> {
     prepare_session(session, &log_store)?;
-    super::find_files(snapshot, log_store, session, predicate)
+    super::find_files(snapshot.snapshot(), log_store, session, predicate)
         .await
         .map(Into::into)
 }
@@ -71,7 +71,7 @@ pub async fn find_files_scan(
     predicate: Expr,
 ) -> DeltaResult<Vec<Add>> {
     prepare_session(session, &log_store)?;
-    super::find_files_scan(snapshot, log_store, session, predicate).await
+    super::find_files_scan(snapshot.snapshot(), log_store, session, predicate).await
 }
 
 pub async fn scan_files_where_matches(
@@ -81,11 +81,11 @@ pub async fn scan_files_where_matches(
     predicate: Expr,
 ) -> DataFusionResult<Option<MatchedFilesScan>> {
     prepare_session(session, &log_store)?;
-    super::scan_files_where_matches(session, snapshot, log_store, predicate)
+    super::scan_files_where_matches(session, snapshot.snapshot(), log_store, predicate)
         .await
         .map(|scan| scan.map(MatchedFilesScan))
 }
 
 pub fn add_actions_partition_mem_table(snapshot: &EagerSnapshot) -> DeltaResult<Option<MemTable>> {
-    super::add_actions_partition_mem_table(snapshot)
+    super::add_actions_partition_mem_table(snapshot.snapshot())
 }

--- a/crates/core/src/delta_datafusion/bench_support.rs
+++ b/crates/core/src/delta_datafusion/bench_support.rs
@@ -87,5 +87,5 @@ pub async fn scan_files_where_matches(
 }
 
 pub fn add_actions_partition_mem_table(snapshot: &EagerSnapshot) -> DeltaResult<Option<MemTable>> {
-    super::add_actions_partition_mem_table(snapshot.snapshot())
+    super::try_materialized_add_actions_partition_mem_table(snapshot.snapshot())
 }

--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -30,7 +30,7 @@ use crate::delta_datafusion::{
     normalize_path_as_file_id, resolve_file_column_name,
 };
 use crate::errors::{DeltaResult, DeltaTableError};
-use crate::kernel::{ActiveAddOptions, Add, AddStatsPolicy, EagerSnapshot, LogicalFileView};
+use crate::kernel::{ActiveAddOptions, Add, AddStatsPolicy, LogicalFileView, Snapshot};
 use crate::logstore::{LogStore, LogStoreRef};
 
 #[derive(Debug, Hash, Eq, PartialEq)]
@@ -53,7 +53,7 @@ pub(crate) struct FindFiles {
     )
 )]
 pub(crate) async fn find_files(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: LogStoreRef,
     session: &dyn Session,
     predicate: Option<Expr>,
@@ -289,7 +289,7 @@ struct MatchingFilesScanSeed {
 
 async fn collect_matching_files(
     session: &dyn Session,
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: Option<&LogStoreRef>,
     predicate: Expr,
     file_column_name: &str,
@@ -310,7 +310,7 @@ async fn collect_matching_files(
     let predicate = analysis.predicate();
 
     let mut builder = DeltaScanNext::builder()
-        .with_snapshot(snapshot.snapshot().clone())
+        .with_snapshot(snapshot.clone())
         .with_file_skipping_predicates(skipping_pred.clone())
         .with_file_column(file_column_name);
     if let Some(log_store) = log_store {
@@ -412,13 +412,13 @@ fn join_batches_with_add_actions(
     )
 )]
 pub(in crate::delta_datafusion) async fn find_files_scan(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: LogStoreRef,
     session: &dyn Session,
     expression: Expr,
 ) -> DeltaResult<Vec<Add>> {
     let file_column_name = resolve_file_column_name(snapshot.input_schema().as_ref(), None)?;
-    let table_root = snapshot.snapshot().inner.table_root().clone();
+    let table_root = snapshot.table_configuration().table_root().clone();
     let mut candidate_map: HashMap<_, _> = snapshot
         .file_views(log_store.as_ref(), None)
         .try_fold(HashMap::new(), |mut candidate_map, view| {
@@ -478,7 +478,7 @@ pub(in crate::delta_datafusion) async fn find_files_scan(
 /// partition predicates without materializing full add-action metadata.
 /// Returns `None` when the snapshot contains no add actions.
 pub(crate) fn add_actions_partition_mem_table(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
 ) -> DeltaResult<Option<MemTable>> {
     add_actions_partition_mem_table_from_batches(snapshot.add_actions_partition_batches()?)
 }
@@ -540,7 +540,7 @@ fn add_actions_partition_mem_table_from_batches(
 }
 
 async fn scan_memory_table(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: &dyn LogStore,
     predicate: &Expr,
 ) -> DeltaResult<Vec<Add>> {
@@ -548,10 +548,7 @@ async fn scan_memory_table(
         predicate: None,
         stats: AddStatsPolicy::None,
     };
-    let add_action_batches = snapshot
-        .snapshot()
-        .active_add_batches(log_store, options)
-        .await?;
+    let add_action_batches = snapshot.active_add_batches(log_store, options).await?;
     let actions: Vec<Add> = add_action_batches
         .iter()
         .flat_map(|batch| {
@@ -559,9 +556,7 @@ async fn scan_memory_table(
         })
         .collect_vec();
 
-    let partition_batches = snapshot
-        .snapshot()
-        .active_add_partition_batches_from(&add_action_batches)?;
+    let partition_batches = snapshot.active_add_partition_batches_from(&add_action_batches)?;
     let Some(mem_table) = add_actions_partition_mem_table_from_batches(partition_batches)? else {
         return Ok(vec![]);
     };
@@ -630,7 +625,7 @@ impl MatchedFilesScan {
 /// - A kernel predicate (best effort) which can be used to filter log replays.
 pub(crate) async fn scan_files_where_matches(
     session: &dyn Session,
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: LogStoreRef,
     predicate: Expr,
 ) -> Result<Option<MatchedFilesScan>> {
@@ -661,7 +656,7 @@ pub(crate) async fn scan_files_where_matches(
     )
     .with_missing_file_policy(MissingSelectedFilePolicy::Ignore);
     let selected_provider = DeltaScanNext::builder()
-        .with_snapshot(snapshot.snapshot().clone())
+        .with_snapshot(snapshot.clone())
         .with_file_skipping_predicates(file_skipping_predicates)
         .with_file_column(FILE_ID_COLUMN_DEFAULT)
         .with_log_store(log_store)
@@ -696,6 +691,7 @@ mod tests {
         delta_datafusion::{
             DataFusionMixins as _, DeltaSessionExt as _, create_session, resolve_file_column_name,
         },
+        kernel::{EagerSnapshot, Snapshot},
         protocol::SaveMode,
         test_utils::{
             TestResult, multibatch_add_actions_for_partition,
@@ -708,6 +704,60 @@ mod tests {
     };
 
     use super::*;
+
+    fn candidate_paths(result: &FindFiles) -> BTreeSet<String> {
+        result
+            .candidates
+            .iter()
+            .map(|add| add.path.clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_find_files_lazy_snapshot_matches_eager_compatibility_path() -> TestResult {
+        let table = DeltaTable::new_in_memory()
+            .write(vec![get_record_batch(None, false)])
+            .with_partition_columns(["modified"])
+            .await?;
+
+        let log_store = table.log_store();
+        let lazy = Snapshot::try_new(
+            log_store.as_ref(),
+            crate::DeltaTableConfig {
+                require_files: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+        let eager = EagerSnapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
+        let session = create_session().into_inner().state();
+        table.update_datafusion_session(&session)?;
+        session.ensure_log_store_registered(log_store.as_ref())?;
+
+        assert!(!lazy.has_materialized_files_for_test());
+
+        for (predicate, expected_partition_scan, expected_candidates) in [
+            (None, true, 2),
+            (Some(col("modified").eq(lit("2021-02-02"))), true, 1),
+            (Some(col("value").gt(lit(10i32))), false, 1),
+        ] {
+            let lazy_result =
+                find_files(&lazy, log_store.clone(), &session, predicate.clone()).await?;
+            let eager_result =
+                find_files(eager.snapshot(), log_store.clone(), &session, predicate).await?;
+
+            assert_eq!(lazy_result.partition_scan, expected_partition_scan);
+            assert_eq!(lazy_result.candidates.len(), expected_candidates);
+            assert_eq!(
+                candidate_paths(&lazy_result),
+                candidate_paths(&eager_result)
+            );
+            assert!(!lazy.has_materialized_files_for_test());
+        }
+
+        Ok(())
+    }
 
     #[test]
     fn extract_partition_only_predicate_returns_only_referenced_columns() {
@@ -748,11 +798,11 @@ mod tests {
 
         let ctx = create_session().into_inner();
         let session = ctx.state();
-        let snapshot = table.snapshot()?.snapshot().clone();
+        let eager = table.snapshot()?.snapshot().clone();
+        let snapshot = eager.snapshot();
         let log_store = table.log_store();
         let predicate = col("id").gt(lit(-1i64));
-        let Some(scan) =
-            scan_files_where_matches(&session, &snapshot, log_store, predicate).await?
+        let Some(scan) = scan_files_where_matches(&session, snapshot, log_store, predicate).await?
         else {
             panic!("Expected at least one matching file");
         };
@@ -770,11 +820,11 @@ mod tests {
 
         let ctx = create_session().into_inner();
         let session = ctx.state();
-        let snapshot = table.snapshot()?.snapshot().clone();
+        let eager = table.snapshot()?.snapshot().clone();
+        let snapshot = eager.snapshot();
         let log_store = table.log_store();
         let predicate = col("id").gt(lit(-1i64));
-        let Some(scan) =
-            scan_files_where_matches(&session, &snapshot, log_store, predicate).await?
+        let Some(scan) = scan_files_where_matches(&session, snapshot, log_store, predicate).await?
         else {
             panic!("Expected at least one matching file");
         };
@@ -803,7 +853,7 @@ mod tests {
         let file_column_name = resolve_file_column_name(snapshot.input_schema().as_ref(), None)?;
 
         let by_id = find_files_scan(
-            &snapshot,
+            snapshot.snapshot(),
             log_store.clone(),
             &session,
             col("id").eq(lit(7i64)),
@@ -811,7 +861,7 @@ mod tests {
         .await?;
         assert!(!by_id.is_empty());
         let expected_path = by_id[0].path.clone();
-        let table_root = snapshot.snapshot().inner.table_root().clone();
+        let table_root = snapshot.table_configuration().table_root().clone();
         let expected_file_id = crate::delta_datafusion::normalize_path_as_file_id(
             &expected_path,
             &table_root,
@@ -820,7 +870,7 @@ mod tests {
         let matched_paths = by_id.iter().map(|add| add.path.as_str()).collect_vec();
 
         let matches = find_files_scan(
-            &snapshot,
+            snapshot.snapshot(),
             log_store.clone(),
             &session,
             col("id")
@@ -845,7 +895,7 @@ mod tests {
             "find_files test path",
         )?;
         let no_matches = find_files_scan(
-            &snapshot,
+            snapshot.snapshot(),
             log_store,
             &session,
             col("id")
@@ -874,8 +924,13 @@ mod tests {
         let ctx = create_session().into_inner();
         let session = ctx.state();
 
-        let matches =
-            find_files_scan(&snapshot, log_store, &session, col("id").eq(lit(7i64))).await?;
+        let matches = find_files_scan(
+            snapshot.snapshot(),
+            log_store,
+            &session,
+            col("id").eq(lit(7i64)),
+        )
+        .await?;
 
         assert_eq!(matches.len(), 1);
         assert!(matches[0].path.ends_with(".parquet"));
@@ -915,8 +970,13 @@ mod tests {
         let snapshot = table.snapshot()?.snapshot().clone();
         let log_store = table.log_store();
 
-        let matches =
-            find_files_scan(&snapshot, log_store, &session, col("price").eq(lit(10i64))).await?;
+        let matches = find_files_scan(
+            snapshot.snapshot(),
+            log_store,
+            &session,
+            col("price").eq(lit(10i64)),
+        )
+        .await?;
 
         assert_eq!(matches.len(), 1);
         assert_eq!(
@@ -995,7 +1055,7 @@ mod tests {
         assert_eq!(file_column_name, format!("{PATH_COLUMN}_2"));
 
         let matches = find_files_scan(
-            &snapshot,
+            snapshot.snapshot(),
             log_store,
             &session,
             col("id")
@@ -1023,14 +1083,17 @@ mod tests {
             .without_files()
             .load()
             .await?;
-        let snapshot = table.snapshot()?.snapshot().clone();
+        let eager = table.snapshot()?.snapshot().clone();
+        let snapshot = eager.snapshot();
         let log_store = table.log_store();
 
         let ctx = create_session().into_inner();
         let session = ctx.state();
 
+        assert!(!snapshot.has_materialized_files_for_test());
+
         let Some(scan) =
-            scan_files_where_matches(&session, &snapshot, log_store, col("id").eq(lit(7i64)))
+            scan_files_where_matches(&session, snapshot, log_store, col("id").eq(lit(7i64)))
                 .await?
         else {
             panic!("Expected at least one matching file");
@@ -1039,6 +1102,7 @@ mod tests {
         let plan = session.create_physical_plan(scan.scan()).await?;
         let data = collect(plan, session.task_ctx()).await?;
         assert!(!data.is_empty());
+        assert!(!snapshot.has_materialized_files_for_test());
 
         Ok(())
     }
@@ -1066,12 +1130,9 @@ mod tests {
             .with_partition_columns(["modified"])
             .await?;
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let matches = scan_memory_table(
-            table.snapshot()?.snapshot(),
-            table.log_store().as_ref(),
-            &predicate,
-        )
-        .await?;
+        let eager = table.snapshot()?.snapshot();
+        let matches =
+            scan_memory_table(eager.snapshot(), table.log_store().as_ref(), &predicate).await?;
         assert!(matches.is_empty());
         Ok(())
     }
@@ -1088,10 +1149,11 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await?;
 
-        let snapshot = table.snapshot()?.snapshot();
-        let total_actions = snapshot.log_data().iter().count();
+        let eager = table.snapshot()?.snapshot();
+        let total_actions = eager.log_data().iter().count();
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let matches = scan_memory_table(snapshot, table.log_store().as_ref(), &predicate).await?;
+        let matches =
+            scan_memory_table(eager.snapshot(), table.log_store().as_ref(), &predicate).await?;
 
         assert!(!matches.is_empty());
         assert!(matches.len() < total_actions);
@@ -1114,15 +1176,15 @@ mod tests {
             require_files: false,
             ..Default::default()
         };
-        let snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, None).await?;
+        let snapshot = Snapshot::try_new(log_store.as_ref(), config, None).await?;
 
-        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+        assert!(!snapshot.has_materialized_files_for_test());
 
         let predicate = col("modified").eq(lit("2021-02-02"));
         let matches = scan_memory_table(&snapshot, log_store.as_ref(), &predicate).await?;
 
         assert!(!matches.is_empty());
-        assert!(!snapshot.snapshot().has_materialized_files_for_test());
+        assert!(!snapshot.has_materialized_files_for_test());
         Ok(())
     }
 
@@ -1142,11 +1204,10 @@ mod tests {
             require_files: false,
             ..Default::default()
         };
-        let snapshot = EagerSnapshot::try_new(log_store.as_ref(), config, None).await?;
+        let snapshot = Snapshot::try_new(log_store.as_ref(), config, None).await?;
         drain_recorded_ops(&mut operations).await;
 
         snapshot
-            .snapshot()
             .active_add_batches(
                 log_store.as_ref(),
                 ActiveAddOptions {
@@ -1194,7 +1255,8 @@ mod tests {
             .with_actions(actions)
             .await?;
 
-        let snapshot = table.snapshot()?.snapshot();
+        let eager = table.snapshot()?.snapshot();
+        let snapshot = eager.snapshot();
         let add_action_batches = snapshot.add_actions_partition_batches()?;
         assert!(
             add_action_batches.len() > 1,

--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -472,11 +472,12 @@ pub(in crate::delta_datafusion) async fn find_files_scan(
     Ok(result)
 }
 
-/// Build a partition-metadata MemTable from snapshot add actions.
+/// Builds a partition metadata [`MemTable`] from snapshot `Add` actions.
 ///
-/// Projects only the `path` column and `partition.*` columns for evaluating
-/// partition predicates without materializing full add-action metadata.
-/// Returns `None` when the snapshot contains no add actions.
+/// DataFusion evaluates partition predicates with the `path` and `partition.*`
+/// columns. Callers must provide a snapshot with materialized `Add` batches.
+/// Use [`scan_memory_table`] with lazy snapshots.
+/// Returns `None` when the snapshot has no `Add` actions.
 pub(crate) fn add_actions_partition_mem_table(
     snapshot: &Snapshot,
 ) -> DeltaResult<Option<MemTable>> {
@@ -546,7 +547,7 @@ async fn scan_memory_table(
 ) -> DeltaResult<Vec<Add>> {
     let options = ActiveAddOptions {
         predicate: None,
-        stats: AddStatsPolicy::None,
+        stats: AddStatsPolicy::RawJson,
     };
     let add_action_batches = snapshot.active_add_batches(log_store, options).await?;
     let actions: Vec<Add> = add_action_batches
@@ -690,6 +691,7 @@ mod tests {
         DeltaTable, DeltaTableBuilder,
         delta_datafusion::{
             DataFusionMixins as _, DeltaSessionExt as _, create_session, resolve_file_column_name,
+            update_datafusion_session,
         },
         kernel::{EagerSnapshot, Snapshot},
         protocol::SaveMode,
@@ -705,12 +707,26 @@ mod tests {
 
     use super::*;
 
-    fn candidate_paths(result: &FindFiles) -> BTreeSet<String> {
-        result
+    fn normalized_candidates(result: &FindFiles) -> Vec<serde_json::Value> {
+        let mut candidates = result
             .candidates
             .iter()
-            .map(|add| add.path.clone())
-            .collect()
+            .map(|add| serde_json::to_value(add).expect("serialize Add action"))
+            .collect::<Vec<_>>();
+        candidates.sort_by(|left, right| left["path"].as_str().cmp(&right["path"].as_str()));
+        candidates
+    }
+
+    async fn lazy_snapshot(table: &DeltaTable) -> TestResult<Snapshot> {
+        Ok(Snapshot::try_new(
+            table.log_store().as_ref(),
+            crate::DeltaTableConfig {
+                require_files: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await?)
     }
 
     #[tokio::test]
@@ -748,10 +764,11 @@ mod tests {
                 find_files(eager.snapshot(), log_store.clone(), &session, predicate).await?;
 
             assert_eq!(lazy_result.partition_scan, expected_partition_scan);
+            assert_eq!(lazy_result.partition_scan, eager_result.partition_scan);
             assert_eq!(lazy_result.candidates.len(), expected_candidates);
             assert_eq!(
-                candidate_paths(&lazy_result),
-                candidate_paths(&eager_result)
+                normalized_candidates(&lazy_result),
+                normalized_candidates(&eager_result)
             );
             assert!(!lazy.has_materialized_files_for_test());
         }
@@ -798,11 +815,11 @@ mod tests {
 
         let ctx = create_session().into_inner();
         let session = ctx.state();
-        let eager = table.snapshot()?.snapshot().clone();
-        let snapshot = eager.snapshot();
         let log_store = table.log_store();
+        let snapshot = lazy_snapshot(&table).await?;
         let predicate = col("id").gt(lit(-1i64));
-        let Some(scan) = scan_files_where_matches(&session, snapshot, log_store, predicate).await?
+        let Some(scan) =
+            scan_files_where_matches(&session, &snapshot, log_store, predicate).await?
         else {
             panic!("Expected at least one matching file");
         };
@@ -820,11 +837,11 @@ mod tests {
 
         let ctx = create_session().into_inner();
         let session = ctx.state();
-        let eager = table.snapshot()?.snapshot().clone();
-        let snapshot = eager.snapshot();
         let log_store = table.log_store();
+        let snapshot = lazy_snapshot(&table).await?;
         let predicate = col("id").gt(lit(-1i64));
-        let Some(scan) = scan_files_where_matches(&session, snapshot, log_store, predicate).await?
+        let Some(scan) =
+            scan_files_where_matches(&session, &snapshot, log_store, predicate).await?
         else {
             panic!("Expected at least one matching file");
         };
@@ -847,13 +864,13 @@ mod tests {
         let session = ctx.state();
         table.update_datafusion_session(&session)?;
 
-        let snapshot = table.snapshot()?.snapshot().clone();
         let log_store = table.log_store();
+        let snapshot = lazy_snapshot(&table).await?;
         session.ensure_log_store_registered(log_store.as_ref())?;
         let file_column_name = resolve_file_column_name(snapshot.input_schema().as_ref(), None)?;
 
         let by_id = find_files_scan(
-            snapshot.snapshot(),
+            &snapshot,
             log_store.clone(),
             &session,
             col("id").eq(lit(7i64)),
@@ -870,7 +887,7 @@ mod tests {
         let matched_paths = by_id.iter().map(|add| add.path.as_str()).collect_vec();
 
         let matches = find_files_scan(
-            snapshot.snapshot(),
+            &snapshot,
             log_store.clone(),
             &session,
             col("id")
@@ -884,9 +901,11 @@ mod tests {
         );
 
         let other_path = snapshot
-            .log_data()
-            .iter()
-            .map(|add| add.path().to_string())
+            .file_views(&log_store, None)
+            .map_ok(|view| view.to_add().path)
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
             .find(|path| !matched_paths.contains(&path.as_str()))
             .expect("expected a non-matching file path");
         let other_file_id = crate::delta_datafusion::normalize_path_as_file_id(
@@ -895,7 +914,7 @@ mod tests {
             "find_files test path",
         )?;
         let no_matches = find_files_scan(
-            snapshot.snapshot(),
+            &snapshot,
             log_store,
             &session,
             col("id")
@@ -918,19 +937,14 @@ mod tests {
             .without_files()
             .load()
             .await?;
-        let snapshot = table.snapshot()?.snapshot().clone();
         let log_store = table.log_store();
+        let snapshot = lazy_snapshot(&table).await?;
 
         let ctx = create_session().into_inner();
         let session = ctx.state();
 
-        let matches = find_files_scan(
-            snapshot.snapshot(),
-            log_store,
-            &session,
-            col("id").eq(lit(7i64)),
-        )
-        .await?;
+        let matches =
+            find_files_scan(&snapshot, log_store, &session, col("id").eq(lit(7i64))).await?;
 
         assert_eq!(matches.len(), 1);
         assert!(matches[0].path.ends_with(".parquet"));
@@ -967,16 +981,11 @@ mod tests {
         let ctx = create_session().into_inner();
         let session = ctx.state();
 
-        let snapshot = table.snapshot()?.snapshot().clone();
         let log_store = table.log_store();
+        let snapshot = lazy_snapshot(&table).await?;
 
-        let matches = find_files_scan(
-            snapshot.snapshot(),
-            log_store,
-            &session,
-            col("price").eq(lit(10i64)),
-        )
-        .await?;
+        let matches =
+            find_files_scan(&snapshot, log_store, &session, col("price").eq(lit(10i64))).await?;
 
         assert_eq!(matches.len(), 1);
         assert_eq!(
@@ -1047,15 +1056,22 @@ mod tests {
         let session = ctx.state();
         table.update_datafusion_session(&session)?;
 
-        let snapshot = table.snapshot()?.snapshot().clone();
         let log_store = table.log_store();
+        let snapshot = lazy_snapshot(&table).await?;
         session.ensure_log_store_registered(log_store.as_ref())?;
 
         let file_column_name = resolve_file_column_name(snapshot.input_schema().as_ref(), None)?;
         assert_eq!(file_column_name, format!("{PATH_COLUMN}_2"));
 
+        let expected_path = snapshot
+            .file_views(&log_store, None)
+            .map_ok(|view| view.to_add().path)
+            .try_next()
+            .await?
+            .expect("expected one active file");
+
         let matches = find_files_scan(
-            snapshot.snapshot(),
+            &snapshot,
             log_store,
             &session,
             col("id")
@@ -1065,10 +1081,7 @@ mod tests {
         .await?;
 
         assert_eq!(matches.len(), 1);
-        assert_eq!(
-            matches[0].path,
-            snapshot.log_data().iter().next().unwrap().path()
-        );
+        assert_eq!(matches[0].path, expected_path);
 
         Ok(())
     }
@@ -1083,9 +1096,8 @@ mod tests {
             .without_files()
             .load()
             .await?;
-        let eager = table.snapshot()?.snapshot().clone();
-        let snapshot = eager.snapshot();
         let log_store = table.log_store();
+        let snapshot = lazy_snapshot(&table).await?;
 
         let ctx = create_session().into_inner();
         let session = ctx.state();
@@ -1093,7 +1105,7 @@ mod tests {
         assert!(!snapshot.has_materialized_files_for_test());
 
         let Some(scan) =
-            scan_files_where_matches(&session, snapshot, log_store, col("id").eq(lit(7i64)))
+            scan_files_where_matches(&session, &snapshot, log_store, col("id").eq(lit(7i64)))
                 .await?
         else {
             panic!("Expected at least one matching file");
@@ -1130,9 +1142,8 @@ mod tests {
             .with_partition_columns(["modified"])
             .await?;
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let eager = table.snapshot()?.snapshot();
-        let matches =
-            scan_memory_table(eager.snapshot(), table.log_store().as_ref(), &predicate).await?;
+        let snapshot = lazy_snapshot(&table).await?;
+        let matches = scan_memory_table(&snapshot, table.log_store().as_ref(), &predicate).await?;
         assert!(matches.is_empty());
         Ok(())
     }
@@ -1149,11 +1160,14 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await?;
 
-        let eager = table.snapshot()?.snapshot();
-        let total_actions = eager.log_data().iter().count();
+        let snapshot = lazy_snapshot(&table).await?;
+        let total_actions = snapshot
+            .file_views(&table.log_store(), None)
+            .try_collect::<Vec<_>>()
+            .await?
+            .len();
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let matches =
-            scan_memory_table(eager.snapshot(), table.log_store().as_ref(), &predicate).await?;
+        let matches = scan_memory_table(&snapshot, table.log_store().as_ref(), &predicate).await?;
 
         assert!(!matches.is_empty());
         assert!(matches.len() < total_actions);
@@ -1236,6 +1250,87 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_lazy_data_discovery_replay_budgets() -> TestResult {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(get_delta_schema().fields().cloned())
+            .with_partition_columns(["modified"])
+            .await?;
+        let table = table
+            .write(vec![get_record_batch(None, false)])
+            .with_save_mode(SaveMode::Append)
+            .await?;
+        let (log_store, mut operations) = recording_log_store(table.log_store());
+        let snapshot = Snapshot::try_new(
+            log_store.as_ref(),
+            crate::DeltaTableConfig {
+                require_files: false,
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+        drain_recorded_ops(&mut operations).await;
+
+        snapshot
+            .active_add_batches(
+                log_store.as_ref(),
+                ActiveAddOptions {
+                    predicate: None,
+                    stats: AddStatsPolicy::None,
+                },
+            )
+            .await?;
+        let single_replay_reads = drain_recorded_ops(&mut operations)
+            .await
+            .into_iter()
+            .filter(|op| op.is_log_replay_read())
+            .count();
+        assert!(single_replay_reads > 0);
+
+        let session = create_session().into_inner().state();
+        update_datafusion_session(&session, &log_store, None)?;
+        session.ensure_log_store_registered(log_store.as_ref())?;
+        let matches = find_files_scan(
+            &snapshot,
+            log_store.clone(),
+            &session,
+            col("value").gt(lit(0i32)),
+        )
+        .await?;
+        let discovery_replay_reads = drain_recorded_ops(&mut operations)
+            .await
+            .into_iter()
+            .filter(|op| op.is_log_replay_read())
+            .count();
+
+        assert!(!matches.is_empty());
+        assert!(
+            discovery_replay_reads <= 2 * single_replay_reads,
+            "data predicate discovery read the log {discovery_replay_reads} times; limit {}",
+            2 * single_replay_reads
+        );
+        assert!(!snapshot.has_materialized_files_for_test());
+        let scan =
+            scan_files_where_matches(&session, &snapshot, log_store, col("value").gt(lit(0i32)))
+                .await?;
+        let scan_replay_reads = drain_recorded_ops(&mut operations)
+            .await
+            .into_iter()
+            .filter(|op| op.is_log_replay_read())
+            .count();
+
+        assert!(scan.is_some());
+        assert!(
+            scan_replay_reads <= 2 * single_replay_reads,
+            "matched file scan planning read the log {scan_replay_reads} times; limit {}",
+            2 * single_replay_reads
+        );
+        assert!(!snapshot.has_materialized_files_for_test());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_scan_memory_table_multibatch_stress_partition_filtering() -> TestResult {
         use std::collections::HashSet;
 
@@ -1255,8 +1350,10 @@ mod tests {
             .with_actions(actions)
             .await?;
 
-        let eager = table.snapshot()?.snapshot();
-        let snapshot = eager.snapshot();
+        let snapshot = lazy_snapshot(&table).await?;
+        let snapshot = Arc::new(snapshot)
+            .ensure_materialized_files(table.log_store().as_ref())
+            .await?;
         let add_action_batches = snapshot.add_actions_partition_batches()?;
         assert!(
             add_action_batches.len() > 1,
@@ -1264,7 +1361,7 @@ mod tests {
         );
 
         let predicate = col("modified").eq(lit("2021-02-02"));
-        let matches = scan_memory_table(snapshot, table.log_store().as_ref(), &predicate).await?;
+        let matches = scan_memory_table(&snapshot, table.log_store().as_ref(), &predicate).await?;
 
         assert_eq!(matches.len(), expected_matches);
 

--- a/crates/core/src/delta_datafusion/find_files.rs
+++ b/crates/core/src/delta_datafusion/find_files.rs
@@ -478,7 +478,7 @@ pub(in crate::delta_datafusion) async fn find_files_scan(
 /// columns. Callers must provide a snapshot with materialized `Add` batches.
 /// Use [`scan_memory_table`] with lazy snapshots.
 /// Returns `None` when the snapshot has no `Add` actions.
-pub(crate) fn add_actions_partition_mem_table(
+pub(crate) fn try_materialized_add_actions_partition_mem_table(
     snapshot: &Snapshot,
 ) -> DeltaResult<Option<MemTable>> {
     add_actions_partition_mem_table_from_batches(snapshot.add_actions_partition_batches()?)
@@ -688,12 +688,12 @@ mod tests {
     use delta_kernel::schema::{DataType, PrimitiveType, StructField};
 
     use crate::{
-        DeltaTable, DeltaTableBuilder,
+        DeltaTable, DeltaTableBuilder, TableProperty,
         delta_datafusion::{
             DataFusionMixins as _, DeltaSessionExt as _, create_session, resolve_file_column_name,
             update_datafusion_session,
         },
-        kernel::{EagerSnapshot, Snapshot},
+        kernel::{Action, EagerSnapshot, Snapshot},
         protocol::SaveMode,
         test_utils::{
             TestResult, multibatch_add_actions_for_partition,
@@ -773,6 +773,106 @@ mod tests {
             assert!(!lazy.has_materialized_files_for_test());
         }
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_find_files_lazy_snapshot_preserves_metadata_rich_adds() -> TestResult {
+        let mut source_add = crate::test_utils::make_test_add(
+            "part=a/metadata-rich.parquet",
+            &[("part", "a")],
+            1_725_000_000_000,
+        );
+        source_add.size = 1234;
+        source_add.stats = Some(
+            serde_json::json!({
+                "numRecords": 7,
+                "minValues": { "id": 1 },
+                "maxValues": { "id": 7 },
+                "nullCount": { "id": 0 }
+            })
+            .to_string(),
+        );
+        source_add.tags = Some(HashMap::from([
+            ("source".to_string(), Some("metadata-rich".to_string())),
+            ("nullable-tag".to_string(), None),
+        ]));
+        source_add.deletion_vector = Some(crate::kernel::DeletionVectorDescriptor {
+            storage_type: crate::kernel::StorageType::Inline,
+            path_or_inline_dv: "AAAA".to_string(),
+            offset: None,
+            size_in_bytes: 0,
+            cardinality: 2,
+        });
+        source_add.base_row_id = Some(41);
+        source_add.default_row_commit_version = Some(3);
+        source_add.clustering_provider = Some("liquid".to_string());
+
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(vec![
+                StructField::new(
+                    "id".to_string(),
+                    DataType::Primitive(PrimitiveType::Integer),
+                    false,
+                ),
+                StructField::new(
+                    "part".to_string(),
+                    DataType::Primitive(PrimitiveType::String),
+                    false,
+                ),
+            ])
+            .with_partition_columns(["part"])
+            .with_configuration_property(TableProperty::EnableDeletionVectors, Some("true"))
+            .with_actions([Action::Add(source_add.clone())])
+            .await?;
+
+        let log_store = table.log_store();
+        let skip_stats_config = crate::DeltaTableConfig {
+            require_files: false,
+            skip_stats: true,
+            ..Default::default()
+        };
+        let lazy = Snapshot::try_new(log_store.as_ref(), skip_stats_config.clone(), None).await?;
+        let eager = EagerSnapshot::try_new(log_store.as_ref(), skip_stats_config, None).await?;
+        let session = create_session().into_inner().state();
+        table.update_datafusion_session(&session)?;
+        session.ensure_log_store_registered(log_store.as_ref())?;
+
+        let predicate = Some(col("part").eq(lit("a")));
+        let lazy_result = find_files(&lazy, log_store.clone(), &session, predicate.clone()).await?;
+        let eager_result = find_files(eager.snapshot(), log_store, &session, predicate).await?;
+
+        assert_eq!(
+            normalized_candidates(&lazy_result),
+            normalized_candidates(&eager_result)
+        );
+        assert_eq!(lazy_result.candidates.len(), 1);
+        let candidate = &lazy_result.candidates[0];
+        assert_eq!(
+            serde_json::to_value(candidate)?,
+            serde_json::to_value(source_add)?
+        );
+        assert!(!lazy.has_materialized_files_for_test());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_try_materialized_partition_mem_table_rejects_lazy_snapshot() -> TestResult {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(get_delta_schema().fields().cloned())
+            .with_partition_columns(["modified"])
+            .await?;
+        let snapshot = lazy_snapshot(&table).await?;
+
+        let error = match try_materialized_add_actions_partition_mem_table(&snapshot) {
+            Ok(_) => panic!("materialized API accepted a lazy snapshot"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(error, DeltaTableError::NotInitializedWithFiles(_)));
         Ok(())
     }
 
@@ -1255,7 +1355,11 @@ mod tests {
             .create()
             .with_columns(get_delta_schema().fields().cloned())
             .with_partition_columns(["modified"])
+            .await?
+            .write(vec![get_record_batch(None, false)])
+            .with_save_mode(SaveMode::Append)
             .await?;
+        crate::checkpoints::create_checkpoint(&table, None).await?;
         let table = table
             .write(vec![get_record_batch(None, false)])
             .with_save_mode(SaveMode::Append)
@@ -1351,19 +1455,26 @@ mod tests {
             .await?;
 
         let snapshot = lazy_snapshot(&table).await?;
-        let snapshot = Arc::new(snapshot)
-            .ensure_materialized_files(table.log_store().as_ref())
+        assert!(!snapshot.has_materialized_files_for_test());
+        let add_action_batches = snapshot
+            .active_add_batches(
+                table.log_store().as_ref(),
+                ActiveAddOptions {
+                    predicate: None,
+                    stats: AddStatsPolicy::None,
+                },
+            )
             .await?;
-        let add_action_batches = snapshot.add_actions_partition_batches()?;
         assert!(
             add_action_batches.len() > 1,
-            "expected multi-batch partition metadata fixture"
+            "expected more than one lazy replay batch"
         );
 
         let predicate = col("modified").eq(lit("2021-02-02"));
         let matches = scan_memory_table(&snapshot, table.log_store().as_ref(), &predicate).await?;
 
         assert_eq!(matches.len(), expected_matches);
+        assert!(!snapshot.has_materialized_files_for_test());
 
         let match_paths = matches
             .iter()

--- a/crates/core/src/kernel/snapshot/iterators.rs
+++ b/crates/core/src/kernel/snapshot/iterators.rs
@@ -37,6 +37,10 @@ const FIELD_NAME_SIZE: &str = "size";
 const FIELD_NAME_MODIFICATION_TIME: &str = "modificationTime";
 const FIELD_NAME_FILE_CONSTANT_VALUES: &str = "fileConstantValues";
 const FIELD_NAME_RAW_PARTITION_VALUES: &str = "partitionValues";
+const FIELD_NAME_TAGS: &str = "tags";
+const FIELD_NAME_BASE_ROW_ID: &str = "baseRowId";
+const FIELD_NAME_DEFAULT_ROW_COMMIT_VERSION: &str = "defaultRowCommitVersion";
+const FIELD_NAME_CLUSTERING_PROVIDER: &str = "clusteringProvider";
 const FIELD_NAME_STATS: &str = "stats";
 const FIELD_NAME_STATS_PARSED: &str = "stats_parsed";
 const FIELD_NAME_PARTITION_VALUES_PARSED: &str = "partitionValues_parsed";
@@ -202,13 +206,44 @@ impl LogicalFileView {
             })
     }
 
-    fn raw_partition_values(&self) -> Option<&MapArray> {
+    fn file_constant_values(&self) -> Option<&StructArray> {
         self.files
             .column_by_name(FIELD_NAME_FILE_CONSTANT_VALUES)
             .and_then(|col| col.as_struct_opt())
-            .and_then(|file_constants| {
-                file_constants.column_by_name(FIELD_NAME_RAW_PARTITION_VALUES)
-            })
+            .filter(|file_constants| file_constants.is_valid(self.index))
+    }
+
+    fn file_constant_map(&self, field_name: &str) -> Option<HashMap<String, Option<String>>> {
+        let values = self
+            .file_constant_values()?
+            .column_by_name(field_name)?
+            .as_map_opt()?;
+        values
+            .is_valid(self.index)
+            .then(|| collect_string_map(&values.value(self.index)))
+            .flatten()
+    }
+
+    fn file_constant_i64(&self, field_name: &str) -> Option<i64> {
+        let values = self
+            .file_constant_values()?
+            .column_by_name(field_name)?
+            .as_primitive_opt::<Int64Type>()?;
+        values
+            .is_valid(self.index)
+            .then(|| values.value(self.index))
+    }
+
+    fn file_constant_string(&self, field_name: &str) -> Option<String> {
+        self.file_constant_values()?
+            .column_by_name(field_name)
+            .and_then(|values| get_string_value(values, self.index))
+            .map(ToString::to_string)
+    }
+
+    fn raw_partition_values(&self) -> Option<&MapArray> {
+        self.file_constant_values()?
+            .column_by_name(FIELD_NAME_RAW_PARTITION_VALUES)
             .and_then(|col| col.as_map_opt())
     }
 
@@ -324,11 +359,12 @@ impl LogicalFileView {
             modification_time: self.modification_time(),
             data_change: true,
             stats: self.stats(),
-            tags: None,
+            tags: self.file_constant_map(FIELD_NAME_TAGS),
             deletion_vector: self.deletion_vector().map(|dv| dv.descriptor()),
-            base_row_id: None,
-            default_row_commit_version: None,
-            clustering_provider: None,
+            base_row_id: self.file_constant_i64(FIELD_NAME_BASE_ROW_ID),
+            default_row_commit_version: self
+                .file_constant_i64(FIELD_NAME_DEFAULT_ROW_COMMIT_VERSION),
+            clustering_provider: self.file_constant_string(FIELD_NAME_CLUSTERING_PROVIDER),
         }
     }
 

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -76,7 +76,8 @@ use crate::delta_datafusion::{
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
 use crate::kernel::{
-    Action, ActiveAddOptions, AddStatsPolicy, EagerSnapshot, LogicalFileView, resolve_snapshot,
+    Action, ActiveAddOptions, AddStatsPolicy, EagerSnapshot, LogicalFileView, Snapshot,
+    resolve_snapshot,
 };
 use crate::logstore::{LogStore, LogStoreRef};
 use crate::operations::CustomExecuteHandler;
@@ -430,6 +431,8 @@ async fn execute(
     operation_id: Uuid,
     writer_properties: Option<WriterProperties>,
 ) -> DeltaResult<(Vec<Action>, DeleteMetrics)> {
+    let eager_snapshot = snapshot;
+    let snapshot = eager_snapshot.snapshot();
     let exec_start = Instant::now();
     let mut metrics = DeleteMetrics {
         num_removed_files: 0,
@@ -442,7 +445,7 @@ async fn execute(
     let Some(predicate) = predicate else {
         // no predicate means all files match.
         // cdc actions are not written when table files are removed.
-        let full_file = collect_full_file_deletes(snapshot.snapshot().active_adds(
+        let full_file = collect_full_file_deletes(snapshot.active_adds(
             log_store.as_ref(),
             ActiveAddOptions {
                 predicate: None,
@@ -485,7 +488,7 @@ async fn execute(
                 // evaluating `partition_predicate` against `partitionValues_parsed` is exact:
                 // a file either fully matches or does not. It is therefore safe to treat this as
                 // the authoritative match set for DELETE.
-                collect_full_file_deletes(snapshot.snapshot().active_adds(
+                collect_full_file_deletes(snapshot.active_adds(
                     log_store.as_ref(),
                     ActiveAddOptions {
                         predicate: Some(Arc::new(delta_predicate)),
@@ -503,14 +506,13 @@ async fn execute(
                 let matching_paths = Arc::new(
                     find_file_paths_by_partition_predicate_datafusion(
                         session,
-                        &snapshot,
+                        snapshot,
                         &partition_predicate,
                     )
                     .await?,
                 );
                 collect_full_file_deletes(
                     snapshot
-                        .snapshot()
                         .active_adds(
                             log_store.as_ref(),
                             ActiveAddOptions {
@@ -538,8 +540,7 @@ async fn execute(
     }
 
     let maybe_scan_plan =
-        scan_files_where_matches(session, snapshot.snapshot(), log_store.clone(), predicate)
-            .await?;
+        scan_files_where_matches(session, snapshot, log_store.clone(), predicate).await?;
     metrics.scan_time_ms = Instant::now().duration_since(scan_start).as_millis() as u64;
 
     let Some(files_scan) = maybe_scan_plan else {
@@ -551,7 +552,6 @@ async fn execute(
 
     let root_url = Arc::new(snapshot.table_configuration().table_root().clone());
     let removes: Vec<_> = snapshot
-        .snapshot()
         .active_adds(
             log_store.as_ref(),
             ActiveAddOptions {
@@ -599,7 +599,7 @@ async fn execute(
         }),
     });
 
-    let (write_plan, write_cdc) = if should_write_cdc(&snapshot)? {
+    let (write_plan, write_cdc) = if should_write_cdc(&eager_snapshot)? {
         // create change set entries for all records we deleted
         let cdc_deletes = files_scan
             .scan()
@@ -659,7 +659,7 @@ async fn execute(
 
 async fn find_file_paths_by_partition_predicate_datafusion(
     session: &dyn Session,
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     predicate: &Expr,
 ) -> DeltaResult<std::collections::HashSet<String>> {
     use arrow_array::StringArray;
@@ -671,7 +671,7 @@ async fn find_file_paths_by_partition_predicate_datafusion(
     use datafusion::datasource::provider_as_source;
     use datafusion::physical_plan::collect;
 
-    let Some(mem_table) = add_actions_partition_mem_table(snapshot.snapshot())? else {
+    let Some(mem_table) = add_actions_partition_mem_table(snapshot)? else {
         return Ok(std::collections::HashSet::new());
     };
 

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -70,8 +70,8 @@ use crate::delta_datafusion::logical::{
 };
 use crate::delta_datafusion::physical::{MetricObserverExec, find_metric_node, get_metric};
 use crate::delta_datafusion::{
-    Expression, add_actions_partition_mem_table, create_session, resolve_session_state,
-    scan_files_where_matches, update_datafusion_session,
+    Expression, create_session, resolve_session_state, scan_files_where_matches,
+    try_materialized_add_actions_partition_mem_table, update_datafusion_session,
 };
 use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, PROTOCOL};
@@ -671,7 +671,7 @@ async fn find_file_paths_by_partition_predicate_datafusion(
     use datafusion::datasource::provider_as_source;
     use datafusion::physical_plan::collect;
 
-    let Some(mem_table) = add_actions_partition_mem_table(snapshot)? else {
+    let Some(mem_table) = try_materialized_add_actions_partition_mem_table(snapshot)? else {
         return Ok(std::collections::HashSet::new());
     };
 

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -538,7 +538,8 @@ async fn execute(
     }
 
     let maybe_scan_plan =
-        scan_files_where_matches(session, &snapshot, log_store.clone(), predicate).await?;
+        scan_files_where_matches(session, snapshot.snapshot(), log_store.clone(), predicate)
+            .await?;
     metrics.scan_time_ms = Instant::now().duration_since(scan_start).as_millis() as u64;
 
     let Some(files_scan) = maybe_scan_plan else {
@@ -670,7 +671,7 @@ async fn find_file_paths_by_partition_predicate_datafusion(
     use datafusion::datasource::provider_as_source;
     use datafusion::physical_plan::collect;
 
-    let Some(mem_table) = add_actions_partition_mem_table(snapshot)? else {
+    let Some(mem_table) = add_actions_partition_mem_table(snapshot.snapshot())? else {
         return Ok(std::collections::HashSet::new());
     };
 

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -284,6 +284,8 @@ async fn execute(
     operation_id: Uuid,
     safe_cast: bool,
 ) -> DeltaResult<(Vec<Action>, UpdateMetrics)> {
+    let eager_snapshot = snapshot;
+    let snapshot = eager_snapshot.snapshot();
     // Validate the predicate and update expressions.
     //
     // If the predicate is not set, then all files need to be updated.
@@ -312,8 +314,7 @@ async fn execute(
     let scan_start = Instant::now();
 
     let maybe_scan_plan =
-        scan_files_where_matches(session, snapshot.snapshot(), log_store.clone(), predicate)
-            .await?;
+        scan_files_where_matches(session, snapshot, log_store.clone(), predicate).await?;
     metrics.scan_time_ms = Instant::now().duration_since(scan_start).as_millis() as u64;
 
     let Some(files_scan) = maybe_scan_plan else {
@@ -378,7 +379,7 @@ async fn execute(
 
     let writer_stats_config = WriterStatsConfig::from_config(snapshot.table_configuration());
     let mut actions = write_execution_plan(
-        Some(snapshot),
+        Some(eager_snapshot),
         session,
         physical_plan.clone(),
         table_partition_cols.to_vec(),
@@ -399,7 +400,6 @@ async fn execute(
 
     let root_url = Arc::new(snapshot.table_configuration().table_root().clone());
     let removes: Vec<_> = snapshot
-        .snapshot()
         .active_adds(
             log_store.as_ref(),
             ActiveAddOptions {
@@ -430,12 +430,12 @@ async fn execute(
 
     metrics.execution_time_ms = Instant::now().duration_since(exec_start).as_millis() as u64;
 
-    if let Ok(true) = should_write_cdc(snapshot) {
+    if let Ok(true) = should_write_cdc(eager_snapshot) {
         match tracker.collect() {
             Ok(cdc_plan) => {
                 let cdc_exec = session.create_physical_plan(&cdc_plan).await?;
                 let cdc_actions = write_execution_plan_cdc(
-                    Some(snapshot),
+                    Some(eager_snapshot),
                     session,
                     cdc_exec,
                     table_partition_cols.to_vec(),

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -312,7 +312,8 @@ async fn execute(
     let scan_start = Instant::now();
 
     let maybe_scan_plan =
-        scan_files_where_matches(session, snapshot, log_store.clone(), predicate).await?;
+        scan_files_where_matches(session, snapshot.snapshot(), log_store.clone(), predicate)
+            .await?;
     metrics.scan_time_ms = Instant::now().duration_since(scan_start).as_millis() as u64;
 
     let Some(files_scan) = maybe_scan_plan else {

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -455,8 +455,13 @@ pub(super) async fn plan_overwrite_rewrite(
                 dropped_pruning_term_count: analysis.dropped_pruning_term_count,
             };
 
-            let Some(files_scan) =
-                scan_files_where_matches(session, snapshot, log_store.clone(), predicate).await?
+            let Some(files_scan) = scan_files_where_matches(
+                session,
+                snapshot.snapshot(),
+                log_store.clone(),
+                predicate,
+            )
+            .await?
             else {
                 return Ok(MatchedFilesRewritePlan {
                     kind: RewriteKind::NoMatch,

--- a/crates/core/src/operations/write/plan.rs
+++ b/crates/core/src/operations/write/plan.rs
@@ -35,7 +35,7 @@ use crate::errors::{DeltaResult, DeltaTableError};
 use crate::kernel::schema::cast::{merge_arrow_schema, normalize_for_delta};
 use crate::kernel::{
     Action, ActiveAddOptions, Add, AddStatsPolicy, DeletionVectorDescriptor, EagerSnapshot,
-    Metadata, ProtocolExt as _, Remove, StructType, StructTypeExt,
+    Metadata, ProtocolExt as _, Remove, Snapshot, StructType, StructTypeExt,
 };
 use crate::logstore::LogStoreRef;
 use crate::operations::cdc::{CDC_COLUMN_NAME, should_write_cdc};
@@ -426,11 +426,12 @@ pub(super) async fn plan_overwrite_rewrite(
     prepared_write: &PreparedWrite,
     operation_id: Uuid,
 ) -> DeltaResult<MatchedFilesRewritePlan> {
-    let Some(snapshot) = snapshot else {
+    let Some(eager_snapshot) = snapshot else {
         return Ok(MatchedFilesRewritePlan::passthrough(
             prepared_write.insert_plan.clone(),
         ));
     };
+    let snapshot = eager_snapshot.snapshot();
 
     debug_assert_eq!(
         mode, prepared_write.mode,
@@ -455,13 +456,8 @@ pub(super) async fn plan_overwrite_rewrite(
                 dropped_pruning_term_count: analysis.dropped_pruning_term_count,
             };
 
-            let Some(files_scan) = scan_files_where_matches(
-                session,
-                snapshot.snapshot(),
-                log_store.clone(),
-                predicate,
-            )
-            .await?
+            let Some(files_scan) =
+                scan_files_where_matches(session, snapshot, log_store.clone(), predicate).await?
             else {
                 return Ok(MatchedFilesRewritePlan {
                     kind: RewriteKind::NoMatch,
@@ -520,7 +516,7 @@ pub(super) async fn plan_overwrite_rewrite(
                 .union(rescued_data)?
                 .build()?;
 
-            let cdc_plan = if should_write_cdc(snapshot)? {
+            let cdc_plan = if should_write_cdc(eager_snapshot)? {
                 Some(
                     LogicalPlanBuilder::new(files_scan.scan().clone())
                         .filter(files_scan.predicate.clone())?
@@ -580,12 +576,11 @@ fn planned_deletion_timestamp_ms() -> DeltaResult<i64> {
 }
 
 async fn collect_all_existing_files(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: &LogStoreRef,
 ) -> DeltaResult<MatchedExistingFiles> {
     Ok(MatchedExistingFiles::new(
         snapshot
-            .snapshot()
             .active_adds(
                 log_store.as_ref(),
                 ActiveAddOptions {
@@ -600,14 +595,13 @@ async fn collect_all_existing_files(
 }
 
 async fn collect_matched_existing_files(
-    snapshot: &EagerSnapshot,
+    snapshot: &Snapshot,
     log_store: &LogStoreRef,
     files_scan: &crate::delta_datafusion::MatchedFilesScan,
 ) -> DeltaResult<MatchedExistingFiles> {
     let table_root = Arc::new(snapshot.table_configuration().table_root().clone());
     let valid_files = Arc::new(files_scan.files_set());
     let files = snapshot
-        .snapshot()
         .active_adds(
             log_store.as_ref(),
             ActiveAddOptions {

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -457,13 +457,6 @@ impl EagerSnapshot {
     ) -> Result<Vec<arrow::record_batch::RecordBatch>, DeltaTableError> {
         self.snapshot().add_actions_batches(flatten)
     }
-
-    #[cfg(feature = "datafusion")]
-    pub(crate) fn add_actions_partition_batches(
-        &self,
-    ) -> Result<Vec<RecordBatch>, DeltaTableError> {
-        self.snapshot().add_actions_partition_batches()
-    }
 }
 
 /// Target number of rows per coalesced batch. Matches DataFusion's default batch size.
@@ -777,8 +770,8 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await?;
 
-        let snapshot = table.snapshot()?.snapshot();
-        let batches = snapshot.add_actions_partition_batches()?;
+        let eager = table.snapshot()?.snapshot();
+        let batches = eager.snapshot().add_actions_partition_batches()?;
         assert!(!batches.is_empty());
 
         let schema = batches[0].schema();

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -770,8 +770,16 @@ mod tests {
             .with_save_mode(SaveMode::Append)
             .await?;
 
-        let eager = table.snapshot()?.snapshot();
-        let batches = eager.snapshot().add_actions_partition_batches()?;
+        let snapshot = Snapshot::try_new(
+            table.log_store().as_ref(),
+            DeltaTableConfig::default(),
+            None,
+        )
+        .await?;
+        let snapshot = Arc::new(snapshot)
+            .ensure_materialized_files(table.log_store().as_ref())
+            .await?;
+        let batches = snapshot.add_actions_partition_batches()?;
         assert!(!batches.is_empty());
 
         let schema = batches[0].schema();


### PR DESCRIPTION
# Description

Use `Snapshot` as the internal state boundary for file discovery in delete, update, and overwrite planning. Each operation unwraps `EagerSnapshot` once at its compatibility boundary and passes `&Snapshot` through the internal discovery path.

Partition predicate discovery reads active adds through Snapshot replay APIs. Lazy snapshots can discover files without materializing file state, and the discovery path reuses the replayed batches for predicate evaluation and `Add` reconstruction.

Preserve complete `Add` actions when converting `LogicalFileView`, including tags, deletion vectors, row tracking fields, and clustering metadata. Existing `EagerSnapshot` entry points remain as compatibility wrappers.

# Related Issue(s)

Part of #4584

PR description drafted and completed code review with Codex