### PR TITLE
fix: include username (userinfo) in object store URL keys

### DIFF
--- a/crates/core/src/delta_datafusion/engine/storage.rs
+++ b/crates/core/src/delta_datafusion/engine/storage.rs
@@ -148,7 +148,9 @@ fn get_store_url(url: &url::Url) -> ObjectStoreUrl {
     ObjectStoreUrl::parse(format!(
         "{}://{}",
         url.scheme(),
-        &url[url::Position::BeforeHost..url::Position::AfterPort],
+        // Use BeforeUsername to include userinfo (e.g., container name for Azure ABFSS URLs)
+        // This ensures different containers on the same account get unique ObjectStoreUrl keys
+        &url[url::Position::BeforeUsername..url::Position::AfterPort],
     ))
     // Safety: The url is guaranteed to be valid as we construct it
     // from a valid url and pass only the parts that object store url


### PR DESCRIPTION
# Description

Object-store instances are cached/keyed by URL; the userinfo (username) component was dropped from the key, so two stores differing only by embedded username collided and resolved to the same instance. Include userinfo in the key.

# Related Issue(s)

—

# Documentation

—