### PR TITLE
fix: truncate timestamp min and max to millisecond precision

### DIFF
--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -6,12 +6,13 @@ use std::{
     ops::AddAssign,
 };
 
+use chrono::Timelike;
 use delta_kernel::expressions::Scalar;
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use parquet::basic::Type;
-use parquet::basic::{ConvertedType, DecimalType, IntType, LogicalType, TimestampType};
+use parquet::basic::{ConvertedType, DecimalType, LogicalType};
 use parquet::file::metadata::ParquetMetaData;
 use parquet::schema::types::{ColumnDescriptor, SchemaDescriptor};
 use parquet::{
@@ -455,10 +456,23 @@ impl From<StatsScalar> for serde_json::Value {
             StatsScalar::Float64(v) => serde_json::Value::from(v),
             StatsScalar::Date(v) => serde_json::Value::from(v.format("%Y-%m-%d").to_string()),
             StatsScalar::Timestamp(v) => {
-                serde_json::Value::from(v.format("%Y-%m-%dT%H:%M:%S%.fZ").to_string())
+                // Timestamps must be truncated to millisecond precision when writing
+                // to JSON for compatibility with the Delta Protocol.
+                let format = if v.nanosecond() == 0 {
+                    // Omit the sub-second component if it is zero
+                    "%Y-%m-%dT%H:%M:%SZ"
+                } else {
+                    "%Y-%m-%dT%H:%M:%S%.3fZ"
+                };
+                serde_json::Value::from(v.format(format).to_string())
             }
             StatsScalar::TimestampNtz(v) => {
-                serde_json::Value::from(v.format("%Y-%m-%d %H:%M:%S%.f").to_string())
+                let format = if v.nanosecond() == 0 {
+                    "%Y-%m-%d %H:%M:%S"
+                } else {
+                    "%Y-%m-%d %H:%M:%S%.3f"
+                };
+                serde_json::Value::from(v.format(format).to_string())
             }
             StatsScalar::Decimal { value, scale } => {
                 // For scale=0, serialize as integer since serde_json would otherwise
@@ -643,9 +657,10 @@ mod tests {
         protocol::{ColumnCountStat, ColumnValueStat},
         table::builder::DeltaTableBuilder,
     };
+    use parquet::basic::{Compression, IntType, TimestampType};
     use parquet::data_type::{ByteArray, FixedLenByteArray};
+    use parquet::file::properties::WriterProperties;
     use parquet::file::statistics::ValueStatistics;
-    use parquet::{basic::Compression, file::properties::WriterProperties};
     use serde_json::{Value, json};
     use std::collections::HashMap;
     use std::path::Path;
@@ -713,20 +728,40 @@ mod tests {
                 Value::from("1998-12-01"),
             ),
             (
-                simple_parquet_stat!(Statistics::Int64, 1641040496789123456),
+                simple_parquet_stat!(Statistics::Int64, 1641040496789723456),
                 Some(LogicalType::Timestamp(TimestampType {
                     is_adjusted_to_u_t_c: true,
                     unit: parquet::basic::TimeUnit::NANOS,
                 })),
-                Value::from("2022-01-01T12:34:56.789123456Z"),
+                // Should be truncated to millisecond precision
+                Value::from("2022-01-01T12:34:56.789Z"),
             ),
             (
-                simple_parquet_stat!(Statistics::Int64, 1641040496789123),
+                simple_parquet_stat!(Statistics::Int64, 1641040496789723456),
+                Some(LogicalType::Timestamp(TimestampType {
+                    is_adjusted_to_u_t_c: false, // Maps to TimestampNanosNtz
+                    unit: parquet::basic::TimeUnit::NANOS,
+                })),
+                // Should be truncated to millisecond precision
+                Value::from("2022-01-01 12:34:56.789"),
+            ),
+            (
+                simple_parquet_stat!(Statistics::Int64, 1641040496789723),
                 Some(LogicalType::Timestamp(TimestampType {
                     is_adjusted_to_u_t_c: true,
                     unit: parquet::basic::TimeUnit::MICROS,
                 })),
-                Value::from("2022-01-01T12:34:56.789123Z"),
+                // Should be truncated to millisecond precision
+                Value::from("2022-01-01T12:34:56.789Z"),
+            ),
+            (
+                simple_parquet_stat!(Statistics::Int64, 1641040496789723),
+                Some(LogicalType::Timestamp(TimestampType {
+                    is_adjusted_to_u_t_c: false, // Maps to TimestampNtz
+                    unit: parquet::basic::TimeUnit::MICROS,
+                })),
+                // Should be truncated to millisecond precision
+                Value::from("2022-01-01 12:34:56.789"),
             ),
             (
                 simple_parquet_stat!(Statistics::Int64, 1641040496789),
@@ -735,6 +770,50 @@ mod tests {
                     unit: parquet::basic::TimeUnit::MILLIS,
                 })),
                 Value::from("2022-01-01T12:34:56.789Z"),
+            ),
+            (
+                simple_parquet_stat!(Statistics::Int64, 1641040496789),
+                Some(LogicalType::Timestamp(TimestampType {
+                    is_adjusted_to_u_t_c: false, // Maps to TimestampNtz
+                    unit: parquet::basic::TimeUnit::MILLIS,
+                })),
+                Value::from("2022-01-01 12:34:56.789"),
+            ),
+            (
+                simple_parquet_stat!(Statistics::Int64, 1641040496000000000),
+                Some(LogicalType::Timestamp(TimestampType {
+                    is_adjusted_to_u_t_c: true,
+                    unit: parquet::basic::TimeUnit::NANOS,
+                })),
+                // No sub-second component
+                Value::from("2022-01-01T12:34:56Z"),
+            ),
+            (
+                simple_parquet_stat!(Statistics::Int64, 1641040496000000000),
+                Some(LogicalType::Timestamp(TimestampType {
+                    is_adjusted_to_u_t_c: false, // Maps to TimestampNanosNtz
+                    unit: parquet::basic::TimeUnit::NANOS,
+                })),
+                // No sub-second component
+                Value::from("2022-01-01 12:34:56"),
+            ),
+            (
+                simple_parquet_stat!(Statistics::Int64, 1641040496000000500),
+                Some(LogicalType::Timestamp(TimestampType {
+                    is_adjusted_to_u_t_c: true,
+                    unit: parquet::basic::TimeUnit::NANOS,
+                })),
+                // Sub-second component truncated to zero milliseconds
+                Value::from("2022-01-01T12:34:56.000Z"),
+            ),
+            (
+                simple_parquet_stat!(Statistics::Int64, 1641040496000000500),
+                Some(LogicalType::Timestamp(TimestampType {
+                    is_adjusted_to_u_t_c: false, // Maps to TimestampNanosNtz
+                    unit: parquet::basic::TimeUnit::NANOS,
+                })),
+                // Sub-second component truncated to zero milliseconds
+                Value::from("2022-01-01 12:34:56.000"),
             ),
             (
                 simple_parquet_stat!(Statistics::Int64, 1234),

--- a/crates/core/tests/it_datafusion/main.rs
+++ b/crates/core/tests/it_datafusion/main.rs
@@ -19,3 +19,4 @@ mod integration_datafusion;
 mod nanosecond_timestamps;
 mod read_delta_log_test;
 mod read_delta_partitions_test;
+mod timestamp_statistics;

--- a/crates/core/tests/it_datafusion/timestamp_statistics.rs
+++ b/crates/core/tests/it_datafusion/timestamp_statistics.rs
@@ -1,0 +1,209 @@
+// Tests handling of min/max statistics for timestamp columns,
+// which must be truncated to millisecond precision according to the Delta Protocol.
+
+use arrow_array::{ArrayRef, RecordBatch, TimestampMicrosecondArray, TimestampNanosecondArray};
+use arrow_schema::{DataType, Field, Schema, TimeUnit};
+use datafusion::prelude::SessionContext;
+use deltalake_core::delta_datafusion::create_session;
+use deltalake_core::{DeltaResult, DeltaTable, DeltaTableError};
+use futures::TryStreamExt;
+use std::sync::Arc;
+
+const START_TIMESTAMP_US: i64 = 1_704_067_200 * 1_000_000; // 2024-01-01 00:00:00 UTC
+const START_TIMESTAMP_NS: i64 = START_TIMESTAMP_US * 1_000;
+const DAY_US: i64 = 60 * 60 * 24 * 1_000_000;
+const DAY_NS: i64 = DAY_US * 1_000;
+
+fn timestamp_nanos_array(values: Vec<i64>, timezone: Option<&str>) -> ArrayRef {
+    let array = TimestampNanosecondArray::from(values);
+    let array = match timezone {
+        Some(tz) => array.with_timezone(tz),
+        None => array,
+    };
+    Arc::new(array)
+}
+
+fn timestamp_micros_array(values: Vec<i64>, timezone: Option<&str>) -> ArrayRef {
+    let array = TimestampMicrosecondArray::from(values);
+    let array = match timezone {
+        Some(tz) => array.with_timezone(tz),
+        None => array,
+    };
+    Arc::new(array)
+}
+
+fn get_timestamp_statistic(
+    statistics: Option<delta_kernel::expressions::Scalar>,
+    timezone: Option<&str>,
+) -> DeltaResult<i64> {
+    use delta_kernel::expressions::Scalar;
+
+    let statistics =
+        statistics.ok_or_else(|| DeltaTableError::generic("missing timestamp statistics"))?;
+    match statistics {
+        Scalar::Struct(data) => match (&data.values()[0], timezone) {
+            #[cfg(feature = "nanosecond-timestamps")]
+            (Scalar::TimestampNanos(v), Some(_)) => Ok(*v),
+            #[cfg(feature = "nanosecond-timestamps")]
+            (Scalar::TimestampNanosNtz(v), None) => Ok(*v),
+            (Scalar::Timestamp(v), Some(_)) => Ok(*v),
+            (Scalar::TimestampNtz(v), None) => Ok(*v),
+            (other, _) => Err(DeltaTableError::generic(format!(
+                "Unexpected scalar for timestamp column: {other:?}"
+            ))),
+        },
+        other => Err(DeltaTableError::generic(format!(
+            "Expected struct statistics, got {other:?}"
+        ))),
+    }
+}
+
+async fn count_where(ctx: &SessionContext, predicate: &str) -> DeltaResult<usize> {
+    let batches = ctx
+        .sql(&format!("select * from test where {predicate}"))
+        .await?
+        .collect()
+        .await?;
+    Ok(batches.iter().map(|b| b.num_rows()).sum())
+}
+
+#[tokio::test]
+async fn stats_truncation_micros() -> DeltaResult<()> {
+    stats_truncation_test(Some("UTC"), false).await
+}
+
+#[tokio::test]
+async fn stats_truncation_micros_ntz() -> DeltaResult<()> {
+    stats_truncation_test(None, false).await
+}
+
+#[cfg(feature = "nanosecond-timestamps")]
+#[tokio::test]
+async fn stats_truncation_nanos() -> DeltaResult<()> {
+    stats_truncation_test(Some("UTC"), true).await
+}
+
+#[cfg(feature = "nanosecond-timestamps")]
+#[tokio::test]
+async fn stats_truncation_nanos_ntz() -> DeltaResult<()> {
+    stats_truncation_test(None, true).await
+}
+
+async fn stats_truncation_test(timezone: Option<&str>, nanos: bool) -> DeltaResult<()> {
+    let unit = if nanos {
+        TimeUnit::Nanosecond
+    } else {
+        TimeUnit::Microsecond
+    };
+    let arrow_schema = Arc::new(Schema::new(vec![Field::new(
+        "timestamp",
+        DataType::Timestamp(unit, timezone.map(Arc::from)),
+        true,
+    )]));
+
+    let (start, day_count) = if nanos {
+        (START_TIMESTAMP_NS, DAY_NS)
+    } else {
+        (START_TIMESTAMP_US, DAY_US)
+    };
+
+    let make_array = |values: Vec<i64>, timezone: Option<&str>| {
+        if nanos {
+            timestamp_nanos_array(values, timezone)
+        } else {
+            timestamp_micros_array(values, timezone)
+        }
+    };
+
+    let batch0 = RecordBatch::try_new(
+        arrow_schema.clone(),
+        vec![make_array(
+            vec![
+                start,
+                start + 123,
+                start + if nanos { 123456789 } else { 123456 },
+            ],
+            timezone,
+        )],
+    )?;
+
+    let table: DeltaTable = DeltaTable::new_in_memory().write(vec![batch0]).await?;
+
+    let batch1 = RecordBatch::try_new(
+        arrow_schema.clone(),
+        vec![make_array(
+            vec![
+                start + day_count,
+                start + day_count + 123,
+                start + day_count + if nanos { 123456 } else { 456 },
+            ],
+            timezone,
+        )],
+    )?;
+    let table = table.write(vec![batch1]).await?;
+    assert_eq!(table.version(), Some(1));
+
+    let actions = table
+        .get_active_add_actions_by_partitions(&[])
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    assert_eq!(actions.len(), 2);
+    let mut batch0_seen = false;
+    let mut batch1_seen = false;
+    for action in actions {
+        let min = get_timestamp_statistic(action.min_values(), timezone)?;
+        let max = get_timestamp_statistic(action.max_values(), timezone)?;
+
+        if min == start {
+            batch0_seen = true;
+            // The maximum is truncated down to have a `.123` millisecond
+            // component when written to JSON stats, then rounded back up by a
+            // millisecond on read so it remains a valid upper bound.
+            let expected_max = if nanos {
+                start + 124_000_000
+            } else {
+                start + 124_000
+            };
+            assert_eq!(max, expected_max);
+        } else if min == start + day_count {
+            batch1_seen = true;
+            // The maximum truncates to value with no millisecond component
+            // and is rounded up by a millisecond.
+            let expected_max = if nanos {
+                start + day_count + 1_000_000
+            } else {
+                start + day_count + 1_000
+            };
+            assert_eq!(max, expected_max);
+        } else {
+            return Err(DeltaTableError::generic(format!(
+                "Unexpected min value for an add action: {min}"
+            )));
+        }
+    }
+    assert!(batch0_seen && batch1_seen);
+
+    // Verify that no rows are incorrectly skipped due to statistics truncation.
+    let day0 = match timezone {
+        Some(_) => "'2024-01-01T00:00:00Z'",
+        None => "'2024-01-01T00:00:00'",
+    };
+    let day1 = match timezone {
+        Some(_) => "'2024-01-02T00:00:00Z'",
+        None => "'2024-01-02T00:00:00'",
+    };
+
+    let ctx: SessionContext = create_session().into();
+    table.update_datafusion_session(&ctx.state())?;
+    ctx.register_table("test", table.table_provider().await?)?;
+
+    // Excludes the first row of `batch0`
+    assert_eq!(count_where(&ctx, &format!("timestamp > {day0}")).await?, 5);
+    // Excludes all of `batch0` and the first row of `batch1`
+    assert_eq!(count_where(&ctx, &format!("timestamp > {day1}")).await?, 2);
+    // Includes all of `batch0` and the first row of `batch1`
+    assert_eq!(count_where(&ctx, &format!("timestamp <= {day1}")).await?, 4);
+
+    Ok(())
+}

--- a/python/tests/test_stats.py
+++ b/python/tests/test_stats.py
@@ -73,11 +73,15 @@ def test_stats_usage_3201(tmp_path):
 
 
 @pytest.mark.pyarrow
-@pytest.mark.parametrize("use_stats_struct", (True, False))
-def test_microsecond_truncation_parquet_stats(tmp_path, use_stats_struct):
+@pytest.mark.parametrize(
+    "use_checkpoint,use_stats_struct", [(True, False), (True, True), (False, False)]
+)
+def test_microsecond_truncation_parquet_stats(
+    tmp_path, use_checkpoint, use_stats_struct
+):
     import pyarrow as pa
 
-    """In checkpoints the min,max value gets truncated to milliseconds precision.
+    """In checkpoints and JSON log files the min,max value gets truncated to milliseconds precision.
     For min values this is not an issue, but for max values we need to round upwards.
 
     This checks whether we can still read tables with truncated timestamp stats.
@@ -127,10 +131,11 @@ def test_microsecond_truncation_parquet_stats(tmp_path, use_stats_struct):
     )
     assert batch1 == result
 
-    dt.optimize.compact()
-    dt.create_checkpoint()
+    if use_checkpoint:
+        dt.optimize.compact()
+        dt.create_checkpoint()
 
-    result = dt.to_pyarrow_table(
+    result_le = dt.to_pyarrow_table(
         filters=[
             (
                 "dt",
@@ -139,7 +144,18 @@ def test_microsecond_truncation_parquet_stats(tmp_path, use_stats_struct):
             ),
         ]
     )
-    assert batch1 == result
+    assert batch1 == result_le
+
+    result_gt = dt.to_pyarrow_table(
+        filters=[
+            (
+                "dt",
+                ">",
+                datetime(2023, 3, 30, 0, 0, 0, 0, tzinfo=timezone.utc),
+            ),
+        ]
+    )
+    assert batch2 == result_gt
 
 
 @pytest.mark.polars

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1117,8 +1117,10 @@ def test_writer_stats(existing_table: DeltaTable, sample_data_pyarrow: "pa.Table
     expected_maxs["decimal"] = 14.0
     expected_maxs["date32"] = "2022-01-05"
     if _nanosecond_timestamps_enabled():
-        expected_maxs["timestamp_ns"] = "1970-01-01T00:00:00.000000004Z"
-        expected_maxs["timestamp_ns_ntz"] = "1970-01-01 00:00:00.000000004"
+        # Nanosecond timestamps are truncated to millisecond precision
+        # in the add action statistics.
+        expected_maxs["timestamp_ns"] = "1970-01-01T00:00:00.000Z"
+        expected_maxs["timestamp_ns_ntz"] = "1970-01-01 00:00:00.000"
 
     assert stats["maxValues"] == expected_maxs
 


### PR DESCRIPTION
# Description

Truncates the min and max statistics for timestamps to millisecond precision, for compliance with the Delta Protocol.

# Related Issue(s)

- closes #4659

# Documentation

https://github.com/delta-io/delta/blob/master/PROTOCOL.md#per-file-statistics