### PR TITLE
feat(python): route to_pyarrow_table and to_pandas through QueryBuilder

### DIFF
--- a/python/deltalake/table.py
+++ b/python/deltalake/table.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import json
+import math
 import warnings
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -113,6 +114,115 @@ def _encode_filter_conjunction(
             str_value = encode_partition_value(value)
         encoded.append((field, op, str_value))
     return encoded
+
+
+def _normalize_filter_dnf(filters: FilterType) -> FilterDNFType:
+    """Normalize tuple filters to disjunctive normal form: a list of
+    conjunctions."""
+    conjunctions: FilterDNFType
+    if all(isinstance(conjunction, list) for conjunction in filters):
+        conjunctions = cast(FilterDNFType, filters)
+    elif all(isinstance(literal, tuple) for literal in filters):
+        conjunctions = [cast(FilterConjunctionType, filters)]
+    else:
+        raise ValueError(
+            "filters must be a list of (column, op, value) tuples (a conjunction), "
+            "or a list of such lists (an OR across conjunctions), not a mix of both"
+        )
+    for conjunction in conjunctions:
+        if not conjunction:
+            raise ValueError(
+                "empty conjunction in filters; pass no filter to match all files"
+            )
+    return conjunctions
+
+
+class _SqlUnrepresentable(Exception):
+    """A filter value that cannot be rendered as a SQL literal."""
+
+
+_SQL_COMPARISON_OPS = {
+    "=": "=",
+    "==": "=",
+    "!=": "<>",
+    "<": "<",
+    ">": ">",
+    "<=": "<=",
+    ">=": ">=",
+}
+
+
+def _sql_ident(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _sql_literal(value: Any) -> str:
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, str):
+        return "'" + value.replace("'", "''") + "'"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise _SqlUnrepresentable(f"non-finite float: {value!r}")
+        return repr(value)
+    if isinstance(value, datetime):
+        return f"TIMESTAMP '{value.isoformat(sep=' ')}'"
+    if isinstance(value, date):
+        return f"DATE '{value.isoformat()}'"
+    raise _SqlUnrepresentable(f"no SQL literal for {type(value).__name__}")
+
+
+def _sql_filter_expr(column: str, op: str, value: Any) -> str:
+    ident = _sql_ident(column)
+    if op in ("in", "not in"):
+        if isinstance(value, str) or not isinstance(value, Iterable):
+            raise ValueError(f"{op!r} requires a collection of values, got: {value!r}")
+        rendered = [_sql_literal(item) for item in value]
+        if not rendered:
+            return "FALSE" if op == "in" else "TRUE"
+        keyword = "IN" if op == "in" else "NOT IN"
+        return f"{ident} {keyword} ({', '.join(rendered)})"
+    sql_op = _SQL_COMPARISON_OPS.get(op)
+    if sql_op is None:
+        raise ValueError(f"invalid filter operator: {op!r}")
+    if isinstance(value, str) and not value:
+        # the empty string selects null values, see `file_uris`
+        if op in ("=", "=="):
+            return f"{ident} IS NULL"
+        if op == "!=":
+            return f"{ident} IS NOT NULL"
+    return f"{ident} {sql_op} {_sql_literal(value)}"
+
+
+def _filters_to_sql(filters: FilterType) -> str:
+    """Render tuple filters (syntax in `file_uris`) as a SQL predicate."""
+    rendered = [
+        " AND ".join(_sql_filter_expr(column, op, value) for column, op, value in conj)
+        for conj in _normalize_filter_dnf(filters)
+    ]
+    if len(rendered) == 1:
+        return rendered[0]
+    return "(" + " OR ".join(f"({conj})" for conj in rendered) + ")"
+
+
+_SQL_TABLE_NAME = "tbl"
+
+
+def _read_query(columns: list[str] | None, filters: FilterType | None) -> str:
+    """Render a read as a single SELECT against the registered table."""
+    if columns is not None and not columns:
+        raise _SqlUnrepresentable("empty projection")
+    projection = (
+        "*" if columns is None else ", ".join(_sql_ident(column) for column in columns)
+    )
+    query = f"SELECT {projection} FROM {_SQL_TABLE_NAME}"
+    if filters:
+        query += " WHERE " + _filters_to_sql(filters)
+    return query
 
 
 class _KeywordArgDefault:
@@ -1181,11 +1291,21 @@ class DeltaTable:
         """
         Build a PyArrow Table using data from the DeltaTable.
 
-        `file_pruning_predicate` selects which *files* are read, pruning at the
-        file level before any data is scanned; see the `file_uris` docstring for
-        its syntax and pruning semantics. `filters` filters *rows* while scanning.
-        A pruning predicate on a non-partition column selects a superset of files,
-        so pair it with an equivalent `filters` expression when you need exact rows:
+        When the read only projects and filters rows -- any combination of
+        `columns` and tuple `filters` -- it runs through the embedded DataFusion
+        engine as a single query: the filters apply to rows exactly, with file
+        pruning derived from them, and tables with reader features such as
+        columnMapping and deletionVectors are supported. Tuple filters follow
+        the conventions documented in `file_uris`, so the empty string matches
+        a null value.
+
+        Everything else scans through a pyarrow dataset: a
+        `pyarrow.dataset.Expression` as `filters`, a custom `filesystem`, or
+        `file_pruning_predicate`, which selects which *files* are read before
+        any data is scanned; see the `file_uris` docstring for its syntax and
+        pruning semantics. A pruning predicate on a non-partition column selects
+        a superset of files, so pair it with an equivalent `filters` expression
+        when you need exact rows:
 
         ```python
         dt.to_pyarrow_table(
@@ -1200,6 +1320,39 @@ class DeltaTable:
             filters: A disjunctive normal form (DNF) predicate for filtering rows, or directly a pyarrow.dataset.Expression
             file_pruning_predicate: A SQL predicate string or tuple filters selecting the files to read
         """
+        query: str | None = None
+        if (
+            filesystem is None
+            and partitions is None
+            and file_pruning_predicate is None
+            and (filters is None or isinstance(filters, list))
+        ):
+            try:
+                query = _read_query(columns, filters)
+            except _SqlUnrepresentable:
+                query = None
+
+        if query is not None:
+            try:
+                import pyarrow
+            except ImportError:
+                raise ImportError(
+                    "Pyarrow is required, install deltalake[pyarrow] for pyarrow read functionality."
+                )
+            if not self._table.has_files():
+                raise DeltaError("Table is instantiated without files.")
+
+            from deltalake.query import QueryBuilder
+
+            reader = QueryBuilder().register(_SQL_TABLE_NAME, self).execute(query)
+            result = pyarrow.RecordBatchReader.from_stream(reader).read_all()
+            # DataFusion reads parquet as arrow view types; cast back to the
+            # table's logical schema so both read paths return the same types
+            schema = pyarrow.schema(self.schema().to_arrow())
+            if columns is not None:
+                schema = pyarrow.schema([schema.field(column) for column in columns])
+            return result.cast(schema)
+
         try:
             from pyarrow.parquet import filters_to_expression  # pyarrow >= 10.0.0
         except ImportError:
@@ -1227,15 +1380,11 @@ class DeltaTable:
         """
         Build a pandas dataframe using data from the DeltaTable.
 
-        `file_pruning_predicate` selects which *files* are read, pruning at the
-        file level before any data is scanned; see the `file_uris` docstring for
-        its syntax and pruning semantics. `filters` filters *rows* while scanning.
-        A pruning predicate on a non-partition column selects a superset of files,
-        so pair it with an equivalent `filters` expression when you need exact rows:
-
-        ```python
-        dt.to_pandas(file_pruning_predicate="value >= 100", filters=[("value", ">=", 100)])
-        ```
+        Routing and filter semantics follow `to_pyarrow_table`: reads with only
+        `columns` and tuple `filters` run through the embedded DataFusion engine
+        and filter rows exactly; a `pyarrow.dataset.Expression`, a custom
+        `filesystem` or `file_pruning_predicate` scan through a pyarrow dataset
+        instead, with file-level pruning as described in `file_uris`.
 
         Args:
             partitions: Deprecated. Pass tuple filters to `file_pruning_predicate` instead
@@ -1294,22 +1443,10 @@ class DeltaTable:
         conjunctions -- and encode every value to its partition string form."""
         if not partition_filters:
             return None
-        conjunctions: FilterDNFType
-        if all(isinstance(conjunction, list) for conjunction in partition_filters):
-            conjunctions = cast(FilterDNFType, partition_filters)
-        elif all(isinstance(literal, tuple) for literal in partition_filters):
-            conjunctions = [cast(FilterConjunctionType, partition_filters)]
-        else:
-            raise ValueError(
-                "filters must be a list of (column, op, value) tuples (a conjunction), "
-                "or a list of such lists (an OR across conjunctions), not a mix of both"
-            )
-        for conjunction in conjunctions:
-            if not conjunction:
-                raise ValueError(
-                    "empty conjunction in filters; pass no filter to match all files"
-                )
-        return [_encode_filter_conjunction(conjunction) for conjunction in conjunctions]
+        return [
+            _encode_filter_conjunction(conjunction)
+            for conjunction in _normalize_filter_dnf(partition_filters)
+        ]
 
     def get_add_actions(self, flatten: bool = False) -> Table:
         """Return an Arrow table describing every file currently in the table.

--- a/python/tests/test_querybuilder_reads.py
+++ b/python/tests/test_querybuilder_reads.py
@@ -1,0 +1,212 @@
+"""Reads through the QueryBuilder path of `to_pyarrow_table` and `to_pandas`.
+
+`to_pyarrow_table` reads through the embedded DataFusion engine when the call
+only projects columns and filters rows with tuple filters; everything else
+scans through a pyarrow dataset as before. These tests pin the equivalence of
+the two paths, the path selection, and the reader features the DataFusion path
+unlocks.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from deltalake import DeltaTable, write_deltalake
+from deltalake.exceptions import DeltaError, DeltaProtocolError
+from deltalake.table import _read_query
+
+PARTITIONED_TABLE = "../crates/test/tests/data/delta-0.8.0-partitioned"
+COLUMN_MAPPED_TABLE = "../crates/test/tests/data/table_with_column_mapping"
+
+
+def _rows(table) -> list[dict]:
+    return sorted(table.to_pylist(), key=lambda row: tuple(map(str, row.values())))
+
+
+def _dataset_path_table(dt: DeltaTable, columns=None, filters=None):
+    """Read through the pyarrow dataset path directly, bypassing the router."""
+    from pyarrow.parquet import filters_to_expression
+
+    expression = filters_to_expression(filters) if filters is not None else None
+    return dt.to_pyarrow_dataset().to_table(columns=columns, filter=expression)
+
+
+def _spy_dataset_path(monkeypatch) -> list:
+    """Record every call that reaches `to_pyarrow_dataset`."""
+    calls = []
+    original = DeltaTable.to_pyarrow_dataset
+
+    def wrapper(self, *args, **kwargs):
+        calls.append(1)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(DeltaTable, "to_pyarrow_dataset", wrapper)
+    return calls
+
+
+def test_read_query_rendering():
+    assert _read_query(None, None) == "SELECT * FROM tbl"
+    assert _read_query(["day", "value"], None) == 'SELECT "day", "value" FROM tbl'
+    assert (
+        _read_query(None, [("name", "=", "O'Brien")])
+        == "SELECT * FROM tbl WHERE \"name\" = 'O''Brien'"
+    )
+    assert (
+        _read_query(None, [('a"b', "<=", 3)]) == 'SELECT * FROM tbl WHERE "a""b" <= 3'
+    )
+    assert (
+        _read_query(None, [[("year", "=", "2021")], [("month", "in", [1, 2])]])
+        == 'SELECT * FROM tbl WHERE (("year" = \'2021\') OR ("month" IN (1, 2)))'
+    )
+    assert (
+        _read_query(None, [("part", "=", ""), ("day", "in", []), ("value", "!=", "")])
+        == 'SELECT * FROM tbl WHERE "part" IS NULL AND FALSE AND "value" IS NOT NULL'
+    )
+
+    with pytest.raises(ValueError, match="invalid filter operator"):
+        _read_query(None, [("day", "=>", "3")])
+    with pytest.raises(ValueError, match="requires a collection"):
+        _read_query(None, [("day", "in", "3")])
+
+
+@pytest.mark.pyarrow
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"columns": ["day", "value"]},
+        {"filters": [("year", "=", "2021")]},
+        {"filters": [[("year", "=", "2020")], [("month", "=", "12")]]},
+        {"filters": [("day", "in", ["4", "5"]), ("year", "=", "2021")]},
+        {"filters": [("day", "not in", ["4", "5"])], "columns": ["value"]},
+        {"filters": [("value", ">=", "5")], "columns": ["value", "year"]},
+    ],
+)
+def test_matches_pyarrow_dataset_path(kwargs):
+    dt = DeltaTable(PARTITIONED_TABLE)
+    via_query = dt.to_pyarrow_table(**kwargs)
+    via_dataset = _dataset_path_table(dt, **kwargs)
+    assert via_query.schema.equals(via_dataset.schema)
+    assert _rows(via_query) == _rows(via_dataset)
+
+
+@pytest.mark.pandas
+@pytest.mark.pyarrow
+def test_to_pandas_matches_pyarrow_path():
+    dt = DeltaTable(PARTITIONED_TABLE)
+    df = dt.to_pandas(filters=[("year", "=", "2020")], columns=["value", "day"])
+    assert list(df.columns) == ["value", "day"]
+    assert sorted(df["value"]) == ["1", "2", "3"]
+
+
+@pytest.mark.pyarrow
+def test_expression_filters_fall_back_to_dataset(monkeypatch):
+    import pyarrow.dataset as ds
+
+    calls = _spy_dataset_path(monkeypatch)
+    dt = DeltaTable(PARTITIONED_TABLE)
+
+    tuple_result = dt.to_pyarrow_table(filters=[("year", "=", "2021")])
+    assert not calls
+
+    expr_result = dt.to_pyarrow_table(filters=ds.field("year") == "2021")
+    assert len(calls) == 1
+    assert _rows(expr_result) == _rows(tuple_result)
+
+
+@pytest.mark.pyarrow
+def test_file_pruning_predicate_falls_back_to_dataset(monkeypatch):
+    calls = _spy_dataset_path(monkeypatch)
+    dt = DeltaTable(PARTITIONED_TABLE)
+
+    by_tuples = dt.to_pyarrow_table(file_pruning_predicate=[("year", "=", "2021")])
+    assert len(calls) == 1
+    assert by_tuples.num_rows == 4
+
+    by_sql = dt.to_pyarrow_table(file_pruning_predicate="year = '2021'")
+    assert len(calls) == 2
+    assert _rows(by_sql) == _rows(by_tuples)
+
+    # the deprecated partitions parameter takes the same path
+    by_partitions = dt.to_pyarrow_table(partitions=[("year", "=", "2021")])
+    assert len(calls) == 3
+    assert _rows(by_partitions) == _rows(by_tuples)
+
+
+@pytest.mark.pyarrow
+def test_custom_filesystem_falls_back_to_dataset(monkeypatch):
+    import pyarrow.fs as pa_fs
+
+    calls = _spy_dataset_path(monkeypatch)
+    root = (Path.cwd().parent / PARTITIONED_TABLE.removeprefix("../")).as_posix()
+    filesystem = pa_fs.SubTreeFileSystem(root, pa_fs.LocalFileSystem())
+
+    table = DeltaTable(PARTITIONED_TABLE).to_pyarrow_table(filesystem=filesystem)
+    assert len(calls) == 1
+    assert table.num_rows == 7
+
+
+@pytest.mark.pyarrow
+def test_unrenderable_filter_value_falls_back_to_dataset(tmp_path, monkeypatch):
+    import pyarrow as pa
+
+    write_deltalake(tmp_path, pa.table({"x": [1.0, 2.0]}))
+    calls = _spy_dataset_path(monkeypatch)
+
+    table = DeltaTable(tmp_path).to_pyarrow_table(filters=[("x", "=", float("nan"))])
+    assert len(calls) == 1
+    assert table.num_rows == 0
+
+
+@pytest.mark.pyarrow
+def test_empty_projection_falls_back_to_dataset(monkeypatch):
+    calls = _spy_dataset_path(monkeypatch)
+    table = DeltaTable(PARTITIONED_TABLE).to_pyarrow_table(columns=[])
+    assert len(calls) == 1
+    assert table.num_columns == 0
+    assert table.num_rows == 7
+
+
+@pytest.mark.pandas
+@pytest.mark.pyarrow
+def test_column_mapped_table_reads():
+    dt = DeltaTable(COLUMN_MAPPED_TABLE)
+
+    df = dt.to_pandas()
+    assert list(df.columns) == ["Company Very Short", "Super Name"]
+    assert len(df) == 5
+
+    filtered = dt.to_pyarrow_table(filters=[("Company Very Short", "=", "BME")])
+    assert filtered["Super Name"].to_pylist() == ["Timothy Lamb"]
+
+
+@pytest.mark.pyarrow
+def test_column_mapped_table_still_rejected_on_dataset_path():
+    import pyarrow.dataset as ds
+
+    dt = DeltaTable(COLUMN_MAPPED_TABLE)
+    with pytest.raises(DeltaProtocolError, match="minimum reader version"):
+        dt.to_pyarrow_table(filters=ds.field("Super Name") == "Timothy Lamb")
+
+
+@pytest.mark.pyarrow
+def test_null_matching_filters(tmp_path):
+    import pyarrow as pa
+
+    data = pa.table({"value": [1, 2, 3], "part": ["a", None, "b"]})
+    write_deltalake(tmp_path, data, partition_by=["part"])
+    dt = DeltaTable(tmp_path)
+
+    nulls = dt.to_pyarrow_table(filters=[("part", "=", "")])
+    assert nulls["value"].to_pylist() == [2]
+    assert nulls["part"].to_pylist() == [None]
+
+    not_nulls = dt.to_pyarrow_table(filters=[("part", "!=", "")])
+    assert sorted(not_nulls["value"].to_pylist()) == [1, 3]
+
+
+@pytest.mark.pyarrow
+def test_without_files_raises():
+    dt = DeltaTable(PARTITIONED_TABLE, without_files=True)
+    with pytest.raises(DeltaError, match="Table is instantiated without files\\."):
+        dt.to_pyarrow_table()

--- a/python/tests/test_table_read.py
+++ b/python/tests/test_table_read.py
@@ -927,7 +927,11 @@ def test_delta_table_to_pandas():
 
     table_path = "../crates/test/tests/data/simple_table"
     dt = DeltaTable(table_path)
-    assert dt.to_pandas().equals(pd.DataFrame({"id": [5, 7, 9]}))
+    assert (
+        dt.to_pandas()
+        .sort_values("id", ignore_index=True)
+        .equals(pd.DataFrame({"id": [5, 7, 9]}))
+    )
 
 
 @pytest.mark.pandas
@@ -1003,10 +1007,12 @@ def test_writer_fails_on_protocol():
     dt.protocol = Mock(return_value=ProtocolVersions(2, 1, None, None))
     with pytest.raises(DeltaProtocolError):
         dt.to_pyarrow_dataset()
+    # the version guard only applies to reads forced through the pyarrow
+    # dataset path; the DataFusion path reads newer protocols natively
     with pytest.raises(DeltaProtocolError):
-        dt.to_pyarrow_table()
+        dt.to_pyarrow_table(file_pruning_predicate=[("id", "=", "5")])
     with pytest.raises(DeltaProtocolError):
-        dt.to_pandas()
+        dt.to_pandas(file_pruning_predicate=[("id", "=", "5")])
 
 
 class ExcPassThroughThread(Thread):

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -3172,8 +3172,10 @@ def test_overwrite_with_partitions(tmp_path: pathlib.Path) -> None:
     new_file_path = new_file_path.joinpath("foo.parquet")
     write_parquet(data, new_file_path)
 
+    # add paths are relative to the table root per the Delta protocol; the
+    # DataFusion read path rejects a leading slash
     action = AddAction(
-        "/ds=2026-01-01/foo.parquet",
+        "ds=2026-01-01/foo.parquet",
         new_file_path.stat().st_size,
         {"ds": "2026-01-01"},
         0,


### PR DESCRIPTION
# Description

Routes `to_pyarrow_table` and `to_pandas` through QueryBuilder (DataFusion) when the call is expressible as SQL: a column projection plus tuple `filters`, rendered as a `SELECT` with a `WHERE` built from the tuples. 

Suggested by @ion-elgreco in the #4585 review ("why should we even go through pyarrow for pandas, we can also do QueryBuilder -> Arro3 -> Pandas").

The immediate win is capability: the DataFusion path has no columnMapping or deletionVectors guard, so tables with those features become readable through `to_pandas`/`to_pyarrow_table` today (tested against the Spark-written column-mapped fixture). Calls that need pyarrow specifics keep the existing dataset path unchanged: `Expression` filters, a custom `filesystem`, `file_pruning_predicate`, or filter values with no SQL literal. Results are cast to the table's logical arrow schema, and equivalence with the pyarrow path is asserted in tests.

Two things to weigh:

- Row order on the QueryBuilder path follows query execution, not log order, and is not deterministic across calls. One existing test is now sorted.
- This adds a second read path. It pays for itself only as step one of converging the dataframe methods on one engine, with `to_pyarrow_dataset` remaining the explicit pyarrow interop surface. 
- Steps two and three are built and stacked on this branch (deprecate the pyarrow fallbacks, then remove them a release later per a typical deprecation facing, but I completely defer to y'all on when/if we can just rip the bandaid off). 

FrankPortman/delta-rs#4 (deprecate the pyarrow fallbacks), then FrankPortman/delta-rs#5 (remove them) are stacked on this, and IMHO this PR is not worth landing in isolation so if this is not a useful direction, I can just close all 3.

Happy to unstack and just put up a larger PR if that makes sense.

# Related Issue(s)

- follow up to #4585

# Documentation

Covered in the stacked follow-ups. This PR changes no documented behavior for supported calls.
