### PR TITLE
refactor: harden datafusion execution plan contracts

### DIFF
--- a/crates/core/src/delta_datafusion/column_mapping.rs
+++ b/crates/core/src/delta_datafusion/column_mapping.rs
@@ -24,7 +24,8 @@ use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::CardinalityEffect;
 use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, PlanProperties,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr,
+    PlanProperties, ReplaceChildrenOptions,
 };
 use delta_kernel::schema::{
     DataType as KernelDataType, SchemaRef as KernelSchemaRef, StructField, StructType,
@@ -182,9 +183,10 @@ impl ExecutionPlan for ColumnMappingExec {
         vec![&self.input]
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         mut children: Vec<Arc<dyn ExecutionPlan>>,
+        options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if children.len() != 1 {
             return Err(DataFusionError::Internal(format!(
@@ -192,11 +194,31 @@ impl ExecutionPlan for ColumnMappingExec {
                 children.len()
             )));
         }
+        let input = children.remove(0);
+        let properties = match options.children_properties {
+            ChildrenPropertiesMode::Keep => Arc::clone(&self.properties),
+            ChildrenPropertiesMode::Recompute => Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(Arc::clone(&self.physical_schema)),
+                input.properties().partitioning.clone(),
+                input.properties().emission_type,
+                input.properties().boundedness,
+            )),
+        };
         Ok(Arc::new(Self {
-            input: children.remove(0),
-            physical_schema: self.physical_schema.clone(),
-            properties: self.properties.clone(),
+            input,
+            physical_schema: Arc::clone(&self.physical_schema),
+            properties,
         }))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(
@@ -236,12 +258,10 @@ impl ExecutionPlan for ColumnMappingExec {
 
     fn apply_expressions(
         &self,
-        expr_rewriter: &mut dyn FnMut(
+        _expr_rewriter: &mut dyn FnMut(
             &Arc<dyn PhysicalExpr>,
         ) -> Result<TreeNodeRecursion, DataFusionError>,
     ) -> Result<TreeNodeRecursion, DataFusionError> {
-        // Traverse child execution plan with the expression rewriter
-        self.input.apply_expressions(expr_rewriter)?;
         Ok(TreeNodeRecursion::Continue)
     }
 }
@@ -476,6 +496,7 @@ mod tests {
     use arrow_array::types::Int32Type;
     use arrow_array::{Int32Array, ListArray, StringArray, StringViewArray, StructArray};
     use arrow_buffer::OffsetBuffer;
+    use datafusion::physical_plan::empty::EmptyExec;
     use delta_kernel::schema::ArrayType;
 
     use super::*;
@@ -680,6 +701,48 @@ mod tests {
         assert_eq!(out.schema().field(0).name(), "col-id");
         assert_eq!(out.schema().field(1).name(), "_change_type");
         assert_eq!(field_id(out.schema().field(1)), None);
+    }
+
+    #[test]
+    fn replace_children_preserves_property_cache_and_schema() {
+        let logical_schema = logical_kernel_schema();
+        let logical_arrow_schema = logical_batch().schema();
+        let one_partition = EmptyExec::new(Arc::clone(&logical_arrow_schema));
+        let same_properties_input: Arc<dyn ExecutionPlan> = Arc::new(one_partition.clone());
+        let one_partition_input: Arc<dyn ExecutionPlan> = Arc::new(one_partition);
+        let two_partition_input: Arc<dyn ExecutionPlan> =
+            Arc::new(EmptyExec::new(logical_arrow_schema).with_partitions(2));
+        assert!(Arc::ptr_eq(
+            one_partition_input.properties(),
+            same_properties_input.properties()
+        ));
+
+        let mapped = ColumnMappingExec::try_new(
+            one_partition_input,
+            &logical_schema,
+            ColumnMappingMode::Name,
+        )
+        .expect("ColumnMappingExec::try_new failed");
+        let original_properties = Arc::clone(mapped.properties());
+        let original_schema = mapped.schema();
+
+        let keep = Arc::clone(&mapped)
+            .replace_children(
+                vec![same_properties_input],
+                ReplaceChildrenOptions::new(ChildrenPropertiesMode::Keep),
+            )
+            .expect("Keep mode rejected matching child properties");
+        assert!(Arc::ptr_eq(&original_properties, keep.properties()));
+
+        let recompute = mapped
+            .replace_children(
+                vec![two_partition_input],
+                ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+            )
+            .expect("Recompute mode rejected changed child properties");
+        assert!(!Arc::ptr_eq(&original_properties, recompute.properties()));
+        assert_eq!(recompute.properties().partitioning.partition_count(), 2);
+        assert_eq!(recompute.schema(), original_schema);
     }
 
     #[test]

--- a/crates/core/src/delta_datafusion/data_validation.rs
+++ b/crates/core/src/delta_datafusion/data_validation.rs
@@ -31,7 +31,8 @@ use datafusion::physical_plan::execution_plan::CardinalityEffect;
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
 use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, PlanProperties,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr,
+    PlanProperties, ReplaceChildrenOptions, apply_expression_roots,
 };
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 use datafusion::prelude::{Expr, binary_expr, col, ident};
@@ -531,6 +532,22 @@ impl DataValidationExec {
             properties,
         })
     }
+
+    fn with_new_input_same_properties(&self, input: Arc<dyn ExecutionPlan>) -> Self {
+        Self {
+            input,
+            check_expression: Arc::clone(&self.check_expression),
+            properties: Arc::clone(&self.properties),
+        }
+    }
+
+    fn try_with_new_input(&self, input: Arc<dyn ExecutionPlan>) -> Result<Self> {
+        Self::try_new(
+            input,
+            Arc::clone(&self.check_expression),
+            Some(self.schema()),
+        )
+    }
 }
 
 impl DisplayAs for DataValidationExec {
@@ -562,9 +579,10 @@ impl ExecutionPlan for DataValidationExec {
         vec![&self.input]
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         mut children: Vec<Arc<dyn ExecutionPlan>>,
+        options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if children.len() != 1 {
             return plan_err!(
@@ -572,11 +590,23 @@ impl ExecutionPlan for DataValidationExec {
                 children.len()
             );
         }
-        Ok(Arc::new(Self {
-            input: children.remove(0),
-            check_expression: Arc::clone(&self.check_expression),
-            properties: self.properties.clone(),
-        }))
+        let input = children.remove(0);
+        match options.children_properties {
+            ChildrenPropertiesMode::Keep => {
+                Ok(Arc::new(self.with_new_input_same_properties(input)))
+            }
+            ChildrenPropertiesMode::Recompute => Ok(Arc::new(self.try_with_new_input(input)?)),
+        }
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(
@@ -617,11 +647,7 @@ impl ExecutionPlan for DataValidationExec {
         config: &ConfigOptions,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
         if let Some(repartitioned) = self.input.repartitioned(target_partitions, config)? {
-            Ok(Some(Arc::new(Self {
-                input: repartitioned,
-                check_expression: Arc::clone(&self.check_expression),
-                properties: self.properties.clone(),
-            })))
+            Ok(Some(Arc::new(self.try_with_new_input(repartitioned)?)))
         } else {
             Ok(None)
         }
@@ -633,11 +659,9 @@ impl ExecutionPlan for DataValidationExec {
 
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
         let input_with_fetch = self.input.with_fetch(limit)?;
-        Some(Arc::new(Self {
-            input: input_with_fetch,
-            check_expression: Arc::clone(&self.check_expression),
-            properties: self.properties.clone(),
-        }))
+        Some(Arc::new(
+            self.with_new_input_same_properties(input_with_fetch),
+        ))
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
@@ -659,12 +683,7 @@ impl ExecutionPlan for DataValidationExec {
             &Arc<dyn PhysicalExpr>,
         ) -> Result<TreeNodeRecursion, DataFusionError>,
     ) -> Result<TreeNodeRecursion, DataFusionError> {
-        // Visit this node's own check expression so that any column-index remapping
-        // performed by the physical optimizer is applied to it (e.g. after a
-        // ProjectionExec is inserted below this node by the optimizer).
-        expr_rewriter(&self.check_expression)?;
-        self.input.apply_expressions(expr_rewriter)?;
-        Ok(TreeNodeRecursion::Continue)
+        apply_expression_roots([&self.check_expression], expr_rewriter)
     }
 }
 
@@ -963,7 +982,9 @@ mod tests {
     use datafusion::datasource::provider_as_source;
     use datafusion::logical_expr::{Extension, LogicalPlanBuilder};
     use datafusion::physical_plan::empty::EmptyExec;
-    use datafusion::physical_plan::{collect, displayable};
+    use datafusion::physical_plan::{
+        ChildrenPropertiesMode, ReplaceChildrenOptions, collect, displayable,
+    };
     use datafusion::prelude::{SessionContext, binary_expr, col};
     use futures::StreamExt;
 
@@ -1353,27 +1374,132 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_validation_with_new_children() -> Result<()> {
+    #[test]
+    fn test_validation_plan_walk_visits_owned_expressions_once() -> Result<()> {
         let schema = create_test_schema(true);
-        let batch = create_test_batch(
-            schema.clone(),
-            vec![Some(10), Some(20)],
-            vec![Some("a"), Some("b")],
+        let ctx = SessionContext::new();
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+
+        let inner = DataValidationExec::try_new_with_predicates(
+            &ctx.state(),
+            input,
+            vec![col("id").gt(datafusion::prelude::lit(0i32))],
+        )?;
+        let inner_expected = Arc::clone(
+            &inner
+                .downcast_ref::<DataValidationExec>()
+                .unwrap()
+                .check_expression,
+        );
+        let outer = DataValidationExec::try_new_with_predicates(
+            &ctx.state(),
+            inner,
+            vec![col("id").lt(datafusion::prelude::lit(100i32))],
+        )?;
+        let outer_validation = outer.downcast_ref::<DataValidationExec>().unwrap();
+        let expected = Arc::clone(&outer_validation.check_expression);
+
+        let mut roots = Vec::new();
+        outer.apply(|plan| {
+            plan.apply_expressions(&mut |expr| {
+                roots.push(Arc::clone(expr));
+                Ok(TreeNodeRecursion::Continue)
+            })?;
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+
+        assert_eq!(roots.len(), 2, "validation plan must expose two roots");
+        assert_eq!(
+            roots
+                .iter()
+                .filter(|root| Arc::ptr_eq(root, &expected))
+                .count(),
+            1,
+            "plan walker must visit the outer validation expression once"
+        );
+        assert_eq!(
+            roots
+                .iter()
+                .filter(|root| Arc::ptr_eq(root, &inner_expected))
+                .count(),
+            1,
+            "plan walker must visit the inner validation expression once"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_validation_replace_children_honors_property_mode() -> Result<()> {
+        let schema = create_test_schema(true);
+        let ctx = SessionContext::new();
+        let one_partition = EmptyExec::new(Arc::clone(&schema));
+        let same_properties_input: Arc<dyn ExecutionPlan> = Arc::new(one_partition.clone());
+        let one_partition_input: Arc<dyn ExecutionPlan> = Arc::new(one_partition);
+        let two_partition_input: Arc<dyn ExecutionPlan> =
+            Arc::new(EmptyExec::new(schema).with_partitions(2));
+        assert!(Arc::ptr_eq(
+            one_partition_input.properties(),
+            same_properties_input.properties()
+        ));
+
+        let validation = DataValidationExec::try_new_with_predicates(
+            &ctx.state(),
+            one_partition_input,
+            vec![col("id").is_not_null()],
+        )?;
+        let original_properties = Arc::clone(validation.properties());
+
+        let keep = Arc::clone(&validation).replace_children(
+            vec![same_properties_input],
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Keep),
+        )?;
+        assert!(Arc::ptr_eq(&original_properties, keep.properties()));
+
+        let recompute = validation.replace_children(
+            vec![two_partition_input],
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )?;
+        assert!(!Arc::ptr_eq(&original_properties, recompute.properties()));
+        assert_eq!(recompute.properties().partitioning.partition_count(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_validation_repartitioned_recomputes_properties() -> Result<()> {
+        let schema = create_test_schema(true);
+        let batches = vec![
+            create_test_batch(Arc::clone(&schema), vec![Some(10)], vec![Some("a")]),
+            create_test_batch(Arc::clone(&schema), vec![Some(20)], vec![Some("b")]),
+        ];
+        let ctx = SessionContext::new();
+        let input = get_memory_exec(&ctx.state(), schema, batches).await;
+        let validation = DataValidationExec::try_new_with_predicates(
+            &ctx.state(),
+            input,
+            vec![col("id").is_not_null()],
+        )?;
+
+        let repartitioned = validation
+            .repartitioned(2, &ConfigOptions::new())?
+            .expect("MemoryExec::repartitioned returned None for two batches");
+        let child_partition_count = repartitioned.children()[0]
+            .properties()
+            .partitioning
+            .partition_count();
+
+        assert_eq!(child_partition_count, 2);
+        assert_eq!(
+            repartitioned.properties().partitioning.partition_count(),
+            child_partition_count,
+            "wrapper partition count must match its child"
         );
 
-        let ctx = SessionContext::new();
-        let memory_exec1 = get_memory_exec(&ctx.state(), schema.clone(), vec![batch.clone()]).await;
-        let memory_exec2 = get_memory_exec(&ctx.state(), schema, vec![batch]).await;
-
-        let predicates = vec![col("id").is_not_null()];
-        let validated_exec =
-            DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec1, predicates)?;
-
-        // Create new plan with different child
-        let new_exec = validated_exec.with_new_children(vec![memory_exec2])?;
-        assert!(new_exec.downcast_ref::<DataValidationExec>().is_some());
-
+        let row_count = collect(repartitioned, ctx.task_ctx())
+            .await?
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>();
+        assert_eq!(row_count, 2, "repartitioned plan must return two rows");
         Ok(())
     }
 
@@ -1388,7 +1514,10 @@ mod tests {
             DataValidationExec::try_new_with_predicates(&ctx.state(), memory_exec, predicates)?;
 
         // Try to create with wrong number of children
-        let result = validated_exec.with_new_children(vec![]);
+        let result = validated_exec.replace_children(
+            vec![],
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        );
         assert!(result.is_err());
         assert!(
             result

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -544,15 +544,17 @@ impl TableProviderFactory for DeltaTableFactory {
         ctx: &dyn Session,
         cmd: &CreateExternalTable,
     ) -> datafusion::error::Result<Arc<dyn TableProvider>> {
-        let location = cmd
-            .locations
-            .get(0)
-            .expect("The command should have at least one location!");
+        let [location] = cmd.locations.as_slice() else {
+            return Err(DataFusionError::Plan(format!(
+                "Delta tables require one location, got {}",
+                cmd.locations.len()
+            )));
+        };
         let table = if cmd.options.is_empty() {
-            let table_url = ensure_table_uri(&location)?;
+            let table_url = ensure_table_uri(location)?;
             open_table(table_url).await?
         } else {
-            let table_url = ensure_table_uri(&location)?;
+            let table_url = ensure_table_uri(location)?;
             open_table_with_storage_options(table_url, cmd.to_owned().options).await?
         };
         let table_uri = table.log_store().root_url().clone();
@@ -647,6 +649,35 @@ mod tests {
 
     use super::*;
     use crate::delta_datafusion::table_provider::next::{FileSelection, MissingSelectedFilePolicy};
+
+    #[tokio::test]
+    async fn delta_table_factory_rejects_location_counts_other_than_one() {
+        let ctx = SessionContext::new();
+        let factory = DeltaTableFactory {};
+
+        for locations in [vec![], vec!["one".to_string(), "two".to_string()]] {
+            let command = CreateExternalTable::builder(
+                TableReference::bare("invalid_locations"),
+                "unused",
+                "DELTATABLE",
+                Arc::new(DFSchema::empty()),
+            )
+            .with_locations(locations.clone())
+            .build();
+
+            let error = factory
+                .create(&ctx.state(), &command)
+                .await
+                .expect_err("DeltaTableFactory accepted an invalid location count");
+            assert!(matches!(error, DataFusionError::Plan(_)));
+            assert!(
+                error.to_string().contains("require one location"),
+                "unexpected error for {} locations: {error}",
+                locations.len()
+            );
+        }
+    }
+
     // test deserialization of serialized partition values.
     // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#partition-value-serialization
     #[test]

--- a/crates/core/src/delta_datafusion/physical.rs
+++ b/crates/core/src/delta_datafusion/physical.rs
@@ -10,7 +10,8 @@ use datafusion::error::Result as DataFusionResult;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
-    DisplayAs, ExecutionPlan, PhysicalExpr, RecordBatchStream, SendableRecordBatchStream,
+    ChildrenPropertiesMode, DisplayAs, ExecutionPlan, PhysicalExpr, RecordBatchStream,
+    ReplaceChildrenOptions, SendableRecordBatchStream,
 };
 use futures::{Stream, StreamExt};
 
@@ -123,11 +124,22 @@ impl ExecutionPlan for MetricObserverExec {
         })
     }
 
+    fn replace_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        MetricObserverExec::try_new(self.id.clone(), &children, self.update)
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-        MetricObserverExec::try_new(self.id.clone(), &children, self.update)
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -136,12 +148,10 @@ impl ExecutionPlan for MetricObserverExec {
 
     fn apply_expressions(
         &self,
-        expr_rewriter: &mut dyn FnMut(
+        _expr_rewriter: &mut dyn FnMut(
             &Arc<dyn PhysicalExpr>,
         ) -> Result<TreeNodeRecursion, DataFusionError>,
     ) -> Result<TreeNodeRecursion, DataFusionError> {
-        // Traverse child execution plan with the expression rewriter
-        self.parent.apply_expressions(expr_rewriter)?;
         Ok(TreeNodeRecursion::Continue)
     }
 }

--- a/crates/core/src/delta_datafusion/table_provider.rs
+++ b/crates/core/src/delta_datafusion/table_provider.rs
@@ -14,7 +14,8 @@ use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdo
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, PlanProperties,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr,
+    PlanProperties, ReplaceChildrenOptions,
 };
 use datafusion::{catalog::Session, common::HashSet, prelude::Expr};
 use futures::future::BoxFuture;
@@ -606,9 +607,10 @@ impl ExecutionPlan for DeltaScan {
         vec![&self.parquet_scan]
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if children.len() != 1 {
             return Err(DataFusionError::Plan(format!(
@@ -616,13 +618,22 @@ impl ExecutionPlan for DeltaScan {
                 children.len()
             )));
         }
-        Ok(Arc::new(DeltaScan {
-            table_url: self.table_url.clone(),
-            config: self.config.clone(),
-            parquet_scan: children[0].clone(),
-            logical_schema: self.logical_schema.clone(),
-            metrics: self.metrics.clone(),
-        }))
+        Ok(Arc::new(DeltaScan::new(
+            &self.table_url,
+            self.config.clone(),
+            Arc::clone(&children[0]),
+            Arc::clone(&self.logical_schema),
+        )))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn repartitioned(
@@ -682,12 +693,10 @@ impl ExecutionPlan for DeltaScan {
 
     fn apply_expressions(
         &self,
-        expr_rewriter: &mut dyn FnMut(
+        _expr_rewriter: &mut dyn FnMut(
             &Arc<dyn PhysicalExpr>,
         ) -> Result<TreeNodeRecursion, DataFusionError>,
     ) -> Result<TreeNodeRecursion, DataFusionError> {
-        // Traverse child execution plan with the expression rewriter
-        self.parquet_scan.apply_expressions(expr_rewriter)?;
         Ok(TreeNodeRecursion::Continue)
     }
 }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -29,7 +29,8 @@ use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdo
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, Statistics,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan,
+    InputDistributionRequirements, PhysicalExpr, ReplaceChildrenOptions, Statistics,
 };
 use datafusion_physical_expr_adapter::PhysicalExprAdapterFactory;
 use delta_kernel::schema::DataType as KernelDataType;
@@ -186,6 +187,26 @@ impl DeltaScanExec {
         }
     }
 
+    fn with_new_input_same_properties(&self, input: Arc<dyn ExecutionPlan>) -> Self {
+        Self {
+            input,
+            metrics: ExecutionPlanMetricsSet::new(),
+            ..Self::clone(self)
+        }
+    }
+
+    fn with_new_input(&self, input: Arc<dyn ExecutionPlan>) -> Self {
+        Self::new(
+            Arc::clone(&self.scan_plan),
+            input,
+            Arc::clone(&self.transforms),
+            Arc::clone(&self.selection_vectors),
+            Arc::clone(&self.public_file_ids),
+            self.partition_stats.clone(),
+            ExecutionPlanMetricsSet::new(),
+        )
+    }
+
     /// Transform the statistics from the inner physical parquet read plan to the logical
     /// schema we expose via the table provider. We do not attempt to provide meaningful
     /// statistics for metadata columns as we do not expect these to be useful in planning.
@@ -289,11 +310,15 @@ impl ExecutionPlan for DeltaScanExec {
     }
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
+        self.input_distribution_requirements().into_per_child()
+    }
+
+    fn input_distribution_requirements(&self) -> InputDistributionRequirements {
         if self.scan_plan.contract.retained_row_index_field().is_some() {
             // Retained row indexes depend on one stream seeing each file's rows.
-            vec![Distribution::SinglePartition]
+            InputDistributionRequirements::new(vec![Distribution::SinglePartition])
         } else {
-            vec![Distribution::UnspecifiedDistribution]
+            InputDistributionRequirements::new(vec![Distribution::UnspecifiedDistribution])
         }
     }
 
@@ -302,22 +327,31 @@ impl ExecutionPlan for DeltaScanExec {
     //     vec![true]
     // }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+        options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if children.len() != 1 {
             return plan_err!("DeltaScan: wrong number of children {}", children.len());
         }
-        Ok(Arc::new(Self::new(
-            self.scan_plan.clone(),
-            children[0].clone(),
-            self.transforms.clone(),
-            self.selection_vectors.clone(),
-            self.public_file_ids.clone(),
-            self.partition_stats.clone(),
-            self.metrics.clone(),
-        )))
+        let input = children.remove(0);
+        match options.children_properties {
+            ChildrenPropertiesMode::Keep => {
+                Ok(Arc::new(self.with_new_input_same_properties(input)))
+            }
+            ChildrenPropertiesMode::Recompute => Ok(Arc::new(self.with_new_input(input))),
+        }
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn repartitioned(
@@ -332,10 +366,7 @@ impl ExecutionPlan for DeltaScanExec {
         }
 
         if let Some(input) = self.input.repartitioned(target_partitions, config)? {
-            Ok(Some(Arc::new(Self {
-                input,
-                ..self.clone()
-            })))
+            Ok(Some(Arc::new(self.with_new_input(input))))
         } else {
             Ok(None)
         }
@@ -394,9 +425,7 @@ impl ExecutionPlan for DeltaScanExec {
 
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
         let new_input = self.input.with_fetch(limit)?;
-        let mut new_plan = self.clone();
-        new_plan.input = new_input;
-        Some(Arc::new(new_plan))
+        Some(Arc::new(self.with_new_input_same_properties(new_input)))
     }
 
     fn child_stats_requests(&self, partition: Option<usize>) -> Vec<ChildStats> {
@@ -473,12 +502,10 @@ impl ExecutionPlan for DeltaScanExec {
 
     fn apply_expressions(
         &self,
-        expr_rewriter: &mut dyn FnMut(
+        _expr_rewriter: &mut dyn FnMut(
             &Arc<dyn PhysicalExpr>,
         ) -> Result<TreeNodeRecursion, DataFusionError>,
     ) -> Result<TreeNodeRecursion, DataFusionError> {
-        // Apply expressions to the input execution plan
-        self.input.apply_expressions(expr_rewriter)?;
         Ok(TreeNodeRecursion::Continue)
     }
 }
@@ -810,6 +837,7 @@ mod tests {
     use arrow_array::Array;
     use arrow_array::ArrayAccessor;
     use datafusion::{
+        catalog::MemTable,
         common::{ToDFSchema, stats::Precision},
         datasource::TableProvider,
         logical_expr::Operator,
@@ -1821,11 +1849,11 @@ mod tests {
             .downcast_ref::<DeltaScanExec>()
             .expect("expected DeltaScanExec");
 
-        let distribution = exec.required_input_distribution();
+        let distribution = exec.input_distribution_requirements();
         assert!(
             matches!(
-                distribution.as_slice(),
-                [Distribution::UnspecifiedDistribution]
+                distribution.child_distribution(0),
+                Some(Distribution::UnspecifiedDistribution)
             ),
             "unexpected distribution: {distribution:?}"
         );
@@ -1840,9 +1868,12 @@ mod tests {
             exec.metrics.clone(),
         );
 
-        let distribution = retained_exec.required_input_distribution();
+        let distribution = retained_exec.input_distribution_requirements();
         assert!(
-            matches!(distribution.as_slice(), [Distribution::SinglePartition]),
+            matches!(
+                distribution.child_distribution(0),
+                Some(Distribution::SinglePartition)
+            ),
             "unexpected distribution: {distribution:?}"
         );
 
@@ -1886,6 +1917,53 @@ mod tests {
             "unexpected error: {err}"
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_repartitioned_recomputes_properties_and_executes_all_rows() -> TestResult {
+        let (_kernel_type, scan_plan) = int32_scan_plan().await?;
+        let first = value_and_file_id_batch(&[10], &[Some("f1")], false)?;
+        let second = value_and_file_id_batch(&[20], &[Some("f2")], false)?;
+        let input_schema = first.schema();
+        let table = MemTable::try_new(input_schema, vec![vec![first, second]])?;
+        let session = Arc::new(create_session().into_inner());
+        let input = table.scan(&session.state(), None, &[], None).await?;
+
+        let mut public_file_ids = super::super::PublicFileIdMap::default();
+        public_file_ids.insert("f1".to_string(), "f1".to_string());
+        public_file_ids.insert("f2".to_string(), "f2".to_string());
+        let exec = DeltaScanExec::new(
+            scan_plan,
+            input,
+            Arc::new(HashMap::new()),
+            Arc::new(DashMap::new()),
+            Arc::new(public_file_ids),
+            HashMap::new(),
+            ExecutionPlanMetricsSet::new(),
+        );
+
+        let repartitioned = exec
+            .repartitioned(2, &ConfigOptions::new())?
+            .expect("MemoryExec::repartitioned returned None for two batches");
+        let child_partition_count = repartitioned.children()[0]
+            .properties()
+            .partitioning
+            .partition_count();
+
+        assert_eq!(child_partition_count, 2);
+        assert_eq!(
+            repartitioned.properties().partitioning.partition_count(),
+            child_partition_count,
+            "wrapper partition count must match its child"
+        );
+
+        let row_count = collect(repartitioned, session.task_ctx())
+            .await?
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>();
+        assert_eq!(row_count, 2, "repartitioned plan must return two rows");
         Ok(())
     }
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -29,7 +29,8 @@ use datafusion::physical_plan::metrics::{
 };
 use datafusion::physical_plan::statistics::StatisticsArgs;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PhysicalExpr, Statistics,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
+    PhysicalExpr, ReplaceChildrenOptions, Statistics,
 };
 use delta_kernel::schema::{Schema as KernelSchema, SchemaRef as KernelSchemaRef};
 use delta_kernel::{EvaluationHandler, ExpressionRef};
@@ -206,9 +207,10 @@ impl ExecutionPlan for DeltaScanMetaExec {
         vec![]
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if !children.is_empty() {
             return Err(DataFusionError::Plan(
@@ -216,6 +218,16 @@ impl ExecutionPlan for DeltaScanMetaExec {
             ));
         }
         Ok(self.clone())
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn repartitioned(
@@ -320,12 +332,10 @@ impl ExecutionPlan for DeltaScanMetaExec {
 
     fn apply_expressions(
         &self,
-        expr_rewriter: &mut dyn FnMut(
+        _expr_rewriter: &mut dyn FnMut(
             &Arc<dyn PhysicalExpr>,
         ) -> Result<TreeNodeRecursion, DataFusionError>,
     ) -> Result<TreeNodeRecursion, DataFusionError> {
-        // DeltaScanMetaExec has no children execution plans to traverse
-        // Just continue the recursion
         Ok(TreeNodeRecursion::Continue)
     }
 }

--- a/crates/core/src/operations/merge/barrier.rs
+++ b/crates/core/src/operations/merge/barrier.rs
@@ -24,7 +24,9 @@ use datafusion::common::{DataFusionError, Result as DataFusionResult};
 use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 use datafusion::physical_expr::{Distribution, PhysicalExpr};
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan,
+    InputDistributionRequirements, RecordBatchStream, ReplaceChildrenOptions,
+    SendableRecordBatchStream, apply_expression_roots,
 };
 use futures::{Stream, StreamExt};
 
@@ -82,16 +84,23 @@ impl ExecutionPlan for MergeBarrierExec {
     }
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
-        vec![Distribution::KeyPartitioned(vec![self.expr.clone()]); 1]
+        self.input_distribution_requirements().into_per_child()
+    }
+
+    fn input_distribution_requirements(&self) -> InputDistributionRequirements {
+        InputDistributionRequirements::new(vec![Distribution::KeyPartitioned(vec![Arc::clone(
+            &self.expr,
+        )])])
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![&self.input]
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
         if children.len() != 1 {
             return Err(DataFusionError::Plan(
@@ -103,6 +112,16 @@ impl ExecutionPlan for MergeBarrierExec {
             self.file_column.clone(),
             self.expr.clone(),
         )))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(
@@ -125,9 +144,7 @@ impl ExecutionPlan for MergeBarrierExec {
             &Arc<dyn PhysicalExpr>,
         ) -> Result<TreeNodeRecursion, DataFusionError>,
     ) -> Result<TreeNodeRecursion, DataFusionError> {
-        // Traverse child execution plan with the expression rewriter
-        self.input.apply_expressions(expr_rewriter)?;
-        Ok(TreeNodeRecursion::Continue)
+        apply_expression_roots([&self.expr], expr_rewriter)
     }
 }
 

--- a/crates/core/src/operations/merge/mod.rs
+++ b/crates/core/src/operations/merge/mod.rs
@@ -1963,6 +1963,7 @@ mod tests {
     use arrow_schema::Field;
     use dashmap::DashSet;
     use datafusion::assert_batches_sorted_eq;
+    use datafusion::common::tree_node::TreeNodeRecursion;
     use datafusion::common::{Column, ScalarValue, TableReference, ToDFSchema};
     use datafusion::datasource::provider_as_source;
     use datafusion::logical_expr::Expr;
@@ -1971,7 +1972,10 @@ mod tests {
     use datafusion::logical_expr::expr::Placeholder;
     use datafusion::logical_expr::lit;
     use datafusion::logical_expr::{Extension, LogicalPlan, LogicalPlanBuilder};
+    use datafusion::physical_expr::PhysicalExpr;
+    use datafusion::physical_expr::expressions::Column as PhysicalColumn;
     use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::physical_plan::empty::EmptyExec;
     use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
     use datafusion::physical_plan::metrics::MetricBuilder;
     use datafusion::physical_plan::{collect, displayable};
@@ -1991,8 +1995,8 @@ mod tests {
         DataFusionMixins, DeltaScanNext, PATH_COLUMN, resolve_file_column_name,
     };
 
-    use super::barrier::MergeBarrier;
-    use super::validation::MergeValidation;
+    use super::barrier::{MergeBarrier, MergeBarrierExec};
+    use super::validation::{MergeValidation, MergeValidationExec};
     use super::{
         DELETE_COLUMN, MatchParticipationClass, MergeMetrics, OPERATION_COLUMN, OperationType,
         SOURCE_COLUMN, TARGET_COLUMN, TARGET_COPY_COLUMN, TARGET_DELETE_COLUMN,
@@ -2012,6 +2016,44 @@ mod tests {
             .unwrap();
         assert_eq!(table.version(), Some(0));
         table
+    }
+
+    #[test]
+    fn merge_execs_visit_owned_distribution_expression() {
+        let input: Arc<dyn ExecutionPlan> =
+            Arc::new(EmptyExec::new(Arc::new(ArrowSchema::new(vec![
+                Field::new("path", ArrowDataType::Utf8, false),
+            ]))));
+        let expression: Arc<dyn PhysicalExpr> = Arc::new(PhysicalColumn::new("path", 0));
+        let plans: [Arc<dyn ExecutionPlan>; 2] = [
+            Arc::new(MergeBarrierExec::new(
+                Arc::clone(&input),
+                Arc::new("path".to_string()),
+                Arc::clone(&expression),
+            )),
+            Arc::new(MergeValidationExec::new(
+                input,
+                Arc::clone(&expression),
+                Arc::new("path".to_string()),
+                Arc::new("row_ordinal".to_string()),
+            )),
+        ];
+
+        for plan in plans {
+            let mut visits = 0;
+            plan.apply_expressions(&mut |visited| {
+                assert!(Arc::ptr_eq(visited, &expression));
+                visits += 1;
+                Ok(TreeNodeRecursion::Continue)
+            })
+            .expect("apply_expressions failed");
+            assert_eq!(
+                visits,
+                1,
+                "{} must expose its owned expression",
+                plan.name()
+            );
+        }
     }
 
     pub(crate) async fn setup_table_with_non_null_column(
@@ -2677,9 +2719,9 @@ mod tests {
         );
     }
 
-    fn retained_row_index_delta_scan_child<'a>(
-        plan: &'a Arc<dyn ExecutionPlan>,
-    ) -> &'a Arc<dyn ExecutionPlan> {
+    fn retained_row_index_delta_scan_child(
+        plan: &Arc<dyn ExecutionPlan>,
+    ) -> &Arc<dyn ExecutionPlan> {
         let mut scan_children = Vec::new();
         collect_retained_row_index_scan_inputs(plan, &mut scan_children);
 

--- a/crates/core/src/operations/merge/validation.rs
+++ b/crates/core/src/operations/merge/validation.rs
@@ -15,8 +15,9 @@ use datafusion::logical_expr::{
 };
 use datafusion::physical_expr::Distribution;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PhysicalExpr, RecordBatchStream,
-    SendableRecordBatchStream,
+    ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan,
+    InputDistributionRequirements, PhysicalExpr, RecordBatchStream, ReplaceChildrenOptions,
+    SendableRecordBatchStream, apply_expression_roots,
 };
 use datafusion::prelude::DataFrame;
 use futures::{Stream, StreamExt};
@@ -66,16 +67,23 @@ impl ExecutionPlan for MergeValidationExec {
     }
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
-        vec![Distribution::KeyPartitioned(vec![self.file_expr.clone()]); 1]
+        self.input_distribution_requirements().into_per_child()
+    }
+
+    fn input_distribution_requirements(&self) -> InputDistributionRequirements {
+        InputDistributionRequirements::new(vec![Distribution::KeyPartitioned(vec![Arc::clone(
+            &self.file_expr,
+        )])])
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![&self.input]
     }
 
-    fn with_new_children(
+    fn replace_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
+        _options: ReplaceChildrenOptions,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         if children.len() != 1 {
             return Err(DataFusionError::Plan(
@@ -88,6 +96,16 @@ impl ExecutionPlan for MergeValidationExec {
             Arc::clone(&self.file_column),
             Arc::clone(&self.row_ordinal_column),
         )))
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.replace_children(
+            children,
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        )
     }
 
     fn execute(
@@ -110,9 +128,7 @@ impl ExecutionPlan for MergeValidationExec {
             &Arc<dyn PhysicalExpr>,
         ) -> Result<TreeNodeRecursion, DataFusionError>,
     ) -> Result<TreeNodeRecursion, DataFusionError> {
-        // Traverse child execution plan with the expression rewriter
-        self.input.apply_expressions(expr_rewriter)?;
-        Ok(TreeNodeRecursion::Continue)
+        apply_expression_roots([&self.file_expr], expr_rewriter)
     }
 }
 


### PR DESCRIPTION
## Summary

Update the custom DataFusion execution plans to follow the DataFusion 55 contracts for child replacement, property caching, expression traversal, and input distribution.

## Changes

1. Implement `replace_children` across the Delta scan, validation, column mapping, metrics, and merge execution plans.

2. Honor `ChildrenPropertiesMode` by preserving valid property caches or rebuilding them from replacement children.

3. Restrict `apply_expressions` to expressions owned by the current execution plan. DataFusion handles traversal into child plans.

4. Expose scan and merge distribution requirements through `InputDistributionRequirements`.

5. Rebuild wrapper properties after repartitioning and reset execution metrics when a new scan plan is created.

6. Return a planning error when `CREATE EXTERNAL TABLE` receives zero or multiple Delta table locations.

7. Add focused tests for property replacement, repartitioning, expression traversal, distribution requirements, and invalid location counts.


PR description drafted and completed code review with Codex