### PR TITLE
chore: fix failing doc test and run doc tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,3 +135,11 @@ jobs:
       - uses: ./.github/actions/upload-coverage
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Run doc tests
+        shell: bash
+        run: |
+          # llvm-cov doesn't run doc tests, so run them separately
+          cargo test --features ${{ env.DEFAULT_FEATURES }} \
+            --workspace \
+            --doc

--- a/crates/core/src/logstore/parquet_reader.rs
+++ b/crates/core/src/logstore/parquet_reader.rs
@@ -28,6 +28,7 @@ use parquet::file::metadata::{PageIndexPolicy, ParquetMetaData, ParquetMetaDataR
 /// ```no_run
 /// # use std::sync::Arc;
 /// # use deltalake_core::logstore::parquet_reader::ParquetObjectReader;
+/// # use object_store::{ObjectStore, path::Path};
 /// # use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
 /// # async fn run() {
 /// # let store: Arc<dyn ObjectStore> = todo!();


### PR DESCRIPTION
A plain `cargo test` fails on `main` due to a failing doc test, which isn't caught in CI because llvm-cov doesn't run doc tests (https://github.com/taiki-e/cargo-llvm-cov/issues/2).

This PR fixes the doc and adds a CI step to run the doc tests with a plain `cargo test`.