### PR TITLE
feat(core): allow compact on clustered tables

### DIFF
--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -945,6 +945,11 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                         read_snapshot
                             .update(&this.log_store, Some(latest_version))
                             .await?;
+                        PROTOCOL.can_commit(
+                            &read_snapshot,
+                            &this.data.actions,
+                            &this.data.operation,
+                        )?;
                     }
                     let version: Version = latest_version + 1;
                     Span::current().record("target_version", version);
@@ -1227,7 +1232,8 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::kernel::IsolationLevel;
+    use crate::DeltaTable;
+    use crate::kernel::{DataType, IsolationLevel, ProtocolExt as _, StructField};
     use crate::logstore::{LogStore, StorageConfig, default_logstore::DefaultLogStore};
     use crate::protocol::SaveMode;
     use object_store::{PutPayload, memory::InMemory};
@@ -1265,6 +1271,60 @@ mod tests {
             )
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_retry_rejects_concurrent_protocol_change() {
+        let table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([StructField::new("id", DataType::INTEGER, true)])
+            .await
+            .unwrap();
+        let log_store = table.log_store();
+        let snapshot = table.snapshot().unwrap().snapshot();
+        let prepared = CommitBuilder::default()
+            .build(
+                Some(snapshot),
+                log_store.clone(),
+                DeltaOperation::Optimize {
+                    target_size: 1024,
+                    predicate: None,
+                },
+            )
+            .into_prepared_commit_future()
+            .await
+            .unwrap();
+
+        let concurrent = CommitData::new(
+            vec![Action::Protocol(
+                snapshot.protocol().clone().append_writer_features(&[
+                    TableFeature::DomainMetadata,
+                    TableFeature::ClusteredTable,
+                ]),
+            )],
+            DeltaOperation::FileSystemCheck {},
+            HashMap::new(),
+            vec![],
+        )
+        .get_bytes()
+        .unwrap();
+        log_store
+            .write_commit_entry(
+                snapshot.version() + 1,
+                CommitOrBytes::LogBytes(concurrent),
+                Uuid::new_v4(),
+            )
+            .await
+            .unwrap();
+
+        let error = match prepared.await {
+            Ok(_) => panic!("concurrent protocol change must reject the retry"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("ClusteredTable"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -89,6 +89,7 @@ use serde_json::Value;
 use tracing::*;
 use uuid::Uuid;
 
+use delta_kernel::expressions::ColumnName;
 use delta_kernel::table_features::TableFeature;
 use serde::{Deserialize, Serialize};
 
@@ -98,7 +99,7 @@ use crate::kernel::{
     Action, CommitInfo, EagerSnapshot, IsolationLevel, Metadata, Protocol, Transaction, Version,
 };
 use crate::logstore::ObjectStoreRef;
-use crate::logstore::{CommitOrBytes, LogStoreRef};
+use crate::logstore::{CommitOrBytes, LogStore, LogStoreRef};
 use crate::operations::CustomExecuteHandler;
 use crate::protocol::{DeltaOperation, operation_parameter_value};
 use crate::protocol::{cleanup_expired_logs_for, create_checkpoint_for};
@@ -118,6 +119,35 @@ mod state;
 
 const DELTA_LOG_FOLDER: &str = "_delta_log";
 pub(crate) const DEFAULT_RETRIES: usize = 15;
+
+fn validate_commit_protocol(
+    table: &dyn TableReference,
+    data: &CommitData,
+    clustered_compaction: bool,
+) -> Result<(), TransactionError> {
+    if clustered_compaction {
+        PROTOCOL.can_commit_clustered_compaction(table, &data.actions, &data.operation)
+    } else {
+        PROTOCOL.can_commit(table, &data.actions, &data.operation)
+    }
+}
+
+fn validate_clustered_compaction_state(
+    table: &dyn TableReference,
+    log_store: &dyn LogStore,
+    expected_columns: &[ColumnName],
+) -> DeltaResult<()> {
+    let engine = log_store.engine(None);
+    let current_columns = table
+        .eager_snapshot()
+        .snapshot()
+        .inner
+        .get_physical_clustering_columns(engine.as_ref())?;
+    if current_columns.as_deref() != Some(expected_columns) {
+        return Err(TransactionError::CommitConflict(CommitConflictError::MetadataChanged).into());
+    }
+    Ok(())
+}
 // These keys map to typed CommitInfo fields used by common Spark compatible writers. They are not
 // required by the protocol, but leaving them in flattened metadata can produce duplicate JSON keys.
 // Keep this list aligned with validate_reserved_commit_metadata in python/src/lib.rs.
@@ -632,6 +662,7 @@ pub struct CommitBuilder {
     post_commit_hook: Option<PostCommitHookProperties>,
     post_commit_hook_handler: Option<Arc<dyn CustomExecuteHandler>>,
     operation_id: Uuid,
+    clustered_compaction_columns: Option<Vec<ColumnName>>,
 }
 
 impl Default for CommitBuilder {
@@ -644,6 +675,7 @@ impl Default for CommitBuilder {
             post_commit_hook: None,
             post_commit_hook_handler: None,
             operation_id: Uuid::new_v4(),
+            clustered_compaction_columns: None,
         }
     }
 }
@@ -679,6 +711,11 @@ impl<'a> CommitBuilder {
         self
     }
 
+    pub(crate) fn with_clustered_compaction(mut self, columns: Vec<ColumnName>) -> Self {
+        self.clustered_compaction_columns = Some(columns);
+        self
+    }
+
     /// Set a custom execute handler, for pre and post execution
     pub fn with_post_commit_hook_handler(
         mut self,
@@ -709,6 +746,7 @@ impl<'a> CommitBuilder {
             post_commit_hook: self.post_commit_hook,
             post_commit_hook_handler: self.post_commit_hook_handler,
             operation_id: self.operation_id,
+            clustered_compaction_columns: self.clustered_compaction_columns,
         }
     }
 }
@@ -722,6 +760,7 @@ pub struct PreCommit<'a> {
     post_commit_hook: Option<PostCommitHookProperties>,
     post_commit_hook_handler: Option<Arc<dyn CustomExecuteHandler>>,
     operation_id: Uuid,
+    clustered_compaction_columns: Option<Vec<ColumnName>>,
 }
 
 impl<'a> std::future::IntoFuture for PreCommit<'a> {
@@ -752,7 +791,18 @@ impl<'a> PreCommit<'a> {
 
         Box::pin(async move {
             if let Some(table_reference) = this.table_data {
-                PROTOCOL.can_commit(table_reference, &this.data.actions, &this.data.operation)?;
+                if let Some(columns) = &this.clustered_compaction_columns {
+                    validate_clustered_compaction_state(
+                        table_reference,
+                        this.log_store.as_ref(),
+                        columns,
+                    )?;
+                }
+                validate_commit_protocol(
+                    table_reference,
+                    &this.data,
+                    this.clustered_compaction_columns.is_some(),
+                )?;
             }
             let log_entry = this.data.get_bytes()?;
 
@@ -779,6 +829,7 @@ impl<'a> PreCommit<'a> {
                 post_commit: this.post_commit_hook,
                 post_commit_hook_handler: this.post_commit_hook_handler,
                 operation_id: this.operation_id,
+                clustered_compaction_columns: this.clustered_compaction_columns,
             })
         })
     }
@@ -794,6 +845,7 @@ pub struct PreparedCommit<'a> {
     post_commit: Option<PostCommitHookProperties>,
     post_commit_hook_handler: Option<Arc<dyn CustomExecuteHandler>>,
     operation_id: Uuid,
+    clustered_compaction_columns: Option<Vec<ColumnName>>,
 }
 
 impl PreparedCommit<'_> {
@@ -945,12 +997,19 @@ impl<'a> std::future::IntoFuture for PreparedCommit<'a> {
                         read_snapshot
                             .update(&this.log_store, Some(latest_version))
                             .await?;
-                        PROTOCOL.can_commit(
+                    }
+                    if let Some(expected) = &this.clustered_compaction_columns {
+                        validate_clustered_compaction_state(
                             &read_snapshot,
-                            &this.data.actions,
-                            &this.data.operation,
+                            this.log_store.as_ref(),
+                            expected,
                         )?;
                     }
+                    validate_commit_protocol(
+                        &read_snapshot,
+                        &this.data,
+                        this.clustered_compaction_columns.is_some(),
+                    )?;
                     let version: Version = latest_version + 1;
                     Span::current().record("target_version", version);
 
@@ -1233,7 +1292,7 @@ mod tests {
 
     use super::*;
     use crate::DeltaTable;
-    use crate::kernel::{DataType, IsolationLevel, ProtocolExt as _, StructField};
+    use crate::kernel::{DataType, DomainMetadata, IsolationLevel, ProtocolExt as _, StructField};
     use crate::logstore::{LogStore, StorageConfig, default_logstore::DefaultLogStore};
     use crate::protocol::SaveMode;
     use object_store::{PutPayload, memory::InMemory};
@@ -1271,6 +1330,82 @@ mod tests {
             )
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_retry_rejects_concurrent_clustering_change() {
+        let mut table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns([
+                StructField::new("id", DataType::INTEGER, true),
+                StructField::new("value", DataType::INTEGER, true),
+            ])
+            .await
+            .unwrap();
+        let log_store = table.log_store();
+        let snapshot = table.snapshot().unwrap().snapshot();
+        let protocol = snapshot
+            .protocol()
+            .clone()
+            .append_writer_features(&[TableFeature::DomainMetadata, TableFeature::ClusteredTable]);
+        crate::writer::flush_and_commit(
+            vec![
+                Action::Protocol(protocol),
+                Action::DomainMetadata(DomainMetadata {
+                    domain: "delta.clustering".to_string(),
+                    configuration: r#"{"clusteringColumns":[["value"]]}"#.to_string(),
+                    removed: false,
+                }),
+            ],
+            &mut table,
+            None,
+        )
+        .await
+        .unwrap();
+        let snapshot = table.snapshot().unwrap().snapshot();
+        let prepared = CommitBuilder::default()
+            .with_clustered_compaction(vec![ColumnName::new(["value"])])
+            .build(
+                Some(snapshot),
+                log_store.clone(),
+                DeltaOperation::Optimize {
+                    target_size: 1024,
+                    predicate: None,
+                },
+            )
+            .into_prepared_commit_future()
+            .await
+            .unwrap();
+
+        let concurrent = CommitData::new(
+            vec![Action::DomainMetadata(DomainMetadata {
+                domain: "delta.clustering".to_string(),
+                configuration: r#"{"clusteringColumns":[["id"]]}"#.to_string(),
+                removed: false,
+            })],
+            DeltaOperation::FileSystemCheck {},
+            HashMap::new(),
+            vec![],
+        )
+        .get_bytes()
+        .unwrap();
+        log_store
+            .write_commit_entry(
+                snapshot.version() + 1,
+                CommitOrBytes::LogBytes(concurrent),
+                Uuid::new_v4(),
+            )
+            .await
+            .unwrap();
+
+        let error = match prepared.await {
+            Ok(_) => panic!("concurrent clustering change must reject the retry"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("Metadata changed"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/kernel/transaction/protocol.rs
+++ b/crates/core/src/kernel/transaction/protocol.rs
@@ -64,6 +64,8 @@ static WRITER_V6: LazyLock<HashSet<TableFeature>> = LazyLock::new(|| {
         TableFeature::IdentityColumns,
     ])
 });
+const CLUSTERED_COMPACTION_FEATURES: &[TableFeature] =
+    &[TableFeature::DomainMetadata, TableFeature::ClusteredTable];
 
 pub struct ProtocolChecker {
     reader_features: HashSet<TableFeature>,
@@ -71,6 +73,16 @@ pub struct ProtocolChecker {
 }
 
 impl ProtocolChecker {
+    fn clustered_compaction_scope_applies(snapshot: &dyn TableReference) -> bool {
+        snapshot
+            .protocol()
+            .writer_features()
+            .is_some_and(|features| {
+                features.contains(&TableFeature::DomainMetadata)
+                    && features.contains(&TableFeature::ClusteredTable)
+            })
+    }
+
     /// Create a new protocol checker.
     pub fn new(
         reader_features: HashSet<TableFeature>,
@@ -220,6 +232,14 @@ impl ProtocolChecker {
 
     /// Check if delta-rs can write to the given delta table.
     pub fn can_write_to(&self, snapshot: &dyn TableReference) -> Result<(), TransactionError> {
+        self.can_write_to_with_additional_writer_features(snapshot, &[])
+    }
+
+    fn can_write_to_with_additional_writer_features(
+        &self,
+        snapshot: &dyn TableReference,
+        additional_writer_features: &[TableFeature],
+    ) -> Result<(), TransactionError> {
         // NOTE: writers must always support all required reader features
         self.can_read_from(snapshot)?;
         let min_writer_version = snapshot.protocol().min_writer_version();
@@ -238,14 +258,32 @@ impl ProtocolChecker {
         trace!("required writer features: {required_features:?}");
 
         if let Some(features) = required_features {
-            let mut diff = features.difference(&self.writer_features).peekable();
-            if diff.peek().is_some() {
-                return Err(TransactionError::UnsupportedTableFeatures(
-                    diff.cloned().collect(),
-                ));
+            let unsupported = features
+                .into_iter()
+                .filter(|feature| {
+                    !self.writer_features.contains(feature)
+                        && !additional_writer_features.contains(feature)
+                })
+                .collect::<Vec<_>>();
+            if !unsupported.is_empty() {
+                return Err(TransactionError::UnsupportedTableFeatures(unsupported));
             }
         };
         Ok(())
+    }
+
+    pub(crate) fn can_write_clustered_compaction(
+        &self,
+        snapshot: &dyn TableReference,
+    ) -> Result<(), TransactionError> {
+        if Self::clustered_compaction_scope_applies(snapshot) {
+            self.can_write_to_with_additional_writer_features(
+                snapshot,
+                CLUSTERED_COMPACTION_FEATURES,
+            )
+        } else {
+            self.can_write_to(snapshot)
+        }
     }
 
     pub fn can_commit(
@@ -254,7 +292,17 @@ impl ProtocolChecker {
         actions: &[Action],
         operation: &DeltaOperation,
     ) -> Result<(), TransactionError> {
-        self.can_write_to(snapshot)?;
+        self.can_commit_with_additional_writer_features(snapshot, actions, operation, &[])
+    }
+
+    fn can_commit_with_additional_writer_features(
+        &self,
+        snapshot: &dyn TableReference,
+        actions: &[Action],
+        operation: &DeltaOperation,
+        additional_writer_features: &[TableFeature],
+    ) -> Result<(), TransactionError> {
+        self.can_write_to_with_additional_writer_features(snapshot, additional_writer_features)?;
 
         // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#append-only-tables
         let append_only_enabled = if snapshot.protocol().min_writer_version() < 2 {
@@ -286,6 +334,25 @@ impl ProtocolChecker {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn can_commit_clustered_compaction(
+        &self,
+        snapshot: &dyn TableReference,
+        actions: &[Action],
+        operation: &DeltaOperation,
+    ) -> Result<(), TransactionError> {
+        if !matches!(operation, DeltaOperation::Optimize { .. })
+            || !Self::clustered_compaction_scope_applies(snapshot)
+        {
+            return self.can_commit(snapshot, actions, operation);
+        }
+        self.can_commit_with_additional_writer_features(
+            snapshot,
+            actions,
+            operation,
+            CLUSTERED_COMPACTION_FEATURES,
+        )
     }
 }
 
@@ -346,6 +413,19 @@ mod tests {
 
     fn metadata_action(configuration: Option<HashMap<String, Option<String>>>) -> Metadata {
         ActionFactory::metadata(TestSchemas::simple(), None::<Vec<&str>>, configuration)
+    }
+
+    async fn writer_feature_snapshot(features: &[TableFeature]) -> DeltaTableState {
+        DeltaTableState::from_actions(vec![
+            Action::Protocol(
+                ProtocolInner::new(1, 7)
+                    .append_writer_features(features)
+                    .as_kernel(),
+            ),
+            metadata_action(None).into(),
+        ])
+        .await
+        .unwrap()
     }
 
     #[tokio::test]
@@ -799,6 +879,57 @@ mod tests {
             assert!(checker.can_read_from(eager).is_ok());
             assert!(checker.can_write_to(eager).is_ok());
         }
+    }
+
+    #[tokio::test]
+    async fn test_clustered_compaction_features_are_scoped() {
+        let snapshot =
+            writer_feature_snapshot(&[TableFeature::DomainMetadata, TableFeature::ClusteredTable])
+                .await;
+        let eager = snapshot.snapshot();
+        let checker = ProtocolChecker::new(HashSet::new(), HashSet::new());
+
+        assert!(checker.can_write_to(eager).is_err());
+        assert!(checker.can_write_clustered_compaction(eager).is_ok());
+        let operation = DeltaOperation::Optimize {
+            target_size: 1024,
+            predicate: None,
+        };
+        assert!(checker.can_commit(eager, &[], &operation).is_err());
+        assert!(
+            checker
+                .can_commit_clustered_compaction(eager, &[], &operation)
+                .is_ok()
+        );
+        let append = DeltaOperation::Write {
+            mode: SaveMode::Append,
+            partition_by: None,
+            predicate: None,
+        };
+        assert!(
+            checker
+                .can_commit_clustered_compaction(eager, &[], &append)
+                .is_err()
+        );
+
+        let missing_dependency = writer_feature_snapshot(&[TableFeature::ClusteredTable]).await;
+        assert!(
+            checker
+                .can_write_clustered_compaction(missing_dependency.snapshot())
+                .is_err()
+        );
+
+        let snapshot = writer_feature_snapshot(&[
+            TableFeature::DomainMetadata,
+            TableFeature::ClusteredTable,
+            TableFeature::RowTracking,
+        ])
+        .await;
+        assert!(matches!(
+            checker.can_write_clustered_compaction(snapshot.snapshot()),
+            Err(TransactionError::UnsupportedTableFeatures(features))
+                if features == vec![TableFeature::RowTracking]
+        ));
     }
 
     #[tokio::test]

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -20,7 +20,7 @@
 //! let (table, metrics) = OptimizeBuilder::new(table.object_store(), table.state).await?;
 //! ````
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::num::NonZeroU64;
 use std::sync::Arc;
@@ -31,8 +31,8 @@ use arrow::datatypes::SchemaRef;
 use datafusion::catalog::Session;
 use datafusion::execution::context::{SessionContext, SessionState};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
-use delta_kernel::expressions::Scalar;
-use delta_kernel::table_features::ColumnMappingMode;
+use delta_kernel::expressions::{ColumnName, Scalar};
+use delta_kernel::table_features::{ColumnMappingMode, TableFeature};
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
@@ -55,7 +55,9 @@ use crate::delta_datafusion::{
 };
 use crate::errors::{ColumnMappingOperation, DeltaResult, DeltaTableError};
 use crate::kernel::transaction::{CommitBuilder, CommitProperties, DEFAULT_RETRIES, PROTOCOL};
-use crate::kernel::{Action, Add, DataType, PartitionsExt, Remove, StructType, Version};
+use crate::kernel::{
+    Action, Add, DataType, PartitionsExt, PrimitiveType, Remove, StructType, Version,
+};
 use crate::kernel::{EagerSnapshot, resolve_snapshot};
 use crate::logstore::{LogStore, LogStoreRef, ObjectStoreRef};
 use crate::parquet_utils::default_writer_properties;
@@ -273,6 +275,77 @@ pub enum OptimizeType {
     ZOrder(Vec<String>),
 }
 
+fn is_clustered_table(snapshot: &EagerSnapshot) -> bool {
+    snapshot
+        .protocol()
+        .writer_features()
+        .is_some_and(|features| features.contains(&TableFeature::ClusteredTable))
+}
+
+fn validate_optimize_protocol(
+    snapshot: &EagerSnapshot,
+    optimize_type: &OptimizeType,
+) -> Result<(), DeltaTableError> {
+    if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
+        return Err(DeltaTableError::unsupported_column_mapping(
+            ColumnMappingOperation::Write,
+            "OPTIMIZE",
+        ));
+    }
+    if matches!(optimize_type, OptimizeType::Compact) && is_clustered_table(snapshot) {
+        PROTOCOL.can_write_clustered_compaction(snapshot)?;
+    } else {
+        PROTOCOL.can_write_to(snapshot)?;
+    }
+    Ok(())
+}
+
+fn validate_clustering_columns(
+    schema: &StructType,
+    columns: &[ColumnName],
+) -> Result<(), DeltaTableError> {
+    let mut seen = HashSet::new();
+    for column in columns {
+        if !seen.insert(column) {
+            return Err(DeltaTableError::Generic(format!(
+                "Duplicate clustering column: '{column}'"
+            )));
+        }
+        let field = schema.field_at(column)?;
+        let eligible = matches!(
+            field.data_type(),
+            DataType::Primitive(
+                PrimitiveType::Byte
+                    | PrimitiveType::Short
+                    | PrimitiveType::Integer
+                    | PrimitiveType::Long
+                    | PrimitiveType::Float
+                    | PrimitiveType::Double
+                    | PrimitiveType::Date
+                    | PrimitiveType::Timestamp
+                    | PrimitiveType::TimestampNtz
+                    | PrimitiveType::String
+                    | PrimitiveType::Decimal(_)
+            )
+        );
+        #[cfg(feature = "nanosecond-timestamps")]
+        let eligible = eligible
+            || matches!(
+                field.data_type(),
+                DataType::Primitive(
+                    PrimitiveType::TimestampNanos | PrimitiveType::TimestampNanosNtz
+                )
+            );
+        if !eligible {
+            return Err(DeltaTableError::Generic(format!(
+                "Clustering column '{column}' has unsupported type '{}'",
+                field.data_type()
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Optimize a Delta table with given options
 ///
 /// If a target file size is not provided then `delta.targetFileSize` from the
@@ -420,13 +493,7 @@ impl<'a> std::future::IntoFuture for OptimizeBuilder<'a> {
         Box::pin(async move {
             let snapshot =
                 resolve_snapshot(&this.log_store, this.snapshot.clone(), true, None).await?;
-            if snapshot.table_configuration().column_mapping_mode() != ColumnMappingMode::None {
-                return Err(DeltaTableError::unsupported_column_mapping(
-                    ColumnMappingOperation::Write,
-                    "OPTIMIZE",
-                ));
-            }
-            PROTOCOL.can_write_to(&snapshot)?;
+            validate_optimize_protocol(&snapshot, &this.optimize_type)?;
 
             let operation_id = this.get_operation_id();
             this.pre_execute(operation_id).await?;
@@ -555,6 +622,7 @@ impl Default for OptimizeOperations {
 /// Encapsulates the operations required to optimize a Delta Table
 pub struct MergePlan {
     operations: OptimizeOperations,
+    clustered_compaction_columns: Option<Vec<ColumnName>>,
     /// Metrics collected during operation
     metrics: Metrics,
     /// Planner metadata copied into buffered and total metrics
@@ -609,6 +677,7 @@ pub struct MergeTaskParameters {
     num_indexed_cols: DataSkippingNumIndexedCols,
     /// Stats columns, specific columns to collect stats from, takes precedence over num_indexed_cols
     stats_columns: Option<Vec<String>>,
+    required_stats_columns: Vec<ColumnName>,
 }
 
 /// A stream of record batches, with a ParquetError on failure.
@@ -713,7 +782,8 @@ impl MergePlan {
             writer_config,
             task_parameters.num_indexed_cols,
             task_parameters.stats_columns.clone(),
-        )?;
+        )?
+        .with_required_stats_columns(task_parameters.required_stats_columns.clone());
 
         let mut read_stream = read_stream.await?;
 
@@ -975,9 +1045,13 @@ impl MergePlan {
 
                 debug!("committing {} actions", actions.len());
 
-                let commit = CommitBuilder::from(properties)
+                let mut commit_builder = CommitBuilder::from(properties)
                     .with_actions(actions)
-                    .with_operation_id(operation_id)
+                    .with_operation_id(operation_id);
+                if let Some(columns) = &self.clustered_compaction_columns {
+                    commit_builder = commit_builder.with_clustered_compaction(columns.clone());
+                }
+                let commit = commit_builder
                     .with_post_commit_hook_handler(handle.cloned())
                     .with_max_retries(DEFAULT_RETRIES + commits_made)
                     .build(
@@ -1019,6 +1093,30 @@ pub async fn create_merge_plan(
     writer_properties: WriterProperties,
     session: SessionState,
 ) -> Result<MergePlan, DeltaTableError> {
+    validate_optimize_protocol(snapshot, &optimize_type)?;
+    let clustered_compact =
+        matches!(&optimize_type, OptimizeType::Compact) && is_clustered_table(snapshot);
+    let clustering_columns = if clustered_compact {
+        if !snapshot.metadata().partition_columns().is_empty() {
+            return Err(DeltaTableError::Generic(
+                "Clustered tables must not be partitioned".into(),
+            ));
+        }
+        let engine = log_store.engine(None);
+        let columns = snapshot
+            .snapshot()
+            .inner
+            .get_physical_clustering_columns(engine.as_ref())?
+            .ok_or_else(|| {
+                DeltaTableError::Generic(
+                    "Clustered table is missing active delta.clustering domain metadata".into(),
+                )
+            })?;
+        validate_clustering_columns(snapshot.schema().as_ref(), &columns)?;
+        Some(columns)
+    } else {
+        None
+    };
     let target_size = target_size.unwrap_or_else(|| snapshot.table_properties().target_file_size());
     let _ = optimize_target_size_to_i64(target_size)?;
     let partitions_keys = snapshot.metadata().partition_columns();
@@ -1026,7 +1124,8 @@ pub async fn create_merge_plan(
     let (operations, metrics, planner_stats) = match optimize_type {
         OptimizeType::Compact => {
             info!("building compaction plan");
-            build_compaction_plan(log_store, snapshot, filters, target_size).await?
+            build_compaction_plan(log_store, snapshot, filters, target_size, clustered_compact)
+                .await?
         }
         OptimizeType::ZOrder(zorder_columns) => {
             info!("building z-order plan");
@@ -1061,6 +1160,7 @@ pub async fn create_merge_plan(
 
     Ok(MergePlan {
         operations,
+        clustered_compaction_columns: clustering_columns.clone(),
         metrics,
         planner_stats,
         task_parameters: Arc::new(MergeTaskParameters {
@@ -1072,7 +1172,8 @@ pub async fn create_merge_plan(
                 .table_properties()
                 .data_skipping_stats_columns
                 .as_ref()
-                .map(|v| v.iter().map(|v| v.to_string()).collect::<Vec<String>>()),
+                .map(|columns| columns.iter().map(ToString::to_string).collect()),
+            required_stats_columns: clustering_columns.unwrap_or_default(),
         }),
         read_table_version: snapshot.version(),
         read_session: Arc::new(session),
@@ -1205,6 +1306,7 @@ async fn build_compaction_plan(
     snapshot: &EagerSnapshot,
     filters: &[FilterLiteral<'_>],
     target_size: NonZeroU64,
+    preserve_clustering: bool,
 ) -> Result<(OptimizeOperations, Metrics, PlannerStats), DeltaTableError> {
     type PartitionFileEntry = (IndexMap<String, Scalar>, usize, Vec<OrderedFileCandidate>);
 
@@ -1239,13 +1341,16 @@ async fn build_compaction_plan(
         let stable_ordinal = entry.1;
         entry.1 += 1;
 
-        if object_meta.size > target_size.get() {
+        let add = file.to_add();
+        if (preserve_clustering && add.clustering_provider.is_some())
+            || object_meta.size > target_size.get()
+        {
             metrics.total_files_skipped += 1;
             continue;
         }
 
         entry.2.push(OrderedFileCandidate {
-            add: file.to_add(),
+            add,
             stable_ordinal,
             size_bytes: object_meta.size,
         });
@@ -1384,7 +1489,302 @@ async fn build_zorder_plan(
 #[cfg(test)]
 mod compact_planner_tests {
     use super::*;
+    use crate::kernel::{DomainMetadata, ProtocolExt as _, TableFeatures};
+    use crate::logstore::get_actions;
+    use crate::protocol::SaveMode;
+    use crate::writer::test_utils::TestResult;
+    use crate::writer::test_utils::datafusion::{get_data_sorted, write_batch};
+    use crate::writer::test_utils::{get_delta_schema, get_record_batch};
+    use arrow::util::pretty::pretty_format_batches;
+    use delta_kernel::table_features::TableFeature;
     use std::collections::HashMap;
+
+    fn clustering_domain(configuration: &str, removed: bool) -> DomainMetadata {
+        DomainMetadata {
+            domain: "delta.clustering".to_string(),
+            configuration: configuration.to_string(),
+            removed,
+        }
+    }
+
+    async fn rows(table: &DeltaTable) -> Result<String, Box<dyn std::error::Error + 'static>> {
+        Ok(
+            pretty_format_batches(&get_data_sorted(table, "modified, id, value").await)?
+                .to_string(),
+        )
+    }
+
+    async fn active_adds(
+        table: &DeltaTable,
+    ) -> Result<Vec<Add>, Box<dyn std::error::Error + 'static>> {
+        Ok(table
+            .snapshot()?
+            .snapshot()
+            .file_views(table.log_store().as_ref(), None)
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
+            .map(|file| file.to_add())
+            .collect())
+    }
+
+    async fn merge_plan(table: &DeltaTable, optimize_type: OptimizeType) -> DeltaResult<MergePlan> {
+        create_merge_plan(
+            table.log_store().as_ref(),
+            optimize_type,
+            table.snapshot()?.snapshot(),
+            &[],
+            None,
+            default_writer_properties(Compression::ZSTD(ZstdLevel::try_new(4).unwrap())),
+            create_session_state_with_spill_config(None, None),
+        )
+        .await
+    }
+
+    async fn table_with_provider_files(
+        provider_indices: &[usize],
+    ) -> Result<DeltaTable, Box<dyn std::error::Error + 'static>> {
+        let mut table = DeltaTable::new_in_memory()
+            .create()
+            .with_columns(get_delta_schema().fields().cloned())
+            .with_configuration_property(
+                crate::TableProperty::DataSkippingStatsColumns,
+                Some("modified,value"),
+            )
+            .await?;
+        let batch = get_record_batch(None, false);
+        for index in 0..5 {
+            table = write_batch(table, batch.clone()).await;
+            if provider_indices.contains(&index) {
+                let log_store = table.log_store();
+                let snapshot = table.snapshot()?.snapshot();
+                let mut owned = snapshot
+                    .file_views(log_store.as_ref(), None)
+                    .try_next()
+                    .await?
+                    .expect("write must create a file")
+                    .to_add();
+                owned.data_change = false;
+                owned.clustering_provider = Some("spark".to_string());
+                crate::writer::flush_and_commit(vec![Action::Add(owned)], &mut table, None).await?;
+            }
+        }
+
+        Ok(table)
+    }
+
+    async fn clustered_table_with_domain(
+        provider_indices: &[usize],
+        clustering_domain: Option<DomainMetadata>,
+    ) -> Result<DeltaTable, Box<dyn std::error::Error + 'static>> {
+        let table = table_with_provider_files(provider_indices)
+            .await?
+            .set_tbl_properties()
+            .with_properties(HashMap::from([(
+                crate::TableProperty::DataSkippingStatsColumns
+                    .as_ref()
+                    .to_string(),
+                "modified".to_string(),
+            )]))
+            .await?;
+
+        let log_store = table.log_store();
+        let snapshot = table.snapshot()?.snapshot();
+        let mut actions = vec![Action::Protocol(
+            snapshot.protocol().clone().append_writer_features(&[
+                TableFeature::DomainMetadata,
+                TableFeature::ClusteredTable,
+            ]),
+        )];
+        if let Some(domain) = clustering_domain {
+            actions.push(Action::DomainMetadata(domain));
+        }
+
+        let commit = CommitBuilder::default()
+            .with_actions(actions)
+            .build(
+                Some(snapshot),
+                log_store.clone(),
+                DeltaOperation::AddFeature {
+                    name: vec![TableFeatures::DomainMetadata],
+                },
+            )
+            .await?;
+        Ok(DeltaTable::new_with_state(log_store, commit.snapshot()))
+    }
+
+    async fn clustered_table(
+        provider_indices: &[usize],
+    ) -> Result<DeltaTable, Box<dyn std::error::Error + 'static>> {
+        clustered_table_with_domain(
+            provider_indices,
+            Some(clustering_domain(
+                r#"{"clusteringColumns":[["value"]]}"#,
+                false,
+            )),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_compact_clustered_table_preserves_rows_stats_and_domains() -> TestResult {
+        let table = clustered_table(&[]).await?;
+        let rows_before = rows(&table).await?;
+        let version_before = table.version();
+
+        let (table, metrics) = table.optimize().await?;
+
+        assert_eq!(metrics.num_files_removed, 5);
+        assert_eq!(metrics.num_files_added, 1);
+        assert_eq!(table.version(), version_before.map(|version| version + 1));
+        assert_eq!(rows(&table).await?, rows_before);
+
+        let files = active_adds(&table).await?;
+        assert_eq!(files.len(), 1);
+        let output = &files[0];
+        assert_eq!(output.clustering_provider, None);
+        let stats: serde_json::Value = serde_json::from_str(output.stats.as_deref().unwrap())?;
+        for column in ["modified", "value"] {
+            assert!(stats.pointer(&format!("/minValues/{column}")).is_some());
+            assert!(stats.pointer(&format!("/maxValues/{column}")).is_some());
+            assert!(stats.pointer(&format!("/nullCount/{column}")).is_some());
+        }
+        assert!(stats.pointer("/minValues/id").is_none());
+        assert_eq!(
+            table
+                .snapshot()?
+                .table_config()
+                .data_skipping_stats_columns
+                .as_ref()
+                .map(|columns| columns.iter().map(ToString::to_string).collect::<Vec<_>>()),
+            Some(vec!["modified".to_string()])
+        );
+
+        let version = table.version().unwrap();
+        let bytes = table
+            .log_store()
+            .read_commit_entry(version)
+            .await?
+            .expect("optimize commit must exist");
+        assert!(
+            get_actions(version, &bytes)?
+                .iter()
+                .all(|action| !matches!(action, Action::DomainMetadata(_)))
+        );
+
+        let append = table
+            .write([get_record_batch(None, false)])
+            .with_save_mode(SaveMode::Append)
+            .await;
+        assert!(append.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compact_clustered_table_preserves_provider_owned_file() -> TestResult {
+        let table = clustered_table(&[2]).await?;
+        let rows_before = rows(&table).await?;
+        let files_before = active_adds(&table).await?;
+        let owned_path = files_before
+            .iter()
+            .find(|add| add.clustering_provider.as_deref() == Some("spark"))
+            .expect("fixture must contain one provider-owned file")
+            .path
+            .clone();
+
+        let (table, metrics) = table.optimize().await?;
+
+        assert_eq!(metrics.num_files_removed, 4);
+        assert_eq!(metrics.num_files_added, 2);
+        assert_eq!(metrics.total_files_skipped, 1);
+        assert_eq!(rows(&table).await?, rows_before);
+        let files_after = active_adds(&table).await?;
+        assert_eq!(files_after.len(), 3);
+        assert!(files_after.iter().any(|add| {
+            add.path == owned_path && add.clustering_provider.as_deref() == Some("spark")
+        }));
+        assert_eq!(
+            files_after
+                .iter()
+                .filter(|add| add.clustering_provider.is_none())
+                .count(),
+            2
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compact_clustered_table_with_only_provider_owned_files_is_noop() -> TestResult {
+        let table = clustered_table(&[0, 1, 2, 3, 4]).await?;
+        let version = table.version();
+
+        let (table, metrics) = table.optimize().await?;
+
+        assert_eq!(table.version(), version);
+        assert_eq!(metrics.total_files_skipped, 5);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compact_clustered_table_without_active_columns() -> TestResult {
+        let table = clustered_table_with_domain(
+            &[],
+            Some(clustering_domain(r#"{"clusteringColumns":[]}"#, false)),
+        )
+        .await?;
+        let rows_before = rows(&table).await?;
+
+        let (table, metrics) = table.optimize().await?;
+
+        assert_eq!(metrics.num_files_removed, 5);
+        assert_eq!(metrics.num_files_added, 1);
+        assert_eq!(rows(&table).await?, rows_before);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compact_non_clustered_table_ignores_clustering_provider() -> TestResult {
+        let table = table_with_provider_files(&[2]).await?;
+
+        let (_, metrics) = table.optimize().await?;
+
+        assert_eq!(metrics.num_files_removed, 5);
+        assert_eq!(metrics.num_files_added, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compact_clustered_table_rejects_invalid_clustering_domains() -> TestResult {
+        let domains = [
+            None,
+            Some(clustering_domain("{", false)),
+            Some(clustering_domain(
+                r#"{"clusteringColumns":[["value"]]}"#,
+                true,
+            )),
+            Some(clustering_domain(
+                r#"{"clusteringColumns":[["missing"]]}"#,
+                false,
+            )),
+        ];
+
+        for domain in domains {
+            let table = clustered_table_with_domain(&[], domain).await?;
+            assert!(merge_plan(&table, OptimizeType::Compact).await.is_err());
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_create_merge_plan_rejects_zorder_for_clustered_table() -> TestResult {
+        let table = clustered_table(&[]).await?;
+        assert!(
+            merge_plan(&table, OptimizeType::ZOrder(vec!["value".to_string()]))
+                .await
+                .is_err()
+        );
+        Ok(())
+    }
 
     fn candidate(stable_ordinal: usize, size_bytes: u64) -> OrderedFileCandidate {
         OrderedFileCandidate {

--- a/crates/core/src/operations/write/writer.rs
+++ b/crates/core/src/operations/write/writer.rs
@@ -7,7 +7,7 @@ use std::sync::OnceLock;
 
 use arrow_array::RecordBatch;
 use arrow_schema::{ArrowError, SchemaRef as ArrowSchemaRef};
-use delta_kernel::expressions::Scalar;
+use delta_kernel::expressions::{ColumnName, Scalar};
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use futures::{StreamExt, TryStreamExt};
 use indexmap::IndexMap;
@@ -464,6 +464,7 @@ pub struct PartitionWriter {
     num_indexed_cols: DataSkippingNumIndexedCols,
     /// Stats columns, specific columns to collect stats from, takes precedence over num_indexed_cols
     stats_columns: Option<Vec<String>>,
+    required_stats_columns: Vec<ColumnName>,
     in_flight_writers: JoinSet<DeltaResult<(Path, usize, ParquetMetaData)>>,
 }
 
@@ -487,8 +488,14 @@ impl PartitionWriter {
             part_counter: 0,
             num_indexed_cols,
             stats_columns,
+            required_stats_columns: vec![],
             in_flight_writers: JoinSet::new(),
         })
+    }
+
+    pub(crate) fn with_required_stats_columns(mut self, columns: Vec<ColumnName>) -> Self {
+        self.required_stats_columns = columns;
+        self
     }
 
     fn create_writer(
@@ -625,6 +632,7 @@ impl PartitionWriter {
                     &metadata,
                     self.num_indexed_cols,
                     &self.stats_columns,
+                    &self.required_stats_columns,
                 )
                 .map_err(|err| WriteError::CreateAdd {
                     source: Box::new(err),

--- a/crates/core/src/writer/json.rs
+++ b/crates/core/src/writer/json.rs
@@ -408,6 +408,7 @@ impl DeltaWriter<Vec<Value>> for JsonWriter {
                     .data_skipping_stats_columns
                     .as_ref()
                     .map(|cols| cols.iter().map(|c| c.to_string()).collect_vec()),
+                &[],
             )?);
         }
         debug!(actions_count = actions.len(), "flush completed");

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -414,6 +414,7 @@ impl DeltaWriter<RecordBatch> for RecordBatchWriter {
                 &metadata,
                 self.num_indexed_cols,
                 &self.stats_columns,
+                &[],
             )?);
         }
         Ok(actions)

--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -6,7 +6,7 @@ use std::{
     ops::AddAssign,
 };
 
-use delta_kernel::expressions::Scalar;
+use delta_kernel::expressions::{ColumnName, Scalar};
 use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -32,12 +32,14 @@ pub(crate) fn create_add(
     file_metadata: &ParquetMetaData,
     num_indexed_cols: DataSkippingNumIndexedCols,
     stats_columns: &Option<Vec<impl AsRef<str>>>,
+    required_stats_columns: &[ColumnName],
 ) -> Result<Add, DeltaTableError> {
     let stats = stats_from_file_metadata(
         partition_values,
         file_metadata,
         num_indexed_cols,
         stats_columns,
+        required_stats_columns,
     )?;
     let stats_string = serde_json::to_string(&stats)?;
 
@@ -96,6 +98,7 @@ pub(crate) fn stats_from_parquet_metadata(
         num_rows,
         num_indexed_cols,
         stats_columns,
+        &[],
     )
 }
 
@@ -104,6 +107,7 @@ fn stats_from_file_metadata(
     file_metadata: &ParquetMetaData,
     num_indexed_cols: DataSkippingNumIndexedCols,
     stats_columns: &Option<Vec<impl AsRef<str>>>,
+    required_stats_columns: &[ColumnName],
 ) -> Result<Stats, DeltaWriterError> {
     let schema_descriptor = file_metadata.file_metadata().schema_descr();
 
@@ -116,6 +120,7 @@ fn stats_from_file_metadata(
         file_metadata.file_metadata().num_rows(),
         num_indexed_cols,
         stats_columns,
+        required_stats_columns,
     )
 }
 
@@ -126,13 +131,14 @@ fn stats_from_metadata(
     num_rows: i64,
     num_indexed_cols: DataSkippingNumIndexedCols,
     stats_columns: &Option<Vec<impl AsRef<str>>>,
+    required_stats_columns: &[ColumnName],
 ) -> Result<Stats, DeltaWriterError> {
     let mut min_values: HashMap<String, ColumnValueStat> = HashMap::new();
     let mut max_values: HashMap<String, ColumnValueStat> = HashMap::new();
     let mut null_count: HashMap<String, ColumnCountStat> = HashMap::new();
     let dialect = sqlparser::dialect::GenericDialect {};
 
-    let idx_to_iterate = if let Some(stats_cols) = stats_columns {
+    let mut idx_to_iterate = if let Some(stats_cols) = stats_columns {
         let stats_cols = stats_cols
             .iter()
             .map(|v| {
@@ -197,6 +203,22 @@ fn stats_from_metadata(
             "delta.dataSkippingNumIndexedCols valid values are >=-1".to_string(),
         )));
     };
+
+    // Required columns (for example clustering columns) override the table's stats selection.
+    idx_to_iterate.extend(
+        schema_descriptor
+            .columns()
+            .iter()
+            .enumerate()
+            .filter(|(_, column)| {
+                required_stats_columns
+                    .iter()
+                    .any(|required| required.path() == column.path().parts())
+            })
+            .map(|(index, _)| index),
+    );
+    idx_to_iterate.sort_unstable();
+    idx_to_iterate.dedup();
 
     for idx in idx_to_iterate {
         let column_descr = schema_descriptor.column(idx);


### PR DESCRIPTION
# Description

Depends on #4694. Review the feature-only slice at:
https://github.com/ErikBPF/delta-rs/compare/fix/revalidate-protocol-retries...feat/clustering-preserving-compact

Allow `OptimizeType::Compact` on clustered tables while keeping support scoped to this operation.

- preserve files owned by a clustering provider and do not merge across their positions
- leave compacted output provider-unowned
- include every active clustering column in output file statistics without overriding other statistics configuration
- preserve clustering domain metadata and reject concurrent clustering-column changes
- support the valid `CLUSTER BY NONE` state
- continue rejecting Z-order, column mapping, and unrelated unsupported writer features

This does not implement clustering or reclustering.

AI assistance was used to inspect protocol and repository patterns and draft parts of the implementation and tests. I reviewed the full diff, reproduced the failure cases, and can own and debug the changes.

# Related Issue(s)

Related to #2043.

# Documentation

- https://github.com/delta-io/delta/blob/master/PROTOCOL.md
- https://github.com/delta-io/delta/blob/master/docs/src/content/docs/delta-clustering.mdx

No public API or configuration was added.

# Validation

- `cargo fmt --all -- --check`
- `cargo clippy --profile=ci --features azure,datafusion,s3,gcs,glue,hdfs --tests`
- core suite: 1,390 passed, 30 ignored, 0 failed
- CI-equivalent workspace suite: 1,434 passed, 31 ignored, 0 failed
- post-stack retry tests: 2 passed
- post-stack compact planner and behavior tests: 12 passed