### PR TITLE
refactor(python): drop file_pruning_predicate from the dataframe read methods

### DIFF
--- a/docs/how-delta-lake-works/delta-lake-file-skipping.md
+++ b/docs/how-delta-lake-works/delta-lake-file-skipping.md
@@ -74,22 +74,23 @@ Polars can use the Delta table metadata to skip the file that does not contain d
 
 ## File skipping with deltalake
 
-The same skipping is exposed directly on `DeltaTable`: file-listing and read
-methods accept a SQL `predicate` (or tuple filters) and prune files against the
-transaction log before any data is read.
+The same skipping is exposed directly on `DeltaTable`: the file-listing
+methods accept a `file_pruning_predicate` (a SQL string or tuple filters) and
+prune files against the transaction log before any data is read, and `filters`
+on the read methods prunes the same way before filtering rows.
 
 ```python
 dt = DeltaTable("tmp/a_table")
 
 dt.file_uris(file_pruning_predicate="age < 20")  # only the file that may contain age < 20
-dt.to_pandas(file_pruning_predicate="age < 20", filters=[("age", "<", 20)])
+dt.to_pandas(filters=[("age", "<", 20)])
 ```
 
 On non-partition columns like `age` the pruning is conservative: a file is
 dropped only when its min/max statistics prove no row can match, so the file
 list is a complete superset of the matching files. Partition-column predicates
 prune exactly. See
-[Querying Delta Tables](../usage/querying-delta-tables.md#selecting-files-with-predicates)
+[Querying Delta Tables](../usage/querying-delta-tables.md#selecting-files-with-a-pruning-predicate)
 for details.
 
 ## How Delta Lake implements file skipping

--- a/docs/usage/querying-delta-tables.md
+++ b/docs/usage/querying-delta-tables.md
@@ -23,31 +23,31 @@ value: string
 year: string
 month: string
 day: string
->>> dt.to_pandas(file_pruning_predicate=[("year", "=", "2021")], columns=["value"])
+>>> dt.to_pandas(filters=[("year", "=", "2021")], columns=["value"])
       value
 0     6
 1     7
 2     5
 3     4
->>> dt.to_pyarrow_table(file_pruning_predicate="year = 2021", columns=["value"])
+>>> dt.to_pyarrow_table(filters=[("year", "=", "2021")], columns=["value"])
 pyarrow.Table
 value: string
 ```
 
 ## Selecting files with a pruning predicate
 
-`file_pruning_predicate` selects which files are read, before any data is
-scanned. It takes either a SQL string or tuple filters. A flat list of tuples
-is a conjunction (AND); a list of such lists is an OR across the inner AND
-groups:
+`file_pruning_predicate` selects which files a table's log lists, before any
+data is read. It takes either a SQL string or tuple filters. A flat list of
+tuples is a conjunction (AND); a list of such lists is an OR across the inner
+AND groups:
 
 ``` python
 >>> # SQL string
->>> dt.to_pandas(file_pruning_predicate="(year = 2020 AND month = 2) OR (year = 2021 AND month = 12)")
+>>> dt.file_uris(file_pruning_predicate="(year = 2020 AND month = 2) OR (year = 2021 AND month = 12)")
 >>> # flat list of tuples: a single conjunction, year = 2020 AND month = 2
->>> dt.to_pandas(file_pruning_predicate=[("year", "=", "2020"), ("month", "=", "2")])
+>>> dt.file_uris(file_pruning_predicate=[("year", "=", "2020"), ("month", "=", "2")])
 >>> # list of lists: OR across the inner AND groups
->>> dt.to_pandas(
+>>> dt.file_uris(
 ...     file_pruning_predicate=[
 ...         [("year", "=", "2020"), ("month", "=", "2")],
 ...         [("year", "=", "2021"), ("month", "=", "12")],
@@ -55,11 +55,10 @@ groups:
 ... )
 ```
 
-The parameter is accepted everywhere files are selected: `to_pandas`,
-`to_pyarrow_table`, `to_pyarrow_dataset`, `file_uris`, and `partitions`.
-The older `partitions` and `partition_filters` parameters on these methods
-still work but are deprecated in its favor. The predicate may reference any
-column, not just partition columns:
+The parameter is accepted on `file_uris`, `partitions`, and
+`to_pyarrow_dataset`. The older `partitions` and `partition_filters`
+parameters on these methods still work but are deprecated in its favor. The
+predicate may reference any column, not just partition columns:
 
 - **Partition columns** prune exactly: every returned file matches the
   predicate, and only matching files are returned.
@@ -73,12 +72,13 @@ column, not just partition columns:
   [Delta Lake File Skipping](../how-delta-lake-works/delta-lake-file-skipping.md)
   for how to lay out tables so predicates prune well.
 
-As the name says, the predicate prunes files, not rows. Pair it with an
-equivalent `filters=` expression when you need exact rows from a
-non-partition column:
+As the name says, the predicate prunes files, not rows. On `to_pandas` and
+`to_pyarrow_table` there is no pruning parameter for that reason: `filters`
+already prunes files the same way through the dataset fragments and then
+filters the surviving rows exactly, so it is strictly more precise there:
 
 ``` python
->>> dt.to_pandas(file_pruning_predicate="value >= '5'", filters=[("value", ">=", "5")])
+>>> dt.to_pandas(filters=[("value", ">=", "5")])
 ```
 
 The full syntax for both forms is documented on

--- a/docs/usage/querying-delta-tables.md
+++ b/docs/usage/querying-delta-tables.md
@@ -73,12 +73,18 @@ predicate may reference any column, not just partition columns:
   for how to lay out tables so predicates prune well.
 
 As the name says, the predicate prunes files, not rows. On `to_pandas` and
-`to_pyarrow_table` there is no pruning parameter for that reason: `filters`
-already prunes files the same way through the dataset fragments and then
-filters the surviving rows exactly, so it is strictly more precise there:
+`to_pyarrow_table` there is no pruning parameter: `filters` prunes files just
+as effectively through the per-fragment statistics and then filters the
+surviving rows exactly. Both methods are thin wrappers over
+`to_pyarrow_dataset`, so to prune during log replay instead, before any
+per-file fragment setup (which can matter on tables with very large file
+counts), unroll the chain:
 
 ``` python
 >>> dt.to_pandas(filters=[("value", ">=", "5")])
+>>> # unrolled: prune files first, then read; whole surviving files come
+>>> # back unless you also pass a row filter to to_table
+>>> dt.to_pyarrow_dataset(file_pruning_predicate="value >= '5'").to_table().to_pandas()
 ```
 
 The full syntax for both forms is documented on

--- a/docs/usage/working-with-partitions.md
+++ b/docs/usage/working-with-partitions.md
@@ -45,7 +45,7 @@ In this example we restrict our query to the `country="US"` partition.
 ```python
 dt = DeltaTable("tmp/partitioned-table")
 
-pdf = dt.to_pandas(file_pruning_predicate=[("country", "=", "US")])
+pdf = dt.to_pandas(filters=[("country", "=", "US")])
 print(pdf)
 ```
 
@@ -56,21 +56,23 @@ print(pdf)
 ```
 
 A flat list of filter tuples is a conjunction: every filter must hold. To
-combine partitions with OR, pass a list of lists (an OR across the inner AND
-groups) or a SQL `predicate` string:
+combine partitions with OR, pass a list of lists, an OR across the inner AND
+groups:
 
 ```python
-pdf = dt.to_pandas(file_pruning_predicate=[[("country", "=", "US")], [("country", "=", "CA")]])
-pdf = dt.to_pandas(file_pruning_predicate="country = 'US' OR country = 'CA'")
+pdf = dt.to_pandas(filters=[[("country", "=", "US")], [("country", "=", "CA")]])
 ```
 
-The same filters work on [DeltaTable.file_uris()](../api/delta_table/index.md#deltalake.DeltaTable.file_uris)
-and [DeltaTable.partitions()](../api/delta_table/index.md#deltalake.DeltaTable.partitions),
-and may reference non-partition columns as well -- see
-[Querying Delta Tables](querying-delta-tables.md#selecting-files-with-predicates)
+To prune the file list itself, without reading data, use
+[DeltaTable.file_uris()](../api/delta_table/index.md#deltalake.DeltaTable.file_uris)
+or [DeltaTable.partitions()](../api/delta_table/index.md#deltalake.DeltaTable.partitions)
+with `file_pruning_predicate`, which takes the same tuple filters or a SQL
+string and may reference non-partition columns as well. See
+[Querying Delta Tables](querying-delta-tables.md#selecting-files-with-a-pruning-predicate)
 for the pruning semantics.
 
 ```python
+dt.file_uris(file_pruning_predicate="country = 'US' OR country = 'CA'")
 dt.partitions(file_pruning_predicate="country IN ('US', 'CA')")
 ```
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1220,9 +1220,22 @@ class DeltaTable:
         `filters` both prunes files and filters rows: each file's partition
         values and min/max statistics are attached to its dataset fragment, so
         files that cannot contain matching rows are never read, and the
-        surviving rows are filtered exactly. For file pruning without reading
-        data, or to hand a pruned file list to another engine, use
-        `file_uris` or `to_pyarrow_dataset` with `file_pruning_predicate`.
+        surviving rows are filtered exactly.
+
+        This method is a thin wrapper over `to_pyarrow_dataset`. The unrolled
+        chain is equivalent, and passing `file_pruning_predicate` there prunes
+        during log replay, before any per-file fragment setup, which can matter
+        on tables with very large file counts:
+
+        ```python
+        dt.to_pyarrow_table(columns=cols, filters=[("year", "=", "2021")])
+
+        # equivalent, pruning pre-scan; the pruning predicate keeps whole
+        # surviving files, pass filter= to to_table for exact rows
+        dt.to_pyarrow_dataset(
+            file_pruning_predicate="year = 2021"
+        ).to_table(columns=cols)
+        ```
 
         Args:
             partitions: Deprecated. Use `filters`, or `to_pyarrow_dataset` with `file_pruning_predicate`
@@ -1264,9 +1277,22 @@ class DeltaTable:
         `filters` both prunes files and filters rows: each file's partition
         values and min/max statistics are attached to its dataset fragment, so
         files that cannot contain matching rows are never read, and the
-        surviving rows are filtered exactly. For file pruning without reading
-        data, or to hand a pruned file list to another engine, use
-        `file_uris` or `to_pyarrow_dataset` with `file_pruning_predicate`.
+        surviving rows are filtered exactly.
+
+        This method is a thin wrapper over `to_pyarrow_dataset`. The unrolled
+        chain is equivalent, and passing `file_pruning_predicate` there prunes
+        during log replay, before any per-file fragment setup, which can matter
+        on tables with very large file counts:
+
+        ```python
+        dt.to_pandas(columns=cols, filters=[("year", "=", "2021")])
+
+        # equivalent, pruning pre-scan; the pruning predicate keeps whole
+        # surviving files, pass filter= to to_table for exact rows
+        dt.to_pyarrow_dataset(
+            file_pruning_predicate="year = 2021"
+        ).to_table(columns=cols).to_pandas()
+        ```
 
         Args:
             partitions: Deprecated. Use `filters`, or `to_pyarrow_dataset` with `file_pruning_predicate`

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1237,10 +1237,16 @@ class DeltaTable:
                 "Pyarrow is required, install deltalake[pyarrow] for pyarrow read functionality."
             )
 
+        if partitions is not None:
+            warnings.warn(
+                "`partitions` is deprecated; use `filters` instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if filters is not None:
             filters = filters_to_expression(filters)
         return self.to_pyarrow_dataset(
-            partitions=partitions,
+            file_pruning_predicate=partitions,
             filesystem=filesystem,
         ).to_table(columns=columns, filter=filters)
 

--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1213,29 +1213,22 @@ class DeltaTable:
         columns: list[str] | None = None,
         filesystem: str | pa_fs.FileSystem | None = None,
         filters: FilterType | Expression | None = None,
-        file_pruning_predicate: FilePruningPredicateType | None = None,
     ) -> "pyarrow.Table":
         """
         Build a PyArrow Table using data from the DeltaTable.
 
-        `file_pruning_predicate` selects which *files* are read, pruning at the
-        file level before any data is scanned; see the `file_uris` docstring for
-        its syntax and pruning semantics. `filters` filters *rows* while scanning.
-        A pruning predicate on a non-partition column selects a superset of files,
-        so pair it with an equivalent `filters` expression when you need exact rows:
-
-        ```python
-        dt.to_pyarrow_table(
-            file_pruning_predicate="value >= 100", filters=[("value", ">=", 100)]
-        )
-        ```
+        `filters` both prunes files and filters rows: each file's partition
+        values and min/max statistics are attached to its dataset fragment, so
+        files that cannot contain matching rows are never read, and the
+        surviving rows are filtered exactly. For file pruning without reading
+        data, or to hand a pruned file list to another engine, use
+        `file_uris` or `to_pyarrow_dataset` with `file_pruning_predicate`.
 
         Args:
-            partitions: Deprecated. Pass tuple filters to `file_pruning_predicate` instead
+            partitions: Deprecated. Use `filters`, or `to_pyarrow_dataset` with `file_pruning_predicate`
             columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
             filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression
-            file_pruning_predicate: A SQL predicate string or tuple filters selecting the files to read
         """
         try:
             from pyarrow.parquet import filters_to_expression  # pyarrow >= 10.0.0
@@ -1249,7 +1242,6 @@ class DeltaTable:
         return self.to_pyarrow_dataset(
             partitions=partitions,
             filesystem=filesystem,
-            file_pruning_predicate=file_pruning_predicate,
         ).to_table(columns=columns, filter=filters)
 
     def to_pandas(
@@ -1259,35 +1251,29 @@ class DeltaTable:
         filesystem: str | pa_fs.FileSystem | None = None,
         filters: FilterType | Expression | None = None,
         types_mapper: Callable[[pyarrow.DataType], Any] | None = None,
-        file_pruning_predicate: FilePruningPredicateType | None = None,
     ) -> "pd.DataFrame":
         """
         Build a pandas dataframe using data from the DeltaTable.
 
-        `file_pruning_predicate` selects which *files* are read, pruning at the
-        file level before any data is scanned; see the `file_uris` docstring for
-        its syntax and pruning semantics. `filters` filters *rows* while scanning.
-        A pruning predicate on a non-partition column selects a superset of files,
-        so pair it with an equivalent `filters` expression when you need exact rows:
-
-        ```python
-        dt.to_pandas(file_pruning_predicate="value >= 100", filters=[("value", ">=", 100)])
-        ```
+        `filters` both prunes files and filters rows: each file's partition
+        values and min/max statistics are attached to its dataset fragment, so
+        files that cannot contain matching rows are never read, and the
+        surviving rows are filtered exactly. For file pruning without reading
+        data, or to hand a pruned file list to another engine, use
+        `file_uris` or `to_pyarrow_dataset` with `file_pruning_predicate`.
 
         Args:
-            partitions: Deprecated. Pass tuple filters to `file_pruning_predicate` instead
+            partitions: Deprecated. Use `filters`, or `to_pyarrow_dataset` with `file_pruning_predicate`
             columns: The columns to project. This can be a list of column names to include (order and duplicates will be preserved)
             filesystem: A concrete implementation of the Pyarrow FileSystem or a fsspec-compatible interface. If None, the first file path will be used to determine the right FileSystem
             filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression
             types_mapper: A function mapping a pyarrow DataType to a pandas ExtensionDtype
-            file_pruning_predicate: A SQL predicate string or tuple filters selecting the files to read
         """
         return self.to_pyarrow_table(
             partitions=partitions,
             columns=columns,
             filesystem=filesystem,
             filters=filters,
-            file_pruning_predicate=file_pruning_predicate,
         ).to_pandas(types_mapper=types_mapper)
 
     def update_incremental(self) -> None:

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -852,22 +852,24 @@ def test_data_column_predicate_superset(tmp_path: Path):
 
 @pytest.mark.pandas
 @pytest.mark.pyarrow
-def test_to_pandas_predicate_with_filters_exact(tmp_path: Path):
+def test_to_pandas_filters_prune_and_filter_exactly(tmp_path: Path):
     import pyarrow as pa
 
     write_deltalake(tmp_path, pa.table({"value": [1, 5, 10]}))
     write_deltalake(tmp_path, pa.table({"value": [100, 200, 300]}), mode="append")
     dt = DeltaTable(tmp_path)
 
-    # predicate alone prunes files, so whole surviving files come back
-    superset = dt.to_pandas(file_pruning_predicate="value >= 150")
-    assert sorted(superset["value"]) == [100, 200, 300]
-
-    # pairing it with a row filter gives exact rows
-    exact = dt.to_pandas(
-        file_pruning_predicate="value >= 150", filters=[("value", ">=", 150)]
-    )
+    # filters prune files through fragment stats and then filter rows exactly
+    exact = dt.to_pandas(filters=[("value", ">=", 150)])
     assert sorted(exact["value"]) == [200, 300]
+
+    # file pruning alone returns whole surviving files: go through the dataset
+    superset = (
+        dt.to_pyarrow_dataset(file_pruning_predicate="value >= 150")
+        .to_table()
+        .to_pandas()
+    )
+    assert sorted(superset["value"]) == [100, 200, 300]
 
 
 @pytest.mark.pyarrow

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -782,6 +782,19 @@ def test_legacy_dataset_partitions_param_warns():
         dt.to_pyarrow_dataset(partitions=[("year", "=", "2021")])
 
 
+@pytest.mark.pyarrow
+def test_dataframe_partitions_param_warns_with_filters_hint():
+    dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
+
+    # the dataframe methods have no file_pruning_predicate, so their warning
+    # must point at `filters`
+    with pytest.warns(DeprecationWarning, match="use `filters`"):
+        legacy = dt.to_pyarrow_table(partitions=[("year", "=", "2021")])
+    assert (
+        legacy.num_rows == dt.to_pyarrow_table(filters=[("year", "=", "2021")]).num_rows
+    )
+
+
 def test_file_uris_filter_errors():
     dt = DeltaTable("../crates/test/tests/data/delta-0.8.0-partitioned")
 


### PR DESCRIPTION
# Description

Removes `file_pruning_predicate` from `to_pandas` and `to_pyarrow_table` before it ships in a release. 

On these two methods `filters` already prunes files: every dataset fragment carries its partition values and min/max statistics as a guarantee expression, so files that cannot match are skipped before any data is read, and the surviving rows are then filtered exactly. 

A pruning parameter there is a second way to pass the same tuples with strictly weaker semantics (whole files instead of rows). The parameter stays where nothing else does the job: `file_uris`, `partitions`, and `to_pyarrow_dataset`.

The parameter landed in #4585 AFTER python-v1.6.3 cut, so it has never been released and no user can be calling it unless building themselves from Github.

We should land this before the next Python release or just close if it's not important. Doesn't seem super worth a deprecation cycle to land later but of course it costs nothing to leave this up for a bit so I defer to y'all. 

# Related Issue(s)

- follow up to #4585

# Documentation

`docs/usage/querying-delta-tables.md` and the file-skipping page now describe `filters` as the pruning-and-filtering path on the dataframe methods.
