### PR TITLE
fix: preserve row order in deletion vector scans

### DIFF
--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -49,14 +49,14 @@ use crate::kernel::arrow::engine_ext::ExpressionEvaluatorExt;
 const DELTA_MATERIALIZED_PUSHDOWN_SENTINEL: &str =
     "__delta_rs_unpushable_delta_materialized_filter";
 
-/// DeltaScanExec uses these inputs to apply deletion vectors during a physical scan.
+/// Deletion-vector inputs for [`DeltaScanExec`].
 #[derive(Clone, Debug)]
 pub(super) enum DvExecutionState {
-    None,
+    NotPresent,
     Sequential {
-        /// The planner captures these masks. Each execution stream copies them before use.
+        /// Keep masks shared by plan clones. Each execution copies and consumes them.
         selection_vectors: Arc<HashMap<String, Vec<bool>>>,
-        /// The validator compares child files against this whole file ownership map.
+        /// Expected object store and path for each file ID in the child plan.
         physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
     },
 }
@@ -68,7 +68,7 @@ impl DvExecutionState {
 
     fn selection_vectors(&self) -> Option<&HashMap<String, Vec<bool>>> {
         match self {
-            Self::None => None,
+            Self::NotPresent => None,
             Self::Sequential {
                 selection_vectors, ..
             } => Some(selection_vectors),
@@ -77,7 +77,7 @@ impl DvExecutionState {
 
     fn physical_file_identities(&self) -> Option<&super::PhysicalFileIdentityMap> {
         match self {
-            Self::None => None,
+            Self::NotPresent => None,
             Self::Sequential {
                 physical_file_identities,
                 ..
@@ -561,7 +561,8 @@ impl ExecutionPlan for DeltaScanExec {
             input: self.input.execute(partition, context)?,
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
             transforms: Arc::clone(&self.transforms),
-            // Each execution owns its cursors and copies the masks that the planner captured.
+            // Each stream consumes its masks as it reads batches. Deep-copy the masks
+            // once per execution to isolate repeated or concurrent scans.
             selection_vectors: self
                 .dv_state
                 .selection_vectors()
@@ -625,14 +626,7 @@ impl ExecutionPlan for DeltaScanExec {
         let stats = input_stats.first().ok_or_else(|| {
             internal_datafusion_err!("DeltaScanExec expects statistics for exactly one child")
         })?;
-        let mut stats = self.map_statistics(Statistics::clone(stats))?;
-        // When deletion vectors are present, the inner parquet plan's row counts
-        // don't account for deleted rows. Mark num_rows as inexact so DataFusion's
-        // AggregateStatistics optimizer won't short-circuit COUNT(*) with inflated counts.
-        if !self.selection_vectors.is_empty() {
-            stats.num_rows = stats.num_rows.to_inexact();
-        }
-        Ok(Arc::new(stats))
+        self.map_statistics(Statistics::clone(stats)).map(Arc::new)
     }
 
     fn gather_filters_for_pushdown(
@@ -2407,7 +2401,7 @@ mod tests {
             scan_plan,
             input,
             Arc::new(HashMap::new()),
-            DvExecutionState::None,
+            DvExecutionState::NotPresent,
             Arc::new(public_file_ids),
             HashMap::new(),
             ExecutionPlanMetricsSet::new(),

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -13,7 +13,6 @@ use arrow::compute::filter_record_batch;
 use arrow::datatypes::{FieldRef, Schema, SchemaRef, UInt16Type};
 use arrow_array::StringViewArray;
 use arrow_array::{Array, ArrayRef, BooleanArray, UInt64Array};
-use dashmap::DashMap;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::error::{DataFusionError, Result};
 use datafusion::common::tree_node::TreeNodeRecursion;
@@ -26,9 +25,7 @@ use datafusion::physical_expr::utils::collect_columns;
 use datafusion::physical_expr::{Distribution, EquivalenceProperties};
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, PlanProperties};
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
-use datafusion::physical_plan::metrics::{
-    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
-};
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
     ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan,
@@ -52,17 +49,39 @@ use crate::kernel::arrow::engine_ext::ExpressionEvaluatorExt;
 const DELTA_MATERIALIZED_PUSHDOWN_SENTINEL: &str =
     "__delta_rs_unpushable_delta_materialized_filter";
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum DvApplicationMode {
+/// DeltaScanExec uses these inputs to apply deletion vectors during a physical scan.
+#[derive(Clone, Debug)]
+pub(super) enum DvExecutionState {
     None,
-    Sequential,
+    Sequential {
+        /// The planner captures these masks. Each execution stream copies them before use.
+        selection_vectors: Arc<HashMap<String, Vec<bool>>>,
+        /// The validator compares child files against this whole file ownership map.
+        physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
+    },
 }
 
-impl DvApplicationMode {
-    fn as_str(self) -> &'static str {
+impl DvExecutionState {
+    fn is_sequential(&self) -> bool {
+        matches!(self, Self::Sequential { .. })
+    }
+
+    fn selection_vectors(&self) -> Option<&HashMap<String, Vec<bool>>> {
         match self {
-            Self::None => "none",
-            Self::Sequential => "sequential",
+            Self::None => None,
+            Self::Sequential {
+                selection_vectors, ..
+            } => Some(selection_vectors),
+        }
+    }
+
+    fn physical_file_identities(&self) -> Option<&super::PhysicalFileIdentityMap> {
+        match self {
+            Self::None => None,
+            Self::Sequential {
+                physical_file_identities,
+                ..
+            } => Some(physical_file_identities),
         }
     }
 }
@@ -127,7 +146,7 @@ pub(crate) fn consume_dv_mask(
 ///
 /// 1. Inner [`input`](Self::input) plan reads raw Parquet data
 /// 2. Per-file [`transforms`](Self::transforms) convert physical to logical schema
-/// 3. [`selection_vectors`](Self::selection_vectors) filter deleted rows
+/// 3. The scan applies deletion vectors before it returns rows
 /// 4. Result is cast to the projected scan contract's result schema
 #[derive(Clone, Debug)]
 pub struct DeltaScanExec {
@@ -136,14 +155,10 @@ pub struct DeltaScanExec {
     input: Arc<dyn ExecutionPlan>,
     /// Transforms to be applied to data eminating from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
-    /// Selection vectors to be applied to data read from individual files
-    selection_vectors: Arc<DashMap<String, Vec<bool>>>,
-    /// Stable deletion-vector execution mode for this plan.
-    dv_mode: DvApplicationMode,
+    /// The planner records deletion vector masks and physical file ownership here.
+    dv_state: DvExecutionState,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
-    /// Expected physical file ownership keyed by compact scan file id.
-    physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
     /// File id column name carried by the input batches for per file correlation.
@@ -170,12 +185,6 @@ impl DisplayAs for DeltaScanExec {
                 if let Some(row_index_field) = self.scan_plan.contract.retained_row_index_field() {
                     write!(f, ": row_index_column={}", row_index_field.name())?;
                 }
-                write!(
-                    f,
-                    ": dv_mode={}, physical_row_index=false, file_group_layout_locked={}",
-                    self.dv_mode.as_str(),
-                    matches!(self.dv_mode, DvApplicationMode::Sequential)
-                )?;
                 Ok(())
             }
         }
@@ -183,33 +192,15 @@ impl DisplayAs for DeltaScanExec {
 }
 
 impl DeltaScanExec {
-    fn register_dv_file_metric(
-        metrics: &ExecutionPlanMetricsSet,
-        selection_vectors: &DashMap<String, Vec<bool>>,
-    ) {
-        if !selection_vectors.is_empty() {
-            MetricBuilder::new(metrics)
-                .global_counter("dv_files")
-                .add(selection_vectors.len());
-        }
-    }
-
-    pub(crate) fn new(
+    pub(super) fn new(
         scan_plan: Arc<KernelScanPlan>,
         input: Arc<dyn ExecutionPlan>,
         transforms: Arc<HashMap<String, ExpressionRef>>,
-        selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+        dv_state: DvExecutionState,
         public_file_ids: Arc<super::PublicFileIdMap>,
-        physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
         partition_stats: HashMap<String, ColumnStatistics>,
         metrics: ExecutionPlanMetricsSet,
     ) -> Self {
-        let dv_mode = if selection_vectors.is_empty() {
-            DvApplicationMode::None
-        } else {
-            DvApplicationMode::Sequential
-        };
-        Self::register_dv_file_metric(&metrics, &selection_vectors);
         let input_file_id_column = scan_plan.contract.file_id_field.name().to_owned();
         let file_id_column = scan_plan
             .contract
@@ -225,10 +216,8 @@ impl DeltaScanExec {
             scan_plan,
             input,
             transforms,
-            selection_vectors,
-            dv_mode,
+            dv_state,
             public_file_ids,
-            physical_file_identities,
             partition_stats,
             metrics,
             input_file_id_column,
@@ -238,11 +227,9 @@ impl DeltaScanExec {
     }
 
     fn with_new_input_same_properties(&self, input: Arc<dyn ExecutionPlan>) -> Self {
-        let metrics = ExecutionPlanMetricsSet::new();
-        Self::register_dv_file_metric(&metrics, &self.selection_vectors);
         Self {
             input,
-            metrics,
+            metrics: ExecutionPlanMetricsSet::new(),
             ..Self::clone(self)
         }
     }
@@ -252,16 +239,15 @@ impl DeltaScanExec {
             Arc::clone(&self.scan_plan),
             input,
             Arc::clone(&self.transforms),
-            Arc::clone(&self.selection_vectors),
+            self.dv_state.clone(),
             Arc::clone(&self.public_file_ids),
-            Arc::clone(&self.physical_file_identities),
             self.partition_stats.clone(),
             ExecutionPlanMetricsSet::new(),
         )
     }
 
     fn has_deletion_vectors(&self) -> bool {
-        !matches!(self.dv_mode, DvApplicationMode::None)
+        self.dv_state.is_sequential()
     }
 
     fn validate_dv_child_topology(&self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
@@ -280,6 +266,11 @@ impl DeltaScanExec {
             expected: &super::PhysicalFileIdentityMap,
             observed: &mut HashSet<String>,
         ) -> Result<()> {
+            if let Some(fetch) = plan.fetch() {
+                return plan_err!(
+                    "DeltaScanExec rejects child fetch limit {fetch} during sequential deletion vector scans"
+                );
+            }
             if let Some(coalesce) = plan.downcast_ref::<CoalescePartitionsExec>() {
                 return visit(coalesce.input(), expected, observed);
             }
@@ -291,13 +282,13 @@ impl DeltaScanExec {
             }
             let Some(source_exec) = plan.downcast_ref::<DataSourceExec>() else {
                 return plan_err!(
-                    "DeltaScanExec sequential deletion-vector topology contains unsupported node {}",
+                    "DeltaScanExec rejects node {} during sequential deletion vector scans",
                     plan.name()
                 );
             };
             let Some(config) = source_exec.data_source().downcast_ref::<FileScanConfig>() else {
                 return plan_err!(
-                    "DeltaScanExec sequential deletion-vector topology requires FileScanConfig leaves"
+                    "DeltaScanExec requires FileScanConfig leaves during sequential deletion vector scans"
                 );
             };
             if !matches!(
@@ -306,7 +297,12 @@ impl DeltaScanExec {
                     if partitions == config.file_groups.len()
             ) {
                 return plan_err!(
-                    "DeltaScanExec sequential deletion-vector file-group layout is not locked"
+                    "DeltaScanExec requires a locked file group layout during sequential deletion vector scans"
+                );
+            }
+            if config.file_source.filter().is_some() {
+                return plan_err!(
+                    "DeltaScanExec rejects file source filters during sequential deletion vector scans"
                 );
             }
 
@@ -315,29 +311,29 @@ impl DeltaScanExec {
                     let Some(file_id) = file.partition_values.first().and_then(scalar_file_id)
                     else {
                         return plan_err!(
-                            "DeltaScanExec sequential deletion-vector file is missing a compact file id"
+                            "A sequential deletion vector file lacks a compact file id"
                         );
                     };
                     if file.range.is_some() {
                         return plan_err!(
-                            "DeltaScanExec sequential deletion-vector file id '{file_id}' has a byte range"
+                            "Sequential deletion vector file id '{file_id}' uses a byte range"
                         );
                     }
                     let Some(expected_file) = expected.get(file_id) else {
                         return plan_err!(
-                            "DeltaScanExec sequential deletion-vector topology contains unknown file id '{file_id}'"
+                            "Sequential deletion vector scan received unknown file id '{file_id}'"
                         );
                     };
                     if expected_file.object_store_url != config.object_store_url
                         || expected_file.location != file.object_meta.location
                     {
                         return plan_err!(
-                            "DeltaScanExec sequential deletion-vector topology has an inconsistent mapping for file id '{file_id}'"
+                            "Sequential deletion vector file id '{file_id}' has an unexpected store or location"
                         );
                     }
                     if !observed.insert(file_id.to_owned()) {
                         return plan_err!(
-                            "DeltaScanExec sequential deletion-vector topology has duplicate ownership for file id '{file_id}'"
+                            "Sequential deletion vector file id '{file_id}' belongs to multiple child files"
                         );
                     }
                 }
@@ -345,12 +341,15 @@ impl DeltaScanExec {
             Ok(())
         }
 
+        let expected = self.dv_state.physical_file_identities().ok_or_else(|| {
+            internal_datafusion_err!(
+                "DeltaScanExec deletion vector topology validation requires sequential state"
+            )
+        })?;
         let mut observed = HashSet::new();
-        visit(input, &self.physical_file_identities, &mut observed)?;
-        if observed.len() != self.physical_file_identities.len() {
-            return plan_err!(
-                "DeltaScanExec sequential deletion-vector topology is missing selected files"
-            );
+        visit(input, expected, &mut observed)?;
+        if observed.len() != expected.len() {
+            return plan_err!("DeltaScanExec sequential deletion vector scan lacks selected files");
         }
         Ok(())
     }
@@ -412,14 +411,9 @@ impl DeltaScanExec {
 
         stats.column_statistics = new_stats;
         if self.has_deletion_vectors() {
-            // The child statistics describe physical Parquet rows. Sequential DV filtering can
-            // only provide conservative bounds until the DV index carries validated numRecords.
-            stats.num_rows = stats.num_rows.to_inexact();
-            stats.column_statistics = stats
-                .column_statistics
-                .into_iter()
-                .map(ColumnStatistics::to_inexact)
-                .collect();
+            // Child statistics describe physical Parquet rows. This node reports conservative
+            // bounds unless the DV index contains numRecords.
+            stats = stats.to_inexact();
         }
         Ok(stats)
     }
@@ -475,8 +469,8 @@ impl ExecutionPlan for DeltaScanExec {
         if self.scan_plan.contract.retained_row_index_field().is_some()
             || self.has_deletion_vectors()
         {
-            // Retained row indexes and sequential deletion-vector masks depend on one stream
-            // seeing each file's rows in physical order.
+            // DeltaScanExec requires one stream to preserve physical row order for retained row
+            // indexes and sequential DV masks.
             InputDistributionRequirements::new(vec![Distribution::SinglePartition])
         } else {
             InputDistributionRequirements::new(vec![Distribution::UnspecifiedDistribution])
@@ -526,8 +520,8 @@ impl ExecutionPlan for DeltaScanExec {
         if self.scan_plan.contract.retained_row_index_field().is_some()
             || self.has_deletion_vectors()
         {
-            // Each DeltaScanStream keeps row ordinal counters and sequential DV cursors for one
-            // execution partition. Repartitioning can split one file across streams.
+            // A DeltaScanStream stores row ordinals and DV cursors for one execution partition.
+            // DataFusion can split a file across streams after repartitioning.
             return Ok(None);
         }
 
@@ -546,10 +540,8 @@ impl ExecutionPlan for DeltaScanExec {
         // Normal planning enforces this through EnforceDistribution. Keep this check for
         // callers that build DeltaScanExec directly or replace its child plan.
         let retains_row_index = self.scan_plan.contract.retained_row_index_field().is_some();
-        if self.has_deletion_vectors() {
-            self.validate_dv_child_topology(&self.input)?;
-        }
-        if retains_row_index || self.has_deletion_vectors() {
+        let has_deletion_vectors = self.has_deletion_vectors();
+        if retains_row_index || has_deletion_vectors {
             let input_partition_count = self.input.properties().partitioning.partition_count();
             if input_partition_count > 1 {
                 if retains_row_index {
@@ -563,28 +555,18 @@ impl ExecutionPlan for DeltaScanExec {
             }
         }
 
-        let dv_file_ids = self
-            .selection_vectors
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect();
-        let dv_rows_checked =
-            MetricBuilder::new(&self.metrics).counter("dv_rows_checked", partition);
-        let dv_rows_removed =
-            MetricBuilder::new(&self.metrics).counter("dv_rows_removed", partition);
-
         Ok(Box::pin(DeltaScanStream {
             scan_plan: Arc::clone(&self.scan_plan),
             kernel_type: Arc::clone(self.scan_plan.scan.logical_schema()).into(),
             input: self.input.execute(partition, context)?,
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
             transforms: Arc::clone(&self.transforms),
-            // Sequential cursors are execution-local. Reusing the physical plan must start each
-            // stream from the original immutable planning snapshot.
-            selection_vectors: self.selection_vectors.as_ref().clone(),
-            dv_file_ids,
-            dv_rows_checked,
-            dv_rows_removed,
+            // Each execution owns its cursors and copies the masks that the planner captured.
+            selection_vectors: self
+                .dv_state
+                .selection_vectors()
+                .cloned()
+                .unwrap_or_default(),
             public_file_ids: Arc::clone(&self.public_file_ids),
             input_file_id_column: self.input_file_id_column.clone(),
             file_id_column: self.file_id_column.clone(),
@@ -614,9 +596,11 @@ impl ExecutionPlan for DeltaScanExec {
     }
 
     fn fetch(&self) -> Option<usize> {
-        (!self.has_deletion_vectors())
-            .then(|| self.input.fetch())
-            .flatten()
+        if self.has_deletion_vectors() {
+            None
+        } else {
+            self.input.fetch()
+        }
     }
 
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
@@ -739,11 +723,7 @@ struct DeltaScanStream {
     /// Transforms to be applied to data read from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Selection vectors to be applied to data read from individual files
-    selection_vectors: DashMap<String, Vec<bool>>,
-    /// Files that had a DV at planning time; unlike the mutable sequential cursors this is stable.
-    dv_file_ids: HashSet<String>,
-    dv_rows_checked: Count,
-    dv_rows_removed: Count,
+    selection_vectors: HashMap<String, Vec<bool>>,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
     /// File id column name carried by the input batches for per file correlation.
@@ -789,11 +769,8 @@ impl DeltaScanStream {
         file_id: String,
         file_id_idx: usize,
     ) -> Result<RecordBatch> {
-        let input_row_count = batch.num_rows();
-        let has_deletion_vector = self.dv_file_ids.contains(&file_id);
-        let dv_result = if let Some(mut selection_vector) = self.selection_vectors.get_mut(&file_id)
-        {
-            consume_dv_mask(&mut selection_vector, batch.num_rows())
+        let dv_result = if let Some(selection_vector) = self.selection_vectors.get_mut(&file_id) {
+            consume_dv_mask(selection_vector, batch.num_rows())
         } else {
             DvMaskResult {
                 selection: None,
@@ -810,12 +787,6 @@ impl DeltaScanStream {
         } else {
             batch
         };
-        if has_deletion_vector {
-            self.dv_rows_checked.add(input_row_count);
-            self.dv_rows_removed
-                .add(input_row_count.saturating_sub(batch.num_rows()));
-        }
-
         batch.remove_column(file_id_idx);
 
         let result = if let Some(transform) = self.transforms.get(&file_id) {
@@ -1056,7 +1027,7 @@ mod tests {
     use datafusion::{
         catalog::MemTable,
         common::{ToDFSchema, stats::Precision},
-        datasource::TableProvider,
+        datasource::{TableProvider, physical_plan::ParquetSource},
         logical_expr::Operator,
         physical_expr::expressions::{
             BinaryExpr, Column, DynamicFilterPhysicalExpr, lit as physical_lit,
@@ -1065,12 +1036,13 @@ mod tests {
         physical_plan::{
             PhysicalExpr,
             coalesce_partitions::CoalescePartitionsExec,
-            collect, collect_partitioned, displayable,
+            collect, collect_partitioned,
             filter_pushdown::{FilterPushdownPhase, PushedDown},
             repartition::RepartitionExec,
             statistics::StatisticsContext,
         },
-        prelude::{col, lit},
+        physical_planner::DefaultPhysicalPlanner,
+        prelude::{SessionConfig, col, lit},
         scalar::ScalarValue,
     };
     use datafusion_datasource::{
@@ -1237,7 +1209,7 @@ mod tests {
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
             .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
+            .expect("planner must return DeltaScanExec");
 
         let filter = session.state().create_physical_expr(
             col("number").lt(lit(ScalarValue::TimestampMillisecond(Some(7), None))),
@@ -1271,7 +1243,7 @@ mod tests {
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
             .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
+            .expect("planner must return DeltaScanExec");
 
         let letter_idx = exec.schema().index_of("letter")?;
         assert!(exec.schema().field_with_name("letter").is_ok());
@@ -1449,41 +1421,6 @@ mod tests {
         assert_eq!(child_filters.len(), 1);
         assert_eq!(child_filters[0].len(), 1);
         assert!(matches!(child_filters[0][0].discriminant, PushedDown::Yes));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_gather_filters_for_pushdown_rejects_dv_data_filters() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], None).await?;
-        let exec = scan
-            .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
-
-        assert!(
-            !exec.selection_vectors.is_empty(),
-            "fixture must select at least one deletion vector"
-        );
-        let int_idx = exec.schema().index_of("int")?;
-        let int: Arc<dyn PhysicalExpr> = Arc::new(Column::new("int", int_idx));
-        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
-            vec![int],
-            physical_lit(true),
-        ));
-
-        let description = exec.gather_filters_for_pushdown(
-            FilterPushdownPhase::Post,
-            vec![filter],
-            session.state().config().options(),
-        )?;
-
-        let child_filters = description.parent_filters();
-        assert_eq!(child_filters.len(), 1);
-        assert_eq!(child_filters[0].len(), 1);
-        assert!(matches!(child_filters[0][0].discriminant, PushedDown::No));
 
         Ok(())
     }
@@ -1919,16 +1856,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dv_scan_disables_limit_and_fetch_pushdown() -> TestResult {
+    async fn test_dv_scan_rejects_unsafe_pushdowns() -> TestResult {
         let table = open_fs_path(DV_TABLE_PATH);
         let provider = table.table_provider().await?;
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], Some(1)).await?;
         let exec = scan
             .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
+            .expect("planner must return DeltaScanExec");
 
-        assert!(!exec.selection_vectors.is_empty());
         assert!(!exec.supports_limit_pushdown());
         assert!(matches!(
             exec.cardinality_effect(),
@@ -1937,98 +1873,57 @@ mod tests {
         assert_eq!(exec.fetch(), None);
         assert!(exec.with_fetch(Some(1)).is_none());
 
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dv_scan_requires_single_input_partition() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], None).await?;
-        let exec = scan
-            .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
-
-        let distribution = exec.input_distribution_requirements();
+        let int_idx = exec.schema().index_of("int")?;
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("int", int_idx))],
+            physical_lit(true),
+        ));
+        let description = exec.gather_filters_for_pushdown(
+            FilterPushdownPhase::Post,
+            vec![filter],
+            session.state().config().options(),
+        )?;
         assert!(matches!(
-            distribution.child_distribution(0),
-            Some(Distribution::SinglePartition)
+            description.parent_filters()[0][0].discriminant,
+            PushedDown::No
         ));
 
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dv_scan_locks_whole_file_layout() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], None).await?;
-        let exec = scan
-            .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
-        let source_exec = exec
-            .input
-            .downcast_ref::<DataSourceExec>()
-            .expect("single-store fixture should produce a DataSourceExec");
-        let config = source_exec
-            .data_source()
-            .downcast_ref::<FileScanConfig>()
-            .expect("expected parquet FileScanConfig");
-
-        assert!(matches!(
-            config.output_partitioning,
-            Some(Partitioning::UnknownPartitioning(partitions))
-                if partitions == config.file_groups.len()
-        ));
-        assert!(
-            config
-                .file_groups
-                .iter()
-                .all(|group| { group.iter().all(|file| file.range.is_none()) })
+        let batches = collect(scan, session.task_ctx()).await?;
+        assert_eq!(
+            batches.iter().map(RecordBatch::num_rows).sum::<usize>(),
+            1,
+            "the limit must run after DV filtering removes four rows"
         );
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_dv_scan_rejects_ranged_fragments_under_single_output_coalesce() -> TestResult {
+    async fn test_dv_scan_rejects_row_dropping_child_rewrites() -> TestResult {
         let table = open_fs_path(DV_TABLE_PATH);
         let provider = table.table_provider().await?;
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
             .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
+            .expect("planner must return DeltaScanExec");
         let source_exec = exec
             .input
             .downcast_ref::<DataSourceExec>()
-            .expect("single-store fixture should produce a DataSourceExec");
+            .expect("fixture must produce one DataSourceExec");
         let config = source_exec
             .data_source()
             .downcast_ref::<FileScanConfig>()
-            .expect("expected parquet FileScanConfig");
+            .expect("DataSourceExec must hold a parquet FileScanConfig");
 
-        let whole_file = config.file_groups[0][0].clone();
-        let split_at = i64::try_from(whole_file.object_meta.size / 2)?;
-        let file_end = i64::try_from(whole_file.object_meta.size)?;
-        let mut first = whole_file.clone();
-        first.range = Some(FileRange {
+        let mut fragment = config.file_groups[0][0].clone();
+        fragment.range = Some(FileRange {
             start: 0,
-            end: split_at,
-        });
-        let mut second = whole_file;
-        second.range = Some(FileRange {
-            start: split_at,
-            end: file_end,
+            end: i64::try_from(fragment.object_meta.size / 2)?,
         });
         let fragmented_config = FileScanConfigBuilder::from(config.clone())
-            .with_file_groups(vec![
-                FileGroup::new(vec![first]),
-                FileGroup::new(vec![second]),
-            ])
-            .with_output_partitioning(Some(Partitioning::UnknownPartitioning(2)))
+            .with_file_groups(vec![FileGroup::new(vec![fragment])])
+            .with_output_partitioning(Some(Partitioning::UnknownPartitioning(1)))
             .build();
         let fragmented = DataSourceExec::from_data_source(fragmented_config);
         let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(fragmented));
@@ -2039,109 +1934,192 @@ mod tests {
         );
         assert!(
             result.is_err(),
-            "single-output coalescing must not hide ranged DV file fragments"
+            "coalescing to one output must not hide ranged DV file fragments"
         );
 
-        Ok(())
-    }
+        let limited_config = FileScanConfigBuilder::from(config.clone())
+            .with_limit(Some(1))
+            .build();
+        let limited: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(limited_config);
+        let limited_result = Arc::new(exec.clone()).replace_children(
+            vec![limited],
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        );
 
-    #[tokio::test]
-    async fn test_dv_scan_applies_limit_after_deleted_rows() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], Some(1)).await?;
-
-        let batches = collect(scan, session.task_ctx()).await?;
-        let row_count = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
-        assert_eq!(row_count, 1, "one live row exists after four deleted rows");
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dv_scan_downgrades_physical_statistics() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let predicates = provider
-            .schema()
-            .fields()
-            .iter()
-            .map(|field| col(field.name()).is_not_null())
-            .collect::<Vec<_>>();
-        let scan = provider
-            .scan(&session.state(), None, &predicates, None)
-            .await?;
-
-        let statistics = StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
+        let parquet_source = config
+            .file_source
+            .downcast_ref::<ParquetSource>()
+            .expect("FileScanConfig must hold ParquetSource");
+        let filtered_config = FileScanConfigBuilder::from(config.clone())
+            .with_source(Arc::new(parquet_source.with_predicate(physical_lit(false))))
+            .build();
+        let filtered: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(filtered_config);
+        let filtered_result = Arc::new(exec.clone()).replace_children(
+            vec![filtered],
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        );
         assert!(
-            !matches!(statistics.num_rows, Precision::Exact(_)),
-            "physical row count is not an exact live-row count"
-        );
-        for column in &statistics.column_statistics {
-            assert!(!matches!(column.null_count, Precision::Exact(_)));
-            assert!(!matches!(column.min_value, Precision::Exact(_)));
-            assert!(!matches!(column.max_value, Precision::Exact(_)));
-            assert!(!matches!(column.distinct_count, Precision::Exact(_)));
-        }
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dv_scan_explain_reports_containment_mode() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], None).await?;
-
-        let explain = displayable(scan.as_ref()).indent(false).to_string();
-        assert!(explain.contains("dv_mode=sequential"), "{explain}");
-        assert!(explain.contains("physical_row_index=false"), "{explain}");
-        assert!(
-            explain.contains("file_group_layout_locked=true"),
-            "{explain}"
+            limited_result.is_err() && filtered_result.is_err(),
+            "DeltaScanExec must reject child rewrites that remove rows: limit={}, predicate={}",
+            limited_result.is_err(),
+            filtered_result.is_err()
         );
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_sequential_dv_plan_is_repeatable() -> TestResult {
+    async fn test_dv_scan_downgrades_all_exact_physical_statistics() -> TestResult {
         let table = open_fs_path(DV_TABLE_PATH);
         let provider = table.table_provider().await?;
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("planner must return DeltaScanExec");
 
-        let first = collect(Arc::clone(&scan), session.task_ctx()).await?;
-        let second = collect(scan, session.task_ctx()).await?;
-        let first_rows = first.iter().map(RecordBatch::num_rows).sum::<usize>();
-        let second_rows = second.iter().map(RecordBatch::num_rows).sum::<usize>();
-        assert_eq!(first_rows, 1);
-        assert_eq!(second_rows, first_rows);
+        let mut physical = Statistics::new_unknown(exec.input.schema().as_ref());
+        physical.num_rows = Precision::Exact(5);
+        physical.total_byte_size = Precision::Exact(1_006);
+        let first_column = physical
+            .column_statistics
+            .first_mut()
+            .expect("DV fixture must read at least one physical column");
+        first_column.byte_size = Precision::Exact(128);
+        first_column.sum_value = Precision::Exact(ScalarValue::Int64(Some(42)));
 
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dv_scan_reports_file_and_row_metrics() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], None).await?;
-
-        collect(Arc::clone(&scan), session.task_ctx()).await?;
-        let metrics = scan.metrics().expect("DeltaScanExec metrics");
-        assert_eq!(metrics.sum_by_name("dv_files").unwrap().as_usize(), 1);
+        let logical = exec.map_statistics(physical)?;
+        assert_eq!(logical.num_rows, Precision::Inexact(5));
+        assert_eq!(logical.total_byte_size, Precision::Inexact(1_006));
         assert_eq!(
-            metrics.sum_by_name("dv_rows_checked").unwrap().as_usize(),
-            5
+            logical.column_statistics[0].byte_size,
+            Precision::Inexact(128)
         );
         assert_eq!(
-            metrics.sum_by_name("dv_rows_removed").unwrap().as_usize(),
-            4
+            logical.column_statistics[0].sum_value,
+            Precision::Inexact(ScalarValue::Int64(Some(42)))
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_optimized_multi_group_dv_scan_is_concurrently_repeatable() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let config = SessionConfig::new().with_target_partitions(2);
+        let session = Arc::new(datafusion::prelude::SessionContext::new_with_config(config));
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("planner must return DeltaScanExec");
+        let source_exec = exec
+            .input
+            .downcast_ref::<DataSourceExec>()
+            .expect("fixture must produce one DataSourceExec");
+        let source_config = source_exec
+            .data_source()
+            .downcast_ref::<FileScanConfig>()
+            .expect("DataSourceExec must hold a parquet FileScanConfig");
+        let original_file = source_config.file_groups[0][0].clone();
+        let original_file_id = exec
+            .dv_state
+            .selection_vectors()
+            .and_then(|vectors| vectors.keys().next().cloned())
+            .expect("fixture must have one deletion vector mask");
+
+        let duplicate_file_id = "duplicate".to_string();
+        let source_url = url::Url::parse(&format!(
+            "{}{}",
+            source_config.object_store_url.as_str(),
+            original_file.object_meta.location.as_ref()
+        ))?;
+        let source_path = source_url.to_file_path().map_err(|_| {
+            std::io::Error::other(format!("fixture requires a file URL: {source_url}"))
+        })?;
+        let temp_dir = tempfile::tempdir()?;
+        let duplicate_path = temp_dir.path().join("duplicate.parquet");
+        std::fs::copy(&source_path, &duplicate_path)?;
+        let duplicate_location = object_store::path::Path::from_filesystem_path(&duplicate_path)?;
+
+        let mut duplicate_file = original_file.clone();
+        duplicate_file.object_meta.location = duplicate_location.clone();
+        duplicate_file.partition_values =
+            vec![crate::delta_datafusion::file_id::wrap_file_id_value(
+                duplicate_file_id.clone(),
+            )];
+        let grouped_config = FileScanConfigBuilder::from(source_config.clone())
+            .with_file_groups(vec![
+                FileGroup::new(vec![original_file]),
+                FileGroup::new(vec![duplicate_file]),
+            ])
+            .with_output_partitioning(Some(Partitioning::UnknownPartitioning(2)))
+            .build();
+        let grouped_input = DataSourceExec::from_data_source(grouped_config);
+
+        let mut selection_vectors = exec.dv_state.selection_vectors().unwrap().clone();
+        let duplicate_mask = selection_vectors
+            .get(&original_file_id)
+            .expect("fixture must provide the original mask")
+            .clone();
+        selection_vectors.insert(duplicate_file_id.clone(), duplicate_mask);
+        let mut identities = exec
+            .dv_state
+            .physical_file_identities()
+            .expect("fixture must provide sequential DV identities")
+            .clone();
+        identities.insert(
+            duplicate_file_id.clone(),
+            super::super::PhysicalFileIdentity {
+                object_store_url: source_config.object_store_url.clone(),
+                location: duplicate_location,
+            },
+        );
+        let dv_state = DvExecutionState::Sequential {
+            selection_vectors: Arc::new(selection_vectors),
+            physical_file_identities: Arc::new(identities),
+        };
+
+        let grouped_scan: Arc<dyn ExecutionPlan> = Arc::new(DeltaScanExec::new(
+            Arc::clone(&exec.scan_plan),
+            grouped_input,
+            Arc::clone(&exec.transforms),
+            dv_state,
+            Arc::clone(&exec.public_file_ids),
+            exec.partition_stats.clone(),
+            ExecutionPlanMetricsSet::new(),
+        ));
+
+        let optimized = DefaultPhysicalPlanner::default().optimize_physical_plan(
+            grouped_scan,
+            &session.state(),
+            |_, _| {},
+        )?;
+        let optimized_scan = optimized
+            .downcast_ref::<DeltaScanExec>()
+            .expect("optimizer must retain DeltaScanExec");
+        assert!(
+            optimized_scan
+                .input
+                .downcast_ref::<CoalescePartitionsExec>()
+                .is_some(),
+            "fixture must exercise multiple file groups under one coalescing node"
+        );
+
+        let (first, second) = tokio::join!(
+            collect(Arc::clone(&optimized), session.task_ctx()),
+            collect(optimized, session.task_ctx())
+        );
+        let expected = vec![
+            "+--------+-----+------------+",
+            "| letter | int | date       |",
+            "+--------+-----+------------+",
+            "| b      | 228 | 1978-12-01 |",
+            "| b      | 228 | 1978-12-01 |",
+            "+--------+-----+------------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &first?);
+        assert_batches_sorted_eq!(&expected, &second?);
 
         Ok(())
     }
@@ -2204,11 +2182,11 @@ mod tests {
         Ok((kernel_type, Arc::new(scan_plan)))
     }
 
-    fn selection_vectors_f1_f2() -> Arc<DashMap<String, Vec<bool>>> {
-        let selection_vectors: Arc<DashMap<String, Vec<bool>>> = Arc::new(DashMap::new());
-        selection_vectors.insert("f1".to_string(), vec![true, false]);
-        selection_vectors.insert("f2".to_string(), vec![false, true]);
-        selection_vectors
+    fn selection_vectors_f1_f2() -> HashMap<String, Vec<bool>> {
+        HashMap::from([
+            ("f1".to_string(), vec![true, false]),
+            ("f2".to_string(), vec![false, true]),
+        ])
     }
 
     fn value_and_file_id_batch(
@@ -2252,7 +2230,7 @@ mod tests {
     fn test_scan_stream(
         scan_plan: Arc<KernelScanPlan>,
         kernel_type: KernelDataType,
-        selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+        selection_vectors: HashMap<String, Vec<bool>>,
         input_batches: Vec<RecordBatch>,
         file_id_column: Option<String>,
     ) -> DeltaScanStream {
@@ -2264,11 +2242,8 @@ mod tests {
             .unwrap_or_else(|| Arc::clone(&scan_plan.contract.output_schema));
         let input_file_id_column = scan_plan.contract.file_id_field.name().clone();
         let mut public_file_ids = super::super::PublicFileIdMap::default();
-        for selection_vector in selection_vectors.iter() {
-            public_file_ids.insert(
-                selection_vector.key().clone(),
-                selection_vector.key().clone(),
-            );
+        for file_id in selection_vectors.keys() {
+            public_file_ids.insert(file_id.clone(), file_id.clone());
         }
         for batch in &input_batches {
             if let Ok(file_id_idx) = file_id_column_idx(batch, &input_file_id_column) {
@@ -2294,13 +2269,7 @@ mod tests {
             input,
             baseline_metrics: BaselineMetrics::new(&ExecutionPlanMetricsSet::new(), 0),
             transforms: Arc::new(HashMap::new()),
-            selection_vectors: selection_vectors.as_ref().clone(),
-            dv_file_ids: selection_vectors
-                .iter()
-                .map(|entry| entry.key().clone())
-                .collect(),
-            dv_rows_checked: Count::new(),
-            dv_rows_removed: Count::new(),
+            selection_vectors,
             public_file_ids: Arc::new(public_file_ids),
             input_file_id_column,
             file_id_column,
@@ -2356,9 +2325,8 @@ mod tests {
             retain_row_index(scan_plan, "row_ordinal"),
             Arc::clone(&exec.input),
             Arc::clone(&exec.transforms),
-            Arc::clone(&exec.selection_vectors),
+            exec.dv_state.clone(),
             Arc::clone(&exec.public_file_ids),
-            Arc::clone(&exec.physical_file_identities),
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -2395,9 +2363,8 @@ mod tests {
             retain_row_index(scan_plan, "row_ordinal"),
             repartitioned_input,
             Arc::clone(&exec.transforms),
-            Arc::clone(&exec.selection_vectors),
+            exec.dv_state.clone(),
             Arc::clone(&exec.public_file_ids),
-            Arc::clone(&exec.physical_file_identities),
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -2433,9 +2400,8 @@ mod tests {
             scan_plan,
             input,
             Arc::new(HashMap::new()),
-            Arc::new(DashMap::new()),
+            DvExecutionState::None,
             Arc::new(public_file_ids),
-            Arc::new(super::super::PhysicalFileIdentityMap::default()),
             HashMap::new(),
             ExecutionPlanMetricsSet::new(),
         );
@@ -2470,13 +2436,7 @@ mod tests {
         let scan_plan = retain_row_index(scan_plan, "row_ordinal");
         let batch = value_and_file_id_batch(&[10, 11], &[Some("f1"), Some("f1")], false)?;
 
-        let mut stream = test_scan_stream(
-            scan_plan,
-            kernel_type,
-            Arc::new(DashMap::new()),
-            Vec::new(),
-            None,
-        );
+        let mut stream = test_scan_stream(scan_plan, kernel_type, HashMap::new(), Vec::new(), None);
 
         assert!(stream.schema().column_with_name("row_ordinal").is_some());
         let outputs = stream.batch_project(batch)?;
@@ -2496,13 +2456,7 @@ mod tests {
             false,
         )?;
 
-        let mut stream = test_scan_stream(
-            scan_plan,
-            kernel_type,
-            Arc::new(DashMap::new()),
-            Vec::new(),
-            None,
-        );
+        let mut stream = test_scan_stream(scan_plan, kernel_type, HashMap::new(), Vec::new(), None);
 
         let outputs = stream.batch_project(batch)?;
         assert_eq!(outputs.len(), 2);
@@ -2524,7 +2478,7 @@ mod tests {
         let mut stream = test_scan_stream(
             scan_plan,
             kernel_type,
-            Arc::new(DashMap::new()),
+            HashMap::new(),
             vec![first, second],
             None,
         );
@@ -2656,7 +2610,7 @@ mod tests {
         let mut stream = test_scan_stream(
             Arc::clone(&scan_plan),
             kernel_type,
-            Arc::new(DashMap::new()),
+            HashMap::new(),
             Vec::new(),
             None,
         );
@@ -2680,7 +2634,7 @@ mod tests {
         let mut stream = test_scan_stream(
             Arc::clone(&scan_plan),
             kernel_type,
-            Arc::new(DashMap::new()),
+            HashMap::new(),
             Vec::new(),
             None,
         );
@@ -2853,7 +2807,7 @@ mod tests {
         let mut stream = test_scan_stream(
             scan_plan,
             kernel_type,
-            Arc::new(DashMap::new()),
+            HashMap::new(),
             vec![first, second],
             Some("file_id".to_string()),
         );
@@ -2902,16 +2856,11 @@ mod tests {
     #[test]
     fn test_dv_mask_exhaustion_across_batches() {
         use super::{DvMaskResult, consume_dv_mask};
-        use dashmap::DashMap;
 
-        let selection_vectors: DashMap<String, Vec<bool>> = DashMap::new();
         let file_id = "test_file.parquet".to_string();
-        selection_vectors.insert(file_id.clone(), vec![false, true]);
+        let mut selection_vectors = HashMap::from([(file_id.clone(), vec![false, true])]);
 
-        let result1 = {
-            let mut sv = selection_vectors.get_mut(&file_id).unwrap();
-            consume_dv_mask(&mut sv, 5)
-        };
+        let result1 = consume_dv_mask(selection_vectors.get_mut(&file_id).unwrap(), 5);
         assert_eq!(
             result1,
             DvMaskResult {
@@ -2923,8 +2872,8 @@ mod tests {
             selection_vectors.remove(&file_id);
         }
 
-        let result2 = if let Some(mut sv) = selection_vectors.get_mut(&file_id) {
-            consume_dv_mask(&mut sv, 5)
+        let result2 = if let Some(sv) = selection_vectors.get_mut(&file_id) {
+            consume_dv_mask(sv, 5)
         } else {
             DvMaskResult {
                 selection: None,

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -3,7 +3,7 @@
 //! This module implements [`DeltaScanExec`], the core execution plan that reads Parquet files
 //! and applies Delta Lake protocol transformations to produce logical table data.
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -26,12 +26,17 @@ use datafusion::physical_expr::utils::collect_columns;
 use datafusion::physical_expr::{Distribution, EquivalenceProperties};
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, PlanProperties};
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
-use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+};
 use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
     ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan,
     InputDistributionRequirements, PhysicalExpr, ReplaceChildrenOptions, Statistics,
+    coalesce_partitions::CoalescePartitionsExec, union::UnionExec,
 };
+use datafusion::scalar::ScalarValue;
+use datafusion_datasource::{file_scan_config::FileScanConfig, source::DataSourceExec};
 use datafusion_physical_expr_adapter::PhysicalExprAdapterFactory;
 use delta_kernel::schema::DataType as KernelDataType;
 use delta_kernel::table_features::TableFeature;
@@ -46,6 +51,21 @@ use crate::kernel::arrow::engine_ext::ExpressionEvaluatorExt;
 
 const DELTA_MATERIALIZED_PUSHDOWN_SENTINEL: &str =
     "__delta_rs_unpushable_delta_materialized_filter";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DvApplicationMode {
+    None,
+    Sequential,
+}
+
+impl DvApplicationMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Sequential => "sequential",
+        }
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct DvMaskResult {
@@ -118,8 +138,12 @@ pub struct DeltaScanExec {
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Selection vectors to be applied to data read from individual files
     selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+    /// Stable deletion-vector execution mode for this plan.
+    dv_mode: DvApplicationMode,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
+    /// Expected physical file ownership keyed by compact scan file id.
+    physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
     /// File id column name carried by the input batches for per file correlation.
@@ -146,6 +170,12 @@ impl DisplayAs for DeltaScanExec {
                 if let Some(row_index_field) = self.scan_plan.contract.retained_row_index_field() {
                     write!(f, ": row_index_column={}", row_index_field.name())?;
                 }
+                write!(
+                    f,
+                    ": dv_mode={}, physical_row_index=false, file_group_layout_locked={}",
+                    self.dv_mode.as_str(),
+                    matches!(self.dv_mode, DvApplicationMode::Sequential)
+                )?;
                 Ok(())
             }
         }
@@ -153,15 +183,33 @@ impl DisplayAs for DeltaScanExec {
 }
 
 impl DeltaScanExec {
+    fn register_dv_file_metric(
+        metrics: &ExecutionPlanMetricsSet,
+        selection_vectors: &DashMap<String, Vec<bool>>,
+    ) {
+        if !selection_vectors.is_empty() {
+            MetricBuilder::new(metrics)
+                .global_counter("dv_files")
+                .add(selection_vectors.len());
+        }
+    }
+
     pub(crate) fn new(
         scan_plan: Arc<KernelScanPlan>,
         input: Arc<dyn ExecutionPlan>,
         transforms: Arc<HashMap<String, ExpressionRef>>,
         selection_vectors: Arc<DashMap<String, Vec<bool>>>,
         public_file_ids: Arc<super::PublicFileIdMap>,
+        physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
         partition_stats: HashMap<String, ColumnStatistics>,
         metrics: ExecutionPlanMetricsSet,
     ) -> Self {
+        let dv_mode = if selection_vectors.is_empty() {
+            DvApplicationMode::None
+        } else {
+            DvApplicationMode::Sequential
+        };
+        Self::register_dv_file_metric(&metrics, &selection_vectors);
         let input_file_id_column = scan_plan.contract.file_id_field.name().to_owned();
         let file_id_column = scan_plan
             .contract
@@ -178,7 +226,9 @@ impl DeltaScanExec {
             input,
             transforms,
             selection_vectors,
+            dv_mode,
             public_file_ids,
+            physical_file_identities,
             partition_stats,
             metrics,
             input_file_id_column,
@@ -188,9 +238,11 @@ impl DeltaScanExec {
     }
 
     fn with_new_input_same_properties(&self, input: Arc<dyn ExecutionPlan>) -> Self {
+        let metrics = ExecutionPlanMetricsSet::new();
+        Self::register_dv_file_metric(&metrics, &self.selection_vectors);
         Self {
             input,
-            metrics: ExecutionPlanMetricsSet::new(),
+            metrics,
             ..Self::clone(self)
         }
     }
@@ -202,9 +254,105 @@ impl DeltaScanExec {
             Arc::clone(&self.transforms),
             Arc::clone(&self.selection_vectors),
             Arc::clone(&self.public_file_ids),
+            Arc::clone(&self.physical_file_identities),
             self.partition_stats.clone(),
             ExecutionPlanMetricsSet::new(),
         )
+    }
+
+    fn has_deletion_vectors(&self) -> bool {
+        !matches!(self.dv_mode, DvApplicationMode::None)
+    }
+
+    fn validate_dv_child_topology(&self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
+        fn scalar_file_id(value: &ScalarValue) -> Option<&str> {
+            match value {
+                ScalarValue::Dictionary(_, value) => scalar_file_id(value),
+                ScalarValue::Utf8(Some(value)) | ScalarValue::LargeUtf8(Some(value)) => {
+                    Some(value.as_str())
+                }
+                _ => None,
+            }
+        }
+
+        fn visit(
+            plan: &Arc<dyn ExecutionPlan>,
+            expected: &super::PhysicalFileIdentityMap,
+            observed: &mut HashSet<String>,
+        ) -> Result<()> {
+            if let Some(coalesce) = plan.downcast_ref::<CoalescePartitionsExec>() {
+                return visit(coalesce.input(), expected, observed);
+            }
+            if let Some(union) = plan.downcast_ref::<UnionExec>() {
+                for input in union.inputs() {
+                    visit(input, expected, observed)?;
+                }
+                return Ok(());
+            }
+            let Some(source_exec) = plan.downcast_ref::<DataSourceExec>() else {
+                return plan_err!(
+                    "DeltaScanExec sequential deletion-vector topology contains unsupported node {}",
+                    plan.name()
+                );
+            };
+            let Some(config) = source_exec.data_source().downcast_ref::<FileScanConfig>() else {
+                return plan_err!(
+                    "DeltaScanExec sequential deletion-vector topology requires FileScanConfig leaves"
+                );
+            };
+            if !matches!(
+                config.output_partitioning,
+                Some(datafusion::physical_expr::Partitioning::UnknownPartitioning(partitions))
+                    if partitions == config.file_groups.len()
+            ) {
+                return plan_err!(
+                    "DeltaScanExec sequential deletion-vector file-group layout is not locked"
+                );
+            }
+
+            for group in &config.file_groups {
+                for file in group.iter() {
+                    let Some(file_id) = file.partition_values.first().and_then(scalar_file_id)
+                    else {
+                        return plan_err!(
+                            "DeltaScanExec sequential deletion-vector file is missing a compact file id"
+                        );
+                    };
+                    if file.range.is_some() {
+                        return plan_err!(
+                            "DeltaScanExec sequential deletion-vector file id '{file_id}' has a byte range"
+                        );
+                    }
+                    let Some(expected_file) = expected.get(file_id) else {
+                        return plan_err!(
+                            "DeltaScanExec sequential deletion-vector topology contains unknown file id '{file_id}'"
+                        );
+                    };
+                    if expected_file.object_store_url != config.object_store_url
+                        || expected_file.location != file.object_meta.location
+                    {
+                        return plan_err!(
+                            "DeltaScanExec sequential deletion-vector topology has an inconsistent mapping for file id '{file_id}'"
+                        );
+                    }
+                    if !observed.insert(file_id.to_owned()) {
+                        return plan_err!(
+                            "DeltaScanExec sequential deletion-vector topology has duplicate ownership for file id '{file_id}'"
+                        );
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        let mut observed = HashSet::new();
+        visit(input, &self.physical_file_identities, &mut observed)?;
+        if observed.len() != self.physical_file_identities.len() {
+            return plan_err!(
+                "DeltaScanExec sequential deletion-vector topology is missing selected files"
+            );
+        }
+        Ok(())
     }
 
     /// Transform the statistics from the inner physical parquet read plan to the logical
@@ -263,6 +411,16 @@ impl DeltaScanExec {
         }
 
         stats.column_statistics = new_stats;
+        if self.has_deletion_vectors() {
+            // The child statistics describe physical Parquet rows. Sequential DV filtering can
+            // only provide conservative bounds until the DV index carries validated numRecords.
+            stats.num_rows = stats.num_rows.to_inexact();
+            stats.column_statistics = stats
+                .column_statistics
+                .into_iter()
+                .map(ColumnStatistics::to_inexact)
+                .collect();
+        }
         Ok(stats)
     }
 
@@ -314,8 +472,11 @@ impl ExecutionPlan for DeltaScanExec {
     }
 
     fn input_distribution_requirements(&self) -> InputDistributionRequirements {
-        if self.scan_plan.contract.retained_row_index_field().is_some() {
-            // Retained row indexes depend on one stream seeing each file's rows.
+        if self.scan_plan.contract.retained_row_index_field().is_some()
+            || self.has_deletion_vectors()
+        {
+            // Retained row indexes and sequential deletion-vector masks depend on one stream
+            // seeing each file's rows in physical order.
             InputDistributionRequirements::new(vec![Distribution::SinglePartition])
         } else {
             InputDistributionRequirements::new(vec![Distribution::UnspecifiedDistribution])
@@ -336,6 +497,9 @@ impl ExecutionPlan for DeltaScanExec {
             return plan_err!("DeltaScan: wrong number of children {}", children.len());
         }
         let input = children.remove(0);
+        if self.has_deletion_vectors() {
+            self.validate_dv_child_topology(&input)?;
+        }
         match options.children_properties {
             ChildrenPropertiesMode::Keep => {
                 Ok(Arc::new(self.with_new_input_same_properties(input)))
@@ -359,9 +523,11 @@ impl ExecutionPlan for DeltaScanExec {
         target_partitions: usize,
         config: &ConfigOptions,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
-        if self.scan_plan.contract.retained_row_index_field().is_some() {
-            // Each DeltaScanStream keeps row ordinal counters for one execution partition.
-            // Repartitioning can split one file across streams and break ordinal contiguity.
+        if self.scan_plan.contract.retained_row_index_field().is_some()
+            || self.has_deletion_vectors()
+        {
+            // Each DeltaScanStream keeps row ordinal counters and sequential DV cursors for one
+            // execution partition. Repartitioning can split one file across streams.
             return Ok(None);
         }
 
@@ -379,14 +545,33 @@ impl ExecutionPlan for DeltaScanExec {
     ) -> Result<SendableRecordBatchStream> {
         // Normal planning enforces this through EnforceDistribution. Keep this check for
         // callers that build DeltaScanExec directly or replace its child plan.
-        if self.scan_plan.contract.retained_row_index_field().is_some() {
+        let retains_row_index = self.scan_plan.contract.retained_row_index_field().is_some();
+        if self.has_deletion_vectors() {
+            self.validate_dv_child_topology(&self.input)?;
+        }
+        if retains_row_index || self.has_deletion_vectors() {
             let input_partition_count = self.input.properties().partitioning.partition_count();
             if input_partition_count > 1 {
+                if retains_row_index {
+                    return plan_err!(
+                        "DeltaScanExec retained row indexes require a single input partition, got {input_partition_count}"
+                    );
+                }
                 return plan_err!(
-                    "DeltaScanExec retained row indexes require a single input partition, got {input_partition_count}"
+                    "DeltaScanExec sequential deletion vectors require a single input partition, got {input_partition_count}"
                 );
             }
         }
+
+        let dv_file_ids = self
+            .selection_vectors
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect();
+        let dv_rows_checked =
+            MetricBuilder::new(&self.metrics).counter("dv_rows_checked", partition);
+        let dv_rows_removed =
+            MetricBuilder::new(&self.metrics).counter("dv_rows_removed", partition);
 
         Ok(Box::pin(DeltaScanStream {
             scan_plan: Arc::clone(&self.scan_plan),
@@ -394,7 +579,12 @@ impl ExecutionPlan for DeltaScanExec {
             input: self.input.execute(partition, context)?,
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
             transforms: Arc::clone(&self.transforms),
-            selection_vectors: Arc::clone(&self.selection_vectors),
+            // Sequential cursors are execution-local. Reusing the physical plan must start each
+            // stream from the original immutable planning snapshot.
+            selection_vectors: self.selection_vectors.as_ref().clone(),
+            dv_file_ids,
+            dv_rows_checked,
+            dv_rows_removed,
             public_file_ids: Arc::clone(&self.public_file_ids),
             input_file_id_column: self.input_file_id_column.clone(),
             file_id_column: self.file_id_column.clone(),
@@ -412,18 +602,27 @@ impl ExecutionPlan for DeltaScanExec {
     }
 
     fn supports_limit_pushdown(&self) -> bool {
-        self.input.supports_limit_pushdown()
+        !self.has_deletion_vectors() && self.input.supports_limit_pushdown()
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
-        CardinalityEffect::Equal
+        if self.has_deletion_vectors() {
+            CardinalityEffect::LowerEqual
+        } else {
+            CardinalityEffect::Equal
+        }
     }
 
     fn fetch(&self) -> Option<usize> {
-        self.input.fetch()
+        (!self.has_deletion_vectors())
+            .then(|| self.input.fetch())
+            .flatten()
     }
 
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        if self.has_deletion_vectors() {
+            return None;
+        }
         let new_input = self.input.with_fetch(limit)?;
         Some(Arc::new(self.with_new_input_same_properties(new_input)))
     }
@@ -451,6 +650,13 @@ impl ExecutionPlan for DeltaScanExec {
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
         _config: &ConfigOptions,
     ) -> Result<FilterDescription> {
+        if self.has_deletion_vectors() {
+            return Ok(FilterDescription::all_unsupported(
+                &parent_filters,
+                &self.children(),
+            ));
+        }
+
         // Parent filters are bound against the logical output schema. For column mapped tables
         // the child parquet schema uses physical column names, so pushing the parent filter
         // through this exec again can rewrite it against the wrong child field. Provider level
@@ -533,7 +739,11 @@ struct DeltaScanStream {
     /// Transforms to be applied to data read from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Selection vectors to be applied to data read from individual files
-    selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+    selection_vectors: DashMap<String, Vec<bool>>,
+    /// Files that had a DV at planning time; unlike the mutable sequential cursors this is stable.
+    dv_file_ids: HashSet<String>,
+    dv_rows_checked: Count,
+    dv_rows_removed: Count,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
     /// File id column name carried by the input batches for per file correlation.
@@ -579,6 +789,8 @@ impl DeltaScanStream {
         file_id: String,
         file_id_idx: usize,
     ) -> Result<RecordBatch> {
+        let input_row_count = batch.num_rows();
+        let has_deletion_vector = self.dv_file_ids.contains(&file_id);
         let dv_result = if let Some(mut selection_vector) = self.selection_vectors.get_mut(&file_id)
         {
             consume_dv_mask(&mut selection_vector, batch.num_rows())
@@ -598,6 +810,11 @@ impl DeltaScanStream {
         } else {
             batch
         };
+        if has_deletion_vector {
+            self.dv_rows_checked.add(input_row_count);
+            self.dv_rows_removed
+                .add(input_row_count.saturating_sub(batch.num_rows()));
+        }
 
         batch.remove_column(file_id_idx);
 
@@ -846,13 +1063,21 @@ mod tests {
         },
         physical_expr::{Distribution, Partitioning},
         physical_plan::{
-            PhysicalExpr, collect, collect_partitioned,
+            PhysicalExpr,
+            coalesce_partitions::CoalescePartitionsExec,
+            collect, collect_partitioned, displayable,
             filter_pushdown::{FilterPushdownPhase, PushedDown},
             repartition::RepartitionExec,
             statistics::StatisticsContext,
         },
         prelude::{col, lit},
         scalar::ScalarValue,
+    };
+    use datafusion_datasource::{
+        FileRange,
+        file_groups::FileGroup,
+        file_scan_config::{FileScanConfig, FileScanConfigBuilder},
+        source::DataSourceExec,
     };
 
     use super::*;
@@ -1224,6 +1449,41 @@ mod tests {
         assert_eq!(child_filters.len(), 1);
         assert_eq!(child_filters[0].len(), 1);
         assert!(matches!(child_filters[0][0].discriminant, PushedDown::Yes));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_gather_filters_for_pushdown_rejects_dv_data_filters() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        assert!(
+            !exec.selection_vectors.is_empty(),
+            "fixture must select at least one deletion vector"
+        );
+        let int_idx = exec.schema().index_of("int")?;
+        let int: Arc<dyn PhysicalExpr> = Arc::new(Column::new("int", int_idx));
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![int],
+            physical_lit(true),
+        ));
+
+        let description = exec.gather_filters_for_pushdown(
+            FilterPushdownPhase::Post,
+            vec![filter],
+            session.state().config().options(),
+        )?;
+
+        let child_filters = description.parent_filters();
+        assert_eq!(child_filters.len(), 1);
+        assert_eq!(child_filters[0].len(), 1);
+        assert!(matches!(child_filters[0][0].discriminant, PushedDown::No));
 
         Ok(())
     }
@@ -1658,6 +1918,234 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_dv_scan_disables_limit_and_fetch_pushdown() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], Some(1)).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        assert!(!exec.selection_vectors.is_empty());
+        assert!(!exec.supports_limit_pushdown());
+        assert!(matches!(
+            exec.cardinality_effect(),
+            CardinalityEffect::LowerEqual
+        ));
+        assert_eq!(exec.fetch(), None);
+        assert!(exec.with_fetch(Some(1)).is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_requires_single_input_partition() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        let distribution = exec.input_distribution_requirements();
+        assert!(matches!(
+            distribution.child_distribution(0),
+            Some(Distribution::SinglePartition)
+        ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_locks_whole_file_layout() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+        let source_exec = exec
+            .input
+            .downcast_ref::<DataSourceExec>()
+            .expect("single-store fixture should produce a DataSourceExec");
+        let config = source_exec
+            .data_source()
+            .downcast_ref::<FileScanConfig>()
+            .expect("expected parquet FileScanConfig");
+
+        assert!(matches!(
+            config.output_partitioning,
+            Some(Partitioning::UnknownPartitioning(partitions))
+                if partitions == config.file_groups.len()
+        ));
+        assert!(
+            config
+                .file_groups
+                .iter()
+                .all(|group| { group.iter().all(|file| file.range.is_none()) })
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_rejects_ranged_fragments_under_single_output_coalesce() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+        let source_exec = exec
+            .input
+            .downcast_ref::<DataSourceExec>()
+            .expect("single-store fixture should produce a DataSourceExec");
+        let config = source_exec
+            .data_source()
+            .downcast_ref::<FileScanConfig>()
+            .expect("expected parquet FileScanConfig");
+
+        let whole_file = config.file_groups[0][0].clone();
+        let split_at = i64::try_from(whole_file.object_meta.size / 2)?;
+        let file_end = i64::try_from(whole_file.object_meta.size)?;
+        let mut first = whole_file.clone();
+        first.range = Some(FileRange {
+            start: 0,
+            end: split_at,
+        });
+        let mut second = whole_file;
+        second.range = Some(FileRange {
+            start: split_at,
+            end: file_end,
+        });
+        let fragmented_config = FileScanConfigBuilder::from(config.clone())
+            .with_file_groups(vec![
+                FileGroup::new(vec![first]),
+                FileGroup::new(vec![second]),
+            ])
+            .with_output_partitioning(Some(Partitioning::UnknownPartitioning(2)))
+            .build();
+        let fragmented = DataSourceExec::from_data_source(fragmented_config);
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(fragmented));
+
+        let result = Arc::new(exec.clone()).replace_children(
+            vec![coalesced],
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        );
+        assert!(
+            result.is_err(),
+            "single-output coalescing must not hide ranged DV file fragments"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_applies_limit_after_deleted_rows() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], Some(1)).await?;
+
+        let batches = collect(scan, session.task_ctx()).await?;
+        let row_count = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
+        assert_eq!(row_count, 1, "one live row exists after four deleted rows");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_downgrades_physical_statistics() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let predicates = provider
+            .schema()
+            .fields()
+            .iter()
+            .map(|field| col(field.name()).is_not_null())
+            .collect::<Vec<_>>();
+        let scan = provider
+            .scan(&session.state(), None, &predicates, None)
+            .await?;
+
+        let statistics = StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
+        assert!(
+            !matches!(statistics.num_rows, Precision::Exact(_)),
+            "physical row count is not an exact live-row count"
+        );
+        for column in &statistics.column_statistics {
+            assert!(!matches!(column.null_count, Precision::Exact(_)));
+            assert!(!matches!(column.min_value, Precision::Exact(_)));
+            assert!(!matches!(column.max_value, Precision::Exact(_)));
+            assert!(!matches!(column.distinct_count, Precision::Exact(_)));
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_explain_reports_containment_mode() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+
+        let explain = displayable(scan.as_ref()).indent(false).to_string();
+        assert!(explain.contains("dv_mode=sequential"), "{explain}");
+        assert!(explain.contains("physical_row_index=false"), "{explain}");
+        assert!(
+            explain.contains("file_group_layout_locked=true"),
+            "{explain}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_sequential_dv_plan_is_repeatable() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+
+        let first = collect(Arc::clone(&scan), session.task_ctx()).await?;
+        let second = collect(scan, session.task_ctx()).await?;
+        let first_rows = first.iter().map(RecordBatch::num_rows).sum::<usize>();
+        let second_rows = second.iter().map(RecordBatch::num_rows).sum::<usize>();
+        assert_eq!(first_rows, 1);
+        assert_eq!(second_rows, first_rows);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_reports_file_and_row_metrics() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+
+        collect(Arc::clone(&scan), session.task_ctx()).await?;
+        let metrics = scan.metrics().expect("DeltaScanExec metrics");
+        assert_eq!(metrics.sum_by_name("dv_files").unwrap().as_usize(), 1);
+        assert_eq!(
+            metrics.sum_by_name("dv_rows_checked").unwrap().as_usize(),
+            5
+        );
+        assert_eq!(
+            metrics.sum_by_name("dv_rows_removed").unwrap().as_usize(),
+            4
+        );
+
+        Ok(())
+    }
+
     // DV test helpers
     const DV_TABLE_PATH: &str = "../../dat/v0.0.3/reader_tests/generated/deletion_vectors/delta";
 
@@ -1806,7 +2294,13 @@ mod tests {
             input,
             baseline_metrics: BaselineMetrics::new(&ExecutionPlanMetricsSet::new(), 0),
             transforms: Arc::new(HashMap::new()),
-            selection_vectors,
+            selection_vectors: selection_vectors.as_ref().clone(),
+            dv_file_ids: selection_vectors
+                .iter()
+                .map(|entry| entry.key().clone())
+                .collect(),
+            dv_rows_checked: Count::new(),
+            dv_rows_removed: Count::new(),
             public_file_ids: Arc::new(public_file_ids),
             input_file_id_column,
             file_id_column,
@@ -1864,6 +2358,7 @@ mod tests {
             Arc::clone(&exec.transforms),
             Arc::clone(&exec.selection_vectors),
             Arc::clone(&exec.public_file_ids),
+            Arc::clone(&exec.physical_file_identities),
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -1902,6 +2397,7 @@ mod tests {
             Arc::clone(&exec.transforms),
             Arc::clone(&exec.selection_vectors),
             Arc::clone(&exec.public_file_ids),
+            Arc::clone(&exec.physical_file_identities),
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -1939,6 +2435,7 @@ mod tests {
             Arc::new(HashMap::new()),
             Arc::new(DashMap::new()),
             Arc::new(public_file_ids),
+            Arc::new(super::super::PhysicalFileIdentityMap::default()),
             HashMap::new(),
             ExecutionPlanMetricsSet::new(),
         );

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -27,7 +27,6 @@ use arrow_array::{
 use arrow_cast::{CastOptions, cast_with_options};
 use arrow_schema::{DataType, FieldRef, Schema, SchemaBuilder, SchemaRef};
 use chrono::{TimeZone as _, Utc};
-use dashmap::DashMap;
 use datafusion::{
     catalog::Session,
     common::{
@@ -65,6 +64,7 @@ use tracing::debug;
 use url::Url;
 
 pub use self::exec::DeltaScanExec;
+use self::exec::DvExecutionState;
 use self::exec_meta::DeltaScanMetaExec;
 use self::expr_adapter::{DeltaPhysicalExprAdapterFactory, relax_schema_nested_nullability};
 pub(crate) use self::plan::{KernelScanPlan, ProjectedScanContract, supports_filters_pushdown};
@@ -89,10 +89,10 @@ mod replay;
 
 type ScanMetadataStream = Pin<Box<dyn Stream<Item = Result<ScanMetadata, DeltaTableError>> + Send>>;
 type PublicFileIdMap = HashMap<String, String>;
-pub(crate) type PhysicalFileIdentityMap = HashMap<String, PhysicalFileIdentity>;
+type PhysicalFileIdentityMap = HashMap<String, PhysicalFileIdentity>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct PhysicalFileIdentity {
+struct PhysicalFileIdentity {
     object_store_url: ObjectStoreUrl,
     location: Path,
 }
@@ -100,7 +100,7 @@ pub(crate) struct PhysicalFileIdentity {
 struct ReplayedScanFiles {
     files: Vec<ScanFileContext>,
     transforms: HashMap<String, Arc<Expression>>,
-    dvs: DashMap<String, Vec<bool>>,
+    dvs: HashMap<String, Vec<bool>>,
     public_file_ids: PublicFileIdMap,
     metrics: ExecutionPlanMetricsSet,
 }
@@ -160,7 +160,7 @@ pub(super) async fn execution_plan(
                 Arc::new(scan_plan),
                 vec![file_rows],
                 Arc::new(transforms),
-                Arc::new(dvs),
+                Arc::new(dvs.into_iter().collect()),
                 Arc::new(public_file_ids),
                 retain_file_id.then_some(file_id_field),
                 metrics,
@@ -202,7 +202,7 @@ pub(super) async fn replay_deletion_vectors(
     let dv_stream = stream.dv_stream.build();
     // Only files with `dv_info.has_vector()` spawn tasks, so every item should carry a DV.
     // Guard with a typed error (instead of panic) in case that invariant drifts.
-    let dvs: DashMap<_, _> = dv_stream
+    let dvs: HashMap<_, _> = dv_stream
         .and_then(|(url, dv, num_records)| {
             ready(match dv {
                 Some(keep_mask) => normalize_dv_keep_mask_for_api(keep_mask, num_records, &url)
@@ -421,19 +421,27 @@ async fn get_data_scan_plan(
     let has_deletion_vectors = !dvs.is_empty();
     let mut partition_stats = HashMap::new();
 
-    let physical_file_identities = files
-        .iter()
-        .enumerate()
-        .map(|(file_index, file)| {
-            Ok((
-                compact_internal_file_id(file_index),
-                PhysicalFileIdentity {
-                    object_store_url: file.file_url.as_object_store_url(),
-                    location: Path::from_url_path(file.file_url.path())?,
-                },
-            ))
-        })
-        .try_collect::<_, PhysicalFileIdentityMap, DataFusionError>()?;
+    let dv_state = if has_deletion_vectors {
+        let physical_file_identities = files
+            .iter()
+            .enumerate()
+            .map(|(file_index, file)| {
+                Ok((
+                    compact_internal_file_id(file_index),
+                    PhysicalFileIdentity {
+                        object_store_url: file.file_url.as_object_store_url(),
+                        location: Path::from_url_path(file.file_url.path())?,
+                    },
+                ))
+            })
+            .try_collect::<_, PhysicalFileIdentityMap, DataFusionError>()?;
+        DvExecutionState::Sequential {
+            selection_vectors: Arc::new(dvs),
+            physical_file_identities: Arc::new(physical_file_identities),
+        }
+    } else {
+        DvExecutionState::None
+    };
 
     // Convert files into DataFusion `PartitionedFile`s grouped by object store.
     // Create one `DataSourceExec` plan for each store.
@@ -459,10 +467,7 @@ async fn get_data_scan_plan(
         // on `partition_values`, so partition values must be set first.
         partitioned_file.partition_values = vec![file_value.clone()];
         partitioned_file = partitioned_file.with_statistics(Arc::new(f.stats));
-        Ok::<_, DataFusionError>((
-            f.file_url.as_object_store_url(),
-            (partitioned_file, None::<Vec<bool>>),
-        ))
+        Ok::<_, DataFusionError>((f.file_url.as_object_store_url(), partitioned_file))
     };
 
     // Group the files by their object store url. Since datafusion assumes that all files in a
@@ -473,41 +478,40 @@ async fn get_data_scan_plan(
         .map(to_partitioned_file)
         .try_collect::<_, Vec<_>, _>()?;
 
-    let files_by_store = partitioned_files.into_iter().into_group_map();
+    let files_by_store = partitioned_files
+        .into_iter()
+        .into_group_map()
+        .into_iter()
+        .map(|(store, files)| (store, files, has_deletion_vectors));
 
     // TODO(roeap); not sure exactly how row tracking is implemented in kernel right now
     // so leaving predicate as None for now until we are sure this is safe to do.
     let table_config = scan_plan.table_configuration();
-    let predicate =
-        if table_config.is_feature_enabled(&TableFeature::RowTracking) || has_deletion_vectors {
-            None
-        } else {
-            scan_plan.parquet_predicate.as_ref()
-        };
-    let parquet_limit = if has_deletion_vectors { None } else { limit };
+    let predicate = if table_config.is_feature_enabled(&TableFeature::RowTracking) {
+        None
+    } else {
+        scan_plan.parquet_predicate.as_ref()
+    };
     let file_id_field = scan_plan.contract.file_id_field.clone();
     let pq_plan = get_read_plan(
         session,
         files_by_store,
         &scan_plan.parquet_read_schema,
         &scan_plan.parquet_predicate_schema,
-        parquet_limit,
+        limit,
         &file_id_field,
         predicate,
-        has_deletion_vectors,
     )
     .await?;
 
     let transforms = Arc::new(transforms);
-    let dvs = Arc::new(dvs);
     let public_file_ids = Arc::new(public_file_ids);
     let exec = DeltaScanExec::new(
         Arc::new(scan_plan),
         pq_plan,
         Arc::clone(&transforms),
-        Arc::clone(&dvs),
+        dv_state,
         Arc::clone(&public_file_ids),
-        Arc::new(physical_file_identities),
         partition_stats,
         metrics,
     );
@@ -551,7 +555,7 @@ fn update_partition_stats(
     Ok(())
 }
 
-type FilesByStore = (ObjectStoreUrl, Vec<(PartitionedFile, Option<Vec<bool>>)>);
+type FilesByStore = (ObjectStoreUrl, Vec<PartitionedFile>, bool);
 
 fn compact_internal_file_id(file_index: usize) -> String {
     file_index.to_string()
@@ -560,8 +564,8 @@ fn compact_internal_file_id(file_index: usize) -> String {
 fn remap_deletion_vectors_to_internal_file_ids(
     files: &[ScanFileContext],
     mut dvs_by_url: HashMap<String, Vec<bool>>,
-) -> Result<DashMap<String, Vec<bool>>> {
-    let dvs = DashMap::new();
+) -> Result<HashMap<String, Vec<bool>>> {
+    let mut dvs = HashMap::new();
     for (file_index, file) in files.iter().enumerate() {
         if dvs_by_url.is_empty() {
             break;
@@ -668,13 +672,6 @@ fn partitioned_files_to_file_groups_with_limit(
     file_groups
 }
 
-fn lock_dv_file_group_layout(
-    builder: FileScanConfigBuilder,
-    file_group_count: usize,
-) -> FileScanConfigBuilder {
-    builder.with_output_partitioning(Some(Partitioning::UnknownPartitioning(file_group_count)))
-}
-
 async fn get_read_plan(
     state: &dyn Session,
     files_by_store: impl IntoIterator<Item = FilesByStore>,
@@ -689,7 +686,6 @@ async fn get_read_plan(
     limit: Option<usize>,
     file_id_field: &FieldRef,
     predicate: Option<&Expr>,
-    has_deletion_vectors: bool,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut plans = Vec::new();
 
@@ -711,7 +707,7 @@ async fn get_read_plan(
     let parquet_predicate_df_schema = parquet_predicate_schema.clone().to_dfschema()?;
     let adapter_factory = Arc::new(DeltaPhysicalExprAdapterFactory);
 
-    for (store_url, files) in files_by_store.into_iter() {
+    for (store_url, files, has_deletion_vectors) in files_by_store.into_iter() {
         let reader_factory = Arc::new(CachedParquetFileReaderFactory::new(
             state.runtime_env().object_store(&store_url)?,
             state.runtime_env().cache_manager.get_file_metadata_cache(),
@@ -771,7 +767,7 @@ async fn get_read_plan(
             }
         }
 
-        let file_groups = partitioned_files_to_file_groups(files.into_iter().map(|file| file.0));
+        let file_groups = partitioned_files_to_file_groups(files);
         let (file_groups, statistics) =
             compute_all_files_statistics(file_groups, full_table_schema, true, false)?;
 
@@ -782,7 +778,8 @@ async fn get_read_plan(
             .with_limit(if has_deletion_vectors { None } else { limit })
             .with_expr_adapter(Some(adapter_factory.clone() as _));
         let builder = if has_deletion_vectors {
-            lock_dv_file_group_layout(builder, file_group_count)
+            builder
+                .with_output_partitioning(Some(Partitioning::UnknownPartitioning(file_group_count)))
         } else {
             builder
         };
@@ -1407,10 +1404,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_data.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -1425,7 +1419,6 @@ mod tests {
             None,
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1449,7 +1442,6 @@ mod tests {
             Some(1),
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1478,7 +1470,6 @@ mod tests {
             Some(1),
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1538,10 +1529,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_data.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -1556,7 +1544,6 @@ mod tests {
             None,
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1595,7 +1582,6 @@ mod tests {
             None,
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1766,14 +1752,8 @@ mod tests {
             .push(wrap_file_id_value("second:///test_data.parquet"));
 
         let files_by_store = vec![
-            (
-                store_url_1.as_object_store_url(),
-                vec![(file_1, None::<Vec<bool>>)],
-            ),
-            (
-                store_url_2.as_object_store_url(),
-                vec![(file_2, None::<Vec<bool>>)],
-            ),
+            (store_url_1.as_object_store_url(), vec![file_1], false),
+            (store_url_2.as_object_store_url(), vec![file_2], false),
         ];
 
         let file_id_field =
@@ -1789,7 +1769,6 @@ mod tests {
             None,
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1838,10 +1817,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_data.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -1857,7 +1833,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1905,10 +1880,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_rewrite_failure.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -1924,7 +1896,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1985,10 +1956,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_view_literal.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -2004,7 +1972,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2062,10 +2029,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_sql_literal.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -2081,7 +2045,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2140,10 +2103,7 @@ mod tests {
             "memory:///test_column_mapping_pushdown.parquet",
         ));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -2159,7 +2119,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2230,10 +2189,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_binary_view.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -2249,7 +2205,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -38,6 +38,7 @@ use datafusion::{
     datasource::physical_plan::{ParquetSource, parquet::CachedParquetFileReaderFactory},
     error::DataFusionError,
     execution::object_store::ObjectStoreUrl,
+    physical_expr::Partitioning,
     physical_plan::{
         ExecutionPlan,
         empty::EmptyExec,
@@ -88,6 +89,13 @@ mod replay;
 
 type ScanMetadataStream = Pin<Box<dyn Stream<Item = Result<ScanMetadata, DeltaTableError>> + Send>>;
 type PublicFileIdMap = HashMap<String, String>;
+pub(crate) type PhysicalFileIdentityMap = HashMap<String, PhysicalFileIdentity>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PhysicalFileIdentity {
+    object_store_url: ObjectStoreUrl,
+    location: Path,
+}
 
 struct ReplayedScanFiles {
     files: Vec<ScanFileContext>,
@@ -410,7 +418,22 @@ async fn get_data_scan_plan(
         public_file_ids,
         metrics,
     } = replayed;
+    let has_deletion_vectors = !dvs.is_empty();
     let mut partition_stats = HashMap::new();
+
+    let physical_file_identities = files
+        .iter()
+        .enumerate()
+        .map(|(file_index, file)| {
+            Ok((
+                compact_internal_file_id(file_index),
+                PhysicalFileIdentity {
+                    object_store_url: file.file_url.as_object_store_url(),
+                    location: Path::from_url_path(file.file_url.path())?,
+                },
+            ))
+        })
+        .try_collect::<_, PhysicalFileIdentityMap, DataFusionError>()?;
 
     // Convert files into DataFusion `PartitionedFile`s grouped by object store.
     // Create one `DataSourceExec` plan for each store.
@@ -455,20 +478,23 @@ async fn get_data_scan_plan(
     // TODO(roeap); not sure exactly how row tracking is implemented in kernel right now
     // so leaving predicate as None for now until we are sure this is safe to do.
     let table_config = scan_plan.table_configuration();
-    let predicate = if table_config.is_feature_enabled(&TableFeature::RowTracking) {
-        None
-    } else {
-        scan_plan.parquet_predicate.as_ref()
-    };
+    let predicate =
+        if table_config.is_feature_enabled(&TableFeature::RowTracking) || has_deletion_vectors {
+            None
+        } else {
+            scan_plan.parquet_predicate.as_ref()
+        };
+    let parquet_limit = if has_deletion_vectors { None } else { limit };
     let file_id_field = scan_plan.contract.file_id_field.clone();
     let pq_plan = get_read_plan(
         session,
         files_by_store,
         &scan_plan.parquet_read_schema,
         &scan_plan.parquet_predicate_schema,
-        limit,
+        parquet_limit,
         &file_id_field,
         predicate,
+        has_deletion_vectors,
     )
     .await?;
 
@@ -481,6 +507,7 @@ async fn get_data_scan_plan(
         Arc::clone(&transforms),
         Arc::clone(&dvs),
         Arc::clone(&public_file_ids),
+        Arc::new(physical_file_identities),
         partition_stats,
         metrics,
     );
@@ -641,6 +668,13 @@ fn partitioned_files_to_file_groups_with_limit(
     file_groups
 }
 
+fn lock_dv_file_group_layout(
+    builder: FileScanConfigBuilder,
+    file_group_count: usize,
+) -> FileScanConfigBuilder {
+    builder.with_output_partitioning(Some(Partitioning::UnknownPartitioning(file_group_count)))
+}
+
 async fn get_read_plan(
     state: &dyn Session,
     files_by_store: impl IntoIterator<Item = FilesByStore>,
@@ -655,6 +689,7 @@ async fn get_read_plan(
     limit: Option<usize>,
     file_id_field: &FieldRef,
     predicate: Option<&Expr>,
+    has_deletion_vectors: bool,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut plans = Vec::new();
 
@@ -696,8 +731,7 @@ async fn get_read_plan(
         // TODO(roeap); we might be able to also push selection vectors into the read plan
         // by creating parquet access plans. However we need to make sure this does not
         // interfere with other delta features like row ids.
-        let has_selection_vectors = files.iter().any(|(_, sv)| sv.is_some());
-        if !has_selection_vectors && let Some(pred) = predicate {
+        if !has_deletion_vectors && let Some(pred) = predicate {
             match state.create_physical_expr(pred.clone(), &parquet_predicate_df_schema) {
                 Ok(physical) => match adapter_factory
                     .create(parquet_predicate_schema.clone(), full_read_schema.clone())
@@ -741,12 +775,18 @@ async fn get_read_plan(
         let (file_groups, statistics) =
             compute_all_files_statistics(file_groups, full_table_schema, true, false)?;
 
-        let config = FileScanConfigBuilder::new(store_url, Arc::new(file_source))
+        let file_group_count = file_groups.len();
+        let builder = FileScanConfigBuilder::new(store_url, Arc::new(file_source))
             .with_file_groups(file_groups)
             .with_statistics(statistics)
-            .with_limit(limit)
-            .with_expr_adapter(Some(adapter_factory.clone() as _))
-            .build();
+            .with_limit(if has_deletion_vectors { None } else { limit })
+            .with_expr_adapter(Some(adapter_factory.clone() as _));
+        let builder = if has_deletion_vectors {
+            lock_dv_file_group_layout(builder, file_group_count)
+        } else {
+            builder
+        };
+        let config = builder.build();
 
         plans.push(DataSourceExec::from_data_source(config) as Arc<dyn ExecutionPlan>);
     }
@@ -1385,6 +1425,7 @@ mod tests {
             None,
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1408,6 +1449,7 @@ mod tests {
             Some(1),
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1436,6 +1478,7 @@ mod tests {
             Some(1),
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1513,6 +1556,7 @@ mod tests {
             None,
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1551,6 +1595,7 @@ mod tests {
             None,
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1744,6 +1789,7 @@ mod tests {
             None,
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1811,6 +1857,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1877,6 +1924,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1956,6 +2004,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2032,6 +2081,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2109,6 +2159,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2198,6 +2249,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -27,6 +27,7 @@ use arrow_array::{
 use arrow_cast::{CastOptions, cast_with_options};
 use arrow_schema::{DataType, FieldRef, Schema, SchemaBuilder, SchemaRef};
 use chrono::{TimeZone as _, Utc};
+use dashmap::DashMap;
 use datafusion::{
     catalog::Session,
     common::{
@@ -172,17 +173,11 @@ pub(super) async fn execution_plan(
     get_data_scan_plan(session, scan_plan, replayed, limit).await
 }
 
-/// Materialize deletion vector keep masks for every file in the scan that has one.
+/// Load deletion-vector keep masks for the selected files.
 ///
-/// Deletion vectors are loaded as a side-effect of consuming [`ScanFileStream`].  We drain the
-/// full stream here (discarding file contexts, stats, and partition values) because the DV
-/// loading tasks are spawned lazily during stream poll.  A dedicated DV-only stream that skips
-/// stats parsing is possible but not yet warranted — this path is not latency-sensitive and the
-/// file-list is typically small.
-///
-/// [`ReceiverStreamBuilder::build`] returns a merged stream that includes a JoinSet checker;
-/// `.try_collect().await` below will not complete until every spawned DV-loading task has
-/// finished, so no results are lost.
+/// Drain [`ScanFileStream`] to start the DV loading tasks, then collect their
+/// results through [`ReceiverStreamBuilder::build`]. A successful collection
+/// waits for all DV tasks to finish.
 pub(super) async fn replay_deletion_vectors(
     engine: Arc<dyn Engine>,
     scan_plan: &KernelScanPlan,
@@ -200,9 +195,8 @@ pub(super) async fn replay_deletion_vectors(
     while stream.try_next().await?.is_some() {}
 
     let dv_stream = stream.dv_stream.build();
-    // Only files with `dv_info.has_vector()` spawn tasks, so every item should carry a DV.
-    // Guard with a typed error (instead of panic) in case that invariant drifts.
-    let dvs: HashMap<_, _> = dv_stream
+    // A DV task must return a keep mask.
+    let dvs: DashMap<_, _> = dv_stream
         .and_then(|(url, dv, num_records)| {
             ready(match dv {
                 Some(keep_mask) => normalize_dv_keep_mask_for_api(keep_mask, num_records, &url)
@@ -440,7 +434,7 @@ async fn get_data_scan_plan(
             physical_file_identities: Arc::new(physical_file_identities),
         }
     } else {
-        DvExecutionState::None
+        DvExecutionState::NotPresent
     };
 
     // Convert files into DataFusion `PartitionedFile`s grouped by object store.


### PR DESCRIPTION
# Description

`DeltaScanExec` consumes deletion vectors as per file keep masks in physical Parquet row order. DataFusion could filter, limit, split, or replace the child scan before mask application. Those rewrites could apply mask entries to the wrong rows.

This PR blocks predicate, limit, fetch, and repartition pushdown for scans with deletion vectors. It locks scans to whole file groups and requires a single input partition.

`DeltaScanExec` now validates child rewrites against the planned file identities. It rejects filtered or fetched sources, byte-ranged files, unsupported nodes, and missing, duplicate, or remapped files. Each execution stream receives its own mask copy, which keeps repeated and concurrent executions independent.

Deletion vector scans also report conservative cardinality and statistics because the Parquet child describes physical rows before deletion vector filtering.