### PR TITLE
chore: demonstrate conditional put/conflict checker behavior with PySpark

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -85,7 +85,7 @@ jobs:
         run: make develop
 
       - name: Run tests
-        run: uv run --no-sync pytest -n auto -m '((s3 or azure) and integration) or not integration and not benchmark and not no_pyarrow' --doctest-modules
+        run: uv run --no-sync pytest -n auto -m '((s3 or azure) and integration and not pyspark) or not integration and not benchmark and not no_pyarrow' --doctest-modules
 
       - name: Test without pandas
         run: |
@@ -200,6 +200,9 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "21"
+
+      - name: Start emulated services
+        run: docker compose up -d
 
       - name: Build and install deltalake
         run: make develop-pyspark

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -58,15 +58,19 @@ def wait_till_host_is_available(host: str, timeout_sec: int = 0.5):
         sleep(spacing)
 
 
-def _s3_bucket_name(worker_id: str) -> str:
+def _s3_bucket_name(worker_id: str = "master") -> str:
     if worker_id == "master":
         return "deltars"
     return f"deltars-{worker_id}"
 
 
 @pytest.fixture(scope="session")
-def s3_localstack_creds(worker_id: str):
+def s3_localstack_creds(request):
     endpoint_url = "http://localhost:4566"
+    # Get worker_id if available (for xdist), otherwise use "master"
+    worker_id = getattr(request.config, "workerinput", {"workerid": "master"}).get(
+        "workerid", "master"
+    )
     bucket_name = _s3_bucket_name(worker_id)
 
     config = dict(
@@ -145,7 +149,10 @@ def s3_localstack(monkeypatch, s3_localstack_creds):
 
 
 @pytest.fixture(scope="session")
-def s3_localstack_bucket_name(worker_id: str):
+def s3_localstack_bucket_name(request):
+    worker_id = getattr(request.config, "workerinput", {"workerid": "master"}).get(
+        "workerid", "master"
+    )
     return _s3_bucket_name(worker_id)
 
 

--- a/python/tests/pyspark_integration/test_s3_conflict_checker.py
+++ b/python/tests/pyspark_integration/test_s3_conflict_checker.py
@@ -1,0 +1,286 @@
+"""Test DeltaLake conflict checker with PySpark optimization version mismatches.
+
+This test verifies that the conflict checker correctly handles scenarios where:
+1. A DeltaTable is loaded at version 3
+2. PySpark optimizes the table to version 4
+3. The stale DeltaTable at version 3 tries to write
+4. Conflict checker detects the version mismatch and prevents the write
+
+The test demonstrates the conflict detection behavior in delta-rs DeltaLake implementation
+where concurrent modifications (like PySpark optimization) are properly detected and conflicted.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from deltalake import DeltaTable, write_deltalake
+from deltalake.transaction import CommitProperties
+
+# Import the get_spark utility that handles S3 configuration through environment variables
+from .utils import get_spark
+
+
+@pytest.mark.pyspark
+@pytest.mark.pyarrow
+@pytest.mark.s3
+@pytest.mark.integration
+@pytest.mark.timeout(timeout=30, method="thread")
+def test_deltalake_version_conflict_with_optimize(
+    s3_localstack, s3_localstack_bucket_root_uri
+):
+    """Test conflict checker when DeltaTable at v3 tries to write after optimize to v4.
+
+    This test demonstrates the conflict checker behavior:
+    1. Write initial data to create version 0
+    2. Write more data to create version 1
+    3. Write more data to create version 2
+    4. Load DeltaTable at version 3 (current state)
+    5. Use PySpark to optimize table (advances to version 4)
+    6. Try to write with stale DeltaTable reference expecting to conflict
+    7. Conflict checker detects version mismatch and prevents the write
+
+    Expected result: Conflict checker throws exception indicating concurrent transaction
+    deleted data, preventing the stale write from corrupting the table.
+    """
+    # Create local table path
+    table_path = f"{s3_localstack_bucket_root_uri}/pyspark_integ/{uuid4()}"
+
+    # Import pyarrow for data creation
+    import pyarrow as pa
+
+    # Create sample data for initial writes
+    data_v0 = pa.table(
+        {
+            "id": pa.array([1, 2, 3], type=pa.int32()),
+            "value": pa.array(["a", "b", "c"], type=pa.string()),
+        }
+    )
+
+    # Write version 0 (initial table creation)
+    write_deltalake(table_path, data_v0, mode="overwrite")
+
+    # Write version 1 (first append)
+    data_v1 = pa.table(
+        {
+            "id": pa.array([4, 5, 6], type=pa.int32()),
+            "value": pa.array(["d", "e", "f"], type=pa.string()),
+        }
+    )
+    write_deltalake(table_path, data_v1, mode="append")
+
+    # Write version 2 (second append)
+    data_v2 = pa.table(
+        {
+            "id": pa.array([7, 8, 9], type=pa.int32()),
+            "value": pa.array(["g", "h", "i"], type=pa.string()),
+        }
+    )
+    write_deltalake(table_path, data_v2, mode="append")
+
+    # Load DeltaTable at current version (which should be 2, but let's verify)
+    dt_at_version_2 = DeltaTable(table_path)
+
+    # Get the current version to understand the starting point
+    current_version = dt_at_version_2.version()
+    print(f"Current version after initial writes: {current_version}")
+
+    # Write version 3 (third append)
+    data_v3 = pa.table(
+        {
+            "id": pa.array([10, 11, 12], type=pa.int32()),
+            "value": pa.array(["j", "k", "l"], type=pa.string()),
+        }
+    )
+    write_deltalake(table_path, data_v3, mode="append")
+
+    # Now we're at version 3 - load DeltaTable at this version
+    dt_at_version_3 = DeltaTable(table_path)
+    assert dt_at_version_3.version() == 3, (
+        f"Expected version 3, got {dt_at_version_3.version()}"
+    )
+
+    # Use PySpark to optimize the table - this should create version 4
+    spark = get_spark()
+
+    # No additional S3 configuration needed for local files
+
+    # Read and optimize the Delta table using PySpark
+    df = spark.read.format("delta").load(table_path)
+    df.write.format("delta").mode("overwrite").option("optimizeWrite", "true").save(
+        table_path
+    )
+
+    # Verify we're now at version 4 by loading a fresh DeltaTable
+    dt_after_optimize = DeltaTable(table_path)
+    assert dt_after_optimize.version() == 4, (
+        f"Expected version 4+, got {dt_after_optimize.version()}"
+    )
+    print(f"Version after PySpark optimization: {dt_after_optimize.version()}")
+
+    # Try to write with the stale DeltaTable reference that thinks it's at version 3
+    # The conflict checker should detect that the table is now at version 4
+    # This should either:
+    # 1. Fail with a conflict error, OR
+    # 2. Successfully write version 5 after detecting the conflict and updating
+
+    data_v5 = pa.table(
+        {
+            "id": pa.array([13, 14, 15], type=pa.int32()),
+            "value": pa.array(["m", "n", "o"], type=pa.string()),
+        }
+    )
+
+    # This should use the internal conflict checking mechanism
+    # Based on the existing test patterns, we need to provide transaction info
+
+    from deltalake.transaction import Transaction
+
+    # Try to write with stale reference
+    try:
+        write_deltalake(
+            dt_at_version_3,
+            data_v5,
+            mode="append",
+            commit_properties=CommitProperties(
+                app_transactions=[Transaction(app_id="test_conflict", version=3)]
+            ),
+        )
+        # If we get here, the write succeeded (likely created version 5)
+
+        # Verify we now have version 5
+        dt_final = DeltaTable(table_path)
+        print(f"Final version: {dt_final.version()}")
+
+        # The write should have created version 5
+        assert dt_final.version() == 5, f"Expected version 5+, got {dt_final.version()}"
+
+    except Exception as e:
+        # If we get here, the conflict checker prevented the write
+        print(f"Conflict checker prevented write: {e}")
+
+        # Verify the table is still at version 4 (no new version created)
+        dt_after_failure = DeltaTable(table_path)
+        assert dt_after_failure.version() == 4, (
+            f"Expected version 4 after failed write, got {dt_after_failure.version()}"
+        )
+
+
+@pytest.mark.pyspark
+@pytest.mark.pyarrow
+@pytest.mark.s3
+@pytest.mark.integration
+@pytest.mark.timeout(timeout=30, method="thread")
+def test_deltalake_version_conflict_with_spark_overlapping_writes(
+    s3_localstack, s3_localstack_bucket_root_uri
+):
+    """
+    This is a little different than the test above in that it let's Apache
+    Spark attempt to optimize with a stale version loaded in its state.
+    """
+    # Create local table path
+    table_path = f"{s3_localstack_bucket_root_uri}/pyspark_integ/{uuid4()}"
+
+    # Import pyarrow for data creation
+    import pyarrow as pa
+
+    # Create sample data for initial writes
+    data_v0 = pa.table(
+        {
+            "id": pa.array([1, 2, 3], type=pa.int32()),
+            "value": pa.array(["a", "b", "c"], type=pa.string()),
+        }
+    )
+
+    # Write version 0 (initial table creation)
+    write_deltalake(table_path, data_v0, mode="overwrite")
+
+    # Write version 1 (first append)
+    data_v1 = pa.table(
+        {
+            "id": pa.array([4, 5, 6], type=pa.int32()),
+            "value": pa.array(["d", "e", "f"], type=pa.string()),
+        }
+    )
+    write_deltalake(table_path, data_v1, mode="append")
+
+    # Write version 2 (second append)
+    data_v2 = pa.table(
+        {
+            "id": pa.array([7, 8, 9], type=pa.int32()),
+            "value": pa.array(["g", "h", "i"], type=pa.string()),
+        }
+    )
+    write_deltalake(table_path, data_v2, mode="append")
+
+    # Load DeltaTable at current version (which should be 2, but let's verify)
+    dt_at_version_2 = DeltaTable(table_path)
+
+    # Get the current version to understand the starting point
+    current_version = dt_at_version_2.version()
+    print(f"Current version after initial writes: {current_version}")
+
+    # Write version 3 (third append)
+    data_v3 = pa.table(
+        {
+            "id": pa.array([10, 11, 12], type=pa.int32()),
+            "value": pa.array(["j", "k", "l"], type=pa.string()),
+        }
+    )
+    write_deltalake(table_path, data_v3, mode="append")
+
+    # Now we're at version 3 - load DeltaTable at this version
+    dt_at_version_3 = DeltaTable(table_path)
+    assert dt_at_version_3.version() == 3, (
+        f"Expected version 3, got {dt_at_version_3.version()}"
+    )
+
+    # Use PySpark to optimize the table - this should create version 4
+    spark = get_spark()
+
+    # No additional S3 configuration needed for local files
+
+    # Read and optimize the Delta table using PySpark
+    df = spark.read.format("delta").load(table_path)
+
+    data_v4 = pa.table(
+        {
+            "id": pa.array([13, 14, 15], type=pa.int32()),
+            "value": pa.array(["m", "n", "o"], type=pa.string()),
+        }
+    )
+
+    # This should use the internal conflict checking mechanism
+    # Based on the existing test patterns, we need to provide transaction info
+
+    # Try to write with stale reference
+    try:
+        write_deltalake(
+            dt_at_version_3,
+            data_v4,
+            mode="append",
+        )
+        # If we get here, the write succeeded (likely created version 5)
+
+        # Verify we now have version 5
+        dt_final = DeltaTable(table_path)
+        print(f"Final version: {dt_final.version()}")
+
+        # The write should have created version 5
+        assert dt_final.version() == 4, f"Expected version 5+, got {dt_final.version()}"
+
+    except Exception as e:
+        # If we get here, the conflict checker prevented the write
+        print(f"Conflict checker prevented write: {e}")
+
+        # Verify the table is still at version 4 (no new version created)
+        dt_after_failure = DeltaTable(table_path)
+        assert dt_after_failure.version() == 4, (
+            f"Expected version 4 after failed write, got {dt_after_failure.version()}"
+        )
+
+    df.write.format("delta").mode("overwrite").option("optimizeWrite", "true").save(
+        table_path
+    )
+    dt_final = DeltaTable(table_path)
+    assert dt_final.version() == 5

--- a/python/tests/pyspark_integration/utils.py
+++ b/python/tests/pyspark_integration/utils.py
@@ -5,6 +5,8 @@ if TYPE_CHECKING:
 
 
 def get_spark():
+    import os
+
     import delta
     import delta.pip_utils
     import delta.tables
@@ -19,7 +21,54 @@ def get_spark():
         )
         .config("spark.sql.ansi.enabled", "false")
     )
-    return delta.pip_utils.configure_spark_with_delta_pip(builder).getOrCreate()
+
+    # Add hadoop-aws dependency for S3A filesystem support
+    builder = builder.config(
+        "spark.jars.packages", "org.apache.hadoop:hadoop-aws:3.3.6"
+    )
+    builder = builder.config(
+        "spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem"
+    )
+
+    # Configure S3 access using environment variables for MinIO/LocalStack integration
+    aws_endpoint = os.environ.get(
+        "AWS_ENDPOINT_URL", "http://localhost:4566"
+    )  # Default to MinIO
+    aws_access_key = os.environ.get(
+        "AWS_ACCESS_KEY_ID", "deltalake"
+    )  # Default MinIO credentials
+    aws_secret_key = os.environ.get(
+        "AWS_SECRET_ACCESS_KEY", "weloverust"
+    )  # Default MinIO secret
+
+    # Configure both s3 and s3a schemes for compatibility
+    builder = builder.config("spark.hadoop.fs.s3a.access.key", aws_access_key)
+    builder = builder.config("spark.hadoop.fs.s3a.secret.key", aws_secret_key)
+    builder = builder.config("spark.hadoop.fs.s3a.endpoint", aws_endpoint)
+    builder = builder.config("spark.hadoop.fs.s3a.path.style.access", "true")
+    builder = builder.config(
+        "spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem"
+    )
+
+    # Additional S3A configuration for proper connectivity
+    builder = builder.config("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
+    builder = builder.config("spark.hadoop.fs.s3a.connection.timeout", "30000")
+    builder = builder.config("spark.hadoop.fs.s3a.socket.timeout", "30000")
+
+    # Legacy s3 scheme mapping to s3a for compatibility with older Delta Lake versions
+    builder = builder.config(
+        "spark.hadoop.fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem"
+    )
+    builder = builder.config("spark.hadoop.fs.s3.awsAccessKeyId", aws_access_key)
+    builder = builder.config("spark.hadoop.fs.s3.awsSecretAccessKey", aws_secret_key)
+    builder = builder.config("spark.hadoop.fs.s3.endpoint", aws_endpoint)
+
+    return delta.pip_utils.configure_spark_with_delta_pip(
+        builder,
+        extra_packages=[
+            "org.apache.spark:spark-hadoop-cloud_2.13:4.0.1",
+        ],
+    ).getOrCreate()
 
 
 def assert_spark_read_equal(


### PR DESCRIPTION
This is mostly to prove to myself the behavior of append writes to a table which is also being optimized by Apache Spark. I don't fully trust these tests even though they logically make sense and demonstrate the behavior I was expecting.

I feel like there _must_ be some possible race condition with a distributed system like S3 but because the Rust side of the equation will always use conditional puts, I _think_ that ensures safey in a multi-write system where a Rust process is appending and a Spark process is optimizing.

I **don't** think this would be safe if there were multiple Spark writers running concurrently however.

References #4482
