### PR TITLE
chore: modify log statements that might produce excess logs on large tables

### DIFF
--- a/crates/core/src/kernel/transaction/protocol.rs
+++ b/crates/core/src/kernel/transaction/protocol.rs
@@ -126,7 +126,10 @@ impl ProtocolChecker {
         snapshot: &EagerSnapshot,
         schema: &Schema,
     ) -> Result<(), TransactionError> {
-        trace!("checking to see if {snapshot:?} can write timestampntz");
+        trace!(
+            "checking if snapshot v{} can write timestampntz",
+            snapshot.version()
+        );
         self.check_can_write_feature(
             snapshot,
             contains_timestampntz(schema.fields()),
@@ -142,7 +145,10 @@ impl ProtocolChecker {
         snapshot: &EagerSnapshot,
         schema: &Schema,
     ) -> Result<(), TransactionError> {
-        trace!("checking to see if {snapshot:?} can write timestampnanos");
+        trace!(
+            "checking if snapshot v{} can write timestampnanos",
+            snapshot.version()
+        );
         let contains_nanos = contains_timestamp_nanos(schema.fields());
         self.check_can_write_feature(snapshot, contains_nanos, TableFeature::TimestampNanos)?;
         self.check_can_write_feature(
@@ -158,7 +164,10 @@ impl ProtocolChecker {
         snapshot: &EagerSnapshot,
         schema: &Schema,
     ) -> Result<(), TransactionError> {
-        trace!("checking to see if {snapshot:?} can write variant");
+        trace!(
+            "checking if snapshot v{} can write variant",
+            snapshot.version()
+        );
         let contains_variant = contains_variant(schema.fields());
         let required_features: Option<&[TableFeature]> =
             match snapshot.protocol().min_writer_version() {

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -881,7 +881,11 @@ impl MergePlan {
                     .boxed()
             }
             OptimizeOperations::ZOrder(zorder_columns, bins) => {
-                debug!("Starting zorder with the columns: {zorder_columns:?} {bins:?}");
+                debug!(
+                    zorder_columns = ?zorder_columns,
+                    num_partitions = bins.len(),
+                    "starting zorder"
+                );
 
                 let exec_context = Arc::new(zorder::ZOrderExecContext::new(
                     zorder_columns,
@@ -1364,7 +1368,10 @@ async fn build_zorder_plan(
             .or_insert_with(|| (partition_values, MergeBin::new()))
             .1
             .add(file.to_add());
-        debug!("partition_files inside the zorder plan: {partition_files:?}");
+        debug!(
+            num_partitions = partition_files.len(),
+            "built zorder partition plan"
+        );
     }
     metrics.partitions_optimized = partition_files.len() as u64;
 
@@ -1597,7 +1604,7 @@ pub(super) mod zorder {
         fn zorder_key_datafusion(
             columns: &[ColumnarValue],
         ) -> Result<ColumnarValue, DataFusionError> {
-            debug!("zorder_key_datafusion: {columns:#?}");
+            debug!(num_columns = columns.len(), "zorder_key_datafusion invoked");
             let length = columns
                 .iter()
                 .map(|col| match col {

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -117,13 +117,13 @@ async fn collect_keep_version_paths(
     );
     let engine = log_store.engine(None);
     let mut keep_files = collect_active_paths(snapshot.as_ref(), log_store).await?;
-    debug!("keep version {initial_version}: {keep_files:#?}");
+    debug!(version = %initial_version, num_files = keep_files.len(), "collected keep-version paths");
 
     for version in remaining_versions {
         log_store.refresh().await?;
         snapshot = snapshot.update(engine.clone(), Some(*version)).await?;
         let version_files = collect_active_paths(snapshot.as_ref(), log_store).await?;
-        debug!("keep version {version}: {version_files:#?}");
+        debug!(version = %version, num_files = version_files.len(), "collected keep-version paths");
         keep_files.extend(version_files);
     }
 


### PR DESCRIPTION
While cleaning up logging in delta-kernel-rs I decided to point the :parrot: at our codebase for log statements that might produce excess log lines when working with larger tables.

Any log statement which may result in a debug print of a `Snapshot` runs the risk of printing a `Debug` representation of the entire reconciled transaction log v_v