### PR TITLE
feat(datafusion): DeltaScanExecCodec — wire codec for kernel-based scans

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -48,6 +48,7 @@ datafusion = { workspace = true, optional = true }
 datafusion-datasource = { workspace = true, optional = true }
 datafusion-physical-expr-adapter = { workspace = true, optional = true }
 datafusion-proto = { workspace = true, optional = true }
+prost = { version = "0.14.1", optional = true }
 
 # serde
 serde = { workspace = true, features = ["derive"] }
@@ -121,6 +122,7 @@ datafusion = [
     "datafusion-datasource",
     "datafusion-physical-expr-adapter",
     "datafusion-proto",
+    "dep:prost",
 ]
 datafusion-ext = ["datafusion"]
 json = ["parquet/json"]

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -77,6 +77,7 @@ pub(crate) use find_files::*;
 pub(crate) use table_provider::next::normalize_path_as_file_id;
 pub use table_provider::{
     DeltaScanConfig, DeltaScanConfigBuilder, TableProviderBuilder, next::DeltaScanExec,
+    next::DeltaScanExecCodec,
 };
 pub(crate) use table_provider::{
     next::FILE_ID_COLUMN_DEFAULT, resolve_file_column_name, update_datafusion_session,

--- a/crates/core/src/delta_datafusion/table_provider/next/codec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/codec.rs
@@ -1,0 +1,153 @@
+//! Wire codec for [`DeltaScanExec`] — makes kernel-based Delta scans usable in
+//! distributed DataFusion engines (Ballista, datafusion-distributed, custom
+//! schedulers) that serialize physical plans between processes.
+//!
+//! `DeltaScanExec` holds live kernel state (scan plan, per-file transforms,
+//! deletion-vector masks) that has no stable wire form. What IS wire-safe is the
+//! request that produced it: the serializable [`DeltaScan`] provider (whose
+//! snapshot embeds the materialized file list) plus the `scan()` arguments.
+//! [`DeltaScanExecCodec`] therefore serializes that request ([`ScanReplay`],
+//! captured at plan time) and **replays the scan** on the receiving side:
+//!
+//! - metadata replay is served from the snapshot's materialized files
+//!   (`scan_metadata_seeded`) — no log-store round trip;
+//! - deletion vectors and data files are read through the object stores registered
+//!   in the receiving side's `RuntimeEnv` (taken from the decode `TaskContext`).
+//!
+//! Addresses <https://github.com/delta-io/delta-rs/issues/4171>.
+
+use std::sync::Arc;
+
+use datafusion::common::error::{DataFusionError, Result};
+use datafusion::execution::{SessionStateBuilder, TaskContext};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_proto::logical_plan::{
+    DefaultLogicalExtensionCodec, from_proto::parse_exprs, to_proto::serialize_exprs,
+};
+use datafusion_proto::physical_plan::{PhysicalExtensionCodec, PhysicalProtoConverterExtension};
+use datafusion_proto::protobuf::LogicalExprList;
+use prost::Message;
+use serde::{Deserialize, Serialize};
+
+use super::scan::DeltaScanExec;
+use super::{DeltaScan, ScanReplay};
+
+/// Serialized form of a [`ScanReplay`]. Filter expressions travel as a
+/// prost-encoded [`LogicalExprList`] (datafusion-proto), everything else as
+/// serde via the already-serializable [`DeltaScan`].
+#[derive(Serialize, Deserialize)]
+struct DeltaScanExecWire {
+    provider: DeltaScan,
+    projection: Option<Vec<usize>>,
+    filters: Vec<u8>,
+    limit: Option<usize>,
+}
+
+/// Physical extension codec for [`DeltaScanExec`].
+///
+/// Compose it with an engine's own codec (try Delta first, fall back), mirroring
+/// how [`DeltaLogicalCodec`](crate::delta_datafusion::DeltaLogicalCodec) is used
+/// on the logical side.
+#[derive(Debug, Default)]
+pub struct DeltaScanExecCodec {}
+
+impl DeltaScanExecCodec {
+    fn internal(what: impl std::fmt::Display) -> DataFusionError {
+        DataFusionError::Internal(format!("DeltaScanExecCodec: {what}"))
+    }
+
+    /// Run the replayed scan to completion from a synchronous decode context.
+    ///
+    /// `PhysicalExtensionCodec::try_decode` is sync while `scan()` is async (it may
+    /// read deletion vectors). Inside a multi-thread tokio runtime the blocking is
+    /// delegated via `block_in_place`; outside any runtime a local executor drives
+    /// the future.
+    fn block_on_scan(
+        replay_fut: impl std::future::Future<Output = Result<Arc<dyn ExecutionPlan>>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(|| handle.block_on(replay_fut))
+            }
+            Ok(_) => Err(Self::internal(
+                "decoding requires a multi-thread tokio runtime (current-thread runtime would deadlock)",
+            )),
+            Err(_) => futures::executor::block_on(replay_fut),
+        }
+    }
+}
+
+impl PhysicalExtensionCodec for DeltaScanExecCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        _inputs: &[Arc<dyn ExecutionPlan>],
+        ctx: &TaskContext,
+        _proto_converter: &dyn PhysicalProtoConverterExtension,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let wire: DeltaScanExecWire = serde_json::from_slice(buf)
+            .map_err(|e| Self::internal(format!("unable to decode wire form: {e}")))?;
+
+        // The receiving side's session: same config the plan was created under
+        // (shipped in the TaskContext) + the receiving side's RuntimeEnv, so data
+        // and deletion-vector IO resolve through ITS object store registry.
+        let state = SessionStateBuilder::new()
+            .with_config(ctx.session_config().clone())
+            .with_runtime_env(ctx.runtime_env().clone())
+            .with_default_features()
+            .build();
+
+        let expr_list = LogicalExprList::decode(wire.filters.as_slice())
+            .map_err(|e| Self::internal(format!("unable to decode filter exprs: {e}")))?;
+        let filters = parse_exprs(expr_list.expr.iter(), ctx, &DefaultLogicalExtensionCodec {})?;
+
+        // Replaying `scan()` rebuilds the full plan — including the parquet read
+        // child — deterministically from the embedded snapshot, so the framework's
+        // decoded child (`_inputs`) is intentionally unused.
+        Self::block_on_scan(async {
+            use datafusion::catalog::TableProvider as _;
+            wire.provider
+                .scan(&state, wire.projection.as_ref(), &filters, wire.limit)
+                .await
+        })
+    }
+
+    fn try_encode(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+        buf: &mut Vec<u8>,
+        _proto_converter: &dyn PhysicalProtoConverterExtension,
+    ) -> Result<()> {
+        // Both scan shapes carry the same replay: the data-reading DeltaScanExec and
+        // the metadata-only DeltaScanMetaExec (COUNT(*)-style plans). Replaying the
+        // request on the receiving side re-derives whichever shape applies.
+        let any = node.as_ref() as &dyn std::any::Any;
+        let replay = if let Some(exec) = any.downcast_ref::<DeltaScanExec>() {
+            exec.replay()
+        } else if let Some(exec) = any.downcast_ref::<super::scan::DeltaScanMetaExec>() {
+            exec.replay()
+        } else {
+            return Err(Self::internal("not a Delta scan node"));
+        };
+        let replay: &ScanReplay = replay.ok_or_else(|| {
+            Self::internal(
+                "Delta scan carries no scan replay — plans must be produced via DeltaScan::scan \
+                 (TableProvider) to be wire-serializable",
+            )
+        })?;
+
+        let filters = LogicalExprList {
+            expr: serialize_exprs(replay.filters.iter(), &DefaultLogicalExtensionCodec {})?,
+        }
+        .encode_to_vec();
+
+        let wire = DeltaScanExecWire {
+            provider: replay.provider.clone(),
+            projection: replay.projection.clone(),
+            filters,
+            limit: replay.limit,
+        };
+        serde_json::to_writer(buf, &wire)
+            .map_err(|e| Self::internal(format!("unable to encode wire form: {e}")))
+    }
+}

--- a/crates/core/src/delta_datafusion/table_provider/next/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/mod.rs
@@ -44,6 +44,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 use uuid::Uuid;
 
+pub use self::codec::DeltaScanExecCodec;
 pub use self::scan::DeltaScanExec;
 pub(crate) use self::scan::KernelScanPlan;
 use self::scan::ProjectedScanContract;
@@ -58,6 +59,7 @@ use crate::logstore::LogStoreRef;
 use crate::protocol::SaveMode;
 use crate::table::normalize_table_url;
 
+pub mod codec;
 mod scan;
 
 /// Default column name for the file id column we add to files read from disk.
@@ -478,6 +480,20 @@ impl SnapshotWrapper {
     }
 }
 
+/// The originating `TableProvider::scan` request, captured at plan time.
+///
+/// `DeltaScanExec` itself holds live kernel state that has no wire form; what IS
+/// wire-safe is the request that produced it: the (serializable) provider plus the
+/// scan arguments. `DeltaScanExecCodec` serializes this and replays `scan()` on the
+/// receiving side to reconstruct an equivalent plan from the embedded snapshot.
+#[derive(Clone, Debug)]
+pub struct ScanReplay {
+    pub(crate) provider: DeltaScan,
+    pub(crate) projection: Option<Vec<usize>>,
+    pub(crate) filters: Vec<Expr>,
+    pub(crate) limit: Option<usize>,
+}
+
 /// An executable, serializable Delta table scan.
 ///
 /// `DeltaScan` captures everything needed to read a consistent set of data files from a
@@ -755,7 +771,7 @@ impl TableProvider for DeltaScan {
             .await?;
         let stream = self.scan_metadata_stream(&scan_plan, engine.clone());
 
-        scan::execution_plan(
+        let plan = scan::execution_plan(
             &self.config,
             session,
             scan_plan,
@@ -764,7 +780,27 @@ impl TableProvider for DeltaScan {
             limit,
             resolved_file_selection.as_ref(),
         )
-        .await
+        .await?;
+
+        // Capture the request that produced this plan so DeltaScanExecCodec can
+        // replay it across a wire boundary (distributed engines ship physical
+        // plans between processes).
+        let replay = || {
+            Arc::new(ScanReplay {
+                provider: self.clone(),
+                projection: projection.cloned(),
+                filters: filters.to_vec(),
+                limit,
+            })
+        };
+        let any = plan.as_ref() as &dyn std::any::Any;
+        if let Some(exec) = any.downcast_ref::<scan::DeltaScanExec>() {
+            return Ok(Arc::new(exec.clone().with_replay(replay())));
+        }
+        if let Some(exec) = any.downcast_ref::<scan::DeltaScanMetaExec>() {
+            return Ok(Arc::new(exec.clone().with_replay(replay())));
+        }
+        Ok(plan)
     }
 
     async fn insert_into(

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -130,6 +130,10 @@ pub struct DeltaScanExec {
     properties: Arc<PlanProperties>,
     /// Aggregated partition column statistics
     partition_stats: HashMap<String, ColumnStatistics>,
+    /// The originating scan request, when planned via `DeltaScan::scan`. Enables
+    /// wire serialization by replaying the scan on the receiving side
+    /// (see [`DeltaScanExecCodec`](crate::delta_datafusion::DeltaScanExecCodec)).
+    replay: Option<Arc<super::super::ScanReplay>>,
 }
 
 impl DisplayAs for DeltaScanExec {
@@ -184,6 +188,7 @@ impl DeltaScanExec {
             input_file_id_column,
             file_id_column,
             properties,
+            replay: None,
         }
     }
 
@@ -196,7 +201,7 @@ impl DeltaScanExec {
     }
 
     fn with_new_input(&self, input: Arc<dyn ExecutionPlan>) -> Self {
-        Self::new(
+        let mut rebuilt = Self::new(
             Arc::clone(&self.scan_plan),
             input,
             Arc::clone(&self.transforms),
@@ -204,7 +209,21 @@ impl DeltaScanExec {
             Arc::clone(&self.public_file_ids),
             self.partition_stats.clone(),
             ExecutionPlanMetricsSet::new(),
-        )
+        );
+        // Keep the plan wire-serializable after child swaps.
+        rebuilt.replay = self.replay.clone();
+        rebuilt
+    }
+
+    /// Attach the originating scan request for wire serialization support.
+    pub(crate) fn with_replay(mut self, replay: Arc<super::super::ScanReplay>) -> Self {
+        self.replay = Some(replay);
+        self
+    }
+
+    /// The originating scan request, when available.
+    pub(crate) fn replay(&self) -> Option<&Arc<super::super::ScanReplay>> {
+        self.replay.as_ref()
     }
 
     /// Transform the statistics from the inner physical parquet read plan to the logical

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -80,6 +80,9 @@ pub(crate) struct DeltaScanMetaExec {
     file_id_field: Option<FieldRef>,
     /// plan properties
     properties: Arc<PlanProperties>,
+    /// The originating scan request, when planned via `DeltaScan::scan`. Enables
+    /// wire serialization by replaying the scan on the receiving side.
+    replay: Option<Arc<super::super::ScanReplay>>,
 }
 
 impl DisplayAs for DeltaScanMetaExec {
@@ -146,7 +149,19 @@ impl DeltaScanMetaExec {
             metrics,
             file_id_field,
             properties,
+            replay: None,
         }
+    }
+
+    /// Attach the originating scan request for wire serialization support.
+    pub(crate) fn with_replay(mut self, replay: Arc<super::super::ScanReplay>) -> Self {
+        self.replay = Some(replay);
+        self
+    }
+
+    /// The originating scan request, when available.
+    pub(crate) fn replay(&self) -> Option<&Arc<super::super::ScanReplay>> {
+        self.replay.as_ref()
     }
 
     fn effective_row_count_for_file(&self, file_id: &str, row_count: usize) -> Result<usize> {

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -64,7 +64,7 @@ use tracing::debug;
 use url::Url;
 
 pub use self::exec::DeltaScanExec;
-use self::exec_meta::DeltaScanMetaExec;
+pub(crate) use self::exec_meta::DeltaScanMetaExec;
 use self::expr_adapter::{DeltaPhysicalExprAdapterFactory, relax_schema_nested_nullability};
 pub(crate) use self::plan::{KernelScanPlan, ProjectedScanContract, supports_filters_pushdown};
 use self::replay::{ScanFileContext, ScanFileStream};


### PR DESCRIPTION
# Description

Kernel-based scans (`DeltaScanExec`, `DeltaScanMetaExec`) hold live kernel state with no wire form, so they cannot cross the physical plan-serde boundary of distributed engines (Ballista, datafusion-distributed, custom schedulers). This PR makes them serializable by capturing and replaying the request that produced them, rather than trying to serialize the live state:

- `ScanReplay` — captures (provider, projection, filters, limit) at plan time in `DeltaScan::scan()`, attached to both scan exec shapes; survives `with_new_children`/`repartitioned` (propagated through `with_new_input`).
- `DeltaScanExecCodec` (`PhysicalExtensionCodec`) — encodes the replay (the provider is already fully serde, with the snapshot embedding the materialized file list; filters travel as a datafusion-proto `LogicalExprList`) and re-runs `scan()` on decode. Metadata replays from the embedded snapshot via `scan_metadata_seeded` (no log-store round trip); deletion-vector and data IO resolve through the receiving side's `RuntimeEnv` from the decode `TaskContext`. The framework-decoded child is intentionally discarded — the replay rebuilds an identical parquet plan deterministically.
- Sync/async bridge: decode delegates via `block_in_place` inside a multi-thread tokio runtime, falls back to a local executor outside one, and errors loudly on a current-thread runtime (would deadlock).

Verified end-to-end in Apache DataFusion Ballista (2-executor cluster over MinIO): distributed SELECT w/ predicate pushdown, joins, time travel, and — the case that has no workaround without this codec — **partitioned tables**, whose partition values arrive via per-file transforms, including the metadata-only `DeltaScanMetaExec` COUNT path. `cargo test --lib --features datafusion next`: no regressions vs main (identical pass/fail set).

Happy to adjust the wire format (e.g. proto instead of serde_json) or the replay-capture placement to maintainer preference.

# Related Issue(s)

- addresses #4171

# Documentation

Module docs on `table_provider/next/codec.rs` describe the replay design and its IO characteristics.