### PR TITLE
feat: multi-field updates and nullable flag on UpdateFieldMetadata

### DIFF
--- a/crates/core/src/operations/update_field_metadata.rs
+++ b/crates/core/src/operations/update_field_metadata.rs
@@ -26,6 +26,8 @@ pub struct UpdateFieldMetadataBuilder {
     field_name: String,
     /// HashMap of the metadata to upsert
     metadata: HashMap<String, MetadataValue>,
+    /// When set, also update the field's `nullable` flag in the schema
+    nullable: Option<bool>,
     /// Delta object store for handling data files
     log_store: LogStoreRef,
     /// Additional information to add to the commit
@@ -48,6 +50,7 @@ impl UpdateFieldMetadataBuilder {
         Self {
             metadata: HashMap::new(),
             field_name: String::new(),
+            nullable: None,
             snapshot,
             log_store,
             commit_properties: CommitProperties::default(),
@@ -64,6 +67,16 @@ impl UpdateFieldMetadataBuilder {
     /// Specify the metadata to be added or modified on a field
     pub fn with_metadata(mut self, metadata: HashMap<String, MetadataValue>) -> Self {
         self.metadata = metadata;
+        self
+    }
+
+    /// Also update the field's `nullable` flag in the table schema.
+    ///
+    /// Relaxing (`false` → `true`) is always safe. Tightening (`true` → `false`) is only valid
+    /// when the column contains no NULL values — the caller is responsible for verifying this
+    /// before committing; this operation does not scan the data.
+    pub fn with_nullable(mut self, nullable: bool) -> Self {
+        self.nullable = Some(nullable);
         self
     }
 
@@ -84,6 +97,7 @@ fn plan_update_field_metadata_actions(
     snapshot: SnapshotMetadataRef<'_>,
     field_name: &str,
     metadata_update: HashMap<String, MetadataValue>,
+    nullable: Option<bool>,
 ) -> DeltaResult<(Vec<Action>, DeltaOperation)> {
     let table_schema = snapshot.table_configuration.logical_schema();
 
@@ -112,6 +126,11 @@ fn plan_update_field_metadata_actions(
             })
             .or_insert(value);
     });
+
+    // Apply the nullability change, if requested (see `with_nullable` for the contract)
+    if let Some(nullable) = nullable {
+        field.nullable = nullable;
+    }
 
     let updated_table_schema =
         StructType::try_new(table_schema.fields().map(|f| match f.name == field.name {
@@ -161,6 +180,7 @@ impl std::future::IntoFuture for UpdateFieldMetadataBuilder {
                 snapshot.snapshot().metadata_state(),
                 &this.field_name,
                 this.metadata.clone(),
+                this.nullable,
             )?;
 
             let commit = CommitBuilder::from(this.commit_properties.clone())
@@ -219,7 +239,74 @@ mod tests {
             .await?;
 
         assert!(!snapshot.snapshot().has_materialized_files_for_test());
+        Ok(())
+    }
+}
 
+#[cfg(feature = "datafusion")]
+#[cfg(test)]
+mod nullable_tests {
+    use delta_kernel::schema::MetadataValue;
+    use std::collections::HashMap;
+
+    use crate::DeltaResult;
+    use crate::writer::test_utils::{create_bare_table, get_record_batch};
+
+    /// `with_nullable(false)` must flip the schema field's `nullable` flag, not just its
+    /// metadata map — reporting and NOT NULL enforcement read the flag.
+    #[tokio::test]
+    async fn with_nullable_updates_the_schema_flag() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let table = create_bare_table().write(vec![batch]).await.unwrap();
+        assert!(
+            table.snapshot()?.schema().field("value").unwrap().nullable,
+            "test premise: 'value' starts nullable"
+        );
+
+        let table = table
+            .update_field_metadata()
+            .with_field_name("value")
+            .with_nullable(false)
+            .await
+            .unwrap();
+
+        let field = table.snapshot()?.schema().field("value").unwrap().clone();
+        assert!(!field.nullable, "nullable flag updated in the schema");
+
+        // And back: relaxing is always safe.
+        let table = table
+            .update_field_metadata()
+            .with_field_name("value")
+            .with_nullable(true)
+            .await
+            .unwrap();
+        assert!(table.snapshot()?.schema().field("value").unwrap().nullable);
+        Ok(())
+    }
+
+    /// Without `with_nullable`, the operation keeps its metadata-only behavior.
+    #[tokio::test]
+    async fn metadata_only_update_leaves_nullable_untouched() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let table = create_bare_table().write(vec![batch]).await.unwrap();
+
+        let table = table
+            .update_field_metadata()
+            .with_field_name("value")
+            .with_metadata(HashMap::from([(
+                "isUnique".to_string(),
+                MetadataValue::Boolean(true),
+            )]))
+            .await
+            .unwrap();
+
+        let field = table.snapshot()?.schema().field("value").unwrap().clone();
+        assert!(field.nullable, "nullable flag unchanged");
+        assert_eq!(
+            field.metadata.get("isUnique"),
+            Some(&MetadataValue::Boolean(true)),
+            "metadata written"
+        );
         Ok(())
     }
 }

--- a/crates/core/src/operations/update_field_metadata.rs
+++ b/crates/core/src/operations/update_field_metadata.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::schema::{MetadataValue, StructType};
+use delta_kernel::schema::{MetadataValue, StructField, StructType};
 use futures::future::BoxFuture;
 use itertools::Itertools;
 
@@ -18,16 +18,28 @@ use crate::logstore::LogStoreRef;
 use crate::protocol::DeltaOperation;
 use crate::{DeltaResult, DeltaTableError};
 
-/// Update a field's metadata in a schema. If the key does not exists, the entry is inserted.
+/// A queued metadata (+ optional nullability) change for a single field.
+#[derive(Clone, Debug, Default)]
+pub struct FieldMetadataUpdate {
+    /// HashMap of the metadata to upsert on the field
+    pub metadata: HashMap<String, MetadataValue>,
+    /// When set, also update the field's `nullable` flag in the schema
+    pub nullable: Option<bool>,
+}
+
+/// Update one or more fields' metadata in a schema. If a key does not exist, the entry is
+/// inserted. All queued field updates are applied in a single commit.
 pub struct UpdateFieldMetadataBuilder {
     /// A snapshot of the table's state
     snapshot: Option<EagerSnapshot>,
-    /// The name of the field where the metadata may be updated
+    /// The name of the field targeted by the single-field builder methods
     field_name: String,
-    /// HashMap of the metadata to upsert
+    /// HashMap of the metadata to upsert (single-field builder methods)
     metadata: HashMap<String, MetadataValue>,
-    /// When set, also update the field's `nullable` flag in the schema
+    /// When set, also update the field's `nullable` flag in the schema (single-field methods)
     nullable: Option<bool>,
+    /// Per-field updates queued via `with_field_update`
+    updates: HashMap<String, FieldMetadataUpdate>,
     /// Delta object store for handling data files
     log_store: LogStoreRef,
     /// Additional information to add to the commit
@@ -51,6 +63,7 @@ impl UpdateFieldMetadataBuilder {
             metadata: HashMap::new(),
             field_name: String::new(),
             nullable: None,
+            updates: HashMap::new(),
             snapshot,
             log_store,
             commit_properties: CommitProperties::default(),
@@ -80,6 +93,23 @@ impl UpdateFieldMetadataBuilder {
         self
     }
 
+    /// Queue a metadata (+ optional nullability) update for a field. May be called multiple
+    /// times for different fields; all queued updates land in a single commit. Calling it twice
+    /// for the same field replaces the earlier entry. Composes with the single-field
+    /// `with_field_name`/`with_metadata`/`with_nullable` methods (which win on conflict).
+    pub fn with_field_update(
+        mut self,
+        field_name: &str,
+        metadata: HashMap<String, MetadataValue>,
+        nullable: Option<bool>,
+    ) -> Self {
+        self.updates.insert(
+            field_name.into(),
+            FieldMetadataUpdate { metadata, nullable },
+        );
+        self
+    }
+
     /// Additional metadata to be added to commit info
     pub fn with_commit_properties(mut self, commit_properties: CommitProperties) -> Self {
         self.commit_properties = commit_properties;
@@ -95,48 +125,58 @@ impl UpdateFieldMetadataBuilder {
 
 fn plan_update_field_metadata_actions(
     snapshot: SnapshotMetadataRef<'_>,
-    field_name: &str,
-    metadata_update: HashMap<String, MetadataValue>,
-    nullable: Option<bool>,
+    updates: HashMap<String, FieldMetadataUpdate>,
 ) -> DeltaResult<(Vec<Action>, DeltaOperation)> {
+    if updates.is_empty() {
+        return Err(DeltaTableError::Generic(
+            "No field updates provided".to_string(),
+        ));
+    }
+
     let table_schema = snapshot.table_configuration.logical_schema();
 
-    let Some(field) = table_schema.field(field_name) else {
-        return Err(DeltaTableError::Generic(
-            "No field with the provided name in the schema".to_string(),
-        ));
-    };
-    let mut field = field.clone();
-
-    for key in metadata_update.keys() {
-        if key.starts_with("delta.") {
+    let mut updated_fields: HashMap<String, StructField> = HashMap::new();
+    for (field_name, update) in updates {
+        let Some(field) = table_schema.field(&field_name) else {
             return Err(DeltaTableError::Generic(
-                "Not allowed to modify protected metadata e.g. `delta.columnMapping.id`"
-                    .to_string(),
+                "No field with the provided name in the schema".to_string(),
             ));
+        };
+        let mut field = field.clone();
+
+        for key in update.metadata.keys() {
+            if key.starts_with("delta.") {
+                return Err(DeltaTableError::Generic(
+                    "Not allowed to modify protected metadata e.g. `delta.columnMapping.id`"
+                        .to_string(),
+                ));
+            }
         }
+
+        update.metadata.into_iter().for_each(|(key, value)| {
+            field
+                .metadata
+                .entry(key)
+                .and_modify(|meta| {
+                    *meta = value.clone();
+                })
+                .or_insert(value);
+        });
+
+        // Apply the nullability change, if requested (see `with_nullable` for the contract)
+        if let Some(nullable) = update.nullable {
+            field.nullable = nullable;
+        }
+
+        updated_fields.insert(field_name, field);
     }
 
-    metadata_update.into_iter().for_each(|(key, value)| {
-        field
-            .metadata
-            .entry(key)
-            .and_modify(|meta| {
-                *meta = value.clone();
-            })
-            .or_insert(value);
-    });
-
-    // Apply the nullability change, if requested (see `with_nullable` for the contract)
-    if let Some(nullable) = nullable {
-        field.nullable = nullable;
-    }
-
-    let updated_table_schema =
-        StructType::try_new(table_schema.fields().map(|f| match f.name == field.name {
-            true => field.clone(),
-            false => f.clone(),
-        }))?;
+    let updated_table_schema = StructType::try_new(table_schema.fields().map(|f| {
+        updated_fields
+            .get(&f.name)
+            .cloned()
+            .unwrap_or_else(|| f.clone())
+    }))?;
 
     let mut metadata = snapshot.metadata.clone();
 
@@ -176,12 +216,21 @@ impl std::future::IntoFuture for UpdateFieldMetadataBuilder {
             let operation_id = this.get_operation_id();
             this.pre_execute(operation_id).await?;
 
-            let (actions, operation) = plan_update_field_metadata_actions(
-                snapshot.snapshot().metadata_state(),
-                &this.field_name,
-                this.metadata.clone(),
-                this.nullable,
-            )?;
+            // Merge the single-field builder methods into the queued updates. The single-field
+            // entry wins when the same field was also queued via `with_field_update`.
+            let mut updates = this.updates.clone();
+            if !this.field_name.is_empty() {
+                updates.insert(
+                    this.field_name.clone(),
+                    FieldMetadataUpdate {
+                        metadata: this.metadata.clone(),
+                        nullable: this.nullable,
+                    },
+                );
+            }
+
+            let (actions, operation) =
+                plan_update_field_metadata_actions(snapshot.snapshot().metadata_state(), updates)?;
 
             let commit = CommitBuilder::from(this.commit_properties.clone())
                 .with_actions(actions)
@@ -306,6 +355,86 @@ mod nullable_tests {
             field.metadata.get("isUnique"),
             Some(&MetadataValue::Boolean(true)),
             "metadata written"
+        );
+        Ok(())
+    }
+
+    /// `with_field_update` applies several fields' metadata in ONE commit — the atomic
+    /// primitive behind composite primary keys.
+    #[tokio::test]
+    async fn multi_field_update_is_one_commit() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let table = create_bare_table().write(vec![batch]).await.unwrap();
+        let version_before = table.version();
+
+        let table = table
+            .update_field_metadata()
+            .with_field_update(
+                "id",
+                HashMap::from([("isPrimaryKey".to_string(), MetadataValue::Boolean(true))]),
+                None,
+            )
+            .with_field_update(
+                "value",
+                HashMap::from([("isPrimaryKey".to_string(), MetadataValue::Boolean(true))]),
+                Some(false),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            table.version(),
+            version_before.map(|v| v + 1),
+            "all field updates land in a single commit"
+        );
+        let schema = table.snapshot()?.schema().clone();
+        for name in ["id", "value"] {
+            assert_eq!(
+                schema.field(name).unwrap().metadata.get("isPrimaryKey"),
+                Some(&MetadataValue::Boolean(true)),
+                "metadata written on {name}"
+            );
+        }
+        assert!(!schema.field("value").unwrap().nullable, "nullable applied");
+        Ok(())
+    }
+
+    /// An unknown field anywhere in the batch fails the whole operation — nothing commits.
+    #[tokio::test]
+    async fn multi_field_update_unknown_field_commits_nothing() -> DeltaResult<()> {
+        let batch = get_record_batch(None, false);
+        let mut table = create_bare_table().write(vec![batch]).await.unwrap();
+        let version_before = table.version();
+
+        let err = table
+            .clone()
+            .update_field_metadata()
+            .with_field_update(
+                "id",
+                HashMap::from([("isPrimaryKey".to_string(), MetadataValue::Boolean(true))]),
+                None,
+            )
+            .with_field_update(
+                "no_such_column",
+                HashMap::from([("isPrimaryKey".to_string(), MetadataValue::Boolean(true))]),
+                None,
+            )
+            .await
+            .expect_err("unknown field must fail");
+        assert!(err.to_string().contains("No field with the provided name"));
+
+        table.load().await?;
+        assert_eq!(table.version(), version_before, "no commit was written");
+        assert!(
+            table
+                .snapshot()?
+                .schema()
+                .field("id")
+                .unwrap()
+                .metadata
+                .get("isPrimaryKey")
+                .is_none(),
+            "valid field in the failed batch untouched"
         );
         Ok(())
     }


### PR DESCRIPTION
# Description

Two extensions to the `UpdateFieldMetadata` operation:

- **Multi-field updates in a single commit** — update metadata for several fields atomically instead of one commit per field (one schema action, one commit).
- **`with_nullable`** — allow updating a field's nullable flag through the same operation (schema-evolution rules still apply; widening only).

We drive column-level metadata curation from an application UI where users edit several fields at once — per-field commits were producing noisy history and racing table versions.

# Related Issue(s)

—

# Documentation

Rustdoc on the new builder methods.