### PR TITLE
feat(core)!: delete PartitionFilter in favor of kernel predicates

### DIFF
--- a/crates/core/src/delta_datafusion/expr.rs
+++ b/crates/core/src/delta_datafusion/expr.rs
@@ -1415,7 +1415,7 @@ mod test {
         use super::super::parse_sql_predicate_to_kernel;
         use super::*;
         use crate::kernel::schema::partitions::{
-            FilterValue, dnf_to_kernel_predicate, literal_to_kernel_predicate,
+            FilterOp, FilterValue, dnf_to_kernel_predicate, literal_to_kernel_predicate,
         };
 
         fn test_schema() -> StructType {
@@ -1454,12 +1454,12 @@ mod test {
             let from_dnf = dnf_to_kernel_predicate(
                 &[
                     vec![
-                        ("year", "=", FilterValue::Scalar("2020")),
-                        ("month", "=", FilterValue::Scalar("2")),
+                        ("year", FilterOp::Eq, FilterValue::Scalar("2020")),
+                        ("month", FilterOp::Eq, FilterValue::Scalar("2")),
                     ],
                     vec![
-                        ("year", "=", FilterValue::Scalar("2021")),
-                        ("month", "=", FilterValue::Scalar("12")),
+                        ("year", FilterOp::Eq, FilterValue::Scalar("2021")),
+                        ("month", FilterOp::Eq, FilterValue::Scalar("12")),
                     ],
                 ],
                 &schema,
@@ -1478,7 +1478,7 @@ mod test {
                 parse_sql_predicate_to_kernel("year IN (2020, 2021)", &schema, &session.state())
                     .unwrap();
             let from_literal = literal_to_kernel_predicate(
-                &("year", "in", FilterValue::Set(vec!["2020", "2021"])),
+                &("year", FilterOp::In, FilterValue::Set(vec!["2020", "2021"])),
                 &schema,
             )
             .unwrap();

--- a/crates/core/src/kernel/schema/partitions.rs
+++ b/crates/core/src/kernel/schema/partitions.rs
@@ -1,134 +1,15 @@
 //! Delta Table partition handling logic.
 use std::convert::TryFrom;
+use std::fmt;
+use std::str::FromStr;
 
 use delta_kernel::expressions::{Expression, JunctionPredicateOp, Predicate, Scalar};
 use delta_kernel::schema::StructType;
-use serde::{Serialize, Serializer};
 
 use crate::errors::{DeltaResult, DeltaTableError};
 
 /// A special value used in Hive to represent the null partition in partitioned tables
 pub const NULL_PARTITION_VALUE_DATA_PATH: &str = "__HIVE_DEFAULT_PARTITION__";
-
-/// A Enum used for selecting the partition value operation when filtering a DeltaTable partition.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum PartitionValue {
-    /// The partition value with the equal operator
-    Equal(String),
-    /// The partition value with the not equal operator
-    NotEqual(String),
-    /// The partition value with the greater than operator
-    GreaterThan(String),
-    /// The partition value with the greater than or equal operator
-    GreaterThanOrEqual(String),
-    /// The partition value with the less than operator
-    LessThan(String),
-    /// The partition value with the less than or equal operator
-    LessThanOrEqual(String),
-    /// The partition values with the in operator
-    In(Vec<String>),
-    /// The partition values with the not in operator
-    NotIn(Vec<String>),
-}
-
-/// A Struct used for filtering a DeltaTable partition by key and value.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PartitionFilter {
-    /// The key of the PartitionFilter
-    pub key: String,
-    /// The value of the PartitionFilter
-    pub value: PartitionValue,
-}
-
-/// Create desired string representation for PartitionFilter.
-/// Used in places like predicate in operationParameters, etc.
-impl Serialize for PartitionFilter {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let s = match &self.value {
-            PartitionValue::Equal(value) => format!("{} = '{value}'", self.key),
-            PartitionValue::NotEqual(value) => format!("{} != '{value}'", self.key),
-            PartitionValue::GreaterThan(value) => format!("{} > '{value}'", self.key),
-            PartitionValue::GreaterThanOrEqual(value) => format!("{} >= '{value}'", self.key),
-            PartitionValue::LessThan(value) => format!("{} < '{value}'", self.key),
-            PartitionValue::LessThanOrEqual(value) => format!("{} <= '{value}'", self.key),
-            // used upper case for IN and NOT similar to SQL
-            PartitionValue::In(values) => {
-                let quoted_values: Vec<String> = values.iter().map(|v| format!("'{v}'")).collect();
-                format!("{} IN ({})", self.key, quoted_values.join(", "))
-            }
-            PartitionValue::NotIn(values) => {
-                let quoted_values: Vec<String> = values.iter().map(|v| format!("'{v}'")).collect();
-                format!("{} NOT IN ({})", self.key, quoted_values.join(", "))
-            }
-        };
-        serializer.serialize_str(&s)
-    }
-}
-
-/// Create a PartitionFilter from a filter Tuple with the structure (key, operation, value).
-impl TryFrom<(&str, &str, &str)> for PartitionFilter {
-    type Error = DeltaTableError;
-
-    /// Try to create a PartitionFilter from a Tuple of (key, operation, value).
-    /// Returns a DeltaTableError in case of a malformed filter.
-    fn try_from(filter: (&str, &str, &str)) -> Result<Self, DeltaTableError> {
-        match filter {
-            (key, "=", value) if !key.is_empty() => Ok(PartitionFilter {
-                key: key.to_owned(),
-                value: PartitionValue::Equal(value.to_owned()),
-            }),
-            (key, "!=", value) if !key.is_empty() => Ok(PartitionFilter {
-                key: key.to_owned(),
-                value: PartitionValue::NotEqual(value.to_owned()),
-            }),
-            (key, ">", value) if !key.is_empty() => Ok(PartitionFilter {
-                key: key.to_owned(),
-                value: PartitionValue::GreaterThan(value.to_owned()),
-            }),
-            (key, ">=", value) if !key.is_empty() => Ok(PartitionFilter {
-                key: key.to_owned(),
-                value: PartitionValue::GreaterThanOrEqual(value.to_owned()),
-            }),
-            (key, "<", value) if !key.is_empty() => Ok(PartitionFilter {
-                key: key.to_owned(),
-                value: PartitionValue::LessThan(value.to_owned()),
-            }),
-            (key, "<=", value) if !key.is_empty() => Ok(PartitionFilter {
-                key: key.to_owned(),
-                value: PartitionValue::LessThanOrEqual(value.to_owned()),
-            }),
-            (_, _, _) => Err(DeltaTableError::InvalidPartitionFilter {
-                partition_filter: format!("{filter:?}"),
-            }),
-        }
-    }
-}
-
-/// Create a PartitionFilter from a filter Tuple with the structure (key, operation, list(value)).
-impl TryFrom<(&str, &str, &[&str])> for PartitionFilter {
-    type Error = DeltaTableError;
-
-    /// Try to create a PartitionFilter from a Tuple of (key, operation, list(value)).
-    /// Returns a DeltaTableError in case of a malformed filter.
-    fn try_from(filter: (&str, &str, &[&str])) -> Result<Self, DeltaTableError> {
-        match filter {
-            (key, "in", value) if !key.is_empty() => Ok(PartitionFilter {
-                key: key.to_owned(),
-                value: PartitionValue::In(value.iter().map(|x| x.to_string()).collect()),
-            }),
-            (key, "not in", value) if !key.is_empty() => Ok(PartitionFilter {
-                key: key.to_owned(),
-                value: PartitionValue::NotIn(value.iter().map(|x| x.to_string()).collect()),
-            }),
-            (_, _, _) => Err(DeltaTableError::InvalidPartitionFilter {
-                partition_filter: format!("{filter:?}"),
-            }),
-        }
-    }
-}
 
 /// A Struct DeltaTablePartition used to represent a partition of a DeltaTable.
 #[derive(Clone, Debug, PartialEq)]
@@ -183,6 +64,77 @@ impl TryFrom<&str> for DeltaTablePartition {
     }
 }
 
+/// The comparison operator of a `(column, op, value)` filter literal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FilterOp {
+    /// `=`
+    Eq,
+    /// `!=`
+    Ne,
+    /// `<`
+    Lt,
+    /// `<=`
+    Le,
+    /// `>`
+    Gt,
+    /// `>=`
+    Ge,
+    /// `in`
+    In,
+    /// `not in`
+    NotIn,
+}
+
+impl FilterOp {
+    /// The operator string accepted by [`FromStr`], e.g. `"="` or `"not in"`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FilterOp::Eq => "=",
+            FilterOp::Ne => "!=",
+            FilterOp::Lt => "<",
+            FilterOp::Le => "<=",
+            FilterOp::Gt => ">",
+            FilterOp::Ge => ">=",
+            FilterOp::In => "in",
+            FilterOp::NotIn => "not in",
+        }
+    }
+
+    /// Set operators compare against a [`FilterValue::Set`], scalar operators
+    /// against a [`FilterValue::Scalar`].
+    fn matches_value(self, value: &FilterValue<'_>) -> bool {
+        matches!(self, FilterOp::In | FilterOp::NotIn) == matches!(value, FilterValue::Set(_))
+    }
+}
+
+impl fmt::Display for FilterOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for FilterOp {
+    type Err = DeltaTableError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "=" => FilterOp::Eq,
+            "!=" => FilterOp::Ne,
+            "<" => FilterOp::Lt,
+            "<=" => FilterOp::Le,
+            ">" => FilterOp::Gt,
+            ">=" => FilterOp::Ge,
+            "in" => FilterOp::In,
+            "not in" => FilterOp::NotIn,
+            _ => {
+                return Err(DeltaTableError::InvalidPartitionFilter {
+                    partition_filter: format!("unknown operator {s:?}"),
+                });
+            }
+        })
+    }
+}
+
 /// The value of a `(column, op, value)` filter literal: a single partition-value
 /// encoded string, or a set of them for `in` / `not in`.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -195,7 +147,45 @@ pub enum FilterValue<'a> {
 
 /// A `(column, op, value)` comparison, mirroring the tuple filters accepted by
 /// the Python bindings.
-pub type FilterLiteral<'a> = (&'a str, &'a str, FilterValue<'a>);
+pub type FilterLiteral<'a> = (&'a str, FilterOp, FilterValue<'a>);
+
+/// Validate a raw `(column, op, value)` tuple into a [`FilterLiteral`],
+/// parsing the operator string.
+///
+/// This is the boundary where stringly-typed filters (e.g. from FFI) enter:
+/// an unknown operator, an empty column name, or an operator/value shape
+/// mismatch all yield the pinned `InvalidPartitionFilter` error.
+pub fn filter_literal<'a>(
+    column: &'a str,
+    op: &str,
+    value: FilterValue<'a>,
+) -> DeltaResult<FilterLiteral<'a>> {
+    match op.parse::<FilterOp>() {
+        Ok(parsed) if !column.is_empty() && parsed.matches_value(&value) => {
+            Ok((column, parsed, value))
+        }
+        _ => Err(invalid_filter_error(column, op, &value)),
+    }
+}
+
+/// Render a filter literal as the predicate string recorded in commit metadata
+/// (`operationParameters.predicate`), e.g. `key = 'value'` or `key IN ('a', 'b')`.
+pub fn literal_to_predicate_string(literal: &FilterLiteral<'_>) -> String {
+    let (column, op, value) = literal;
+    match value {
+        FilterValue::Scalar(v) => format!("{column} {op} '{v}'"),
+        // upper case for IN and NOT IN, similar to SQL
+        FilterValue::Set(vs) => {
+            let op = match op {
+                FilterOp::In => "IN",
+                FilterOp::NotIn => "NOT IN",
+                other => other.as_str(),
+            };
+            let quoted: Vec<String> = vs.iter().map(|v| format!("'{v}'")).collect();
+            format!("{column} {op} ({})", quoted.join(", "))
+        }
+    }
+}
 
 /// Translate a single filter literal into a kernel [`Predicate`].
 ///
@@ -208,12 +198,8 @@ pub fn literal_to_kernel_predicate(
     table_schema: &StructType,
 ) -> DeltaResult<Predicate> {
     let (column, op, value) = literal;
-    let op_matches_value = match value {
-        FilterValue::Scalar(_) => matches!(*op, "=" | "!=" | "<" | "<=" | ">" | ">="),
-        FilterValue::Set(_) => matches!(*op, "in" | "not in"),
-    };
-    if column.is_empty() || !op_matches_value {
-        return Err(invalid_filter_error(literal));
+    if column.is_empty() || !op.matches_value(value) {
+        return Err(invalid_filter_error(column, op.as_str(), value));
     }
     let Some(field) = table_schema.field(column) else {
         return Err(DeltaTableError::SchemaMismatch {
@@ -227,11 +213,11 @@ pub fn literal_to_kernel_predicate(
     };
 
     let col = Expression::column([field.name()]);
-    Ok(match (*op, value) {
+    Ok(match (op, value) {
         // NOTE: In SQL NULL is not equal to anything, including itself. However when specifying partition filters
         // we have allowed to equality against null. So here we have to handle null values explicitly by using
         // is_null and is_not_null methods directly.
-        ("=", FilterValue::Scalar(raw)) => {
+        (FilterOp::Eq, FilterValue::Scalar(raw)) => {
             let scalar = dt.parse_scalar(raw)?;
             if scalar.is_null() {
                 col.is_null()
@@ -239,7 +225,7 @@ pub fn literal_to_kernel_predicate(
                 col.eq(scalar)
             }
         }
-        ("!=", FilterValue::Scalar(raw)) => {
+        (FilterOp::Ne, FilterValue::Scalar(raw)) => {
             let scalar = dt.parse_scalar(raw)?;
             if scalar.is_null() {
                 col.is_not_null()
@@ -247,20 +233,21 @@ pub fn literal_to_kernel_predicate(
                 col.ne(scalar)
             }
         }
-        ("<", FilterValue::Scalar(raw)) => col.lt(dt.parse_scalar(raw)?),
-        ("<=", FilterValue::Scalar(raw)) => col.le(dt.parse_scalar(raw)?),
-        (">", FilterValue::Scalar(raw)) => col.gt(dt.parse_scalar(raw)?),
-        (">=", FilterValue::Scalar(raw)) => col.ge(dt.parse_scalar(raw)?),
-        (op @ ("in" | "not in"), FilterValue::Set(raws)) => {
+        (FilterOp::Lt, FilterValue::Scalar(raw)) => col.lt(dt.parse_scalar(raw)?),
+        (FilterOp::Le, FilterValue::Scalar(raw)) => col.le(dt.parse_scalar(raw)?),
+        (FilterOp::Gt, FilterValue::Scalar(raw)) => col.gt(dt.parse_scalar(raw)?),
+        (FilterOp::Ge, FilterValue::Scalar(raw)) => col.ge(dt.parse_scalar(raw)?),
+        (op @ (FilterOp::In | FilterOp::NotIn), FilterValue::Set(raws)) => {
             let values = raws
                 .iter()
                 .map(|v| dt.parse_scalar(v))
                 .collect::<Result<Vec<_>, _>>()?;
-            let (term, junction): (Box<dyn Fn(Scalar) -> Predicate>, _) = if op == "in" {
-                (Box::new(|v| col.clone().eq(v)), JunctionPredicateOp::Or)
-            } else {
-                (Box::new(|v| col.clone().ne(v)), JunctionPredicateOp::And)
-            };
+            let (term, junction): (Box<dyn Fn(Scalar) -> Predicate>, _) =
+                if matches!(op, FilterOp::In) {
+                    (Box::new(|v| col.clone().eq(v)), JunctionPredicateOp::Or)
+                } else {
+                    (Box::new(|v| col.clone().ne(v)), JunctionPredicateOp::And)
+                };
             let predicates = values.into_iter().map(term).collect::<Vec<_>>();
             Predicate::junction(junction, predicates)
         }
@@ -268,8 +255,7 @@ pub fn literal_to_kernel_predicate(
     })
 }
 
-fn invalid_filter_error(literal: &FilterLiteral<'_>) -> DeltaTableError {
-    let (column, op, value) = literal;
+fn invalid_filter_error(column: &str, op: &str, value: &FilterValue<'_>) -> DeltaTableError {
     let value = match value {
         FilterValue::Scalar(v) => format!("{v:?}"),
         FilterValue::Set(vs) => format!("{vs:?}"),
@@ -323,96 +309,107 @@ pub fn dnf_to_kernel_predicate(
     })
 }
 
-/// Translate a conjunction of [`PartitionFilter`]s into a kernel [`Predicate`].
-///
-/// Unlike [`dnf_to_kernel_predicate`], an empty slice yields an empty AND
-/// junction, which is vacuously true: callers treat "no filters" as "match
-/// every file".
-pub fn to_kernel_predicate(
-    filters: &[PartitionFilter],
-    table_schema: &StructType,
-) -> DeltaResult<Predicate> {
-    let predicates = filters
-        .iter()
-        .map(|filter| filter_to_kernel_predicate(filter, table_schema))
-        .collect::<DeltaResult<Vec<_>>>()?;
-    Ok(Predicate::junction(JunctionPredicateOp::And, predicates))
-}
-
-fn filter_to_kernel_predicate(
-    filter: &PartitionFilter,
-    table_schema: &StructType,
-) -> DeltaResult<Predicate> {
-    let (op, value) = match &filter.value {
-        PartitionValue::Equal(v) => ("=", FilterValue::Scalar(v)),
-        PartitionValue::NotEqual(v) => ("!=", FilterValue::Scalar(v)),
-        PartitionValue::GreaterThan(v) => (">", FilterValue::Scalar(v)),
-        PartitionValue::GreaterThanOrEqual(v) => (">=", FilterValue::Scalar(v)),
-        PartitionValue::LessThan(v) => ("<", FilterValue::Scalar(v)),
-        PartitionValue::LessThanOrEqual(v) => ("<=", FilterValue::Scalar(v)),
-        PartitionValue::In(vs) => (
-            "in",
-            FilterValue::Set(vs.iter().map(String::as_str).collect()),
-        ),
-        PartitionValue::NotIn(vs) => (
-            "not in",
-            FilterValue::Set(vs.iter().map(String::as_str).collect()),
-        ),
-    };
-    literal_to_kernel_predicate(&(filter.key.as_str(), op, value), table_schema)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::kernel::StructField;
     use delta_kernel::schema::{DataType, PrimitiveType};
-    use serde_json::json;
 
-    fn check_json_serialize(filter: PartitionFilter, expected_json: &str) {
-        assert_eq!(serde_json::to_value(filter).unwrap(), json!(expected_json))
+    #[test]
+    fn test_filter_op_from_str() {
+        let cases = [
+            ("=", FilterOp::Eq),
+            ("!=", FilterOp::Ne),
+            ("<", FilterOp::Lt),
+            ("<=", FilterOp::Le),
+            (">", FilterOp::Gt),
+            (">=", FilterOp::Ge),
+            ("in", FilterOp::In),
+            ("not in", FilterOp::NotIn),
+        ];
+        for (raw, op) in cases {
+            assert_eq!(raw.parse::<FilterOp>().unwrap(), op);
+            assert_eq!(op.as_str(), raw);
+        }
+        for raw in ["==", "IN", "NOT IN", "like", "=>", ""] {
+            assert!(raw.parse::<FilterOp>().is_err(), "{raw:?} must not parse");
+        }
     }
 
     #[test]
-    fn test_serialize_partition_filter() {
-        check_json_serialize(
-            PartitionFilter::try_from(("date", "=", "2022-05-22")).unwrap(),
-            "date = '2022-05-22'",
+    fn test_filter_literal_parsing() {
+        assert_eq!(
+            filter_literal("date", "=", FilterValue::Scalar("2022-05-22")).unwrap(),
+            ("date", FilterOp::Eq, FilterValue::Scalar("2022-05-22")),
         );
-        check_json_serialize(
-            PartitionFilter::try_from(("date", "!=", "2022-05-22")).unwrap(),
-            "date != '2022-05-22'",
+        assert_eq!(
+            filter_literal("date", "not in", FilterValue::Set(vec!["a", "b"])).unwrap(),
+            ("date", FilterOp::NotIn, FilterValue::Set(vec!["a", "b"])),
         );
-        check_json_serialize(
-            PartitionFilter::try_from(("date", ">", "2022-05-22")).unwrap(),
-            "date > '2022-05-22'",
+
+        // unknown op, empty column, and op/value shape mismatches all surface
+        // the pinned InvalidPartitionFilter message
+        let err = filter_literal("col", "=>", FilterValue::Scalar("3")).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            r#"Invalid partition filter found: ("col", "=>", "3")."#
         );
-        check_json_serialize(
-            PartitionFilter::try_from(("date", ">=", "2022-05-22")).unwrap(),
-            "date >= '2022-05-22'",
+        let err = filter_literal("col", "=", FilterValue::Set(vec!["3", "20"])).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            r#"Invalid partition filter found: ("col", "=", ["3", "20"])."#
         );
-        check_json_serialize(
-            PartitionFilter::try_from(("date", "<", "2022-05-22")).unwrap(),
-            "date < '2022-05-22'",
-        );
-        check_json_serialize(
-            PartitionFilter::try_from(("date", "<=", "2022-05-22")).unwrap(),
-            "date <= '2022-05-22'",
-        );
-        check_json_serialize(
-            PartitionFilter::try_from(("date", "in", vec!["2023-11-04", "2023-06-07"].as_slice()))
-                .unwrap(),
-            "date IN ('2023-11-04', '2023-06-07')",
-        );
-        check_json_serialize(
-            PartitionFilter::try_from((
-                "date",
-                "not in",
-                vec!["2023-11-04", "2023-06-07"].as_slice(),
-            ))
-            .unwrap(),
-            "date NOT IN ('2023-11-04', '2023-06-07')",
-        );
+        assert!(filter_literal("col", "in", FilterValue::Scalar("3")).is_err());
+        assert!(filter_literal("", "=", FilterValue::Scalar("3")).is_err());
+    }
+
+    #[test]
+    fn test_literal_to_predicate_string() {
+        let cases = [
+            (
+                ("date", FilterOp::Eq, FilterValue::Scalar("2022-05-22")),
+                "date = '2022-05-22'",
+            ),
+            (
+                ("date", FilterOp::Ne, FilterValue::Scalar("2022-05-22")),
+                "date != '2022-05-22'",
+            ),
+            (
+                ("date", FilterOp::Gt, FilterValue::Scalar("2022-05-22")),
+                "date > '2022-05-22'",
+            ),
+            (
+                ("date", FilterOp::Ge, FilterValue::Scalar("2022-05-22")),
+                "date >= '2022-05-22'",
+            ),
+            (
+                ("date", FilterOp::Lt, FilterValue::Scalar("2022-05-22")),
+                "date < '2022-05-22'",
+            ),
+            (
+                ("date", FilterOp::Le, FilterValue::Scalar("2022-05-22")),
+                "date <= '2022-05-22'",
+            ),
+            (
+                (
+                    "date",
+                    FilterOp::In,
+                    FilterValue::Set(vec!["2023-11-04", "2023-06-07"]),
+                ),
+                "date IN ('2023-11-04', '2023-06-07')",
+            ),
+            (
+                (
+                    "date",
+                    FilterOp::NotIn,
+                    FilterValue::Set(vec!["2023-11-04", "2023-06-07"]),
+                ),
+                "date NOT IN ('2023-11-04', '2023-06-07')",
+            ),
+        ];
+        for (literal, expected) in cases {
+            assert_eq!(literal_to_predicate_string(&literal), expected);
+        }
     }
 
     #[test]
@@ -454,89 +451,67 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_to_kernel_predicate_equal() {
+    fn test_literal_to_kernel_predicate_equal() {
         let schema = StructType::try_new(vec![
             StructField::new("name", DataType::Primitive(PrimitiveType::String), true),
             StructField::new("age", DataType::Primitive(PrimitiveType::Integer), true),
         ])
         .unwrap();
-        let filter = PartitionFilter {
-            key: "name".to_string(),
-            value: PartitionValue::Equal("Alice".to_string()),
-        };
+        let literal = ("name", FilterOp::Eq, FilterValue::Scalar("Alice"));
 
-        let predicate = filter_to_kernel_predicate(&filter, &schema).unwrap();
+        let predicate = literal_to_kernel_predicate(&literal, &schema).unwrap();
 
         let expected = Expression::column(["name"]).eq(Scalar::String("Alice".into()));
         assert_eq!(predicate, expected);
     }
 
     #[test]
-    fn test_filter_to_kernel_predicate_not_equal() {
+    fn test_literal_to_kernel_predicate_not_equal() {
         let schema = StructType::try_new(vec![StructField::new(
             "status",
             DataType::Primitive(PrimitiveType::String),
             true,
         )])
         .unwrap();
-        let filter = PartitionFilter {
-            key: "status".to_string(),
-            value: PartitionValue::NotEqual("inactive".to_string()),
-        };
+        let literal = ("status", FilterOp::Ne, FilterValue::Scalar("inactive"));
 
-        let predicate = filter_to_kernel_predicate(&filter, &schema).unwrap();
+        let predicate = literal_to_kernel_predicate(&literal, &schema).unwrap();
 
         let expected = Expression::column(["status"]).ne(Scalar::String("inactive".into()));
         assert_eq!(predicate, expected);
     }
 
     #[test]
-    fn test_filter_to_kernel_predicate_comparisons() {
+    fn test_literal_to_kernel_predicate_comparisons() {
         let schema = StructType::try_new(vec![
             StructField::new("score", DataType::Primitive(PrimitiveType::Integer), true),
             StructField::new("price", DataType::Primitive(PrimitiveType::Long), true),
         ])
         .unwrap();
 
-        // Test less than
-        let filter = PartitionFilter {
-            key: "score".to_string(),
-            value: PartitionValue::LessThan("100".to_string()),
-        };
-        let predicate = filter_to_kernel_predicate(&filter, &schema).unwrap();
+        let literal = ("score", FilterOp::Lt, FilterValue::Scalar("100"));
+        let predicate = literal_to_kernel_predicate(&literal, &schema).unwrap();
         let expected = Expression::column(["score"]).lt(Scalar::Integer(100));
         assert_eq!(predicate, expected);
 
-        // Test less than or equal
-        let filter = PartitionFilter {
-            key: "score".to_string(),
-            value: PartitionValue::LessThanOrEqual("100".to_string()),
-        };
-        let predicate = filter_to_kernel_predicate(&filter, &schema).unwrap();
+        let literal = ("score", FilterOp::Le, FilterValue::Scalar("100"));
+        let predicate = literal_to_kernel_predicate(&literal, &schema).unwrap();
         let expected = Expression::column(["score"]).le(Scalar::Integer(100));
         assert_eq!(predicate, expected);
 
-        // Test greater than
-        let filter = PartitionFilter {
-            key: "price".to_string(),
-            value: PartitionValue::GreaterThan("50".to_string()),
-        };
-        let predicate = filter_to_kernel_predicate(&filter, &schema).unwrap();
+        let literal = ("price", FilterOp::Gt, FilterValue::Scalar("50"));
+        let predicate = literal_to_kernel_predicate(&literal, &schema).unwrap();
         let expected = Expression::column(["price"]).gt(Scalar::Long(50));
         assert_eq!(predicate, expected);
 
-        // Test greater than or equal
-        let filter = PartitionFilter {
-            key: "price".to_string(),
-            value: PartitionValue::GreaterThanOrEqual("50".to_string()),
-        };
-        let predicate = filter_to_kernel_predicate(&filter, &schema).unwrap();
+        let literal = ("price", FilterOp::Ge, FilterValue::Scalar("50"));
+        let predicate = literal_to_kernel_predicate(&literal, &schema).unwrap();
         let expected = Expression::column(["price"]).ge(Scalar::Long(50));
         assert_eq!(predicate, expected);
     }
 
     #[test]
-    fn test_filter_to_kernel_predicate_in_operations() {
+    fn test_literal_to_kernel_predicate_in_operations() {
         let schema = StructType::try_new(vec![StructField::new(
             "category",
             DataType::Primitive(PrimitiveType::String),
@@ -550,12 +525,12 @@ mod tests {
             Scalar::String("electronics".to_string()),
         ];
 
-        // Test In operation
-        let filter = PartitionFilter {
-            key: "category".to_string(),
-            value: PartitionValue::In(vec!["books".to_string(), "electronics".to_string()]),
-        };
-        let predicate = filter_to_kernel_predicate(&filter, &schema).unwrap();
+        let literal = (
+            "category",
+            FilterOp::In,
+            FilterValue::Set(vec!["books", "electronics"]),
+        );
+        let predicate = literal_to_kernel_predicate(&literal, &schema).unwrap();
         let expected_inner = categories
             .clone()
             .into_iter()
@@ -564,12 +539,12 @@ mod tests {
         let expected = Predicate::junction(JunctionPredicateOp::Or, expected_inner);
         assert_eq!(predicate, expected);
 
-        // Test NotIn operation
-        let filter = PartitionFilter {
-            key: "category".to_string(),
-            value: PartitionValue::NotIn(vec!["books".to_string(), "electronics".to_string()]),
-        };
-        let predicate = filter_to_kernel_predicate(&filter, &schema).unwrap();
+        let literal = (
+            "category",
+            FilterOp::NotIn,
+            FilterValue::Set(vec!["books", "electronics"]),
+        );
+        let predicate = literal_to_kernel_predicate(&literal, &schema).unwrap();
         let expected_inner = categories
             .into_iter()
             .map(|s| column.clone().ne(s))
@@ -579,7 +554,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_to_kernel_predicate_empty_in_list() {
+    fn test_literal_to_kernel_predicate_empty_in_list() {
         let schema = StructType::try_new(vec![StructField::new(
             "tag",
             DataType::Primitive(PrimitiveType::String),
@@ -587,16 +562,12 @@ mod tests {
         )])
         .unwrap();
 
-        let filter = PartitionFilter {
-            key: "tag".to_string(),
-            value: PartitionValue::In(vec![]),
-        };
-        let result = filter_to_kernel_predicate(&filter, &schema);
-        assert!(result.is_ok());
+        let literal = ("tag", FilterOp::In, FilterValue::Set(vec![]));
+        assert!(literal_to_kernel_predicate(&literal, &schema).is_ok());
     }
 
     #[test]
-    fn test_filter_to_kernel_predicate_field_not_found() {
+    fn test_literal_to_kernel_predicate_field_not_found() {
         let schema = StructType::try_new(vec![StructField::new(
             "existing_field",
             DataType::Primitive(PrimitiveType::String),
@@ -604,13 +575,8 @@ mod tests {
         )])
         .unwrap();
 
-        let filter = PartitionFilter {
-            key: "nonexistent_field".to_string(),
-            value: PartitionValue::Equal("value".to_string()),
-        };
-
-        let result = filter_to_kernel_predicate(&filter, &schema);
-        assert!(result.is_err());
+        let literal = ("nonexistent_field", FilterOp::Eq, FilterValue::Scalar("v"));
+        let result = literal_to_kernel_predicate(&literal, &schema);
         assert!(matches!(
             result.unwrap_err(),
             DeltaTableError::SchemaMismatch { .. }
@@ -618,7 +584,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_to_kernel_predicate_non_primitive_field() {
+    fn test_literal_to_kernel_predicate_non_primitive_field() {
         let nested_struct = StructType::try_new(vec![StructField::new(
             "inner",
             DataType::Primitive(PrimitiveType::String),
@@ -632,13 +598,8 @@ mod tests {
         )])
         .unwrap();
 
-        let filter = PartitionFilter {
-            key: "nested".to_string(),
-            value: PartitionValue::Equal("value".to_string()),
-        };
-
-        let result = filter_to_kernel_predicate(&filter, &schema);
-        assert!(result.is_err());
+        let literal = ("nested", FilterOp::Eq, FilterValue::Scalar("value"));
+        let result = literal_to_kernel_predicate(&literal, &schema);
         assert!(matches!(
             result.unwrap_err(),
             DeltaTableError::SchemaMismatch { .. }
@@ -646,7 +607,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_to_kernel_predicate_different_data_types() {
+    fn test_literal_to_kernel_predicate_different_data_types() {
         let schema = StructType::try_new(vec![
             StructField::new(
                 "bool_field",
@@ -672,26 +633,18 @@ mod tests {
         ])
         .unwrap();
 
-        // Test boolean field
-        let filter = PartitionFilter {
-            key: "bool_field".to_string(),
-            value: PartitionValue::Equal("true".to_string()),
-        };
-        assert!(filter_to_kernel_predicate(&filter, &schema).is_ok());
+        let literal = ("bool_field", FilterOp::Eq, FilterValue::Scalar("true"));
+        assert!(literal_to_kernel_predicate(&literal, &schema).is_ok());
 
-        // Test date field
-        let filter = PartitionFilter {
-            key: "date_field".to_string(),
-            value: PartitionValue::GreaterThan("2023-01-01".to_string()),
-        };
-        assert!(filter_to_kernel_predicate(&filter, &schema).is_ok());
+        let literal = (
+            "date_field",
+            FilterOp::Gt,
+            FilterValue::Scalar("2023-01-01"),
+        );
+        assert!(literal_to_kernel_predicate(&literal, &schema).is_ok());
 
-        // Test float field
-        let filter = PartitionFilter {
-            key: "float_field".to_string(),
-            value: PartitionValue::LessThan("3.14".to_string()),
-        };
-        assert!(filter_to_kernel_predicate(&filter, &schema).is_ok());
+        let literal = ("float_field", FilterOp::Lt, FilterValue::Scalar("3.14"));
+        assert!(literal_to_kernel_predicate(&literal, &schema).is_ok());
     }
 
     fn dnf_test_schema() -> StructType {
@@ -707,10 +660,10 @@ mod tests {
         let schema = dnf_test_schema();
         let dnf = vec![
             vec![
-                ("year", "=", FilterValue::Scalar("2020")),
-                ("month", "=", FilterValue::Scalar("2")),
+                ("year", FilterOp::Eq, FilterValue::Scalar("2020")),
+                ("month", FilterOp::Eq, FilterValue::Scalar("2")),
             ],
-            vec![("year", "=", FilterValue::Scalar("2021"))],
+            vec![("year", FilterOp::Eq, FilterValue::Scalar("2021"))],
         ];
 
         let predicate = dnf_to_kernel_predicate(&dnf, &schema).unwrap();
@@ -734,7 +687,7 @@ mod tests {
     #[test]
     fn test_dnf_to_kernel_predicate_single_conjunction_unwrapped() {
         let schema = dnf_test_schema();
-        let literal = ("year", ">=", FilterValue::Scalar("2021"));
+        let literal = ("year", FilterOp::Ge, FilterValue::Scalar("2021"));
 
         let predicate = dnf_to_kernel_predicate(&[vec![literal.clone()]], &schema).unwrap();
 
@@ -758,26 +711,30 @@ mod tests {
     }
 
     #[test]
-    fn test_literal_to_kernel_predicate_invalid_op() {
+    fn test_literal_to_kernel_predicate_shape_mismatch() {
         let schema = dnf_test_schema();
-        let result =
-            literal_to_kernel_predicate(&("year", "like", FilterValue::Scalar("2021")), &schema);
+
+        // scalar ops reject set values and vice versa
+        let result = literal_to_kernel_predicate(
+            &("year", FilterOp::Eq, FilterValue::Set(vec!["2021"])),
+            &schema,
+        );
         assert!(matches!(
             result.unwrap_err(),
             DeltaTableError::InvalidPartitionFilter { .. }
         ));
-
-        // scalar ops reject set values and vice versa
-        let result =
-            literal_to_kernel_predicate(&("year", "=", FilterValue::Set(vec!["2021"])), &schema);
-        assert!(result.is_err());
-        let result =
-            literal_to_kernel_predicate(&("year", "in", FilterValue::Scalar("2021")), &schema);
-        assert!(result.is_err());
+        let result = literal_to_kernel_predicate(
+            &("year", FilterOp::In, FilterValue::Scalar("2021")),
+            &schema,
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            DeltaTableError::InvalidPartitionFilter { .. }
+        ));
     }
 
     #[test]
-    fn test_filter_to_kernel_predicate_invalid_scalar_value() {
+    fn test_literal_to_kernel_predicate_invalid_scalar_value() {
         let schema = StructType::try_new(vec![StructField::new(
             "number",
             DataType::Primitive(PrimitiveType::Integer),
@@ -785,12 +742,7 @@ mod tests {
         )])
         .unwrap();
 
-        let filter = PartitionFilter {
-            key: "number".to_string(),
-            value: PartitionValue::Equal("not_a_number".to_string()),
-        };
-
-        let result = filter_to_kernel_predicate(&filter, &schema);
-        assert!(result.is_err());
+        let literal = ("number", FilterOp::Eq, FilterValue::Scalar("not_a_number"));
+        assert!(literal_to_kernel_predicate(&literal, &schema).is_err());
     }
 }

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -46,7 +46,7 @@ use crate::checkpoints::parse_last_checkpoint_hint;
 use crate::kernel::arrow::engine_ext::{ExpressionEvaluatorExt, rb_from_scan_meta};
 use crate::kernel::{ARROW_HANDLER, StructType, spawn_blocking_with_span};
 use crate::logstore::{LogStore, LogStoreExt};
-use crate::{DeltaResult, DeltaTableConfig, DeltaTableError, PartitionFilter, to_kernel_predicate};
+use crate::{DeltaResult, DeltaTableConfig, DeltaTableError};
 
 pub use self::log_data::*;
 use self::stats_projection::FIELD_STATS;
@@ -1506,26 +1506,6 @@ impl EagerSnapshot {
         self.snapshot.file_views(log_store, predicate)
     }
 
-    /// Stream the file views matching the given partition `filters`.
-    ///
-    /// Deprecated in favor of [`file_views`](Self::file_views) with a kernel predicate, which
-    /// supports richer expressions than simple partition equality filters.
-    #[deprecated(since = "0.29.0", note = "Use `files` with kernel predicate instead.")]
-    pub fn file_views_by_partitions(
-        &self,
-        log_store: &dyn LogStore,
-        filters: &[PartitionFilter],
-    ) -> BoxStream<'_, DeltaResult<LogicalFileView>> {
-        if filters.is_empty() {
-            return self.file_views(log_store, None);
-        }
-        let predicate = match to_kernel_predicate(filters, self.snapshot.schema().as_ref()) {
-            Ok(predicate) => Arc::new(predicate),
-            Err(err) => return Box::pin(once(ready(Err(err)))),
-        };
-        self.file_views(log_store, Some(predicate))
-    }
-
     /// Return the latest committed transaction version for the given application id, if any.
     ///
     /// This is used to implement idempotent writes: an application records its own monotonic
@@ -1588,6 +1568,9 @@ mod tests {
     use super::*;
     use crate::{
         DeltaTable, DeltaTableConfig, TableProperty, checkpoints,
+        kernel::schema::partitions::{
+            FilterOp, FilterValue, conjunction_to_kernel_predicate, dnf_to_kernel_predicate,
+        },
         kernel::transaction::CommitData,
         kernel::transaction::{CommitBuilder, TableReference},
         kernel::{Action, DataType, PrimitiveType, StructField, StructType},
@@ -3856,10 +3839,10 @@ mod tests {
         let snapshot = Snapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
         let eager = EagerSnapshot::try_new(log_store.as_ref(), Default::default(), None).await?;
 
-        let predicate = Arc::new(to_kernel_predicate(
+        let predicate = Arc::new(conjunction_to_kernel_predicate(
             &[
-                PartitionFilter::try_from(("month", "=", "2"))?,
-                PartitionFilter::try_from(("year", "=", "2020"))?,
+                ("month", FilterOp::Eq, FilterValue::Scalar("2")),
+                ("year", FilterOp::Eq, FilterValue::Scalar("2020")),
             ],
             eager.schema().as_ref(),
         )?);
@@ -3897,8 +3880,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_file_views_with_dnf_predicate() -> TestResult {
-        use crate::kernel::schema::partitions::{FilterValue, dnf_to_kernel_predicate};
-
         let base = TestTables::Delta0_8_0Partitioned
             .table_builder()?
             .build_storage()?;
@@ -3906,12 +3887,12 @@ mod tests {
 
         let dnf = vec![
             vec![
-                ("year", "=", FilterValue::Scalar("2020")),
-                ("month", "=", FilterValue::Scalar("2")),
+                ("year", FilterOp::Eq, FilterValue::Scalar("2020")),
+                ("month", FilterOp::Eq, FilterValue::Scalar("2")),
             ],
             vec![
-                ("year", "=", FilterValue::Scalar("2021")),
-                ("month", "=", FilterValue::Scalar("12")),
+                ("year", FilterOp::Eq, FilterValue::Scalar("2021")),
+                ("month", FilterOp::Eq, FilterValue::Scalar("12")),
             ],
         ];
         let predicate = Arc::new(dnf_to_kernel_predicate(&dnf, snapshot.schema().as_ref())?);
@@ -3949,10 +3930,10 @@ mod tests {
             .build_storage()?;
         let snapshot = Snapshot::try_new(base.as_ref(), Default::default(), None).await?;
 
-        let predicate = Arc::new(to_kernel_predicate(
+        let predicate = Arc::new(conjunction_to_kernel_predicate(
             &[
-                PartitionFilter::try_from(("year", "=", "2020"))?,
-                PartitionFilter::try_from(("month", "=", "2"))?,
+                ("year", FilterOp::Eq, FilterValue::Scalar("2020")),
+                ("month", FilterOp::Eq, FilterValue::Scalar("2")),
             ],
             snapshot.schema().as_ref(),
         )?);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -20,10 +20,11 @@
 //! async {
 //!   let table_url = Url::from_directory_path("/abs/test/tests/data/simple_table").unwrap();
 //!   let table = deltalake_core::open_table_with_version(table_url, 0).await.unwrap();
-//!   let filter = [deltalake_core::PartitionFilter {
-//!       key: "month".to_string(),
-//!       value: deltalake_core::PartitionValue::Equal("12".to_string()),
-//!   }];
+//!   let filter = [(
+//!       "month",
+//!       deltalake_core::FilterOp::Eq,
+//!       deltalake_core::FilterValue::Scalar("12"),
+//!   )];
 //!   let files = table.get_files_by_partitions(&filter).await.unwrap();
 //! };
 //! ```
@@ -432,14 +433,16 @@ mod tests {
         let table = crate::open_table(table_url).await.unwrap();
 
         let filters = vec![
-            crate::PartitionFilter {
-                key: "month".to_string(),
-                value: crate::PartitionValue::Equal("2".to_string()),
-            },
-            crate::PartitionFilter {
-                key: "year".to_string(),
-                value: crate::PartitionValue::Equal("2020".to_string()),
-            },
+            (
+                "month",
+                crate::FilterOp::Eq,
+                crate::FilterValue::Scalar("2"),
+            ),
+            (
+                "year",
+                crate::FilterOp::Eq,
+                crate::FilterValue::Scalar("2020"),
+            ),
         ];
 
         assert_eq!(
@@ -461,10 +464,11 @@ mod tests {
             ]
         );
 
-        let filters = vec![crate::PartitionFilter {
-            key: "month".to_string(),
-            value: crate::PartitionValue::NotEqual("2".to_string()),
-        }];
+        let filters = vec![(
+            "month",
+            crate::FilterOp::Ne,
+            crate::FilterValue::Scalar("2"),
+        )];
         assert_eq!(
             table.get_files_by_partitions(&filters).await.unwrap(),
             vec![
@@ -483,10 +487,11 @@ mod tests {
             ]
         );
 
-        let filters = vec![crate::PartitionFilter {
-            key: "month".to_string(),
-            value: crate::PartitionValue::In(vec!["2".to_string(), "12".to_string()]),
-        }];
+        let filters = vec![(
+            "month",
+            crate::FilterOp::In,
+            crate::FilterValue::Set(vec!["2", "12"]),
+        )];
         assert_eq!(
             table.get_files_by_partitions(&filters).await.unwrap(),
             vec![
@@ -505,10 +510,11 @@ mod tests {
             ]
         );
 
-        let filters = vec![crate::PartitionFilter {
-            key: "month".to_string(),
-            value: crate::PartitionValue::NotIn(vec!["2".to_string(), "12".to_string()]),
-        }];
+        let filters = vec![(
+            "month",
+            crate::FilterOp::NotIn,
+            crate::FilterValue::Set(vec!["2", "12"]),
+        )];
         assert_eq!(
             table.get_files_by_partitions(&filters).await.unwrap(),
             vec![
@@ -530,10 +536,7 @@ mod tests {
         let table_url = url::Url::from_directory_path(table_path).unwrap();
         let table = crate::open_table(table_url).await.unwrap();
 
-        let filters = vec![crate::PartitionFilter {
-            key: "k".to_string(),
-            value: crate::PartitionValue::Equal("A".to_string()),
-        }];
+        let filters = vec![("k", crate::FilterOp::Eq, crate::FilterValue::Scalar("A"))];
         assert_eq!(
             table.get_files_by_partitions(&filters).await.unwrap(),
             vec![Path::from(
@@ -541,10 +544,7 @@ mod tests {
             )]
         );
 
-        let filters = vec![crate::PartitionFilter {
-            key: "k".to_string(),
-            value: crate::PartitionValue::Equal("".to_string()),
-        }];
+        let filters = vec![("k", crate::FilterOp::Eq, crate::FilterValue::Scalar(""))];
         assert_eq!(
             table.get_files_by_partitions(&filters).await.unwrap(),
             vec![Path::from(
@@ -571,10 +571,7 @@ mod tests {
             ]
         );
 
-        let filters = vec![crate::PartitionFilter {
-            key: "x".to_string(),
-            value: crate::PartitionValue::Equal("A/A".to_string()),
-        }];
+        let filters = vec![("x", crate::FilterOp::Eq, crate::FilterValue::Scalar("A/A"))];
         assert_eq!(
             table.get_files_by_partitions(&filters).await.unwrap(),
             vec![Path::parse(
@@ -594,19 +591,13 @@ mod tests {
         let table_url = url::Url::from_directory_path(table_path).unwrap();
         let table = crate::open_table(table_url).await.unwrap();
 
-        let filters = vec![crate::PartitionFilter {
-            key: "x".to_string(),
-            value: crate::PartitionValue::LessThanOrEqual("9".to_string()),
-        }];
+        let filters = vec![("x", crate::FilterOp::Le, crate::FilterValue::Scalar("9"))];
         assert_eq!(
             table.get_files_by_partitions(&filters).await.unwrap().len(),
             1
         );
 
-        let filters = vec![crate::PartitionFilter {
-            key: "y".to_string(),
-            value: crate::PartitionValue::LessThan("10.0".to_string()),
-        }];
+        let filters = vec![("y", crate::FilterOp::Lt, crate::FilterValue::Scalar("10.0"))];
         assert_eq!(
             table.get_files_by_partitions(&filters).await.unwrap().len(),
             1

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -63,7 +63,10 @@ use crate::protocol::DeltaOperation;
 use crate::table::config::TablePropertiesExt as _;
 use crate::table::state::DeltaTableState;
 use crate::writer::utils::arrow_schema_without_partitions;
-use crate::{DeltaTable, ObjectMeta, PartitionFilter, to_kernel_predicate};
+use crate::{
+    DeltaTable, FilterLiteral, ObjectMeta, conjunction_to_kernel_predicate,
+    literal_to_predicate_string,
+};
 
 /// Planner used by optimize.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -280,7 +283,7 @@ pub struct OptimizeBuilder<'a> {
     /// Delta object store for handling data files
     log_store: LogStoreRef,
     /// Filters to select specific table partitions to be optimized
-    filters: &'a [PartitionFilter],
+    filters: &'a [FilterLiteral<'a>],
     /// Desired file size after bin-packing files
     target_size: Option<NonZeroU64>,
     /// Properties passed to underlying parquet writer
@@ -332,8 +335,9 @@ impl<'a> OptimizeBuilder<'a> {
         self
     }
 
-    /// Only optimize files that return true for the specified partition filter
-    pub fn with_filters(mut self, filters: &'a [PartitionFilter]) -> Self {
+    /// Only optimize files matching the given conjunction of `(column, op, value)`
+    /// partition filter literals
+    pub fn with_filters(mut self, filters: &'a [FilterLiteral<'a>]) -> Self {
         self.filters = filters;
         self
     }
@@ -1010,7 +1014,7 @@ pub async fn create_merge_plan(
     log_store: &dyn LogStore,
     optimize_type: OptimizeType,
     snapshot: &EagerSnapshot,
-    filters: &[PartitionFilter],
+    filters: &[FilterLiteral<'_>],
     target_size: Option<NonZeroU64>,
     writer_properties: WriterProperties,
     session: SessionState,
@@ -1043,9 +1047,12 @@ pub async fn create_merge_plan(
         "merge plan created"
     );
 
+    // rendered predicate strings land in operationParameters in the commit log;
+    // the format is pinned, e.g. `key = 'value'` and `key IN ('a', 'b')`
+    let rendered_filters: Vec<String> = filters.iter().map(literal_to_predicate_string).collect();
     let input_parameters = OptimizeInput {
         target_size,
-        predicate: serde_json::to_string(filters).ok(),
+        predicate: serde_json::to_string(&rendered_filters).ok(),
     };
     let file_schema = arrow_schema_without_partitions(
         &Arc::new(snapshot.schema().as_ref().try_into_arrow()?),
@@ -1196,7 +1203,7 @@ fn plan_compaction_bins_in_stable_order(
 async fn build_compaction_plan(
     log_store: &dyn LogStore,
     snapshot: &EagerSnapshot,
-    filters: &[PartitionFilter],
+    filters: &[FilterLiteral<'_>],
     target_size: NonZeroU64,
 ) -> Result<(OptimizeOperations, Metrics, PlannerStats), DeltaTableError> {
     type PartitionFileEntry = (IndexMap<String, Scalar>, usize, Vec<OrderedFileCandidate>);
@@ -1210,7 +1217,7 @@ async fn build_compaction_plan(
     let predicate = if filters.is_empty() {
         None
     } else {
-        Some(Arc::new(to_kernel_predicate(
+        Some(Arc::new(conjunction_to_kernel_predicate(
             filters,
             snapshot.schema().as_ref(),
         )?))
@@ -1312,7 +1319,7 @@ async fn build_zorder_plan(
     zorder_columns: Vec<String>,
     snapshot: &EagerSnapshot,
     partition_keys: &[String],
-    filters: &[PartitionFilter],
+    filters: &[FilterLiteral<'_>],
 ) -> Result<(OptimizeOperations, Metrics, PlannerStats), DeltaTableError> {
     if zorder_columns.is_empty() {
         return Err(DeltaTableError::Generic(
@@ -1341,7 +1348,7 @@ async fn build_zorder_plan(
     let predicate = if filters.is_empty() {
         None
     } else {
-        Some(Arc::new(to_kernel_predicate(
+        Some(Arc::new(conjunction_to_kernel_predicate(
             filters,
             snapshot.schema().as_ref(),
         )?))

--- a/crates/core/src/table/mod.rs
+++ b/crates/core/src/table/mod.rs
@@ -23,7 +23,7 @@ use crate::logstore::{
     LogStoreConfig, LogStoreExt, LogStoreRef, ObjectStoreRef, commit_uri_from_version,
     extract_version_from_filename,
 };
-use crate::partitions::PartitionFilter;
+use crate::partitions::FilterLiteral;
 use crate::{DeltaResult, DeltaTableBuilder, DeltaTableError};
 
 mod blind;
@@ -308,10 +308,11 @@ impl DeltaTable {
         state.snapshot().file_views(&self.log_store, predicate)
     }
 
-    /// Stream all logical files matching the provided `PartitionFilter`s.
+    /// Stream all logical files matching the provided conjunction (AND) of
+    /// `(column, op, value)` partition filter literals.
     pub fn get_active_add_actions_by_partitions(
         &self,
-        filters: &[PartitionFilter],
+        filters: &[FilterLiteral<'_>],
     ) -> BoxStream<'_, DeltaResult<LogicalFileView>> {
         let Some(state) = self.state.as_ref() else {
             return Box::pin(futures::stream::once(async {
@@ -323,21 +324,23 @@ impl DeltaTable {
             return state.snapshot().file_views(&self.log_store, None);
         }
 
-        let predicate =
-            match crate::to_kernel_predicate(filters, state.snapshot().schema().as_ref()) {
-                Ok(predicate) => Arc::new(predicate),
-                Err(err) => return Box::pin(once(ready(Err(err)))),
-            };
+        let predicate = match crate::conjunction_to_kernel_predicate(
+            filters,
+            state.snapshot().schema().as_ref(),
+        ) {
+            Ok(predicate) => Arc::new(predicate),
+            Err(err) => return Box::pin(once(ready(Err(err)))),
+        };
         state
             .snapshot()
             .file_views(&self.log_store, Some(predicate))
     }
 
     /// Returns the file list tracked in current table state filtered by provided
-    /// `PartitionFilter`s.
+    /// partition filter literals.
     pub async fn get_files_by_partitions(
         &self,
-        filters: &[PartitionFilter],
+        filters: &[FilterLiteral<'_>],
     ) -> Result<Vec<Path>, DeltaTableError> {
         Ok(self
             .get_active_add_actions_by_partitions(filters)
@@ -351,7 +354,7 @@ impl DeltaTable {
     /// Return the file uris as strings for the partition(s)
     pub async fn get_file_uris_by_partitions(
         &self,
-        filters: &[PartitionFilter],
+        filters: &[FilterLiteral<'_>],
     ) -> Result<Vec<String>, DeltaTableError> {
         let files = self.get_files_by_partitions(filters).await?;
         Ok(files

--- a/crates/core/tests/it_datafusion/command_optimize.rs
+++ b/crates/core/tests/it_datafusion/command_optimize.rs
@@ -26,7 +26,7 @@ use deltalake_core::protocol::DeltaOperation;
 use deltalake_core::test_utils::TestTables;
 use deltalake_core::writer::{DeltaWriter, RecordBatchWriter};
 use deltalake_core::{
-    DeltaTable, NULL_PARTITION_VALUE_DATA_PATH, PartitionFilter, Path, open_table,
+    DeltaTable, FilterOp, FilterValue, NULL_PARTITION_VALUE_DATA_PATH, Path, open_table,
 };
 use futures::TryStreamExt;
 use object_store::ObjectStoreExt as _;
@@ -737,7 +737,7 @@ async fn write(
 async fn test_compact_subset_partition_filter_preserves_full_partition_values()
 -> Result<(), Box<dyn Error>> {
     let context = setup_multi_partition_optimize_table().await?;
-    let filter = vec![PartitionFilter::try_from(("part_b", "=", "x"))?];
+    let filter = vec![("part_b", FilterOp::Eq, FilterValue::Scalar("x"))];
 
     let (updated, metrics) = context
         .table
@@ -758,7 +758,7 @@ async fn test_compact_subset_partition_filter_preserves_full_partition_values()
 async fn test_zorder_subset_partition_filter_preserves_full_partition_values()
 -> Result<(), Box<dyn Error>> {
     let context = setup_multi_partition_optimize_table().await?;
-    let filter = vec![PartitionFilter::try_from(("part_b", "=", "x"))?];
+    let filter = vec![("part_b", FilterOp::Eq, FilterValue::Scalar("x"))];
 
     let (updated, metrics) = context
         .table
@@ -807,7 +807,7 @@ async fn test_optimize_with_partitions() -> Result<(), Box<dyn Error>> {
     .await?;
 
     let version = dt.version().unwrap();
-    let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
+    let filter = vec![("date", FilterOp::Eq, FilterValue::Scalar("2022-05-22"))];
 
     let optimize = dt.optimize().with_filters(&filter);
     let (dt, metrics) = optimize.await?;
@@ -1014,7 +1014,7 @@ async fn test_conflict_for_remove_actions() -> Result<(), Box<dyn Error>> {
     let df_context: SessionContext = DeltaSessionContext::default().into();
 
     //create the merge plan, remove a file, and execute the plan.
-    let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
+    let filter = vec![("date", FilterOp::Eq, FilterValue::Scalar("2022-05-22"))];
     let plan = create_merge_plan(
         &dt.log_store(),
         OptimizeType::Compact,
@@ -1081,7 +1081,7 @@ async fn test_no_conflict_for_append_actions() -> Result<(), Box<dyn Error>> {
 
     let df_context: SessionContext = DeltaSessionContext::default().into();
 
-    let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
+    let filter = vec![("date", FilterOp::Eq, FilterValue::Scalar("2022-05-22"))];
     let plan = create_merge_plan(
         &dt.log_store(),
         OptimizeType::Compact,
@@ -1206,7 +1206,7 @@ async fn test_idempotent() -> Result<(), Box<dyn Error>> {
 
     let version = dt.version().unwrap();
 
-    let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
+    let filter = vec![("date", FilterOp::Eq, FilterValue::Scalar("2022-05-22"))];
 
     let optimize = dt
         .optimize()
@@ -1376,7 +1376,7 @@ async fn test_idempotent_with_multiple_bins() -> Result<(), Box<dyn Error>> {
 
     let version = dt.version().unwrap();
 
-    let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
+    let filter = vec![("date", FilterOp::Eq, FilterValue::Scalar("2022-05-22"))];
 
     let optimize = dt
         .optimize()
@@ -1709,7 +1709,7 @@ async fn test_commit_info() -> Result<(), Box<dyn Error>> {
 
     let version = dt.version().unwrap();
 
-    let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
+    let filter = vec![("date", FilterOp::Eq, FilterValue::Scalar("2022-05-22"))];
 
     let optimize = dt
         .optimize()
@@ -1958,7 +1958,7 @@ async fn test_zorder_partitioned() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    let filter = vec![PartitionFilter::try_from(("date", "=", "2022-05-22"))?];
+    let filter = vec![("date", FilterOp::Eq, FilterValue::Scalar("2022-05-22"))];
 
     let optimize = dt
         .optimize()

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -56,7 +56,8 @@ use deltalake::parquet::basic::{Compression, Encoding};
 use deltalake::parquet::errors::ParquetError;
 use deltalake::parquet::file::properties::{EnabledStatistics, WriterProperties};
 use deltalake::partitions::{
-    FilterLiteral, FilterValue, PartitionFilter, dnf_to_kernel_predicate, to_kernel_predicate,
+    FilterLiteral, FilterValue, conjunction_to_kernel_predicate, dnf_to_kernel_predicate,
+    filter_literal,
 };
 use deltalake::protocol::log_compaction::compact_logs;
 use deltalake::protocol::{DeltaOperation, SaveMode};
@@ -868,9 +869,9 @@ impl RawDeltaTable {
                 cmd = cmd.with_custom_execute_handler(Arc::new(LakeFSCustomExecuteHandler {}))
             }
 
+            let partition_filters = partition_filters.unwrap_or_default();
             let converted_filters =
-                convert_partition_filters(partition_filters.unwrap_or_default())
-                    .map_err(PythonError::from)?;
+                convert_partition_filters(&partition_filters).map_err(PythonError::from)?;
             cmd = cmd.with_filters(&converted_filters);
 
             rt().block_on(cmd.into_future())
@@ -946,9 +947,9 @@ impl RawDeltaTable {
                 cmd = cmd.with_custom_execute_handler(Arc::new(LakeFSCustomExecuteHandler {}))
             }
 
+            let partition_filters = partition_filters.unwrap_or_default();
             let converted_filters =
-                convert_partition_filters(partition_filters.unwrap_or_default())
-                    .map_err(PythonError::from)?;
+                convert_partition_filters(&partition_filters).map_err(PythonError::from)?;
             cmd = cmd.with_filters(&converted_filters);
 
             rt().block_on(cmd.into_future())
@@ -1626,9 +1627,9 @@ impl RawDeltaTable {
 
             match mode {
                 SaveMode::Overwrite => {
-                    let converted_filters =
-                        convert_partition_filters(partitions_filters.unwrap_or_default())
-                            .map_err(PythonError::from)?;
+                    let partitions_filters = partitions_filters.unwrap_or_default();
+                    let converted_filters = convert_partition_filters(&partitions_filters)
+                        .map_err(PythonError::from)?;
 
                     let state = self.cloned_state()?;
                     let log_store = self.log_store()?;
@@ -1636,8 +1637,11 @@ impl RawDeltaTable {
                         None
                     } else {
                         Some(Arc::new(
-                            to_kernel_predicate(&converted_filters, state.schema().as_ref())
-                                .map_err(PythonError::from)?,
+                            conjunction_to_kernel_predicate(
+                                &converted_filters,
+                                state.schema().as_ref(),
+                            )
+                            .map_err(PythonError::from)?,
                         ) as PredicateRef)
                     };
                     let add_actions: Vec<_> = rt()
@@ -2420,50 +2424,33 @@ fn set_writer_properties(writer_properties: PyWriterProperties) -> DeltaResult<W
     Ok(properties.build())
 }
 
-/// Translate DNF filter tuples into a kernel predicate, without materializing
-/// `PartitionFilter`s along the way.
+/// Translate DNF filter tuples into a kernel predicate.
 fn kernel_dnf_predicate(
     dnf: &[PyFilterConjunction],
     table_schema: &delta_kernel::schema::StructType,
 ) -> Result<delta_kernel::expressions::Predicate, DeltaTableError> {
     let dnf: Vec<Vec<FilterLiteral<'_>>> = dnf
         .iter()
-        .map(|conjunction| {
-            conjunction
-                .iter()
-                .map(|(column, op, value)| {
-                    let value = match value {
-                        PartitionFilterValue::Single(v) => FilterValue::Scalar(v.as_ref()),
-                        PartitionFilterValue::Multiple(vs) => {
-                            FilterValue::Set(vs.iter().map(|v| v.as_ref()).collect())
-                        }
-                    };
-                    (column.as_ref(), op.as_ref(), value)
-                })
-                .collect()
-        })
-        .collect();
+        .map(|conjunction| convert_partition_filters(conjunction))
+        .collect::<Result<_, _>>()?;
     dnf_to_kernel_predicate(&dnf, table_schema)
 }
 
+/// Parse raw `(column, op, value)` tuples into typed filter literals borrowing
+/// from the Python-backed strings.
 fn convert_partition_filters(
-    partitions_filters: Vec<(PyBackedStr, PyBackedStr, PartitionFilterValue)>,
-) -> Result<Vec<PartitionFilter>, DeltaTableError> {
+    partitions_filters: &[(PyBackedStr, PyBackedStr, PartitionFilterValue)],
+) -> Result<Vec<FilterLiteral<'_>>, DeltaTableError> {
     partitions_filters
-        .into_iter()
-        .map(|filter| match filter {
-            (key, op, PartitionFilterValue::Single(v)) => {
-                let key: &'_ str = key.as_ref();
-                let op: &'_ str = op.as_ref();
-                let v: &'_ str = v.as_ref();
-                PartitionFilter::try_from((key, op, v))
-            }
-            (key, op, PartitionFilterValue::Multiple(v)) => {
-                let key: &'_ str = key.as_ref();
-                let op: &'_ str = op.as_ref();
-                let v: Vec<&'_ str> = v.iter().map(|v| v.as_ref()).collect();
-                PartitionFilter::try_from((key, op, v.as_slice()))
-            }
+        .iter()
+        .map(|(column, op, value)| {
+            let value = match value {
+                PartitionFilterValue::Single(v) => FilterValue::Scalar(v.as_ref()),
+                PartitionFilterValue::Multiple(vs) => {
+                    FilterValue::Set(vs.iter().map(|v| v.as_ref()).collect())
+                }
+            };
+            filter_literal(column.as_ref(), op.as_ref(), value)
         })
         .collect()
 }


### PR DESCRIPTION
# Description

Deletes `PartitionFilter` and `PartitionValue`, their `TryFrom` and `Serialize` impls, the `to_kernel_predicate`/`filter_to_kernel_predicate` shims, and the deprecated `EagerSnapshot::file_views_by_partitions`. #4585 left `PartitionFilter` with no translation logic of its own.

This finishes the cleanup roeap described in #1923 ("removing the PartitionFilter type is more of a cleanup at this point") and discussed w/ ion-elgreco in the #4585 review.

Replacement is a typed `FilterOp` enum (`Eq/Ne/Lt/Le/Gt/Ge/In/NotIn`, `FromStr` for the eight pinned op strings), so the crate ends with one op vocabulary. `FilterLiteral` carries it. Former users migrate as follows:

- `operations/optimize.rs` takes `&[FilterLiteral]`; the operationParameters predicate string is byte-identical (pinned by `command_optimize` tests).
- `table/mod.rs`: `get_active_add_actions_by_partitions`, `get_files_by_partitions`, `get_file_uris_by_partitions` take `&[FilterLiteral]`. The kernel-predicate path (`get_active_add_actions_by_predicate`) is unchanged and remains the general API.
- `python/src/lib.rs`: `convert_partition_filters` produces `FilterLiteral`s. No Python-visible change.

On deprecation windows, `file_views_by_partitions` has been deprecated since 0.29.0. 

`PartitionFilter` itself and the three `table/mod.rs` signatures were never marked deprecated, so this deletes public Rust API without a cycle. 

Both #1923 and the #4585 review sounded like "delete now" but if a cycle is preferred instead, I can convert this to `#[deprecated]` shims for one release and delete in the next. Rust 1.0.0 seems like a great time to do this though, assuming it's still desired.

Python behavior pinned by the existing filter tests, including exact error strings.

# Related Issue(s)

- follow up to #4585
- completes the cleanup discussed in #1923

# Documentation

No user-facing docs change; rustdoc moves to the new types.
