### PR TITLE
chore: add regression test for percent encoding as part of #4684

### DIFF
--- a/crates/core/src/operations/filesystem_check.rs
+++ b/crates/core/src/operations/filesystem_check.rs
@@ -307,6 +307,8 @@ impl std::future::IntoFuture for FileSystemCheckBuilder {
 mod tests {
     use std::collections::HashMap;
 
+    use object_store::{ObjectStoreExt as _, PutPayload};
+
     use super::*;
     use crate::kernel::{
         DataType, DeletionVectorDescriptor, EagerSnapshot, PrimitiveType, Snapshot, StorageType,
@@ -432,6 +434,115 @@ mod tests {
             .await?;
         assert!(active_files.is_empty());
 
+        Ok(())
+    }
+
+    const FSCK_PATH_CASES: &[(&str, &str)] = &[
+        (
+            "partition=a/file with spaces.parquet",
+            "partition=a/file%20with%20spaces.parquet",
+        ),
+        (
+            "partition=a/file%20with%20spaces.parquet",
+            "partition=a/file%2520with%2520spaces.parquet",
+        ),
+    ];
+
+    async fn fsck_path_table(physical_path: &str, wire_path: &str) -> DeltaResult<DeltaTable> {
+        let add = crate::test_utils::make_test_add(physical_path, &[("partition", "a")], 0);
+        // Check the encoded path that Add writes to the log.
+        assert_eq!(serde_json::to_value(&add)?["path"], wire_path);
+        DeltaTable::new_in_memory()
+            .create()
+            .with_columns([
+                StructField::new("id", DataType::INTEGER, false),
+                StructField::new("partition", DataType::STRING, false),
+            ])
+            .with_partition_columns(["partition"])
+            .with_actions([Action::Add(add)])
+            .await
+    }
+
+    #[tokio::test]
+    async fn fsck_preserves_present_files_with_spaces_or_literal_percent_sequences()
+    -> DeltaResult<()> {
+        for &(physical_path, wire_path) in FSCK_PATH_CASES {
+            let table = fsck_path_table(physical_path, wire_path).await?;
+            let version = table.snapshot()?.version();
+            // Use parse to preserve literal percent signs in the object path.
+            table
+                .object_store()
+                .put(
+                    &object_store::path::Path::parse(physical_path)?,
+                    PutPayload::from_static(b"data"),
+                )
+                .await?;
+
+            let (table, metrics) = table.filesystem_check().await?;
+
+            assert!(
+                metrics.files_removed.is_empty(),
+                "{physical_path}: {metrics:?}"
+            );
+            assert_eq!(table.snapshot()?.version(), version);
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fsck_removes_missing_files_with_spaces_or_literal_percent_sequences() -> DeltaResult<()>
+    {
+        for &(physical_path, wire_path) in FSCK_PATH_CASES {
+            let table = fsck_path_table(physical_path, wire_path).await?;
+            let version = table.snapshot()?.version();
+            let log_store = table.log_store();
+
+            let (table, metrics) = table.filesystem_check().with_dry_run(true).await?;
+            assert!(metrics.dry_run);
+            assert_eq!(metrics.files_removed, vec![physical_path]);
+            assert_eq!(table.snapshot()?.version(), version);
+
+            let (table, metrics) = table.filesystem_check().await?;
+            assert!(!metrics.dry_run);
+            assert_eq!(metrics.files_removed, vec![physical_path]);
+            assert_eq!(table.snapshot()?.version(), version + 1);
+
+            let snapshot = Snapshot::try_new(
+                log_store.as_ref(),
+                DeltaTableConfig {
+                    require_files: false,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await?;
+            let active_files: Vec<_> = snapshot
+                .active_adds(
+                    log_store.as_ref(),
+                    ActiveAddOptions {
+                        predicate: None,
+                        stats: AddStatsPolicy::None,
+                    },
+                )
+                .try_collect()
+                .await?;
+            assert!(active_files.is_empty(), "{physical_path}");
+
+            // Read the JSON path before Remove deserialization decodes it.
+            let commit = log_store
+                .read_commit_entry(version + 1)
+                .await?
+                .expect("expected the FSCK commit");
+            let actions = serde_json::Deserializer::from_slice(&commit)
+                .into_iter::<serde_json::Value>()
+                .collect::<Result<Vec<_>, _>>()?;
+            let removes: Vec<_> = actions
+                .iter()
+                .filter_map(|action| action.get("remove"))
+                .collect();
+            assert_eq!(removes.len(), 1);
+            assert_eq!(removes[0]["path"], wire_path);
+        }
         Ok(())
     }
 

--- a/crates/core/src/operations/restore.rs
+++ b/crates/core/src/operations/restore.rs
@@ -657,6 +657,69 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn restore_file_key_preserves_valid_dv_identity() -> DeltaResult<()> {
+        // Use the Delta protocol examples with '@' in the inline data and UUID path.
+        // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deletion-vector-descriptor-schema
+        let inline = DeletionVectorDescriptor {
+            storage_type: StorageType::Inline,
+            path_or_inline_dv: "wi5b=000010000siXQKl0rr91000f55c8Xg0@@D72lkbi5=-{L".into(),
+            offset: None,
+            size_in_bytes: 40,
+            cardinality: 6,
+        };
+        let persisted = DeletionVectorDescriptor {
+            storage_type: StorageType::UuidRelativePath,
+            path_or_inline_dv: "ab^-aqEH.-t@S}K{vb[*k^".into(),
+            offset: Some(4),
+            size_in_bytes: 40,
+            cardinality: 6,
+        };
+        let later = DeletionVectorDescriptor {
+            offset: Some(42),
+            ..persisted.clone()
+        };
+        let cases = [
+            (None, None),
+            (
+                Some(inline),
+                Some("iwi5b=000010000siXQKl0rr91000f55c8Xg0@@D72lkbi5=-{L"),
+            ),
+            (Some(persisted), Some("uab^-aqEH.-t@S}K{vb[*k^@4")),
+            (Some(later), Some("uab^-aqEH.-t@S}K{vb[*k^@42")),
+        ];
+        for (deletion_vector, expected_id) in cases {
+            let mut add = crate::test_utils::make_test_add("file.parquet", &[], 0);
+            add.stats = Some(r#"{"numRecords":30}"#.into());
+            add.deletion_vector = deletion_vector;
+            let table = DeltaTable::new_in_memory()
+                .create()
+                .with_columns([StructField::new("id", DataType::INTEGER, false)])
+                .with_configuration_property(TableProperty::EnableDeletionVectors, Some("true"))
+                .with_actions([Action::Add(add)])
+                .await?;
+            let log_store = table.log_store();
+            let snapshot =
+                Snapshot::try_new(log_store.as_ref(), no_stats_config(false), None).await?;
+            let files: Vec<_> = snapshot
+                .active_adds(
+                    log_store.as_ref(),
+                    ActiveAddOptions {
+                        predicate: None,
+                        stats: AddStatsPolicy::None,
+                    },
+                )
+                .try_collect()
+                .await?;
+            assert_eq!(files.len(), 1);
+
+            let key = restore_file_key(&files[0]);
+            assert_eq!(key.0, Path::parse("file.parquet")?);
+            assert_eq!(key.1.as_deref(), expected_id);
+        }
+        Ok(())
+    }
+
     /// Verify that restore respects constraints that were added/removed in previous version_to_restore
     /// <https://github.com/delta-io/delta-rs/issues/3352>
     #[cfg(feature = "datafusion")]


### PR DESCRIPTION
This came up in an automated review on some changes with #4684 that modified some percent encoding handling. Those are the bane of my existence.
