### PR TITLE
fix(datafusion): apply deletion vectors by physical row position

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -159,3 +159,8 @@ harness = false
 
 [package.metadata.cargo-machete]
 ignored = ["foyer", "alloc-stdlib", "brotli-decompressor"]
+
+[[bench]]
+name = "dv_physical_position"
+harness = false
+required-features = ["datafusion"]

--- a/crates/core/benches/dv_physical_position.rs
+++ b/crates/core/benches/dv_physical_position.rs
@@ -1,0 +1,257 @@
+//! Run each candidate in a separate process with the same lockfile and harness.
+//! DV_BENCH_TELEMETRY appends per-sample stage timings and object-store counters.
+
+#[path = "../src/delta_datafusion/table_provider/next/scan/test_support.rs"]
+#[allow(dead_code)]
+mod fixture;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use datafusion::{
+    physical_plan::{ExecutionPlan, execute_stream},
+    prelude::{SessionConfig, SessionContext},
+};
+use deltalake_core::DeltaTableBuilder;
+use futures::{StreamExt, stream::BoxStream};
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, path::Path,
+};
+use serde_json::json;
+use std::{
+    collections::BTreeMap,
+    fmt,
+    fs::OpenOptions,
+    io::Write,
+    ops::Range,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+#[derive(Debug)]
+struct CountedStore {
+    inner: Arc<dyn ObjectStore>,
+    requests: AtomicU64,
+    bytes: AtomicU64,
+}
+impl fmt::Display for CountedStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "benchmark counted store")
+    }
+}
+#[async_trait]
+impl ObjectStore for CountedStore {
+    async fn put_opts(
+        &self,
+        p: &Path,
+        v: PutPayload,
+        o: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        self.inner.put_opts(p, v, o).await
+    }
+    async fn put_multipart_opts(
+        &self,
+        p: &Path,
+        o: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(p, o).await
+    }
+    async fn get_opts(&self, p: &Path, o: GetOptions) -> object_store::Result<GetResult> {
+        let head = o.head;
+        let result = self.inner.get_opts(p, o).await?;
+        self.requests.fetch_add(1, Ordering::Relaxed);
+        if !head {
+            self.bytes
+                .fetch_add(result.range.end - result.range.start, Ordering::Relaxed);
+        }
+        Ok(result)
+    }
+    async fn get_ranges(
+        &self,
+        p: &Path,
+        ranges: &[Range<u64>],
+    ) -> object_store::Result<Vec<Bytes>> {
+        let result = self.inner.get_ranges(p, ranges).await?;
+        self.requests.fetch_add(1, Ordering::Relaxed);
+        self.bytes.fetch_add(
+            result.iter().map(|bytes| bytes.len() as u64).sum(),
+            Ordering::Relaxed,
+        );
+        Ok(result)
+    }
+    fn delete_stream(
+        &self,
+        paths: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        self.inner.delete_stream(paths)
+    }
+    fn list(&self, p: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.inner.list(p)
+    }
+    async fn list_with_delimiter(&self, p: Option<&Path>) -> object_store::Result<ListResult> {
+        self.inner.list_with_delimiter(p).await
+    }
+    async fn copy_opts(&self, a: &Path, b: &Path, o: CopyOptions) -> object_store::Result<()> {
+        self.inner.copy_opts(a, b, o).await
+    }
+}
+
+fn metrics(plan: &Arc<dyn ExecutionPlan>, output: &mut BTreeMap<String, usize>) {
+    use datafusion::physical_plan::metrics::MetricValue;
+    if let Some(metrics) = plan.metrics() {
+        for metric in metrics.iter() {
+            match metric.value() {
+                MetricValue::PruningMetrics {
+                    name,
+                    pruning_metrics,
+                } => {
+                    *output.entry(format!("{name}.pruned")).or_default() +=
+                        pruning_metrics.pruned();
+                    *output.entry(format!("{name}.matched")).or_default() +=
+                        pruning_metrics.matched();
+                }
+                value => *output.entry(value.name().to_owned()).or_default() += value.as_usize(),
+            }
+        }
+    }
+    for child in plan.children() {
+        metrics(child, output);
+    }
+}
+
+fn benchmark(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    for (shape, files, rows, groups) in [
+        ("large", 1, 262_144, vec![16_384, 32_768, 8192]),
+        ("small", 64, 2048, vec![1024, 768, 256]),
+    ] {
+        for density in ["none", "sparse", "dense"] {
+            let fixture = fixture::Fixture::new(
+                (0..files)
+                    .map(|_| fixture::FileSpec {
+                        rows,
+                        groups: groups.clone(),
+                        log_stats: true,
+                        deleted: match density {
+                            "none" => None,
+                            "sparse" => Some((0..rows as u64).filter(|p| p % 100 == 0).collect()),
+                            _ => Some((0..rows as u64).filter(|p| p % 5 != 0).collect()),
+                        },
+                    })
+                    .collect(),
+                1024,
+            )
+            .unwrap();
+            let store = Arc::new(CountedStore {
+                inner: Arc::new(object_store::local::LocalFileSystem::new()),
+                requests: AtomicU64::new(0),
+                bytes: AtomicU64::new(0),
+            });
+            let table = runtime
+                .block_on(
+                    DeltaTableBuilder::from_url(fixture.url())
+                        .unwrap()
+                        .with_storage_backend(store.clone(), fixture.url())
+                        .load(),
+                )
+                .unwrap();
+            for partitions in [1, 2, 4, 8] {
+                let mut config = SessionConfig::new().with_target_partitions(partitions);
+                config.options_mut().optimizer.repartition_file_min_size = 0;
+                config.options_mut().execution.parquet.pushdown_filters = true;
+                let context = SessionContext::new_with_config(config);
+                let provider = runtime
+                    .block_on(async { table.table_provider().await })
+                    .unwrap();
+                context.register_table("dv", provider).unwrap();
+                for selective in [false, true] {
+                    let query = if selective {
+                        format!(
+                            "SELECT id, value FROM dv WHERE id >= {}",
+                            files * rows * 9 / 10
+                        )
+                    } else {
+                        "SELECT id, value FROM dv".into()
+                    };
+                    let expected_rows = fixture
+                        .live_coordinates()
+                        .iter()
+                        .filter(|row| !selective || row.2 >= (files * rows * 9 / 10) as i64)
+                        .count();
+                    let prepared = runtime.block_on(async {
+                        context
+                            .sql(&query)
+                            .await
+                            .unwrap()
+                            .create_physical_plan()
+                            .await
+                            .unwrap()
+                    });
+                    let cache = context
+                        .runtime_env()
+                        .cache_manager
+                        .get_file_metadata_cache();
+                    for cold in [false, true] {
+                        for fresh in [false, true] {
+                            let name = format!(
+                                "dv_positions/{shape}/{density}/p{partitions}/{}/{}/{}",
+                                if selective { "selective" } else { "all" },
+                                if fresh { "fresh" } else { "prepared" },
+                                if cold {
+                                    "cold_metadata"
+                                } else {
+                                    "warm_metadata"
+                                }
+                            );
+                            c.bench_function(&name, |b| b.iter_custom(|iterations| {
+                            let mut elapsed = Duration::ZERO;
+                            let mut planning = Duration::ZERO;
+                            let mut first_read = Duration::ZERO;
+                            let mut streaming = Duration::ZERO;
+                            let before_requests = store.requests.load(Ordering::Relaxed);
+                            let before_bytes = store.bytes.load(Ordering::Relaxed);
+                            let mut last_metrics = BTreeMap::new();
+                            let mut active_footer_reference_bytes = 0;
+                            for _ in 0..iterations {
+                                if cold { cache.clear(); }
+                                let start = Instant::now();
+                                runtime.block_on(async {
+                                    let plan = if fresh { context.sql(&query).await.unwrap().create_physical_plan().await.unwrap() } else { datafusion::physical_plan::execution_plan::reset_plan_states(prepared.clone()).unwrap() };
+                                    planning += start.elapsed();
+                                    let first_start = Instant::now();
+                                    let mut stream = execute_stream(plan.clone(), context.task_ctx()).unwrap();
+                                    let first = stream.next().await.transpose().unwrap();
+                                    let mut row_count = first.as_ref().map_or(0, |batch| batch.num_rows());
+                                    first_read += first_start.elapsed();
+                                    let mut first_metrics = BTreeMap::new();
+                                    metrics(&plan, &mut first_metrics);
+                                    active_footer_reference_bytes = active_footer_reference_bytes.max(first_metrics.get("active_footer_reference_bytes").copied().unwrap_or(0));
+                                    let stream_start = Instant::now();
+                                    while let Some(batch) = stream.next().await { row_count += batch.unwrap().num_rows(); }
+                                    streaming += stream_start.elapsed();
+                                    elapsed += start.elapsed();
+                                    assert_eq!(black_box(row_count), expected_rows);
+                                    last_metrics.clear();
+                                    metrics(&plan, &mut last_metrics);
+                                });
+                            }
+                            if let Ok(path) = std::env::var("DV_BENCH_TELEMETRY") {
+                                let retention: usize = cache.list_entries().values().map(|entry| entry.size_bytes).sum();
+                                let record = json!({"case":name,"iterations":iterations,"elapsed_ns":elapsed.as_nanos(),"planning_ns":planning.as_nanos(),"first_read_ns":first_read.as_nanos(),"stream_ns":streaming.as_nanos(),"object_store_requests":store.requests.load(Ordering::Relaxed)-before_requests,"object_store_bytes":store.bytes.load(Ordering::Relaxed)-before_bytes,"cache_retention_bytes":retention,"sampled_active_footer_reference_bytes":active_footer_reference_bytes,"cache_limit_bytes":cache.cache_limit(),"plan_metrics":last_metrics});
+                                writeln!(OpenOptions::new().create(true).append(true).open(path).unwrap(), "{record}").unwrap();
+                            }
+                            elapsed
+                        }));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+criterion_group! { name = benches; config = Criterion::default().sample_size(10).warm_up_time(Duration::from_millis(100)).measurement_time(Duration::from_millis(500)); targets = benchmark }
+criterion_main!(benches);

--- a/crates/core/benches/dv_physical_position.rs
+++ b/crates/core/benches/dv_physical_position.rs
@@ -164,6 +164,9 @@ fn benchmark(c: &mut Criterion) {
                 config.options_mut().optimizer.repartition_file_min_size = 0;
                 config.options_mut().execution.parquet.pushdown_filters = true;
                 let context = SessionContext::new_with_config(config);
+                context
+                    .runtime_env()
+                    .register_object_store(&url::Url::parse("file:///").unwrap(), store.clone());
                 let provider = runtime
                     .block_on(async { table.table_provider().await })
                     .unwrap();
@@ -215,30 +218,38 @@ fn benchmark(c: &mut Criterion) {
                             let before_requests = store.requests.load(Ordering::Relaxed);
                             let before_bytes = store.bytes.load(Ordering::Relaxed);
                             let mut last_metrics = BTreeMap::new();
+                            let mut last_plan = None;
                             let mut active_footer_reference_bytes = 0;
-                            for _ in 0..iterations {
+                            for iteration in 0..iterations {
                                 if cold { cache.clear(); }
                                 let start = Instant::now();
                                 runtime.block_on(async {
                                     let plan = if fresh { context.sql(&query).await.unwrap().create_physical_plan().await.unwrap() } else { datafusion::physical_plan::execution_plan::reset_plan_states(prepared.clone()).unwrap() };
-                                    planning += start.elapsed();
+                                    let planning_elapsed = start.elapsed();
+                                    planning += planning_elapsed;
                                     let first_start = Instant::now();
                                     let mut stream = execute_stream(plan.clone(), context.task_ctx()).unwrap();
                                     let first = stream.next().await.transpose().unwrap();
                                     let mut row_count = first.as_ref().map_or(0, |batch| batch.num_rows());
-                                    first_read += first_start.elapsed();
-                                    let mut first_metrics = BTreeMap::new();
-                                    metrics(&plan, &mut first_metrics);
-                                    active_footer_reference_bytes = active_footer_reference_bytes.max(first_metrics.get("active_footer_reference_bytes").copied().unwrap_or(0));
+                                    let first_read_elapsed = first_start.elapsed();
+                                    first_read += first_read_elapsed;
+                                    // Metrics accumulate on reused native sources. Snapshot once
+                                    // per sample batch, outside all measured stages.
+                                    if iteration == 0 {
+                                        let mut first_metrics = BTreeMap::new();
+                                        metrics(&plan, &mut first_metrics);
+                                        active_footer_reference_bytes = active_footer_reference_bytes.max(first_metrics.get("active_footer_reference_bytes").copied().unwrap_or(0));
+                                    }
                                     let stream_start = Instant::now();
                                     while let Some(batch) = stream.next().await { row_count += batch.unwrap().num_rows(); }
-                                    streaming += stream_start.elapsed();
-                                    elapsed += start.elapsed();
+                                    let streaming_elapsed = stream_start.elapsed();
+                                    streaming += streaming_elapsed;
+                                    elapsed += planning_elapsed + first_read_elapsed + streaming_elapsed;
                                     assert_eq!(black_box(row_count), expected_rows);
-                                    last_metrics.clear();
-                                    metrics(&plan, &mut last_metrics);
+                                    last_plan = Some(plan);
                                 });
                             }
+                            if let Some(plan) = last_plan { metrics(&plan, &mut last_metrics); }
                             if let Ok(path) = std::env::var("DV_BENCH_TELEMETRY") {
                                 let retention: usize = cache.list_entries().values().map(|entry| entry.size_bytes).sum();
                                 let record = json!({"case":name,"iterations":iterations,"elapsed_ns":elapsed.as_nanos(),"planning_ns":planning.as_nanos(),"first_read_ns":first_read.as_nanos(),"stream_ns":streaming.as_nanos(),"object_store_requests":store.requests.load(Ordering::Relaxed)-before_requests,"object_store_bytes":store.bytes.load(Ordering::Relaxed)-before_bytes,"cache_retention_bytes":retention,"sampled_active_footer_reference_bytes":active_footer_reference_bytes,"cache_limit_bytes":cache.cache_limit(),"plan_metrics":last_metrics});

--- a/crates/core/benches/dv_physical_position.rs
+++ b/crates/core/benches/dv_physical_position.rs
@@ -210,6 +210,37 @@ fn benchmark(c: &mut Criterion) {
                                     "warm_metadata"
                                 }
                             );
+                            // Sample live-reader metadata in a separate, untimed query.
+                            // Pausing a timer mid-stream would let asynchronous prefetch do
+                            // useful work outside the measurement and undercount latency.
+                            let active_footer_reference_bytes = runtime.block_on(async {
+                                let plan = if fresh {
+                                    context
+                                        .sql(&query)
+                                        .await
+                                        .unwrap()
+                                        .create_physical_plan()
+                                        .await
+                                        .unwrap()
+                                } else {
+                                    datafusion::physical_plan::execution_plan::reset_plan_states(
+                                        prepared.clone(),
+                                    )
+                                    .unwrap()
+                                };
+                                let mut stream =
+                                    execute_stream(plan.clone(), context.task_ctx()).unwrap();
+                                stream.next().await.transpose().unwrap();
+                                let mut snapshot = BTreeMap::new();
+                                metrics(&plan, &mut snapshot);
+                                while let Some(batch) = stream.next().await {
+                                    black_box(batch.unwrap());
+                                }
+                                snapshot
+                                    .get("active_footer_reference_bytes")
+                                    .copied()
+                                    .unwrap_or(0)
+                            });
                             c.bench_function(&name, |b| b.iter_custom(|iterations| {
                             let mut elapsed = Duration::ZERO;
                             let mut planning = Duration::ZERO;
@@ -219,8 +250,7 @@ fn benchmark(c: &mut Criterion) {
                             let before_bytes = store.bytes.load(Ordering::Relaxed);
                             let mut last_metrics = BTreeMap::new();
                             let mut last_plan = None;
-                            let mut active_footer_reference_bytes = 0;
-                            for iteration in 0..iterations {
+                            for _ in 0..iterations {
                                 if cold { cache.clear(); }
                                 let start = Instant::now();
                                 runtime.block_on(async {
@@ -233,13 +263,6 @@ fn benchmark(c: &mut Criterion) {
                                     let mut row_count = first.as_ref().map_or(0, |batch| batch.num_rows());
                                     let first_read_elapsed = first_start.elapsed();
                                     first_read += first_read_elapsed;
-                                    // Metrics accumulate on reused native sources. Snapshot once
-                                    // per sample batch, outside all measured stages.
-                                    if iteration == 0 {
-                                        let mut first_metrics = BTreeMap::new();
-                                        metrics(&plan, &mut first_metrics);
-                                        active_footer_reference_bytes = active_footer_reference_bytes.max(first_metrics.get("active_footer_reference_bytes").copied().unwrap_or(0));
-                                    }
                                     let stream_start = Instant::now();
                                     while let Some(batch) = stream.next().await { row_count += batch.unwrap().num_rows(); }
                                     let streaming_elapsed = stream_start.elapsed();

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/deletion_vector.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/deletion_vector.rs
@@ -1,0 +1,301 @@
+//! Immutable deletion-vector lookup by absolute physical Parquet row position.
+
+use arrow_array::{BooleanArray, Int64Array};
+use datafusion::common::{HashMap, Result, exec_err, plan_err};
+
+#[derive(Debug)]
+#[cfg_attr(test, derive(Clone))]
+pub(super) struct DeletionVectorEntry {
+    pub keep_mask: Vec<bool>,
+    pub physical_record_count: u64,
+    pub deleted_cardinality: u64,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct DeletionVectorIndex {
+    pub(super) entries: HashMap<String, DeletionVectorEntry>,
+    selected: HashMap<String, Option<u64>>,
+}
+
+impl DeletionVectorIndex {
+    pub fn try_new(entries: HashMap<String, DeletionVectorEntry>) -> Result<Self> {
+        for (file_id, entry) in &entries {
+            if entry.physical_record_count > i64::MAX as u64 {
+                return plan_err!("numRecords exceeds Parquet Int64 coordinates");
+            }
+            let mask_len = u64::try_from(entry.keep_mask.len()).map_err(|_| {
+                datafusion::common::DataFusionError::Plan(format!(
+                    "deletion-vector mask length overflows u64 for compact file id '{file_id}'"
+                ))
+            })?;
+            if mask_len > entry.physical_record_count {
+                return plan_err!(
+                    "deletion-vector mask length {mask_len} exceeds numRecords {} for compact file id '{file_id}'",
+                    entry.physical_record_count
+                );
+            }
+            let actual_deleted = u64::try_from(
+                entry.keep_mask.iter().filter(|keep| !**keep).count(),
+            )
+            .map_err(|_| {
+                datafusion::common::DataFusionError::Plan(format!(
+                    "deletion-vector cardinality overflows u64 for compact file id '{file_id}'"
+                ))
+            })?;
+            if actual_deleted != entry.deleted_cardinality {
+                return plan_err!(
+                    "deletion-vector cardinality mismatch for compact file id '{file_id}': descriptor={}, actual={actual_deleted}",
+                    entry.deleted_cardinality
+                );
+            }
+            if entry.deleted_cardinality > entry.physical_record_count {
+                return plan_err!(
+                    "deletion-vector cardinality {} exceeds numRecords {} for compact file id '{file_id}'",
+                    entry.deleted_cardinality,
+                    entry.physical_record_count
+                );
+            }
+        }
+        let selected = entries
+            .iter()
+            .map(|(id, entry)| (id.clone(), Some(entry.physical_record_count)))
+            .collect();
+        Ok(Self { entries, selected })
+    }
+
+    pub fn with_selected_files(mut self, selected: HashMap<String, Option<u64>>) -> Result<Self> {
+        for (id, entry) in &self.entries {
+            if selected.get(id) != Some(&Some(entry.physical_record_count)) {
+                return plan_err!(
+                    "selected-file count does not match deletion vector for compact file id '{id}'"
+                );
+            }
+        }
+        self.selected = selected;
+        Ok(self)
+    }
+
+    pub fn has_vectors(&self) -> bool {
+        !self.entries.is_empty()
+    }
+
+    pub fn file_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn has_vector(&self, compact_file_id: &str) -> bool {
+        self.entries.contains_key(compact_file_id)
+    }
+
+    pub fn selection_for_positions(
+        &self,
+        compact_file_id: &str,
+        positions: &Int64Array,
+    ) -> Result<BooleanArray> {
+        let count = self.selected.get(compact_file_id).ok_or_else(|| {
+            datafusion::common::DataFusionError::Execution(format!(
+                "unknown selected compact file id '{compact_file_id}'"
+            ))
+        })?;
+        let entry = self.entries.get(compact_file_id);
+        positions
+            .iter()
+            .map(|position| {
+                let Some(position) = position else {
+                    return exec_err!(
+                        "null physical row position for compact file id '{compact_file_id}'"
+                    );
+                };
+                let position = u64::try_from(position).map_err(|_| {
+                    datafusion::common::DataFusionError::Execution(format!(
+                        "negative physical row position for compact file id '{compact_file_id}'"
+                    ))
+                })?;
+                if let Some(count) = count && position >= *count {
+                    return exec_err!(
+                        "physical row position {position} exceeds numRecords {} for compact file id '{compact_file_id}'",
+                        count
+                    );
+                }
+                // The implicit-live tail is not an index into the materialized mask.
+                let keep = match entry {
+                    Some(entry) if position < entry.keep_mask.len() as u64 => {
+                        let index = usize::try_from(position).map_err(|_| datafusion::common::DataFusionError::Execution("materialized position overflows usize".into()))?;
+                        entry.keep_mask[index]
+                    }
+                    _ => true,
+                };
+                Ok(keep)
+            })
+            .collect::<Result<BooleanArray>>()
+    }
+
+    pub fn live_row_count(
+        &self,
+        compact_file_id: &str,
+        physical_record_count: usize,
+    ) -> Result<usize> {
+        let Some(count) = self.selected.get(compact_file_id) else {
+            return exec_err!("unknown selected compact file id '{compact_file_id}'");
+        };
+        if count.is_some_and(|count| count != physical_record_count as u64) {
+            return exec_err!(
+                "physical record count mismatch for compact file id '{compact_file_id}'"
+            );
+        }
+        let Some(entry) = self.entries.get(compact_file_id) else {
+            return Ok(physical_record_count);
+        };
+        let supplied_record_count = u64::try_from(physical_record_count).map_err(|_| {
+            datafusion::common::DataFusionError::Execution(format!(
+                "physical record count overflows u64 for compact file id '{compact_file_id}'"
+            ))
+        })?;
+        if supplied_record_count != entry.physical_record_count {
+            return exec_err!(
+                "physical record count mismatch for compact file id '{compact_file_id}': expected {}, got {supplied_record_count}",
+                entry.physical_record_count
+            );
+        }
+        usize::try_from(entry.physical_record_count - entry.deleted_cardinality).map_err(|_| {
+            datafusion::common::DataFusionError::Execution(format!(
+                "live row count overflows usize for compact file id '{compact_file_id}'"
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_array::Int64Array;
+    use datafusion::common::HashMap;
+
+    use super::*;
+
+    fn index(mask: Vec<bool>, records: u64, deleted: u64) -> Result<DeletionVectorIndex> {
+        DeletionVectorIndex::try_new(HashMap::from([(
+            "7".to_string(),
+            DeletionVectorEntry {
+                keep_mask: mask,
+                physical_record_count: records,
+                deleted_cardinality: deleted,
+            },
+        )]))
+    }
+
+    #[test]
+    fn unknown_file_cannot_be_counted_as_all_live() -> Result<()> {
+        let index = index(vec![false], 3, 1)?;
+        assert!(index.live_row_count("unknown", 3).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn large_implicit_tail_needs_no_materialized_mask() -> Result<()> {
+        let index = index(vec![false], (1_u64 << 40) + 1, 1)?;
+        assert_eq!(
+            index
+                .selection_for_positions("7", &Int64Array::from(vec![1_i64 << 40]))?
+                .true_count(),
+            1
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn selects_by_absolute_position_and_keeps_sparse_tail() -> Result<()> {
+        let index = index(vec![true, false, true], 6, 1)?;
+        let positions = Int64Array::from(vec![5, 1, 3, 0, 2]);
+
+        let selection = index.selection_for_positions("7", &positions)?;
+
+        assert_eq!(
+            selection.iter().collect::<Vec<_>>(),
+            vec![Some(true), Some(false), Some(true), Some(true), Some(true),]
+        );
+        assert_eq!(index.live_row_count("7", 6)?, 5);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_invalid_positions() -> Result<()> {
+        let index = index(vec![true, false], 3, 1)?;
+
+        for positions in [
+            Int64Array::from(vec![Some(0), None]),
+            Int64Array::from(vec![-1]),
+            Int64Array::from(vec![3]),
+        ] {
+            assert!(index.selection_for_positions("7", &positions).is_err());
+        }
+        assert!(
+            index
+                .selection_for_positions("unknown", &Int64Array::from(vec![0]))
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_invalid_planning_metadata() {
+        assert!(index(vec![true, false, true], 2, 1).is_err());
+        assert!(index(vec![true, false], 2, 0).is_err());
+        assert!(index(vec![true, false], 2, 2).is_err());
+    }
+
+    #[test]
+    fn all_live_and_all_deleted_masks_remain_valid() -> Result<()> {
+        let all_live = index(Vec::new(), 3, 0)?;
+        assert_eq!(all_live.live_row_count("7", 3)?, 3);
+
+        let all_deleted = index(vec![false, false, false], 3, 3)?;
+        let selection =
+            all_deleted.selection_for_positions("7", &Int64Array::from(vec![0, 1, 2]))?;
+        assert_eq!(selection.true_count(), 0);
+        assert_eq!(all_deleted.live_row_count("7", 3)?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn indexed_lookup_matches_reference_for_reordered_predicate_results() -> Result<()> {
+        let mut state = 0x5eed_cafe_u64;
+        for record_count in 1..=64_u64 {
+            let mut full_mask = Vec::with_capacity(record_count as usize);
+            let mut deleted_positions = std::collections::HashSet::new();
+            for position in 0..record_count {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                if state.is_multiple_of(5) {
+                    deleted_positions.insert(position as i64);
+                }
+                full_mask.push(!state.is_multiple_of(5));
+            }
+            let deleted = full_mask.iter().filter(|keep| !**keep).count() as u64;
+            let sparse_len = full_mask
+                .iter()
+                .rposition(|keep| !*keep)
+                .map_or(0, |position| position + 1);
+            let sparse_mask = full_mask[..sparse_len].to_vec();
+            let index = index(sparse_mask.clone(), record_count, deleted)?;
+
+            let mut positions = (0..record_count as i64)
+                .filter(|position| position % 3 != 1)
+                .collect::<Vec<_>>();
+            positions.reverse();
+            let selection =
+                index.selection_for_positions("7", &Int64Array::from(positions.clone()))?;
+
+            let actual = positions
+                .into_iter()
+                .zip(selection.values())
+                .filter_map(|(position, keep)| keep.then_some(position))
+                .collect::<Vec<_>>();
+            let expected = (0..record_count as i64)
+                .filter(|position| position % 3 != 1)
+                .rev()
+                .filter(|position| !deleted_positions.contains(position))
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected, "record_count={record_count}");
+        }
+        Ok(())
+    }
+}

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -13,7 +13,6 @@ use arrow::compute::filter_record_batch;
 use arrow::datatypes::{FieldRef, Schema, SchemaRef, UInt16Type};
 use arrow_array::StringViewArray;
 use arrow_array::{Array, ArrayRef, BooleanArray, UInt64Array};
-use dashmap::DashMap;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::error::{DataFusionError, Result};
 use datafusion::common::tree_node::TreeNodeRecursion;
@@ -26,9 +25,7 @@ use datafusion::physical_expr::utils::collect_columns;
 use datafusion::physical_expr::{Distribution, EquivalenceProperties};
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, PlanProperties};
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
-use datafusion::physical_plan::metrics::{
-    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
-};
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
     ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan,
@@ -52,17 +49,39 @@ use crate::kernel::arrow::engine_ext::ExpressionEvaluatorExt;
 const DELTA_MATERIALIZED_PUSHDOWN_SENTINEL: &str =
     "__delta_rs_unpushable_delta_materialized_filter";
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum DvApplicationMode {
+/// DeltaScanExec uses these inputs to apply deletion vectors during a physical scan.
+#[derive(Clone, Debug)]
+pub(super) enum DvExecutionState {
     None,
-    Sequential,
+    Sequential {
+        /// The planner captures these masks. Each execution stream copies them before use.
+        selection_vectors: Arc<HashMap<String, Vec<bool>>>,
+        /// The validator compares child files against this whole file ownership map.
+        physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
+    },
 }
 
-impl DvApplicationMode {
-    fn as_str(self) -> &'static str {
+impl DvExecutionState {
+    fn is_sequential(&self) -> bool {
+        matches!(self, Self::Sequential { .. })
+    }
+
+    fn selection_vectors(&self) -> Option<&HashMap<String, Vec<bool>>> {
         match self {
-            Self::None => "none",
-            Self::Sequential => "sequential",
+            Self::None => None,
+            Self::Sequential {
+                selection_vectors, ..
+            } => Some(selection_vectors),
+        }
+    }
+
+    fn physical_file_identities(&self) -> Option<&super::PhysicalFileIdentityMap> {
+        match self {
+            Self::None => None,
+            Self::Sequential {
+                physical_file_identities,
+                ..
+            } => Some(physical_file_identities),
         }
     }
 }
@@ -127,7 +146,7 @@ pub(crate) fn consume_dv_mask(
 ///
 /// 1. Inner [`input`](Self::input) plan reads raw Parquet data
 /// 2. Per-file [`transforms`](Self::transforms) convert physical to logical schema
-/// 3. [`selection_vectors`](Self::selection_vectors) filter deleted rows
+/// 3. The scan applies deletion vectors before it returns rows
 /// 4. Result is cast to the projected scan contract's result schema
 #[derive(Clone, Debug)]
 pub struct DeltaScanExec {
@@ -136,14 +155,10 @@ pub struct DeltaScanExec {
     input: Arc<dyn ExecutionPlan>,
     /// Transforms to be applied to data eminating from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
-    /// Selection vectors to be applied to data read from individual files
-    selection_vectors: Arc<DashMap<String, Vec<bool>>>,
-    /// Stable deletion-vector execution mode for this plan.
-    dv_mode: DvApplicationMode,
+    /// The planner records deletion vector masks and physical file ownership here.
+    dv_state: DvExecutionState,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
-    /// Expected physical file ownership keyed by compact scan file id.
-    physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
     /// File id column name carried by the input batches for per file correlation.
@@ -170,12 +185,6 @@ impl DisplayAs for DeltaScanExec {
                 if let Some(row_index_field) = self.scan_plan.contract.retained_row_index_field() {
                     write!(f, ": row_index_column={}", row_index_field.name())?;
                 }
-                write!(
-                    f,
-                    ": dv_mode={}, physical_row_index=false, file_group_layout_locked={}",
-                    self.dv_mode.as_str(),
-                    matches!(self.dv_mode, DvApplicationMode::Sequential)
-                )?;
                 Ok(())
             }
         }
@@ -183,33 +192,15 @@ impl DisplayAs for DeltaScanExec {
 }
 
 impl DeltaScanExec {
-    fn register_dv_file_metric(
-        metrics: &ExecutionPlanMetricsSet,
-        selection_vectors: &DashMap<String, Vec<bool>>,
-    ) {
-        if !selection_vectors.is_empty() {
-            MetricBuilder::new(metrics)
-                .global_counter("dv_files")
-                .add(selection_vectors.len());
-        }
-    }
-
-    pub(crate) fn new(
+    pub(super) fn new(
         scan_plan: Arc<KernelScanPlan>,
         input: Arc<dyn ExecutionPlan>,
         transforms: Arc<HashMap<String, ExpressionRef>>,
-        selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+        dv_state: DvExecutionState,
         public_file_ids: Arc<super::PublicFileIdMap>,
-        physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
         partition_stats: HashMap<String, ColumnStatistics>,
         metrics: ExecutionPlanMetricsSet,
     ) -> Self {
-        let dv_mode = if selection_vectors.is_empty() {
-            DvApplicationMode::None
-        } else {
-            DvApplicationMode::Sequential
-        };
-        Self::register_dv_file_metric(&metrics, &selection_vectors);
         let input_file_id_column = scan_plan.contract.file_id_field.name().to_owned();
         let file_id_column = scan_plan
             .contract
@@ -225,10 +216,8 @@ impl DeltaScanExec {
             scan_plan,
             input,
             transforms,
-            selection_vectors,
-            dv_mode,
+            dv_state,
             public_file_ids,
-            physical_file_identities,
             partition_stats,
             metrics,
             input_file_id_column,
@@ -238,11 +227,9 @@ impl DeltaScanExec {
     }
 
     fn with_new_input_same_properties(&self, input: Arc<dyn ExecutionPlan>) -> Self {
-        let metrics = ExecutionPlanMetricsSet::new();
-        Self::register_dv_file_metric(&metrics, &self.selection_vectors);
         Self {
             input,
-            metrics,
+            metrics: ExecutionPlanMetricsSet::new(),
             ..Self::clone(self)
         }
     }
@@ -252,16 +239,15 @@ impl DeltaScanExec {
             Arc::clone(&self.scan_plan),
             input,
             Arc::clone(&self.transforms),
-            Arc::clone(&self.selection_vectors),
+            self.dv_state.clone(),
             Arc::clone(&self.public_file_ids),
-            Arc::clone(&self.physical_file_identities),
             self.partition_stats.clone(),
             ExecutionPlanMetricsSet::new(),
         )
     }
 
     fn has_deletion_vectors(&self) -> bool {
-        !matches!(self.dv_mode, DvApplicationMode::None)
+        self.dv_state.is_sequential()
     }
 
     fn validate_dv_child_topology(&self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
@@ -280,6 +266,11 @@ impl DeltaScanExec {
             expected: &super::PhysicalFileIdentityMap,
             observed: &mut HashSet<String>,
         ) -> Result<()> {
+            if let Some(fetch) = plan.fetch() {
+                return plan_err!(
+                    "DeltaScanExec rejects child fetch limit {fetch} during sequential deletion vector scans"
+                );
+            }
             if let Some(coalesce) = plan.downcast_ref::<CoalescePartitionsExec>() {
                 return visit(coalesce.input(), expected, observed);
             }
@@ -291,13 +282,13 @@ impl DeltaScanExec {
             }
             let Some(source_exec) = plan.downcast_ref::<DataSourceExec>() else {
                 return plan_err!(
-                    "DeltaScanExec sequential deletion-vector topology contains unsupported node {}",
+                    "DeltaScanExec rejects node {} during sequential deletion vector scans",
                     plan.name()
                 );
             };
             let Some(config) = source_exec.data_source().downcast_ref::<FileScanConfig>() else {
                 return plan_err!(
-                    "DeltaScanExec sequential deletion-vector topology requires FileScanConfig leaves"
+                    "DeltaScanExec requires FileScanConfig leaves during sequential deletion vector scans"
                 );
             };
             if !matches!(
@@ -306,7 +297,12 @@ impl DeltaScanExec {
                     if partitions == config.file_groups.len()
             ) {
                 return plan_err!(
-                    "DeltaScanExec sequential deletion-vector file-group layout is not locked"
+                    "DeltaScanExec requires a locked file group layout during sequential deletion vector scans"
+                );
+            }
+            if config.file_source.filter().is_some() {
+                return plan_err!(
+                    "DeltaScanExec rejects file source filters during sequential deletion vector scans"
                 );
             }
 
@@ -315,29 +311,29 @@ impl DeltaScanExec {
                     let Some(file_id) = file.partition_values.first().and_then(scalar_file_id)
                     else {
                         return plan_err!(
-                            "DeltaScanExec sequential deletion-vector file is missing a compact file id"
+                            "A sequential deletion vector file lacks a compact file id"
                         );
                     };
                     if file.range.is_some() {
                         return plan_err!(
-                            "DeltaScanExec sequential deletion-vector file id '{file_id}' has a byte range"
+                            "Sequential deletion vector file id '{file_id}' uses a byte range"
                         );
                     }
                     let Some(expected_file) = expected.get(file_id) else {
                         return plan_err!(
-                            "DeltaScanExec sequential deletion-vector topology contains unknown file id '{file_id}'"
+                            "Sequential deletion vector scan received unknown file id '{file_id}'"
                         );
                     };
                     if expected_file.object_store_url != config.object_store_url
                         || expected_file.location != file.object_meta.location
                     {
                         return plan_err!(
-                            "DeltaScanExec sequential deletion-vector topology has an inconsistent mapping for file id '{file_id}'"
+                            "Sequential deletion vector file id '{file_id}' has an unexpected store or location"
                         );
                     }
                     if !observed.insert(file_id.to_owned()) {
                         return plan_err!(
-                            "DeltaScanExec sequential deletion-vector topology has duplicate ownership for file id '{file_id}'"
+                            "Sequential deletion vector file id '{file_id}' belongs to multiple child files"
                         );
                     }
                 }
@@ -345,12 +341,15 @@ impl DeltaScanExec {
             Ok(())
         }
 
+        let expected = self.dv_state.physical_file_identities().ok_or_else(|| {
+            internal_datafusion_err!(
+                "DeltaScanExec deletion vector topology validation requires sequential state"
+            )
+        })?;
         let mut observed = HashSet::new();
-        visit(input, &self.physical_file_identities, &mut observed)?;
-        if observed.len() != self.physical_file_identities.len() {
-            return plan_err!(
-                "DeltaScanExec sequential deletion-vector topology is missing selected files"
-            );
+        visit(input, expected, &mut observed)?;
+        if observed.len() != expected.len() {
+            return plan_err!("DeltaScanExec sequential deletion vector scan lacks selected files");
         }
         Ok(())
     }
@@ -412,14 +411,9 @@ impl DeltaScanExec {
 
         stats.column_statistics = new_stats;
         if self.has_deletion_vectors() {
-            // The child statistics describe physical Parquet rows. Sequential DV filtering can
-            // only provide conservative bounds until the DV index carries validated numRecords.
-            stats.num_rows = stats.num_rows.to_inexact();
-            stats.column_statistics = stats
-                .column_statistics
-                .into_iter()
-                .map(ColumnStatistics::to_inexact)
-                .collect();
+            // Child statistics describe physical Parquet rows. This node reports conservative
+            // bounds unless the DV index contains numRecords.
+            stats = stats.to_inexact();
         }
         Ok(stats)
     }
@@ -475,8 +469,8 @@ impl ExecutionPlan for DeltaScanExec {
         if self.scan_plan.contract.retained_row_index_field().is_some()
             || self.has_deletion_vectors()
         {
-            // Retained row indexes and sequential deletion-vector masks depend on one stream
-            // seeing each file's rows in physical order.
+            // DeltaScanExec requires one stream to preserve physical row order for retained row
+            // indexes and sequential DV masks.
             InputDistributionRequirements::new(vec![Distribution::SinglePartition])
         } else {
             InputDistributionRequirements::new(vec![Distribution::UnspecifiedDistribution])
@@ -526,8 +520,8 @@ impl ExecutionPlan for DeltaScanExec {
         if self.scan_plan.contract.retained_row_index_field().is_some()
             || self.has_deletion_vectors()
         {
-            // Each DeltaScanStream keeps row ordinal counters and sequential DV cursors for one
-            // execution partition. Repartitioning can split one file across streams.
+            // A DeltaScanStream stores row ordinals and DV cursors for one execution partition.
+            // DataFusion can split a file across streams after repartitioning.
             return Ok(None);
         }
 
@@ -546,10 +540,8 @@ impl ExecutionPlan for DeltaScanExec {
         // Normal planning enforces this through EnforceDistribution. Keep this check for
         // callers that build DeltaScanExec directly or replace its child plan.
         let retains_row_index = self.scan_plan.contract.retained_row_index_field().is_some();
-        if self.has_deletion_vectors() {
-            self.validate_dv_child_topology(&self.input)?;
-        }
-        if retains_row_index || self.has_deletion_vectors() {
+        let has_deletion_vectors = self.has_deletion_vectors();
+        if retains_row_index || has_deletion_vectors {
             let input_partition_count = self.input.properties().partitioning.partition_count();
             if input_partition_count > 1 {
                 if retains_row_index {
@@ -563,28 +555,18 @@ impl ExecutionPlan for DeltaScanExec {
             }
         }
 
-        let dv_file_ids = self
-            .selection_vectors
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect();
-        let dv_rows_checked =
-            MetricBuilder::new(&self.metrics).counter("dv_rows_checked", partition);
-        let dv_rows_removed =
-            MetricBuilder::new(&self.metrics).counter("dv_rows_removed", partition);
-
         Ok(Box::pin(DeltaScanStream {
             scan_plan: Arc::clone(&self.scan_plan),
             kernel_type: Arc::clone(self.scan_plan.scan.logical_schema()).into(),
             input: self.input.execute(partition, context)?,
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
             transforms: Arc::clone(&self.transforms),
-            // Sequential cursors are execution-local. Reusing the physical plan must start each
-            // stream from the original immutable planning snapshot.
-            selection_vectors: self.selection_vectors.as_ref().clone(),
-            dv_file_ids,
-            dv_rows_checked,
-            dv_rows_removed,
+            // Each execution owns its cursors and copies the masks that the planner captured.
+            selection_vectors: self
+                .dv_state
+                .selection_vectors()
+                .cloned()
+                .unwrap_or_default(),
             public_file_ids: Arc::clone(&self.public_file_ids),
             input_file_id_column: self.input_file_id_column.clone(),
             file_id_column: self.file_id_column.clone(),
@@ -614,9 +596,11 @@ impl ExecutionPlan for DeltaScanExec {
     }
 
     fn fetch(&self) -> Option<usize> {
-        (!self.has_deletion_vectors())
-            .then(|| self.input.fetch())
-            .flatten()
+        if self.has_deletion_vectors() {
+            None
+        } else {
+            self.input.fetch()
+        }
     }
 
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
@@ -739,11 +723,7 @@ struct DeltaScanStream {
     /// Transforms to be applied to data read from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Selection vectors to be applied to data read from individual files
-    selection_vectors: DashMap<String, Vec<bool>>,
-    /// Files that had a DV at planning time; unlike the mutable sequential cursors this is stable.
-    dv_file_ids: HashSet<String>,
-    dv_rows_checked: Count,
-    dv_rows_removed: Count,
+    selection_vectors: HashMap<String, Vec<bool>>,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
     /// File id column name carried by the input batches for per file correlation.
@@ -789,11 +769,8 @@ impl DeltaScanStream {
         file_id: String,
         file_id_idx: usize,
     ) -> Result<RecordBatch> {
-        let input_row_count = batch.num_rows();
-        let has_deletion_vector = self.dv_file_ids.contains(&file_id);
-        let dv_result = if let Some(mut selection_vector) = self.selection_vectors.get_mut(&file_id)
-        {
-            consume_dv_mask(&mut selection_vector, batch.num_rows())
+        let dv_result = if let Some(selection_vector) = self.selection_vectors.get_mut(&file_id) {
+            consume_dv_mask(selection_vector, batch.num_rows())
         } else {
             DvMaskResult {
                 selection: None,
@@ -810,12 +787,6 @@ impl DeltaScanStream {
         } else {
             batch
         };
-        if has_deletion_vector {
-            self.dv_rows_checked.add(input_row_count);
-            self.dv_rows_removed
-                .add(input_row_count.saturating_sub(batch.num_rows()));
-        }
-
         batch.remove_column(file_id_idx);
 
         let result = if let Some(transform) = self.transforms.get(&file_id) {
@@ -1056,7 +1027,7 @@ mod tests {
     use datafusion::{
         catalog::MemTable,
         common::{ToDFSchema, stats::Precision},
-        datasource::TableProvider,
+        datasource::{TableProvider, physical_plan::ParquetSource},
         logical_expr::Operator,
         physical_expr::expressions::{
             BinaryExpr, Column, DynamicFilterPhysicalExpr, lit as physical_lit,
@@ -1065,12 +1036,13 @@ mod tests {
         physical_plan::{
             PhysicalExpr,
             coalesce_partitions::CoalescePartitionsExec,
-            collect, collect_partitioned, displayable,
+            collect, collect_partitioned,
             filter_pushdown::{FilterPushdownPhase, PushedDown},
             repartition::RepartitionExec,
             statistics::StatisticsContext,
         },
-        prelude::{col, lit},
+        physical_planner::DefaultPhysicalPlanner,
+        prelude::{SessionConfig, col, lit},
         scalar::ScalarValue,
     };
     use datafusion_datasource::{
@@ -1237,7 +1209,7 @@ mod tests {
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
             .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
+            .expect("planner must return DeltaScanExec");
 
         let filter = session.state().create_physical_expr(
             col("number").lt(lit(ScalarValue::TimestampMillisecond(Some(7), None))),
@@ -1271,7 +1243,7 @@ mod tests {
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
             .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
+            .expect("planner must return DeltaScanExec");
 
         let letter_idx = exec.schema().index_of("letter")?;
         assert!(exec.schema().field_with_name("letter").is_ok());
@@ -1449,41 +1421,6 @@ mod tests {
         assert_eq!(child_filters.len(), 1);
         assert_eq!(child_filters[0].len(), 1);
         assert!(matches!(child_filters[0][0].discriminant, PushedDown::Yes));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_gather_filters_for_pushdown_rejects_dv_data_filters() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], None).await?;
-        let exec = scan
-            .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
-
-        assert!(
-            !exec.selection_vectors.is_empty(),
-            "fixture must select at least one deletion vector"
-        );
-        let int_idx = exec.schema().index_of("int")?;
-        let int: Arc<dyn PhysicalExpr> = Arc::new(Column::new("int", int_idx));
-        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
-            vec![int],
-            physical_lit(true),
-        ));
-
-        let description = exec.gather_filters_for_pushdown(
-            FilterPushdownPhase::Post,
-            vec![filter],
-            session.state().config().options(),
-        )?;
-
-        let child_filters = description.parent_filters();
-        assert_eq!(child_filters.len(), 1);
-        assert_eq!(child_filters[0].len(), 1);
-        assert!(matches!(child_filters[0][0].discriminant, PushedDown::No));
 
         Ok(())
     }
@@ -1919,16 +1856,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dv_scan_disables_limit_and_fetch_pushdown() -> TestResult {
+    async fn test_dv_scan_rejects_unsafe_pushdowns() -> TestResult {
         let table = open_fs_path(DV_TABLE_PATH);
         let provider = table.table_provider().await?;
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], Some(1)).await?;
         let exec = scan
             .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
+            .expect("planner must return DeltaScanExec");
 
-        assert!(!exec.selection_vectors.is_empty());
         assert!(!exec.supports_limit_pushdown());
         assert!(matches!(
             exec.cardinality_effect(),
@@ -1937,98 +1873,57 @@ mod tests {
         assert_eq!(exec.fetch(), None);
         assert!(exec.with_fetch(Some(1)).is_none());
 
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dv_scan_requires_single_input_partition() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], None).await?;
-        let exec = scan
-            .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
-
-        let distribution = exec.input_distribution_requirements();
+        let int_idx = exec.schema().index_of("int")?;
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("int", int_idx))],
+            physical_lit(true),
+        ));
+        let description = exec.gather_filters_for_pushdown(
+            FilterPushdownPhase::Post,
+            vec![filter],
+            session.state().config().options(),
+        )?;
         assert!(matches!(
-            distribution.child_distribution(0),
-            Some(Distribution::SinglePartition)
+            description.parent_filters()[0][0].discriminant,
+            PushedDown::No
         ));
 
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dv_scan_locks_whole_file_layout() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], None).await?;
-        let exec = scan
-            .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
-        let source_exec = exec
-            .input
-            .downcast_ref::<DataSourceExec>()
-            .expect("single-store fixture should produce a DataSourceExec");
-        let config = source_exec
-            .data_source()
-            .downcast_ref::<FileScanConfig>()
-            .expect("expected parquet FileScanConfig");
-
-        assert!(matches!(
-            config.output_partitioning,
-            Some(Partitioning::UnknownPartitioning(partitions))
-                if partitions == config.file_groups.len()
-        ));
-        assert!(
-            config
-                .file_groups
-                .iter()
-                .all(|group| { group.iter().all(|file| file.range.is_none()) })
+        let batches = collect(scan, session.task_ctx()).await?;
+        assert_eq!(
+            batches.iter().map(RecordBatch::num_rows).sum::<usize>(),
+            1,
+            "the limit must run after DV filtering removes four rows"
         );
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_dv_scan_rejects_ranged_fragments_under_single_output_coalesce() -> TestResult {
+    async fn test_dv_scan_rejects_row_dropping_child_rewrites() -> TestResult {
         let table = open_fs_path(DV_TABLE_PATH);
         let provider = table.table_provider().await?;
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], None).await?;
         let exec = scan
             .downcast_ref::<DeltaScanExec>()
-            .expect("expected DeltaScanExec");
+            .expect("planner must return DeltaScanExec");
         let source_exec = exec
             .input
             .downcast_ref::<DataSourceExec>()
-            .expect("single-store fixture should produce a DataSourceExec");
+            .expect("fixture must produce one DataSourceExec");
         let config = source_exec
             .data_source()
             .downcast_ref::<FileScanConfig>()
-            .expect("expected parquet FileScanConfig");
+            .expect("DataSourceExec must hold a parquet FileScanConfig");
 
-        let whole_file = config.file_groups[0][0].clone();
-        let split_at = i64::try_from(whole_file.object_meta.size / 2)?;
-        let file_end = i64::try_from(whole_file.object_meta.size)?;
-        let mut first = whole_file.clone();
-        first.range = Some(FileRange {
+        let mut fragment = config.file_groups[0][0].clone();
+        fragment.range = Some(FileRange {
             start: 0,
-            end: split_at,
-        });
-        let mut second = whole_file;
-        second.range = Some(FileRange {
-            start: split_at,
-            end: file_end,
+            end: i64::try_from(fragment.object_meta.size / 2)?,
         });
         let fragmented_config = FileScanConfigBuilder::from(config.clone())
-            .with_file_groups(vec![
-                FileGroup::new(vec![first]),
-                FileGroup::new(vec![second]),
-            ])
-            .with_output_partitioning(Some(Partitioning::UnknownPartitioning(2)))
+            .with_file_groups(vec![FileGroup::new(vec![fragment])])
+            .with_output_partitioning(Some(Partitioning::UnknownPartitioning(1)))
             .build();
         let fragmented = DataSourceExec::from_data_source(fragmented_config);
         let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(fragmented));
@@ -2039,109 +1934,192 @@ mod tests {
         );
         assert!(
             result.is_err(),
-            "single-output coalescing must not hide ranged DV file fragments"
+            "coalescing to one output must not hide ranged DV file fragments"
         );
 
-        Ok(())
-    }
+        let limited_config = FileScanConfigBuilder::from(config.clone())
+            .with_limit(Some(1))
+            .build();
+        let limited: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(limited_config);
+        let limited_result = Arc::new(exec.clone()).replace_children(
+            vec![limited],
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        );
 
-    #[tokio::test]
-    async fn test_dv_scan_applies_limit_after_deleted_rows() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], Some(1)).await?;
-
-        let batches = collect(scan, session.task_ctx()).await?;
-        let row_count = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
-        assert_eq!(row_count, 1, "one live row exists after four deleted rows");
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dv_scan_downgrades_physical_statistics() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let predicates = provider
-            .schema()
-            .fields()
-            .iter()
-            .map(|field| col(field.name()).is_not_null())
-            .collect::<Vec<_>>();
-        let scan = provider
-            .scan(&session.state(), None, &predicates, None)
-            .await?;
-
-        let statistics = StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
+        let parquet_source = config
+            .file_source
+            .downcast_ref::<ParquetSource>()
+            .expect("FileScanConfig must hold ParquetSource");
+        let filtered_config = FileScanConfigBuilder::from(config.clone())
+            .with_source(Arc::new(parquet_source.with_predicate(physical_lit(false))))
+            .build();
+        let filtered: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(filtered_config);
+        let filtered_result = Arc::new(exec.clone()).replace_children(
+            vec![filtered],
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        );
         assert!(
-            !matches!(statistics.num_rows, Precision::Exact(_)),
-            "physical row count is not an exact live-row count"
-        );
-        for column in &statistics.column_statistics {
-            assert!(!matches!(column.null_count, Precision::Exact(_)));
-            assert!(!matches!(column.min_value, Precision::Exact(_)));
-            assert!(!matches!(column.max_value, Precision::Exact(_)));
-            assert!(!matches!(column.distinct_count, Precision::Exact(_)));
-        }
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dv_scan_explain_reports_containment_mode() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], None).await?;
-
-        let explain = displayable(scan.as_ref()).indent(false).to_string();
-        assert!(explain.contains("dv_mode=sequential"), "{explain}");
-        assert!(explain.contains("physical_row_index=false"), "{explain}");
-        assert!(
-            explain.contains("file_group_layout_locked=true"),
-            "{explain}"
+            limited_result.is_err() && filtered_result.is_err(),
+            "DeltaScanExec must reject child rewrites that remove rows: limit={}, predicate={}",
+            limited_result.is_err(),
+            filtered_result.is_err()
         );
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_sequential_dv_plan_is_repeatable() -> TestResult {
+    async fn test_dv_scan_downgrades_all_exact_physical_statistics() -> TestResult {
         let table = open_fs_path(DV_TABLE_PATH);
         let provider = table.table_provider().await?;
         let session = Arc::new(create_session().into_inner());
         let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("planner must return DeltaScanExec");
 
-        let first = collect(Arc::clone(&scan), session.task_ctx()).await?;
-        let second = collect(scan, session.task_ctx()).await?;
-        let first_rows = first.iter().map(RecordBatch::num_rows).sum::<usize>();
-        let second_rows = second.iter().map(RecordBatch::num_rows).sum::<usize>();
-        assert_eq!(first_rows, 1);
-        assert_eq!(second_rows, first_rows);
+        let mut physical = Statistics::new_unknown(exec.input.schema().as_ref());
+        physical.num_rows = Precision::Exact(5);
+        physical.total_byte_size = Precision::Exact(1_006);
+        let first_column = physical
+            .column_statistics
+            .first_mut()
+            .expect("DV fixture must read at least one physical column");
+        first_column.byte_size = Precision::Exact(128);
+        first_column.sum_value = Precision::Exact(ScalarValue::Int64(Some(42)));
 
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dv_scan_reports_file_and_row_metrics() -> TestResult {
-        let table = open_fs_path(DV_TABLE_PATH);
-        let provider = table.table_provider().await?;
-        let session = Arc::new(create_session().into_inner());
-        let scan = provider.scan(&session.state(), None, &[], None).await?;
-
-        collect(Arc::clone(&scan), session.task_ctx()).await?;
-        let metrics = scan.metrics().expect("DeltaScanExec metrics");
-        assert_eq!(metrics.sum_by_name("dv_files").unwrap().as_usize(), 1);
+        let logical = exec.map_statistics(physical)?;
+        assert_eq!(logical.num_rows, Precision::Inexact(5));
+        assert_eq!(logical.total_byte_size, Precision::Inexact(1_006));
         assert_eq!(
-            metrics.sum_by_name("dv_rows_checked").unwrap().as_usize(),
-            5
+            logical.column_statistics[0].byte_size,
+            Precision::Inexact(128)
         );
         assert_eq!(
-            metrics.sum_by_name("dv_rows_removed").unwrap().as_usize(),
-            4
+            logical.column_statistics[0].sum_value,
+            Precision::Inexact(ScalarValue::Int64(Some(42)))
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_optimized_multi_group_dv_scan_is_concurrently_repeatable() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let config = SessionConfig::new().with_target_partitions(2);
+        let session = Arc::new(datafusion::prelude::SessionContext::new_with_config(config));
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("planner must return DeltaScanExec");
+        let source_exec = exec
+            .input
+            .downcast_ref::<DataSourceExec>()
+            .expect("fixture must produce one DataSourceExec");
+        let source_config = source_exec
+            .data_source()
+            .downcast_ref::<FileScanConfig>()
+            .expect("DataSourceExec must hold a parquet FileScanConfig");
+        let original_file = source_config.file_groups[0][0].clone();
+        let original_file_id = exec
+            .dv_state
+            .selection_vectors()
+            .and_then(|vectors| vectors.keys().next().cloned())
+            .expect("fixture must have one deletion vector mask");
+
+        let duplicate_file_id = "duplicate".to_string();
+        let source_url = url::Url::parse(&format!(
+            "{}{}",
+            source_config.object_store_url.as_str(),
+            original_file.object_meta.location.as_ref()
+        ))?;
+        let source_path = source_url.to_file_path().map_err(|_| {
+            std::io::Error::other(format!("fixture requires a file URL: {source_url}"))
+        })?;
+        let temp_dir = tempfile::tempdir()?;
+        let duplicate_path = temp_dir.path().join("duplicate.parquet");
+        std::fs::copy(&source_path, &duplicate_path)?;
+        let duplicate_location = object_store::path::Path::from_filesystem_path(&duplicate_path)?;
+
+        let mut duplicate_file = original_file.clone();
+        duplicate_file.object_meta.location = duplicate_location.clone();
+        duplicate_file.partition_values =
+            vec![crate::delta_datafusion::file_id::wrap_file_id_value(
+                duplicate_file_id.clone(),
+            )];
+        let grouped_config = FileScanConfigBuilder::from(source_config.clone())
+            .with_file_groups(vec![
+                FileGroup::new(vec![original_file]),
+                FileGroup::new(vec![duplicate_file]),
+            ])
+            .with_output_partitioning(Some(Partitioning::UnknownPartitioning(2)))
+            .build();
+        let grouped_input = DataSourceExec::from_data_source(grouped_config);
+
+        let mut selection_vectors = exec.dv_state.selection_vectors().unwrap().clone();
+        let duplicate_mask = selection_vectors
+            .get(&original_file_id)
+            .expect("fixture must provide the original mask")
+            .clone();
+        selection_vectors.insert(duplicate_file_id.clone(), duplicate_mask);
+        let mut identities = exec
+            .dv_state
+            .physical_file_identities()
+            .expect("fixture must provide sequential DV identities")
+            .clone();
+        identities.insert(
+            duplicate_file_id.clone(),
+            super::super::PhysicalFileIdentity {
+                object_store_url: source_config.object_store_url.clone(),
+                location: duplicate_location,
+            },
+        );
+        let dv_state = DvExecutionState::Sequential {
+            selection_vectors: Arc::new(selection_vectors),
+            physical_file_identities: Arc::new(identities),
+        };
+
+        let grouped_scan: Arc<dyn ExecutionPlan> = Arc::new(DeltaScanExec::new(
+            Arc::clone(&exec.scan_plan),
+            grouped_input,
+            Arc::clone(&exec.transforms),
+            dv_state,
+            Arc::clone(&exec.public_file_ids),
+            exec.partition_stats.clone(),
+            ExecutionPlanMetricsSet::new(),
+        ));
+
+        let optimized = DefaultPhysicalPlanner::default().optimize_physical_plan(
+            grouped_scan,
+            &session.state(),
+            |_, _| {},
+        )?;
+        let optimized_scan = optimized
+            .downcast_ref::<DeltaScanExec>()
+            .expect("optimizer must retain DeltaScanExec");
+        assert!(
+            optimized_scan
+                .input
+                .downcast_ref::<CoalescePartitionsExec>()
+                .is_some(),
+            "fixture must exercise multiple file groups under one coalescing node"
+        );
+
+        let (first, second) = tokio::join!(
+            collect(Arc::clone(&optimized), session.task_ctx()),
+            collect(optimized, session.task_ctx())
+        );
+        let expected = vec![
+            "+--------+-----+------------+",
+            "| letter | int | date       |",
+            "+--------+-----+------------+",
+            "| b      | 228 | 1978-12-01 |",
+            "| b      | 228 | 1978-12-01 |",
+            "+--------+-----+------------+",
+        ];
+        assert_batches_sorted_eq!(&expected, &first?);
+        assert_batches_sorted_eq!(&expected, &second?);
 
         Ok(())
     }
@@ -2204,11 +2182,11 @@ mod tests {
         Ok((kernel_type, Arc::new(scan_plan)))
     }
 
-    fn selection_vectors_f1_f2() -> Arc<DashMap<String, Vec<bool>>> {
-        let selection_vectors: Arc<DashMap<String, Vec<bool>>> = Arc::new(DashMap::new());
-        selection_vectors.insert("f1".to_string(), vec![true, false]);
-        selection_vectors.insert("f2".to_string(), vec![false, true]);
-        selection_vectors
+    fn selection_vectors_f1_f2() -> HashMap<String, Vec<bool>> {
+        HashMap::from([
+            ("f1".to_string(), vec![true, false]),
+            ("f2".to_string(), vec![false, true]),
+        ])
     }
 
     fn value_and_file_id_batch(
@@ -2252,7 +2230,7 @@ mod tests {
     fn test_scan_stream(
         scan_plan: Arc<KernelScanPlan>,
         kernel_type: KernelDataType,
-        selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+        selection_vectors: HashMap<String, Vec<bool>>,
         input_batches: Vec<RecordBatch>,
         file_id_column: Option<String>,
     ) -> DeltaScanStream {
@@ -2264,11 +2242,8 @@ mod tests {
             .unwrap_or_else(|| Arc::clone(&scan_plan.contract.output_schema));
         let input_file_id_column = scan_plan.contract.file_id_field.name().clone();
         let mut public_file_ids = super::super::PublicFileIdMap::default();
-        for selection_vector in selection_vectors.iter() {
-            public_file_ids.insert(
-                selection_vector.key().clone(),
-                selection_vector.key().clone(),
-            );
+        for file_id in selection_vectors.keys() {
+            public_file_ids.insert(file_id.clone(), file_id.clone());
         }
         for batch in &input_batches {
             if let Ok(file_id_idx) = file_id_column_idx(batch, &input_file_id_column) {
@@ -2294,13 +2269,7 @@ mod tests {
             input,
             baseline_metrics: BaselineMetrics::new(&ExecutionPlanMetricsSet::new(), 0),
             transforms: Arc::new(HashMap::new()),
-            selection_vectors: selection_vectors.as_ref().clone(),
-            dv_file_ids: selection_vectors
-                .iter()
-                .map(|entry| entry.key().clone())
-                .collect(),
-            dv_rows_checked: Count::new(),
-            dv_rows_removed: Count::new(),
+            selection_vectors,
             public_file_ids: Arc::new(public_file_ids),
             input_file_id_column,
             file_id_column,
@@ -2356,9 +2325,8 @@ mod tests {
             retain_row_index(scan_plan, "row_ordinal"),
             Arc::clone(&exec.input),
             Arc::clone(&exec.transforms),
-            Arc::clone(&exec.selection_vectors),
+            exec.dv_state.clone(),
             Arc::clone(&exec.public_file_ids),
-            Arc::clone(&exec.physical_file_identities),
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -2395,9 +2363,8 @@ mod tests {
             retain_row_index(scan_plan, "row_ordinal"),
             repartitioned_input,
             Arc::clone(&exec.transforms),
-            Arc::clone(&exec.selection_vectors),
+            exec.dv_state.clone(),
             Arc::clone(&exec.public_file_ids),
-            Arc::clone(&exec.physical_file_identities),
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -2433,9 +2400,8 @@ mod tests {
             scan_plan,
             input,
             Arc::new(HashMap::new()),
-            Arc::new(DashMap::new()),
+            DvExecutionState::None,
             Arc::new(public_file_ids),
-            Arc::new(super::super::PhysicalFileIdentityMap::default()),
             HashMap::new(),
             ExecutionPlanMetricsSet::new(),
         );
@@ -2470,13 +2436,7 @@ mod tests {
         let scan_plan = retain_row_index(scan_plan, "row_ordinal");
         let batch = value_and_file_id_batch(&[10, 11], &[Some("f1"), Some("f1")], false)?;
 
-        let mut stream = test_scan_stream(
-            scan_plan,
-            kernel_type,
-            Arc::new(DashMap::new()),
-            Vec::new(),
-            None,
-        );
+        let mut stream = test_scan_stream(scan_plan, kernel_type, HashMap::new(), Vec::new(), None);
 
         assert!(stream.schema().column_with_name("row_ordinal").is_some());
         let outputs = stream.batch_project(batch)?;
@@ -2496,13 +2456,7 @@ mod tests {
             false,
         )?;
 
-        let mut stream = test_scan_stream(
-            scan_plan,
-            kernel_type,
-            Arc::new(DashMap::new()),
-            Vec::new(),
-            None,
-        );
+        let mut stream = test_scan_stream(scan_plan, kernel_type, HashMap::new(), Vec::new(), None);
 
         let outputs = stream.batch_project(batch)?;
         assert_eq!(outputs.len(), 2);
@@ -2524,7 +2478,7 @@ mod tests {
         let mut stream = test_scan_stream(
             scan_plan,
             kernel_type,
-            Arc::new(DashMap::new()),
+            HashMap::new(),
             vec![first, second],
             None,
         );
@@ -2656,7 +2610,7 @@ mod tests {
         let mut stream = test_scan_stream(
             Arc::clone(&scan_plan),
             kernel_type,
-            Arc::new(DashMap::new()),
+            HashMap::new(),
             Vec::new(),
             None,
         );
@@ -2680,7 +2634,7 @@ mod tests {
         let mut stream = test_scan_stream(
             Arc::clone(&scan_plan),
             kernel_type,
-            Arc::new(DashMap::new()),
+            HashMap::new(),
             Vec::new(),
             None,
         );
@@ -2853,7 +2807,7 @@ mod tests {
         let mut stream = test_scan_stream(
             scan_plan,
             kernel_type,
-            Arc::new(DashMap::new()),
+            HashMap::new(),
             vec![first, second],
             Some("file_id".to_string()),
         );
@@ -2902,16 +2856,11 @@ mod tests {
     #[test]
     fn test_dv_mask_exhaustion_across_batches() {
         use super::{DvMaskResult, consume_dv_mask};
-        use dashmap::DashMap;
 
-        let selection_vectors: DashMap<String, Vec<bool>> = DashMap::new();
         let file_id = "test_file.parquet".to_string();
-        selection_vectors.insert(file_id.clone(), vec![false, true]);
+        let mut selection_vectors = HashMap::from([(file_id.clone(), vec![false, true])]);
 
-        let result1 = {
-            let mut sv = selection_vectors.get_mut(&file_id).unwrap();
-            consume_dv_mask(&mut sv, 5)
-        };
+        let result1 = consume_dv_mask(selection_vectors.get_mut(&file_id).unwrap(), 5);
         assert_eq!(
             result1,
             DvMaskResult {
@@ -2923,8 +2872,8 @@ mod tests {
             selection_vectors.remove(&file_id);
         }
 
-        let result2 = if let Some(mut sv) = selection_vectors.get_mut(&file_id) {
-            consume_dv_mask(&mut sv, 5)
+        let result2 = if let Some(sv) = selection_vectors.get_mut(&file_id) {
+            consume_dv_mask(sv, 5)
         } else {
             DvMaskResult {
                 selection: None,

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -3,7 +3,7 @@
 //! This module implements [`DeltaScanExec`], the core execution plan that reads Parquet files
 //! and applies Delta Lake protocol transformations to produce logical table data.
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -26,12 +26,17 @@ use datafusion::physical_expr::utils::collect_columns;
 use datafusion::physical_expr::{Distribution, EquivalenceProperties};
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, PlanProperties};
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
-use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+};
 use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
     ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan,
     InputDistributionRequirements, PhysicalExpr, ReplaceChildrenOptions, Statistics,
+    coalesce_partitions::CoalescePartitionsExec, union::UnionExec,
 };
+use datafusion::scalar::ScalarValue;
+use datafusion_datasource::{file_scan_config::FileScanConfig, source::DataSourceExec};
 use datafusion_physical_expr_adapter::PhysicalExprAdapterFactory;
 use delta_kernel::schema::DataType as KernelDataType;
 use delta_kernel::table_features::TableFeature;
@@ -46,6 +51,21 @@ use crate::kernel::arrow::engine_ext::ExpressionEvaluatorExt;
 
 const DELTA_MATERIALIZED_PUSHDOWN_SENTINEL: &str =
     "__delta_rs_unpushable_delta_materialized_filter";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DvApplicationMode {
+    None,
+    Sequential,
+}
+
+impl DvApplicationMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Sequential => "sequential",
+        }
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct DvMaskResult {
@@ -118,8 +138,12 @@ pub struct DeltaScanExec {
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Selection vectors to be applied to data read from individual files
     selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+    /// Stable deletion-vector execution mode for this plan.
+    dv_mode: DvApplicationMode,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
+    /// Expected physical file ownership keyed by compact scan file id.
+    physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
     /// File id column name carried by the input batches for per file correlation.
@@ -146,6 +170,12 @@ impl DisplayAs for DeltaScanExec {
                 if let Some(row_index_field) = self.scan_plan.contract.retained_row_index_field() {
                     write!(f, ": row_index_column={}", row_index_field.name())?;
                 }
+                write!(
+                    f,
+                    ": dv_mode={}, physical_row_index=false, file_group_layout_locked={}",
+                    self.dv_mode.as_str(),
+                    matches!(self.dv_mode, DvApplicationMode::Sequential)
+                )?;
                 Ok(())
             }
         }
@@ -153,15 +183,33 @@ impl DisplayAs for DeltaScanExec {
 }
 
 impl DeltaScanExec {
+    fn register_dv_file_metric(
+        metrics: &ExecutionPlanMetricsSet,
+        selection_vectors: &DashMap<String, Vec<bool>>,
+    ) {
+        if !selection_vectors.is_empty() {
+            MetricBuilder::new(metrics)
+                .global_counter("dv_files")
+                .add(selection_vectors.len());
+        }
+    }
+
     pub(crate) fn new(
         scan_plan: Arc<KernelScanPlan>,
         input: Arc<dyn ExecutionPlan>,
         transforms: Arc<HashMap<String, ExpressionRef>>,
         selection_vectors: Arc<DashMap<String, Vec<bool>>>,
         public_file_ids: Arc<super::PublicFileIdMap>,
+        physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
         partition_stats: HashMap<String, ColumnStatistics>,
         metrics: ExecutionPlanMetricsSet,
     ) -> Self {
+        let dv_mode = if selection_vectors.is_empty() {
+            DvApplicationMode::None
+        } else {
+            DvApplicationMode::Sequential
+        };
+        Self::register_dv_file_metric(&metrics, &selection_vectors);
         let input_file_id_column = scan_plan.contract.file_id_field.name().to_owned();
         let file_id_column = scan_plan
             .contract
@@ -178,7 +226,9 @@ impl DeltaScanExec {
             input,
             transforms,
             selection_vectors,
+            dv_mode,
             public_file_ids,
+            physical_file_identities,
             partition_stats,
             metrics,
             input_file_id_column,
@@ -188,9 +238,11 @@ impl DeltaScanExec {
     }
 
     fn with_new_input_same_properties(&self, input: Arc<dyn ExecutionPlan>) -> Self {
+        let metrics = ExecutionPlanMetricsSet::new();
+        Self::register_dv_file_metric(&metrics, &self.selection_vectors);
         Self {
             input,
-            metrics: ExecutionPlanMetricsSet::new(),
+            metrics,
             ..Self::clone(self)
         }
     }
@@ -202,9 +254,105 @@ impl DeltaScanExec {
             Arc::clone(&self.transforms),
             Arc::clone(&self.selection_vectors),
             Arc::clone(&self.public_file_ids),
+            Arc::clone(&self.physical_file_identities),
             self.partition_stats.clone(),
             ExecutionPlanMetricsSet::new(),
         )
+    }
+
+    fn has_deletion_vectors(&self) -> bool {
+        !matches!(self.dv_mode, DvApplicationMode::None)
+    }
+
+    fn validate_dv_child_topology(&self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
+        fn scalar_file_id(value: &ScalarValue) -> Option<&str> {
+            match value {
+                ScalarValue::Dictionary(_, value) => scalar_file_id(value),
+                ScalarValue::Utf8(Some(value)) | ScalarValue::LargeUtf8(Some(value)) => {
+                    Some(value.as_str())
+                }
+                _ => None,
+            }
+        }
+
+        fn visit(
+            plan: &Arc<dyn ExecutionPlan>,
+            expected: &super::PhysicalFileIdentityMap,
+            observed: &mut HashSet<String>,
+        ) -> Result<()> {
+            if let Some(coalesce) = plan.downcast_ref::<CoalescePartitionsExec>() {
+                return visit(coalesce.input(), expected, observed);
+            }
+            if let Some(union) = plan.downcast_ref::<UnionExec>() {
+                for input in union.inputs() {
+                    visit(input, expected, observed)?;
+                }
+                return Ok(());
+            }
+            let Some(source_exec) = plan.downcast_ref::<DataSourceExec>() else {
+                return plan_err!(
+                    "DeltaScanExec sequential deletion-vector topology contains unsupported node {}",
+                    plan.name()
+                );
+            };
+            let Some(config) = source_exec.data_source().downcast_ref::<FileScanConfig>() else {
+                return plan_err!(
+                    "DeltaScanExec sequential deletion-vector topology requires FileScanConfig leaves"
+                );
+            };
+            if !matches!(
+                config.output_partitioning,
+                Some(datafusion::physical_expr::Partitioning::UnknownPartitioning(partitions))
+                    if partitions == config.file_groups.len()
+            ) {
+                return plan_err!(
+                    "DeltaScanExec sequential deletion-vector file-group layout is not locked"
+                );
+            }
+
+            for group in &config.file_groups {
+                for file in group.iter() {
+                    let Some(file_id) = file.partition_values.first().and_then(scalar_file_id)
+                    else {
+                        return plan_err!(
+                            "DeltaScanExec sequential deletion-vector file is missing a compact file id"
+                        );
+                    };
+                    if file.range.is_some() {
+                        return plan_err!(
+                            "DeltaScanExec sequential deletion-vector file id '{file_id}' has a byte range"
+                        );
+                    }
+                    let Some(expected_file) = expected.get(file_id) else {
+                        return plan_err!(
+                            "DeltaScanExec sequential deletion-vector topology contains unknown file id '{file_id}'"
+                        );
+                    };
+                    if expected_file.object_store_url != config.object_store_url
+                        || expected_file.location != file.object_meta.location
+                    {
+                        return plan_err!(
+                            "DeltaScanExec sequential deletion-vector topology has an inconsistent mapping for file id '{file_id}'"
+                        );
+                    }
+                    if !observed.insert(file_id.to_owned()) {
+                        return plan_err!(
+                            "DeltaScanExec sequential deletion-vector topology has duplicate ownership for file id '{file_id}'"
+                        );
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        let mut observed = HashSet::new();
+        visit(input, &self.physical_file_identities, &mut observed)?;
+        if observed.len() != self.physical_file_identities.len() {
+            return plan_err!(
+                "DeltaScanExec sequential deletion-vector topology is missing selected files"
+            );
+        }
+        Ok(())
     }
 
     /// Transform the statistics from the inner physical parquet read plan to the logical
@@ -263,6 +411,16 @@ impl DeltaScanExec {
         }
 
         stats.column_statistics = new_stats;
+        if self.has_deletion_vectors() {
+            // The child statistics describe physical Parquet rows. Sequential DV filtering can
+            // only provide conservative bounds until the DV index carries validated numRecords.
+            stats.num_rows = stats.num_rows.to_inexact();
+            stats.column_statistics = stats
+                .column_statistics
+                .into_iter()
+                .map(ColumnStatistics::to_inexact)
+                .collect();
+        }
         Ok(stats)
     }
 
@@ -314,8 +472,11 @@ impl ExecutionPlan for DeltaScanExec {
     }
 
     fn input_distribution_requirements(&self) -> InputDistributionRequirements {
-        if self.scan_plan.contract.retained_row_index_field().is_some() {
-            // Retained row indexes depend on one stream seeing each file's rows.
+        if self.scan_plan.contract.retained_row_index_field().is_some()
+            || self.has_deletion_vectors()
+        {
+            // Retained row indexes and sequential deletion-vector masks depend on one stream
+            // seeing each file's rows in physical order.
             InputDistributionRequirements::new(vec![Distribution::SinglePartition])
         } else {
             InputDistributionRequirements::new(vec![Distribution::UnspecifiedDistribution])
@@ -336,6 +497,9 @@ impl ExecutionPlan for DeltaScanExec {
             return plan_err!("DeltaScan: wrong number of children {}", children.len());
         }
         let input = children.remove(0);
+        if self.has_deletion_vectors() {
+            self.validate_dv_child_topology(&input)?;
+        }
         match options.children_properties {
             ChildrenPropertiesMode::Keep => {
                 Ok(Arc::new(self.with_new_input_same_properties(input)))
@@ -359,9 +523,11 @@ impl ExecutionPlan for DeltaScanExec {
         target_partitions: usize,
         config: &ConfigOptions,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
-        if self.scan_plan.contract.retained_row_index_field().is_some() {
-            // Each DeltaScanStream keeps row ordinal counters for one execution partition.
-            // Repartitioning can split one file across streams and break ordinal contiguity.
+        if self.scan_plan.contract.retained_row_index_field().is_some()
+            || self.has_deletion_vectors()
+        {
+            // Each DeltaScanStream keeps row ordinal counters and sequential DV cursors for one
+            // execution partition. Repartitioning can split one file across streams.
             return Ok(None);
         }
 
@@ -379,14 +545,33 @@ impl ExecutionPlan for DeltaScanExec {
     ) -> Result<SendableRecordBatchStream> {
         // Normal planning enforces this through EnforceDistribution. Keep this check for
         // callers that build DeltaScanExec directly or replace its child plan.
-        if self.scan_plan.contract.retained_row_index_field().is_some() {
+        let retains_row_index = self.scan_plan.contract.retained_row_index_field().is_some();
+        if self.has_deletion_vectors() {
+            self.validate_dv_child_topology(&self.input)?;
+        }
+        if retains_row_index || self.has_deletion_vectors() {
             let input_partition_count = self.input.properties().partitioning.partition_count();
             if input_partition_count > 1 {
+                if retains_row_index {
+                    return plan_err!(
+                        "DeltaScanExec retained row indexes require a single input partition, got {input_partition_count}"
+                    );
+                }
                 return plan_err!(
-                    "DeltaScanExec retained row indexes require a single input partition, got {input_partition_count}"
+                    "DeltaScanExec sequential deletion vectors require a single input partition, got {input_partition_count}"
                 );
             }
         }
+
+        let dv_file_ids = self
+            .selection_vectors
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect();
+        let dv_rows_checked =
+            MetricBuilder::new(&self.metrics).counter("dv_rows_checked", partition);
+        let dv_rows_removed =
+            MetricBuilder::new(&self.metrics).counter("dv_rows_removed", partition);
 
         Ok(Box::pin(DeltaScanStream {
             scan_plan: Arc::clone(&self.scan_plan),
@@ -394,7 +579,12 @@ impl ExecutionPlan for DeltaScanExec {
             input: self.input.execute(partition, context)?,
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
             transforms: Arc::clone(&self.transforms),
-            selection_vectors: Arc::clone(&self.selection_vectors),
+            // Sequential cursors are execution-local. Reusing the physical plan must start each
+            // stream from the original immutable planning snapshot.
+            selection_vectors: self.selection_vectors.as_ref().clone(),
+            dv_file_ids,
+            dv_rows_checked,
+            dv_rows_removed,
             public_file_ids: Arc::clone(&self.public_file_ids),
             input_file_id_column: self.input_file_id_column.clone(),
             file_id_column: self.file_id_column.clone(),
@@ -412,18 +602,27 @@ impl ExecutionPlan for DeltaScanExec {
     }
 
     fn supports_limit_pushdown(&self) -> bool {
-        self.input.supports_limit_pushdown()
+        !self.has_deletion_vectors() && self.input.supports_limit_pushdown()
     }
 
     fn cardinality_effect(&self) -> CardinalityEffect {
-        CardinalityEffect::Equal
+        if self.has_deletion_vectors() {
+            CardinalityEffect::LowerEqual
+        } else {
+            CardinalityEffect::Equal
+        }
     }
 
     fn fetch(&self) -> Option<usize> {
-        self.input.fetch()
+        (!self.has_deletion_vectors())
+            .then(|| self.input.fetch())
+            .flatten()
     }
 
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        if self.has_deletion_vectors() {
+            return None;
+        }
         let new_input = self.input.with_fetch(limit)?;
         Some(Arc::new(self.with_new_input_same_properties(new_input)))
     }
@@ -451,6 +650,13 @@ impl ExecutionPlan for DeltaScanExec {
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
         _config: &ConfigOptions,
     ) -> Result<FilterDescription> {
+        if self.has_deletion_vectors() {
+            return Ok(FilterDescription::all_unsupported(
+                &parent_filters,
+                &self.children(),
+            ));
+        }
+
         // Parent filters are bound against the logical output schema. For column mapped tables
         // the child parquet schema uses physical column names, so pushing the parent filter
         // through this exec again can rewrite it against the wrong child field. Provider level
@@ -533,7 +739,11 @@ struct DeltaScanStream {
     /// Transforms to be applied to data read from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Selection vectors to be applied to data read from individual files
-    selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+    selection_vectors: DashMap<String, Vec<bool>>,
+    /// Files that had a DV at planning time; unlike the mutable sequential cursors this is stable.
+    dv_file_ids: HashSet<String>,
+    dv_rows_checked: Count,
+    dv_rows_removed: Count,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
     /// File id column name carried by the input batches for per file correlation.
@@ -579,6 +789,8 @@ impl DeltaScanStream {
         file_id: String,
         file_id_idx: usize,
     ) -> Result<RecordBatch> {
+        let input_row_count = batch.num_rows();
+        let has_deletion_vector = self.dv_file_ids.contains(&file_id);
         let dv_result = if let Some(mut selection_vector) = self.selection_vectors.get_mut(&file_id)
         {
             consume_dv_mask(&mut selection_vector, batch.num_rows())
@@ -598,6 +810,11 @@ impl DeltaScanStream {
         } else {
             batch
         };
+        if has_deletion_vector {
+            self.dv_rows_checked.add(input_row_count);
+            self.dv_rows_removed
+                .add(input_row_count.saturating_sub(batch.num_rows()));
+        }
 
         batch.remove_column(file_id_idx);
 
@@ -846,13 +1063,21 @@ mod tests {
         },
         physical_expr::{Distribution, Partitioning},
         physical_plan::{
-            PhysicalExpr, collect, collect_partitioned,
+            PhysicalExpr,
+            coalesce_partitions::CoalescePartitionsExec,
+            collect, collect_partitioned, displayable,
             filter_pushdown::{FilterPushdownPhase, PushedDown},
             repartition::RepartitionExec,
             statistics::StatisticsContext,
         },
         prelude::{col, lit},
         scalar::ScalarValue,
+    };
+    use datafusion_datasource::{
+        FileRange,
+        file_groups::FileGroup,
+        file_scan_config::{FileScanConfig, FileScanConfigBuilder},
+        source::DataSourceExec,
     };
 
     use super::*;
@@ -1224,6 +1449,41 @@ mod tests {
         assert_eq!(child_filters.len(), 1);
         assert_eq!(child_filters[0].len(), 1);
         assert!(matches!(child_filters[0][0].discriminant, PushedDown::Yes));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_gather_filters_for_pushdown_rejects_dv_data_filters() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        assert!(
+            !exec.selection_vectors.is_empty(),
+            "fixture must select at least one deletion vector"
+        );
+        let int_idx = exec.schema().index_of("int")?;
+        let int: Arc<dyn PhysicalExpr> = Arc::new(Column::new("int", int_idx));
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![int],
+            physical_lit(true),
+        ));
+
+        let description = exec.gather_filters_for_pushdown(
+            FilterPushdownPhase::Post,
+            vec![filter],
+            session.state().config().options(),
+        )?;
+
+        let child_filters = description.parent_filters();
+        assert_eq!(child_filters.len(), 1);
+        assert_eq!(child_filters[0].len(), 1);
+        assert!(matches!(child_filters[0][0].discriminant, PushedDown::No));
 
         Ok(())
     }
@@ -1658,6 +1918,234 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_dv_scan_disables_limit_and_fetch_pushdown() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], Some(1)).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        assert!(!exec.selection_vectors.is_empty());
+        assert!(!exec.supports_limit_pushdown());
+        assert!(matches!(
+            exec.cardinality_effect(),
+            CardinalityEffect::LowerEqual
+        ));
+        assert_eq!(exec.fetch(), None);
+        assert!(exec.with_fetch(Some(1)).is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_requires_single_input_partition() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        let distribution = exec.input_distribution_requirements();
+        assert!(matches!(
+            distribution.child_distribution(0),
+            Some(Distribution::SinglePartition)
+        ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_locks_whole_file_layout() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+        let source_exec = exec
+            .input
+            .downcast_ref::<DataSourceExec>()
+            .expect("single-store fixture should produce a DataSourceExec");
+        let config = source_exec
+            .data_source()
+            .downcast_ref::<FileScanConfig>()
+            .expect("expected parquet FileScanConfig");
+
+        assert!(matches!(
+            config.output_partitioning,
+            Some(Partitioning::UnknownPartitioning(partitions))
+                if partitions == config.file_groups.len()
+        ));
+        assert!(
+            config
+                .file_groups
+                .iter()
+                .all(|group| { group.iter().all(|file| file.range.is_none()) })
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_rejects_ranged_fragments_under_single_output_coalesce() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+        let source_exec = exec
+            .input
+            .downcast_ref::<DataSourceExec>()
+            .expect("single-store fixture should produce a DataSourceExec");
+        let config = source_exec
+            .data_source()
+            .downcast_ref::<FileScanConfig>()
+            .expect("expected parquet FileScanConfig");
+
+        let whole_file = config.file_groups[0][0].clone();
+        let split_at = i64::try_from(whole_file.object_meta.size / 2)?;
+        let file_end = i64::try_from(whole_file.object_meta.size)?;
+        let mut first = whole_file.clone();
+        first.range = Some(FileRange {
+            start: 0,
+            end: split_at,
+        });
+        let mut second = whole_file;
+        second.range = Some(FileRange {
+            start: split_at,
+            end: file_end,
+        });
+        let fragmented_config = FileScanConfigBuilder::from(config.clone())
+            .with_file_groups(vec![
+                FileGroup::new(vec![first]),
+                FileGroup::new(vec![second]),
+            ])
+            .with_output_partitioning(Some(Partitioning::UnknownPartitioning(2)))
+            .build();
+        let fragmented = DataSourceExec::from_data_source(fragmented_config);
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(fragmented));
+
+        let result = Arc::new(exec.clone()).replace_children(
+            vec![coalesced],
+            ReplaceChildrenOptions::new(ChildrenPropertiesMode::Recompute),
+        );
+        assert!(
+            result.is_err(),
+            "single-output coalescing must not hide ranged DV file fragments"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_applies_limit_after_deleted_rows() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], Some(1)).await?;
+
+        let batches = collect(scan, session.task_ctx()).await?;
+        let row_count = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
+        assert_eq!(row_count, 1, "one live row exists after four deleted rows");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_downgrades_physical_statistics() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let predicates = provider
+            .schema()
+            .fields()
+            .iter()
+            .map(|field| col(field.name()).is_not_null())
+            .collect::<Vec<_>>();
+        let scan = provider
+            .scan(&session.state(), None, &predicates, None)
+            .await?;
+
+        let statistics = StatisticsContext::new().compute(scan.as_ref(), &StatisticsArgs::new())?;
+        assert!(
+            !matches!(statistics.num_rows, Precision::Exact(_)),
+            "physical row count is not an exact live-row count"
+        );
+        for column in &statistics.column_statistics {
+            assert!(!matches!(column.null_count, Precision::Exact(_)));
+            assert!(!matches!(column.min_value, Precision::Exact(_)));
+            assert!(!matches!(column.max_value, Precision::Exact(_)));
+            assert!(!matches!(column.distinct_count, Precision::Exact(_)));
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_explain_reports_containment_mode() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+
+        let explain = displayable(scan.as_ref()).indent(false).to_string();
+        assert!(explain.contains("dv_mode=sequential"), "{explain}");
+        assert!(explain.contains("physical_row_index=false"), "{explain}");
+        assert!(
+            explain.contains("file_group_layout_locked=true"),
+            "{explain}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_sequential_dv_plan_is_repeatable() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+
+        let first = collect(Arc::clone(&scan), session.task_ctx()).await?;
+        let second = collect(scan, session.task_ctx()).await?;
+        let first_rows = first.iter().map(RecordBatch::num_rows).sum::<usize>();
+        let second_rows = second.iter().map(RecordBatch::num_rows).sum::<usize>();
+        assert_eq!(first_rows, 1);
+        assert_eq!(second_rows, first_rows);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_reports_file_and_row_metrics() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+
+        collect(Arc::clone(&scan), session.task_ctx()).await?;
+        let metrics = scan.metrics().expect("DeltaScanExec metrics");
+        assert_eq!(metrics.sum_by_name("dv_files").unwrap().as_usize(), 1);
+        assert_eq!(
+            metrics.sum_by_name("dv_rows_checked").unwrap().as_usize(),
+            5
+        );
+        assert_eq!(
+            metrics.sum_by_name("dv_rows_removed").unwrap().as_usize(),
+            4
+        );
+
+        Ok(())
+    }
+
     // DV test helpers
     const DV_TABLE_PATH: &str = "../../dat/v0.0.3/reader_tests/generated/deletion_vectors/delta";
 
@@ -1806,7 +2294,13 @@ mod tests {
             input,
             baseline_metrics: BaselineMetrics::new(&ExecutionPlanMetricsSet::new(), 0),
             transforms: Arc::new(HashMap::new()),
-            selection_vectors,
+            selection_vectors: selection_vectors.as_ref().clone(),
+            dv_file_ids: selection_vectors
+                .iter()
+                .map(|entry| entry.key().clone())
+                .collect(),
+            dv_rows_checked: Count::new(),
+            dv_rows_removed: Count::new(),
             public_file_ids: Arc::new(public_file_ids),
             input_file_id_column,
             file_id_column,
@@ -1864,6 +2358,7 @@ mod tests {
             Arc::clone(&exec.transforms),
             Arc::clone(&exec.selection_vectors),
             Arc::clone(&exec.public_file_ids),
+            Arc::clone(&exec.physical_file_identities),
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -1902,6 +2397,7 @@ mod tests {
             Arc::clone(&exec.transforms),
             Arc::clone(&exec.selection_vectors),
             Arc::clone(&exec.public_file_ids),
+            Arc::clone(&exec.physical_file_identities),
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -1939,6 +2435,7 @@ mod tests {
             Arc::new(HashMap::new()),
             Arc::new(DashMap::new()),
             Arc::new(public_file_ids),
+            Arc::new(super::super::PhysicalFileIdentityMap::default()),
             HashMap::new(),
             ExecutionPlanMetricsSet::new(),
         );

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -2207,9 +2207,8 @@ mod tests {
         let footer =
             parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new_with_options(
                 std::fs::File::open(fixture.directory.path().join("part-0.parquet"))?,
-                parquet::arrow::arrow_reader::ArrowReaderOptions::new().with_page_index_policy(
-                    parquet::file::metadata::PageIndexPolicy::Required,
-                ),
+                parquet::arrow::arrow_reader::ArrowReaderOptions::new()
+                    .with_page_index_policy(parquet::file::metadata::PageIndexPolicy::Required),
             )?;
         assert_eq!(
             footer

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -345,7 +345,13 @@ impl DeltaScanExec {
                     if planned_file.partition_values != file.partition_values {
                         return plan_err!("unplanned partition constants");
                     }
-                    if planned_file.object_meta != file.object_meta {
+                    if planned_file.object_meta != file.object_meta
+                        || planned_file.arrow_schema != file.arrow_schema
+                        || planned_file.statistics != file.statistics
+                        || planned_file.ordering != file.ordering
+                        || planned_file.metadata_size_hint != file.metadata_size_hint
+                        || planned_file.table_reference != file.table_reference
+                    {
                         return plan_err!("immutable planned file metadata changed");
                     }
                     if file.range.is_some() {
@@ -2046,6 +2052,41 @@ mod tests {
             .data_source()
             .downcast_ref::<FileScanConfig>()
             .expect("DataSourceExec must hold a parquet FileScanConfig");
+
+        for change in ["schema", "statistics", "ordering", "hint"] {
+            let mut groups = config
+                .file_groups
+                .iter()
+                .map(|group| group.iter().cloned().collect::<Vec<_>>())
+                .collect::<Vec<_>>();
+            let file = &mut groups[0][0];
+            match change {
+                "schema" => file.arrow_schema = Some(Arc::new(arrow_schema::Schema::empty())),
+                "statistics" => file.statistics = None,
+                "ordering" => {
+                    file.ordering = Some(
+                        datafusion::physical_expr::LexOrdering::new(vec![
+                            datafusion::physical_expr::PhysicalSortExpr::new_default(Arc::new(
+                                Column::new("value", 0),
+                            )),
+                        ])
+                        .unwrap(),
+                    )
+                }
+                _ => file.metadata_size_hint = Some(1),
+            }
+            let replacement = DataSourceExec::from_data_source(
+                FileScanConfigBuilder::from(config.clone())
+                    .with_file_groups(groups.into_iter().map(FileGroup::new).collect())
+                    .build(),
+            );
+            assert!(
+                Arc::new(exec.clone())
+                    .with_new_children(vec![replacement])
+                    .is_err(),
+                "must reject changed per-file {change}"
+            );
+        }
 
         let mut fragment = config.file_groups[0][0].clone();
         fragment.range = Some(FileRange {

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -12,7 +12,7 @@ use arrow::array::{RecordBatch, StringArray};
 use arrow::compute::filter_record_batch;
 use arrow::datatypes::{FieldRef, Schema, SchemaRef, UInt16Type};
 use arrow_array::StringViewArray;
-use arrow_array::{Array, ArrayRef, BooleanArray, UInt64Array};
+use arrow_array::{Array, ArrayRef, UInt64Array};
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::error::{DataFusionError, Result};
 use datafusion::common::tree_node::TreeNodeRecursion;
@@ -25,7 +25,9 @@ use datafusion::physical_expr::utils::collect_columns;
 use datafusion::physical_expr::{Distribution, EquivalenceProperties};
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, PlanProperties};
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
-use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+};
 use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
     ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan,
@@ -40,6 +42,7 @@ use delta_kernel::table_features::TableFeature;
 use delta_kernel::{EvaluationHandler, ExpressionRef};
 use futures::stream::{Stream, StreamExt};
 
+use super::deletion_vector::DeletionVectorIndex;
 use super::expr_adapter::DeltaPhysicalExprAdapterFactory;
 use super::plan::KernelScanPlan;
 use crate::delta_datafusion::file_id::file_id_field;
@@ -49,89 +52,6 @@ use crate::kernel::arrow::engine_ext::ExpressionEvaluatorExt;
 const DELTA_MATERIALIZED_PUSHDOWN_SENTINEL: &str =
     "__delta_rs_unpushable_delta_materialized_filter";
 
-/// DeltaScanExec uses these inputs to apply deletion vectors during a physical scan.
-#[derive(Clone, Debug)]
-pub(super) enum DvExecutionState {
-    None,
-    Sequential {
-        /// The planner captures these masks. Each execution stream copies them before use.
-        selection_vectors: Arc<HashMap<String, Vec<bool>>>,
-        /// The validator compares child files against this whole file ownership map.
-        physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
-    },
-}
-
-impl DvExecutionState {
-    fn is_sequential(&self) -> bool {
-        matches!(self, Self::Sequential { .. })
-    }
-
-    fn selection_vectors(&self) -> Option<&HashMap<String, Vec<bool>>> {
-        match self {
-            Self::None => None,
-            Self::Sequential {
-                selection_vectors, ..
-            } => Some(selection_vectors),
-        }
-    }
-
-    fn physical_file_identities(&self) -> Option<&super::PhysicalFileIdentityMap> {
-        match self {
-            Self::None => None,
-            Self::Sequential {
-                physical_file_identities,
-                ..
-            } => Some(physical_file_identities),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub(crate) struct DvMaskResult {
-    pub selection: Option<Vec<bool>>,
-    pub should_remove: bool,
-}
-
-/// Consume the per-file deletion-vector keep-mask for the current batch.
-///
-/// The keep-mask is stored once per file and consumed incrementally as parquet
-/// batches are produced:
-/// - If the mask is shorter than the batch, missing trailing entries are
-///   treated as `true` (keep row).
-/// - If the mask is longer than the batch, the remainder is preserved for the
-///   next batch from the same file.
-///
-/// This function intentionally does not error when `selection_vector.len()` is
-/// greater than `batch_num_rows`; that is expected when one file spans multiple
-/// input batches.
-pub(crate) fn consume_dv_mask(
-    selection_vector: &mut Vec<bool>,
-    batch_num_rows: usize,
-) -> DvMaskResult {
-    if selection_vector.is_empty() {
-        return DvMaskResult {
-            selection: None,
-            should_remove: true,
-        };
-    }
-
-    if selection_vector.len() >= batch_num_rows {
-        let sv: Vec<bool> = selection_vector.drain(0..batch_num_rows).collect();
-        let is_empty = selection_vector.is_empty();
-        DvMaskResult {
-            selection: Some(sv),
-            should_remove: is_empty,
-        }
-    } else {
-        let mut sv: Vec<bool> = std::mem::take(selection_vector);
-        sv.resize(batch_num_rows, true);
-        DvMaskResult {
-            selection: Some(sv),
-            should_remove: true,
-        }
-    }
-}
-
 /// Physical execution plan for scanning Delta tables.
 ///
 /// Wraps a Parquet reader execution plan and applies Delta Lake protocol transformations
@@ -139,14 +59,14 @@ pub(crate) fn consume_dv_mask(
 ///
 /// - **Column mapping**: Translates physical column names to logical names
 /// - **Partition values**: Materializes partition column values from file paths
-/// - **Deletion vectors**: Filters out deleted rows using per-file selection vectors
+/// - **Deletion vectors**: Filters deleted rows by immutable physical Parquet row position
 /// - **Schema evolution**: Handles missing columns and type coercion
 ///
 /// # Data Flow
 ///
 /// 1. Inner [`input`](Self::input) plan reads raw Parquet data
 /// 2. Per-file [`transforms`](Self::transforms) convert physical to logical schema
-/// 3. The scan applies deletion vectors before it returns rows
+/// 3. [`deletion_vectors`](Self::deletion_vectors) filter deleted rows
 /// 4. Result is cast to the projected scan contract's result schema
 #[derive(Clone, Debug)]
 pub struct DeltaScanExec {
@@ -155,20 +75,29 @@ pub struct DeltaScanExec {
     input: Arc<dyn ExecutionPlan>,
     /// Transforms to be applied to data eminating from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
-    /// The planner records deletion vector masks and physical file ownership here.
-    dv_state: DvExecutionState,
+    /// Immutable deletion vectors keyed by compact scan file id.
+    deletion_vectors: Arc<DeletionVectorIndex>,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
+    /// Expected physical file ownership keyed by compact scan file id.
+    physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
+    /// Authoritative hidden physical input schema and resolved support-column indices.
+    physical_input_contract: Arc<super::PhysicalInputContract>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
-    /// File id column name carried by the input batches for per file correlation.
-    input_file_id_column: String,
     /// User-visible file-id column name when projected in the output.
     file_id_column: Option<String>,
     /// plan properties
     properties: Arc<PlanProperties>,
     /// Aggregated partition column statistics
     partition_stats: HashMap<String, ColumnStatistics>,
+}
+
+pub(super) struct PhysicalScanContext {
+    pub(super) deletion_vectors: Arc<DeletionVectorIndex>,
+    pub(super) public_file_ids: Arc<super::PublicFileIdMap>,
+    pub(super) physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
+    pub(super) physical_input_contract: Arc<super::PhysicalInputContract>,
 }
 
 impl DisplayAs for DeltaScanExec {
@@ -185,6 +114,19 @@ impl DisplayAs for DeltaScanExec {
                 if let Some(row_index_field) = self.scan_plan.contract.retained_row_index_field() {
                     write!(f, ": row_index_column={}", row_index_field.name())?;
                 }
+                write!(
+                    f,
+                    ": dv_mode={}, physical_row_index={}, file_group_layout_locked={}",
+                    if self.has_deletion_vectors() {
+                        "physical_position"
+                    } else {
+                        "none"
+                    },
+                    self.physical_input_contract
+                        .physical_row_position_field
+                        .is_some(),
+                    self.has_deletion_vectors()
+                )?;
                 Ok(())
             }
         }
@@ -192,65 +134,112 @@ impl DisplayAs for DeltaScanExec {
 }
 
 impl DeltaScanExec {
-    pub(super) fn new(
+    fn register_dv_file_metric(
+        metrics: &ExecutionPlanMetricsSet,
+        deletion_vectors: &DeletionVectorIndex,
+    ) {
+        if deletion_vectors.has_vectors() {
+            MetricBuilder::new(metrics)
+                .global_counter("dv_files")
+                .add(deletion_vectors.file_count());
+        }
+    }
+
+    pub(super) fn try_new(
         scan_plan: Arc<KernelScanPlan>,
         input: Arc<dyn ExecutionPlan>,
         transforms: Arc<HashMap<String, ExpressionRef>>,
-        dv_state: DvExecutionState,
-        public_file_ids: Arc<super::PublicFileIdMap>,
+        context: PhysicalScanContext,
         partition_stats: HashMap<String, ColumnStatistics>,
         metrics: ExecutionPlanMetricsSet,
-    ) -> Self {
-        let input_file_id_column = scan_plan.contract.file_id_field.name().to_owned();
+    ) -> Result<Self> {
+        let PhysicalScanContext {
+            deletion_vectors,
+            public_file_ids,
+            physical_file_identities,
+            physical_input_contract,
+        } = context;
+        Self::register_dv_file_metric(&metrics, &deletion_vectors);
         let file_id_column = scan_plan
             .contract
             .retain_file_id
             .then(|| scan_plan.contract.file_id_field.name().to_owned());
         let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(Arc::clone(&scan_plan.contract.output_schema)),
-            input.properties().partitioning.clone(),
+            datafusion::physical_expr::Partitioning::UnknownPartitioning(
+                input.properties().partitioning.partition_count(),
+            ),
             input.properties().emission_type,
             input.properties().boundedness,
         ));
-        Self {
+        let exec = Self {
             scan_plan,
             input,
             transforms,
-            dv_state,
+            deletion_vectors,
             public_file_ids,
+            physical_file_identities,
+            physical_input_contract,
             partition_stats,
             metrics,
-            input_file_id_column,
             file_id_column,
             properties,
+        };
+        if exec.has_deletion_vectors() {
+            exec.validate_dv_child_topology(&exec.input)?;
         }
+        Ok(exec)
+    }
+
+    #[cfg(test)]
+    fn new(
+        scan_plan: Arc<KernelScanPlan>,
+        input: Arc<dyn ExecutionPlan>,
+        transforms: Arc<HashMap<String, ExpressionRef>>,
+        context: PhysicalScanContext,
+        stats: HashMap<String, ColumnStatistics>,
+        metrics: ExecutionPlanMetricsSet,
+    ) -> Self {
+        Self::try_new(scan_plan, input, transforms, context, stats, metrics).unwrap()
     }
 
     fn with_new_input_same_properties(&self, input: Arc<dyn ExecutionPlan>) -> Self {
+        let metrics = ExecutionPlanMetricsSet::new();
+        Self::register_dv_file_metric(&metrics, &self.deletion_vectors);
+        let properties = self.properties.as_ref().clone().with_partitioning(
+            datafusion::physical_expr::Partitioning::UnknownPartitioning(
+                input.properties().partitioning.partition_count(),
+            ),
+        );
         Self {
             input,
-            metrics: ExecutionPlanMetricsSet::new(),
+            metrics,
+            properties: Arc::new(properties),
             ..Self::clone(self)
         }
     }
 
-    fn with_new_input(&self, input: Arc<dyn ExecutionPlan>) -> Self {
-        Self::new(
+    fn with_new_input(&self, input: Arc<dyn ExecutionPlan>) -> Result<Self> {
+        Self::try_new(
             Arc::clone(&self.scan_plan),
             input,
             Arc::clone(&self.transforms),
-            self.dv_state.clone(),
-            Arc::clone(&self.public_file_ids),
+            PhysicalScanContext {
+                deletion_vectors: Arc::clone(&self.deletion_vectors),
+                public_file_ids: Arc::clone(&self.public_file_ids),
+                physical_file_identities: Arc::clone(&self.physical_file_identities),
+                physical_input_contract: Arc::clone(&self.physical_input_contract),
+            },
             self.partition_stats.clone(),
             ExecutionPlanMetricsSet::new(),
         )
     }
 
     fn has_deletion_vectors(&self) -> bool {
-        self.dv_state.is_sequential()
+        self.deletion_vectors.has_vectors()
     }
 
-    fn validate_dv_child_topology(&self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
+    pub(super) fn validate_dv_child_topology(&self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
         fn scalar_file_id(value: &ScalarValue) -> Option<&str> {
             match value {
                 ScalarValue::Dictionary(_, value) => scalar_file_id(value),
@@ -265,6 +254,7 @@ impl DeltaScanExec {
             plan: &Arc<dyn ExecutionPlan>,
             expected: &super::PhysicalFileIdentityMap,
             observed: &mut HashSet<String>,
+            contract: &super::PhysicalInputContract,
         ) -> Result<()> {
             if let Some(fetch) = plan.fetch() {
                 return plan_err!(
@@ -272,25 +262,56 @@ impl DeltaScanExec {
                 );
             }
             if let Some(coalesce) = plan.downcast_ref::<CoalescePartitionsExec>() {
-                return visit(coalesce.input(), expected, observed);
+                return visit(coalesce.input(), expected, observed, contract);
             }
             if let Some(union) = plan.downcast_ref::<UnionExec>() {
                 for input in union.inputs() {
-                    visit(input, expected, observed)?;
+                    visit(input, expected, observed, contract)?;
                 }
                 return Ok(());
             }
             let Some(source_exec) = plan.downcast_ref::<DataSourceExec>() else {
                 return plan_err!(
-                    "DeltaScanExec rejects node {} during sequential deletion vector scans",
+                    "DeltaScanExec deletion-vector topology contains unsupported node {}",
                     plan.name()
                 );
             };
             let Some(config) = source_exec.data_source().downcast_ref::<FileScanConfig>() else {
                 return plan_err!(
-                    "DeltaScanExec requires FileScanConfig leaves during sequential deletion vector scans"
+                    "DeltaScanExec deletion-vector topology requires FileScanConfig leaves"
                 );
             };
+            let source = config
+                .file_source
+                .downcast_ref::<datafusion::datasource::physical_plan::ParquetSource>()
+                .ok_or_else(|| internal_datafusion_err!("expected native Parquet source"))?;
+            let expected_source = contract
+                .sources
+                .iter()
+                .find(|planned| planned.object_store_url == config.object_store_url)
+                .ok_or_else(|| internal_datafusion_err!("unplanned store binding"))?;
+            let original = expected_source
+                .file_source
+                .downcast_ref::<datafusion::datasource::physical_plan::ParquetSource>()
+                .ok_or_else(|| internal_datafusion_err!("lost planned Parquet source"))?;
+            let same_reader = source
+                .parquet_file_reader_factory()
+                .zip(original.parquet_file_reader_factory())
+                .is_some_and(|(a, b)| Arc::ptr_eq(a, b));
+            let same_adapter = config
+                .expr_adapter_factory
+                .as_ref()
+                .zip(expected_source.expr_adapter_factory.as_ref())
+                .is_some_and(|(a, b)| Arc::ptr_eq(a, b));
+            if !Arc::ptr_eq(&config.file_source, &expected_source.file_source)
+                || !same_reader
+                || !same_adapter
+                || plan.schema() != *contract.table_schema.table_schema()
+            {
+                return plan_err!(
+                    "physical input reader, adapter, or support-field lineage changed"
+                );
+            }
             if !matches!(
                 config.output_partitioning,
                 Some(datafusion::physical_expr::Partitioning::UnknownPartitioning(partitions))
@@ -308,32 +329,45 @@ impl DeltaScanExec {
 
             for group in &config.file_groups {
                 for file in group.iter() {
+                    if !file.extensions.is_empty() {
+                        return plan_err!("unplanned reader-affecting file extensions");
+                    }
                     let Some(file_id) = file.partition_values.first().and_then(scalar_file_id)
                     else {
                         return plan_err!(
-                            "A sequential deletion vector file lacks a compact file id"
+                            "DeltaScanExec deletion-vector file is missing a compact file id"
                         );
                     };
+                    let planned_file = contract
+                        .planned_files
+                        .get(file_id)
+                        .ok_or_else(|| internal_datafusion_err!("unplanned partition constants"))?;
+                    if planned_file.partition_values != file.partition_values {
+                        return plan_err!("unplanned partition constants");
+                    }
+                    if planned_file.object_meta != file.object_meta {
+                        return plan_err!("immutable planned file metadata changed");
+                    }
                     if file.range.is_some() {
                         return plan_err!(
-                            "Sequential deletion vector file id '{file_id}' uses a byte range"
+                            "DeltaScanExec deletion-vector file id '{file_id}' has a byte range"
                         );
                     }
                     let Some(expected_file) = expected.get(file_id) else {
                         return plan_err!(
-                            "Sequential deletion vector scan received unknown file id '{file_id}'"
+                            "DeltaScanExec deletion-vector topology contains unknown file id '{file_id}'"
                         );
                     };
                     if expected_file.object_store_url != config.object_store_url
                         || expected_file.location != file.object_meta.location
                     {
                         return plan_err!(
-                            "Sequential deletion vector file id '{file_id}' has an unexpected store or location"
+                            "DeltaScanExec deletion-vector topology has an inconsistent mapping for file id '{file_id}'"
                         );
                     }
                     if !observed.insert(file_id.to_owned()) {
                         return plan_err!(
-                            "Sequential deletion vector file id '{file_id}' belongs to multiple child files"
+                            "DeltaScanExec deletion-vector topology has duplicate ownership for file id '{file_id}'"
                         );
                     }
                 }
@@ -341,15 +375,15 @@ impl DeltaScanExec {
             Ok(())
         }
 
-        let expected = self.dv_state.physical_file_identities().ok_or_else(|| {
-            internal_datafusion_err!(
-                "DeltaScanExec deletion vector topology validation requires sequential state"
-            )
-        })?;
         let mut observed = HashSet::new();
-        visit(input, expected, &mut observed)?;
-        if observed.len() != expected.len() {
-            return plan_err!("DeltaScanExec sequential deletion vector scan lacks selected files");
+        visit(
+            input,
+            &self.physical_file_identities,
+            &mut observed,
+            &self.physical_input_contract,
+        )?;
+        if observed.len() != self.physical_file_identities.len() {
+            return plan_err!("DeltaScanExec deletion-vector topology is missing selected files");
         }
         Ok(())
     }
@@ -469,8 +503,8 @@ impl ExecutionPlan for DeltaScanExec {
         if self.scan_plan.contract.retained_row_index_field().is_some()
             || self.has_deletion_vectors()
         {
-            // DeltaScanExec requires one stream to preserve physical row order for retained row
-            // indexes and sequential DV masks.
+            // Retained row indexes require ordered, stream-local state. Physical-position DVs
+            // retain the PR 0 single-partition containment until the PR 2 optimizer unlock.
             InputDistributionRequirements::new(vec![Distribution::SinglePartition])
         } else {
             InputDistributionRequirements::new(vec![Distribution::UnspecifiedDistribution])
@@ -498,7 +532,7 @@ impl ExecutionPlan for DeltaScanExec {
             ChildrenPropertiesMode::Keep => {
                 Ok(Arc::new(self.with_new_input_same_properties(input)))
             }
-            ChildrenPropertiesMode::Recompute => Ok(Arc::new(self.with_new_input(input))),
+            ChildrenPropertiesMode::Recompute => Ok(Arc::new(self.with_new_input(input)?)),
         }
     }
 
@@ -520,13 +554,13 @@ impl ExecutionPlan for DeltaScanExec {
         if self.scan_plan.contract.retained_row_index_field().is_some()
             || self.has_deletion_vectors()
         {
-            // A DeltaScanStream stores row ordinals and DV cursors for one execution partition.
-            // DataFusion can split a file across streams after repartitioning.
+            // Row ordinals retain stream-local counters. Physical-position DVs retain the PR 0
+            // repartition barrier until the PR 2 optimizer unlock is qualified.
             return Ok(None);
         }
 
         if let Some(input) = self.input.repartitioned(target_partitions, config)? {
-            Ok(Some(Arc::new(self.with_new_input(input))))
+            Ok(Some(Arc::new(self.with_new_input(input)?)))
         } else {
             Ok(None)
         }
@@ -541,6 +575,9 @@ impl ExecutionPlan for DeltaScanExec {
         // callers that build DeltaScanExec directly or replace its child plan.
         let retains_row_index = self.scan_plan.contract.retained_row_index_field().is_some();
         let has_deletion_vectors = self.has_deletion_vectors();
+        if has_deletion_vectors {
+            self.validate_dv_child_topology(&self.input)?;
+        }
         if retains_row_index || has_deletion_vectors {
             let input_partition_count = self.input.properties().partitioning.partition_count();
             if input_partition_count > 1 {
@@ -550,10 +587,15 @@ impl ExecutionPlan for DeltaScanExec {
                     );
                 }
                 return plan_err!(
-                    "DeltaScanExec sequential deletion vectors require a single input partition, got {input_partition_count}"
+                    "DeltaScanExec contained deletion-vector scans require a single input partition, got {input_partition_count}"
                 );
             }
         }
+
+        let dv_rows_checked =
+            MetricBuilder::new(&self.metrics).counter("dv_rows_checked", partition);
+        let dv_rows_removed =
+            MetricBuilder::new(&self.metrics).counter("dv_rows_removed", partition);
 
         Ok(Box::pin(DeltaScanStream {
             scan_plan: Arc::clone(&self.scan_plan),
@@ -561,14 +603,11 @@ impl ExecutionPlan for DeltaScanExec {
             input: self.input.execute(partition, context)?,
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
             transforms: Arc::clone(&self.transforms),
-            // Each execution owns its cursors and copies the masks that the planner captured.
-            selection_vectors: self
-                .dv_state
-                .selection_vectors()
-                .cloned()
-                .unwrap_or_default(),
+            deletion_vectors: Arc::clone(&self.deletion_vectors),
+            physical_input_contract: Arc::clone(&self.physical_input_contract),
+            dv_rows_checked,
+            dv_rows_removed,
             public_file_ids: Arc::clone(&self.public_file_ids),
-            input_file_id_column: self.input_file_id_column.clone(),
             file_id_column: self.file_id_column.clone(),
             row_index_field: self.scan_plan.contract.retained_row_index_field(),
             row_index_by_file: HashMap::new(),
@@ -722,12 +761,14 @@ struct DeltaScanStream {
     baseline_metrics: BaselineMetrics,
     /// Transforms to be applied to data read from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
-    /// Selection vectors to be applied to data read from individual files
-    selection_vectors: HashMap<String, Vec<bool>>,
+    /// Immutable deletion-vector lookup by physical row position.
+    deletion_vectors: Arc<DeletionVectorIndex>,
+    physical_input_contract: Arc<super::PhysicalInputContract>,
+    dv_rows_checked: Count,
+    dv_rows_removed: Count,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
     /// File id column name carried by the input batches for per file correlation.
-    input_file_id_column: String,
     /// User-visible file-id column name when projected in the output.
     file_id_column: Option<String>,
     /// Row index field included in projected output.
@@ -749,11 +790,16 @@ impl DeltaScanStream {
         let elapsed = self.baseline_metrics.elapsed_compute().clone();
         let _timer = elapsed.timer();
 
+        let file_id_idx = self.physical_input_contract.file_id_index;
+        if batch.schema() != *self.physical_input_contract.table_schema.table_schema() {
+            return internal_err!(
+                "physical input schema does not preserve compact file-id field '{}' and its support fields",
+                self.physical_input_contract.file_id_field.name()
+            );
+        }
         if batch.num_rows() == 0 {
             return Ok(vec![RecordBatch::new_empty(self.schema())]);
         }
-
-        let file_id_idx = file_id_column_idx(&batch, &self.input_file_id_column)?;
         let file_runs = split_by_file_id_runs(&batch, file_id_idx)?;
 
         let mut results = Vec::with_capacity(file_runs.len());
@@ -769,25 +815,73 @@ impl DeltaScanStream {
         file_id: String,
         file_id_idx: usize,
     ) -> Result<RecordBatch> {
-        let dv_result = if let Some(selection_vector) = self.selection_vectors.get_mut(&file_id) {
-            consume_dv_mask(selection_vector, batch.num_rows())
-        } else {
-            DvMaskResult {
-                selection: None,
-                should_remove: false,
+        let input_row_count = batch.num_rows();
+        let has_deletion_vector = self.deletion_vectors.has_vector(&file_id);
+        let mut batch = if self
+            .physical_input_contract
+            .physical_row_position_index
+            .is_some()
+        {
+            let position_idx = self
+                .physical_input_contract
+                .physical_row_position_index
+                .ok_or_else(|| {
+                    internal_datafusion_err!(
+                        "physical-position DV mode is missing its row-position field"
+                    )
+                })?;
+            let positions = batch
+                .column(position_idx)
+                .as_any()
+                .downcast_ref::<arrow_array::Int64Array>()
+                .ok_or_else(|| {
+                    internal_datafusion_err!(
+                        "physical row-position column is not a nullable Int64 array"
+                    )
+                })?;
+            if !has_deletion_vector {
+                let count = self
+                    .physical_input_contract
+                    .footer_bounds
+                    .get(&file_id)
+                    .and_then(|bound| bound.get())
+                    .ok_or_else(|| {
+                        internal_datafusion_err!("missing reader-verified physical bounds")
+                    })?;
+                for position in positions.iter() {
+                    if !position.is_some_and(|position| position >= 0 && (position as u64) < *count)
+                    {
+                        return internal_err!(
+                            "physical position outside reader-verified file population"
+                        );
+                    }
+                }
             }
-        };
-
-        if dv_result.should_remove {
-            self.selection_vectors.remove(&file_id);
-        }
-
-        let mut batch = if let Some(selection) = dv_result.selection {
-            filter_record_batch(&batch, &BooleanArray::from(selection))?
+            let selection = self
+                .deletion_vectors
+                .selection_for_positions(&file_id, positions)?;
+            match selection.true_count() {
+                count if count == batch.num_rows() => batch,
+                0 => batch.slice(0, 0),
+                _ => filter_record_batch(&batch, &selection)?,
+            }
         } else {
             batch
         };
-        batch.remove_column(file_id_idx);
+        if has_deletion_vector {
+            self.dv_rows_checked.add(input_row_count);
+            self.dv_rows_removed
+                .add(input_row_count.saturating_sub(batch.num_rows()));
+        }
+
+        let mut hidden_indices = vec![file_id_idx];
+        if let Some(position_idx) = self.physical_input_contract.physical_row_position_index {
+            hidden_indices.push(position_idx);
+        }
+        hidden_indices.sort_unstable_by(|left, right| right.cmp(left));
+        for index in hidden_indices {
+            batch.remove_column(index);
+        }
 
         let result = if let Some(transform) = self.transforms.get(&file_id) {
             let evaluator = ARROW_HANDLER
@@ -914,6 +1008,7 @@ impl RecordBatchStream for DeltaScanStream {
 }
 
 #[inline]
+#[cfg(test)]
 fn file_id_column_idx(batch: &RecordBatch, file_id_column: &str) -> Result<usize> {
     batch
         .schema_ref()
@@ -1426,6 +1521,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_gather_filters_for_pushdown_rejects_dv_data_filters() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        assert!(
+            exec.deletion_vectors.has_vectors(),
+            "fixture must select at least one deletion vector"
+        );
+        let int_idx = exec.schema().index_of("int")?;
+        let int: Arc<dyn PhysicalExpr> = Arc::new(Column::new("int", int_idx));
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![int],
+            physical_lit(true),
+        ));
+
+        let description = exec.gather_filters_for_pushdown(
+            FilterPushdownPhase::Post,
+            vec![filter],
+            session.state().config().options(),
+        )?;
+
+        let child_filters = description.parent_filters();
+        assert_eq!(child_filters.len(), 1);
+        assert_eq!(child_filters[0].len(), 1);
+        assert!(matches!(child_filters[0][0].discriminant, PushedDown::No));
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_gather_filters_for_pushdown_skips_column_mapping_parent_filters() -> TestResult {
         let mut table = open_fs_path("../test/tests/data/table_with_column_mapping");
         table.load().await?;
@@ -1865,6 +1995,7 @@ mod tests {
             .downcast_ref::<DeltaScanExec>()
             .expect("planner must return DeltaScanExec");
 
+        assert!(exec.deletion_vectors.has_vectors());
         assert!(!exec.supports_limit_pushdown());
         assert!(matches!(
             exec.cardinality_effect(),
@@ -1968,6 +2099,509 @@ mod tests {
         Ok(())
     }
 
+    fn fixture_rows(batches: &[RecordBatch]) -> Vec<(i64, i64)> {
+        let mut rows = batches
+            .iter()
+            .flat_map(|batch| {
+                let ids = batch
+                    .column(batch.schema().index_of("id").unwrap())
+                    .as_any()
+                    .downcast_ref::<arrow_array::Int64Array>()
+                    .unwrap();
+                let values = batch
+                    .column(batch.schema().index_of("value").unwrap())
+                    .as_any()
+                    .downcast_ref::<arrow_array::Int64Array>()
+                    .unwrap();
+                ids.values()
+                    .iter()
+                    .copied()
+                    .zip(values.values().iter().copied())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        rows.sort_unstable();
+        rows
+    }
+
+    #[tokio::test]
+    async fn test_optimized_plan_reset_preserves_shared_visibility() -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture};
+        use datafusion::physical_plan::execution_plan::reset_plan_states;
+        let fixture = Fixture::new(
+            vec![FileSpec {
+                rows: 161,
+                groups: vec![37, 53, 71],
+                deleted: Some([0, 1, 37, 90].into_iter().collect()),
+                log_stats: true,
+            }],
+            8,
+        )?;
+        let table = crate::open_table(fixture.url()).await?;
+        let context = datafusion::prelude::SessionContext::new();
+        context.register_table("t", table.table_provider().await?)?;
+        let plan = context
+            .sql("select * from t where id > 0")
+            .await?
+            .create_physical_plan()
+            .await?;
+        fn visibility(plan: &Arc<dyn ExecutionPlan>) -> Arc<DeletionVectorIndex> {
+            if let Some(scan) = plan.downcast_ref::<DeltaScanExec>() {
+                return scan.deletion_vectors.clone();
+            }
+            for child in plan.children() {
+                if child.name().contains("DeltaScan") || !child.children().is_empty() {
+                    return visibility(child);
+                }
+            }
+            panic!("missing Delta scan");
+        }
+        let index = visibility(&plan);
+        let expected = fixture
+            .live_coordinates()
+            .into_iter()
+            .map(|r| (r.2, r.3))
+            .collect::<Vec<_>>();
+        for _ in 0..3 {
+            let reset = reset_plan_states(plan.clone())?;
+            assert!(Arc::ptr_eq(&index, &visibility(&reset)));
+            assert_eq!(
+                fixture_rows(&collect(reset, context.task_ctx()).await?),
+                expected
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_reader_coordinate_matrix_against_generator_oracle() -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture};
+        let fixture = Fixture::new(
+            vec![FileSpec {
+                rows: 161,
+                groups: vec![37, 53, 71],
+                deleted: Some([0, 36, 37, 42, 89, 90, 144, 160].into_iter().collect()),
+                log_stats: true,
+            }],
+            8,
+        )?;
+        let table = crate::open_table(fixture.url()).await?;
+        let provider = table.table_provider().await?;
+        let session = create_session().into_inner();
+        let base_plan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = base_plan.downcast_ref::<DeltaScanExec>().unwrap();
+        let source_exec = exec.input.downcast_ref::<DataSourceExec>().unwrap();
+        let original = source_exec
+            .data_source()
+            .downcast_ref::<FileScanConfig>()
+            .unwrap();
+        let source = original
+            .file_source
+            .downcast_ref::<ParquetSource>()
+            .unwrap();
+        let expected = fixture
+            .live_coordinates()
+            .into_iter()
+            .filter(|row| row.2 >= 40 && row.2 < 145)
+            .collect::<Vec<_>>();
+        let footer =
+            parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new_with_options(
+                std::fs::File::open(fixture.directory.path().join("part-0.parquet"))?,
+                parquet::arrow::arrow_reader::ArrowReaderOptions::new().with_page_index_policy(
+                    parquet::file::metadata::PageIndexPolicy::Required,
+                ),
+            )?;
+        assert_eq!(
+            footer
+                .metadata()
+                .row_groups()
+                .iter()
+                .map(|g| g.num_rows())
+                .collect::<Vec<_>>(),
+            [37, 53, 71]
+        );
+        assert!(
+            footer
+                .metadata()
+                .offset_index()
+                .unwrap()
+                .iter()
+                .all(|group| group.iter().all(|column| column.page_locations().len() > 1))
+        );
+        let mut cases = 0;
+        let mut observed_ranges = false;
+        let mut observed_group_pruning = false;
+        let mut observed_page_pruning = false;
+        for pages in [false, true] {
+            for row_filter in [false, true] {
+                for batch_size in [1, 7, 8192] {
+                    for partitions in [1, 2, 4, 8] {
+                        for repartition in [false, true] {
+                            let mut options = SessionConfig::new()
+                                .with_batch_size(batch_size)
+                                .with_target_partitions(partitions);
+                            options.options_mut().optimizer.repartition_file_scans = repartition;
+                            options.options_mut().optimizer.repartition_file_min_size = 0;
+                            options.options_mut().execution.parquet.enable_page_index = pages;
+                            options.options_mut().execution.parquet.pushdown_filters = row_filter;
+                            let context = datafusion::prelude::SessionContext::new_with_config_rt(
+                                options,
+                                session.runtime_env(),
+                            );
+                            let predicate = context.state().create_physical_expr(
+                                col("id").gt_eq(lit(40_i64)).and(col("id").lt(lit(145_i64))),
+                                &exec.input.schema().to_dfschema()?,
+                            )?;
+                            let native = source
+                                .with_predicate(predicate)
+                                .with_pushdown_filters(row_filter)
+                                .with_enable_page_index(pages);
+                            let config = FileScanConfigBuilder::from(original.clone())
+                                .with_source(Arc::new(native))
+                                .with_output_partitioning(None)
+                                .build();
+                            let input: Arc<dyn ExecutionPlan> =
+                                DataSourceExec::from_data_source(config);
+                            let optimized = DefaultPhysicalPlanner::default()
+                                .optimize_physical_plan(input, &context.state(), |_, _| {})?;
+                            if let Some(source) = optimized.downcast_ref::<DataSourceExec>() {
+                                let config = source
+                                    .data_source()
+                                    .downcast_ref::<FileScanConfig>()
+                                    .unwrap();
+                                observed_ranges |= config
+                                    .file_groups
+                                    .iter()
+                                    .flat_map(|g| g.iter())
+                                    .any(|file| file.range.is_some());
+                            }
+                            let batches = collect(optimized.clone(), context.task_ctx()).await?;
+                            if let Some(metrics) = optimized.metrics() {
+                                for metric in metrics.iter() {
+                                    let name = metric.value().name();
+                                    if let datafusion::physical_plan::metrics::MetricValue::PruningMetrics { pruning_metrics, .. } = metric.value() {
+                                        observed_group_pruning |= name == "row_groups_pruned_statistics" && pruning_metrics.pruned() > 0;
+                                        observed_page_pruning |= name == "page_index_rows_pruned" && pruning_metrics.pruned() > 0;
+                                    }
+                                }
+                            }
+                            let mut visible = Vec::new();
+                            for batch in batches {
+                                let positions = batch
+                                    .column(
+                                        exec.physical_input_contract
+                                            .physical_row_position_index
+                                            .unwrap(),
+                                    )
+                                    .as_any()
+                                    .downcast_ref::<arrow_array::Int64Array>()
+                                    .unwrap();
+                                let ids = batch
+                                    .column(batch.schema().index_of("id")?)
+                                    .as_any()
+                                    .downcast_ref::<arrow_array::Int64Array>()
+                                    .unwrap();
+                                let keep = exec
+                                    .deletion_vectors
+                                    .selection_for_positions("0", positions)?;
+                                for ((id, position), keep) in ids
+                                    .values()
+                                    .iter()
+                                    .zip(positions.values())
+                                    .zip(keep.values())
+                                {
+                                    assert_eq!(
+                                        id, position,
+                                        "reader coordinate differs from generated coordinate: pages={pages}, row_filter={row_filter}, batch={batch_size}, partitions={partitions}, repartition={repartition}"
+                                    );
+                                    if keep && *id >= 40 && *id < 145 {
+                                        visible.push((0, *position as u64, *id, -*id));
+                                    }
+                                }
+                            }
+                            visible.sort_unstable();
+                            assert_eq!(
+                                visible, expected,
+                                "pages={pages}, row_filter={row_filter}, batch={batch_size}, partitions={partitions}, repartition={repartition}"
+                            );
+                            cases += 1;
+                        }
+                    }
+                }
+            }
+        }
+        assert_eq!(cases, 96);
+        assert!(
+            observed_group_pruning,
+            "fixture must execute row-group pruning"
+        );
+        assert!(
+            observed_page_pruning,
+            "fixture must execute page-index pruning"
+        );
+        assert!(
+            observed_ranges,
+            "private coordinate qualification must execute native ranged reads"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_visibility_is_frozen_across_concurrent_plans_and_advancement()
+    -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture};
+        let mut fixture = Fixture::new(
+            vec![FileSpec {
+                rows: 161,
+                groups: vec![37, 53, 71],
+                deleted: Some([1].into_iter().collect()),
+                log_stats: true,
+            }],
+            8,
+        )?;
+        let session = create_session().into_inner();
+        let first_table = crate::open_table(fixture.url()).await?;
+        let first_provider = first_table.table_provider().await?;
+        let first_plan = first_provider
+            .scan(&session.state(), None, &[], None)
+            .await?;
+        use datafusion_proto::logical_plan::LogicalExtensionCodec;
+        let codec = crate::delta_datafusion::DeltaLogicalCodec {};
+        let table_ref = datafusion::common::TableReference::bare("snapshot");
+        let mut encoded = Vec::new();
+        codec.try_encode_table_provider(&table_ref, first_provider.clone(), &mut encoded)?;
+        let decoded = codec.try_decode_table_provider(
+            &encoded,
+            &table_ref,
+            first_provider.schema(),
+            &session.task_ctx(),
+        )?;
+        let expected_first = fixture
+            .live_coordinates()
+            .into_iter()
+            .map(|(_, _, id, value)| (id, value))
+            .collect::<Vec<_>>();
+        fixture.replace_visibility(0, [2].into_iter().collect())?;
+        let second_table = crate::open_table(fixture.url()).await?;
+        let second_provider = second_table.table_provider().await?;
+        let second_plan = second_provider
+            .scan(&session.state(), None, &[], None)
+            .await?;
+        let expected_second = fixture
+            .live_coordinates()
+            .into_iter()
+            .map(|(_, _, id, value)| (id, value))
+            .collect::<Vec<_>>();
+        let (a, b) = tokio::join!(
+            collect(first_plan.clone(), session.task_ctx()),
+            collect(second_plan, session.task_ctx())
+        );
+        assert_eq!(fixture_rows(&a?), expected_first);
+        assert_eq!(fixture_rows(&b?), expected_second);
+        fixture.replace_visibility(0, [3, 4].into_iter().collect())?;
+        let mut advanced = first_table;
+        advanced.update_state().await?;
+        assert_eq!(
+            fixture_rows(&collect(first_plan.clone(), session.task_ctx()).await?),
+            expected_first
+        );
+        let decoded_plan = decoded.scan(&session.state(), None, &[], None).await?;
+        assert_eq!(
+            fixture_rows(&collect(decoded_plan, session.task_ctx()).await?),
+            expected_first
+        );
+        // Cancellation must not consume visibility shared by subsequent streams.
+        drop(first_plan.execute(0, session.task_ctx())?);
+        assert_eq!(
+            fixture_rows(&collect(first_plan, session.task_ctx()).await?),
+            expected_first
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_generated_mixed_scan_checks_coordinates_and_logical_rows_independently()
+    -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture};
+        let fixture = Fixture::new(
+            vec![
+                FileSpec {
+                    rows: 161,
+                    groups: vec![37, 53, 71],
+                    deleted: Some([0, 36, 37, 89, 90, 160].into_iter().collect()),
+                    log_stats: true,
+                },
+                FileSpec {
+                    rows: 107,
+                    groups: vec![41, 66],
+                    deleted: None,
+                    log_stats: false,
+                },
+            ],
+            8,
+        )?;
+        let table = crate::open_table(fixture.url()).await?;
+        let provider = table.table_provider().await?;
+        let session = create_session().into_inner();
+        let plan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = plan.downcast_ref::<DeltaScanExec>().unwrap();
+        let physical = collect(exec.input.clone(), session.task_ctx()).await?;
+        let expected_by_id = fixture
+            .coordinates
+            .iter()
+            .map(|row| (row.2, *row))
+            .collect::<HashMap<_, _>>();
+        let mut actual_visible = Vec::new();
+        for batch in physical {
+            let positions = batch
+                .column(
+                    exec.physical_input_contract
+                        .physical_row_position_index
+                        .unwrap(),
+                )
+                .as_any()
+                .downcast_ref::<arrow_array::Int64Array>()
+                .unwrap();
+            let ids = batch
+                .column(batch.schema().index_of("id")?)
+                .as_any()
+                .downcast_ref::<arrow_array::Int64Array>()
+                .unwrap();
+            for (id, position) in ids.values().iter().zip(positions.values()) {
+                assert_eq!(*position as u64, expected_by_id[id].1);
+            }
+            for (file_id, run) in
+                split_by_file_id_runs(&batch, exec.physical_input_contract.file_id_index)?
+            {
+                let positions = run
+                    .column(
+                        exec.physical_input_contract
+                            .physical_row_position_index
+                            .unwrap(),
+                    )
+                    .as_any()
+                    .downcast_ref::<arrow_array::Int64Array>()
+                    .unwrap();
+                let selection = exec
+                    .deletion_vectors
+                    .selection_for_positions(&file_id, positions)?;
+                let ids = run
+                    .column(run.schema().index_of("id")?)
+                    .as_any()
+                    .downcast_ref::<arrow_array::Int64Array>()
+                    .unwrap();
+                for (id, keep) in ids.values().iter().zip(selection.values()) {
+                    if keep {
+                        actual_visible.push(expected_by_id[id]);
+                    }
+                }
+            }
+        }
+        actual_visible.sort_unstable();
+        assert_eq!(actual_visible, fixture.live_coordinates());
+        let expected = fixture
+            .live_coordinates()
+            .iter()
+            .map(|row| (row.2, row.3))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            fixture_rows(&collect(plan.clone(), session.task_ctx()).await?),
+            expected
+        );
+        assert_eq!(
+            fixture_rows(&collect(plan, session.task_ctx()).await?),
+            expected
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[expect(deprecated, reason = "qualify both supported child replacement APIs")]
+    async fn test_dv_provenance_rejects_extensions_and_fabricated_positions() -> TestResult {
+        use datafusion::datasource::physical_plan::parquet::ParquetAccessPlan;
+        use datafusion::physical_plan::projection::ProjectionExec;
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan.downcast_ref::<DeltaScanExec>().unwrap();
+        let source = exec.input.downcast_ref::<DataSourceExec>().unwrap();
+        let config = source
+            .data_source()
+            .downcast_ref::<FileScanConfig>()
+            .unwrap();
+        let mut files = config.file_groups[0].iter().cloned().collect::<Vec<_>>();
+        files[0].extensions.insert(ParquetAccessPlan::new_all(1));
+        let injected = DataSourceExec::from_data_source(
+            FileScanConfigBuilder::from(config.clone())
+                .with_file_groups(vec![FileGroup::new(files)])
+                .build(),
+        );
+        assert!(
+            Arc::new(exec.clone())
+                .with_new_children(vec![injected.clone()])
+                .is_err()
+        );
+        assert!(
+            Arc::new(exec.clone())
+                .replace_children(
+                    vec![injected],
+                    ReplaceChildrenOptions::new(ChildrenPropertiesMode::Keep)
+                )
+                .is_err()
+        );
+        let position = exec
+            .physical_input_contract
+            .physical_row_position_index
+            .unwrap();
+        for computed in [false, true] {
+            let expressions = exec
+                .input
+                .schema()
+                .fields()
+                .iter()
+                .enumerate()
+                .map(|(index, field)| {
+                    let column: Arc<dyn PhysicalExpr> = Arc::new(Column::new(field.name(), index));
+                    let expression = if index == position {
+                        if computed {
+                            Arc::new(BinaryExpr::new(column, Operator::Plus, physical_lit(0_i64)))
+                                as Arc<dyn PhysicalExpr>
+                        } else {
+                            physical_lit(ScalarValue::Int64(None))
+                        }
+                    } else {
+                        column
+                    };
+                    (expression, field.name().clone())
+                })
+                .collect::<Vec<_>>();
+            let fabricated: Arc<dyn ExecutionPlan> =
+                Arc::new(ProjectionExec::try_new(expressions, exec.input.clone())?);
+            for (actual, expected) in fabricated
+                .schema()
+                .fields()
+                .iter()
+                .zip(exec.input.schema().fields())
+            {
+                assert_eq!(
+                    (actual.name(), actual.data_type(), actual.is_nullable()),
+                    (
+                        expected.name(),
+                        expected.data_type(),
+                        expected.is_nullable()
+                    )
+                );
+            }
+            assert!(
+                Arc::new(exec.clone())
+                    .with_new_children(vec![fabricated])
+                    .is_err()
+            );
+        }
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_dv_scan_downgrades_all_exact_physical_statistics() -> TestResult {
         let table = open_fs_path(DV_TABLE_PATH);
@@ -2022,26 +2656,10 @@ mod tests {
             .downcast_ref::<FileScanConfig>()
             .expect("DataSourceExec must hold a parquet FileScanConfig");
         let original_file = source_config.file_groups[0][0].clone();
-        let original_file_id = exec
-            .dv_state
-            .selection_vectors()
-            .and_then(|vectors| vectors.keys().next().cloned())
-            .expect("fixture must have one deletion vector mask");
+        let original_file_id = exec.deletion_vectors.entries.keys().next().unwrap().clone();
 
         let duplicate_file_id = "duplicate".to_string();
-        let source_url = url::Url::parse(&format!(
-            "{}{}",
-            source_config.object_store_url.as_str(),
-            original_file.object_meta.location.as_ref()
-        ))?;
-        let source_path = source_url.to_file_path().map_err(|_| {
-            std::io::Error::other(format!("fixture requires a file URL: {source_url}"))
-        })?;
-        let temp_dir = tempfile::tempdir()?;
-        let duplicate_path = temp_dir.path().join("duplicate.parquet");
-        std::fs::copy(&source_path, &duplicate_path)?;
-        let duplicate_location = object_store::path::Path::from_filesystem_path(&duplicate_path)?;
-
+        let duplicate_location = original_file.object_meta.location.clone();
         let mut duplicate_file = original_file.clone();
         duplicate_file.object_meta.location = duplicate_location.clone();
         duplicate_file.partition_values =
@@ -2055,19 +2673,19 @@ mod tests {
             ])
             .with_output_partitioning(Some(Partitioning::UnknownPartitioning(2)))
             .build();
-        let grouped_input = DataSourceExec::from_data_source(grouped_config);
+        let grouped_input: Arc<dyn ExecutionPlan> =
+            DataSourceExec::from_data_source(grouped_config);
+        let mut grouped_contract = exec.physical_input_contract.as_ref().clone();
+        grouped_contract.sources.clear();
+        grouped_contract.planned_files.clear();
+        grouped_contract.bind_sources(&grouped_input)?;
 
-        let mut selection_vectors = exec.dv_state.selection_vectors().unwrap().clone();
-        let duplicate_mask = selection_vectors
-            .get(&original_file_id)
-            .expect("fixture must provide the original mask")
-            .clone();
-        selection_vectors.insert(duplicate_file_id.clone(), duplicate_mask);
-        let mut identities = exec
-            .dv_state
-            .physical_file_identities()
-            .expect("fixture must provide sequential DV identities")
-            .clone();
+        let mut entries = exec.deletion_vectors.entries.clone();
+        entries.insert(
+            duplicate_file_id.clone(),
+            entries[&original_file_id].clone(),
+        );
+        let mut identities = exec.physical_file_identities.as_ref().clone();
         identities.insert(
             duplicate_file_id.clone(),
             super::super::PhysicalFileIdentity {
@@ -2075,17 +2693,16 @@ mod tests {
                 location: duplicate_location,
             },
         );
-        let dv_state = DvExecutionState::Sequential {
-            selection_vectors: Arc::new(selection_vectors),
-            physical_file_identities: Arc::new(identities),
-        };
-
         let grouped_scan: Arc<dyn ExecutionPlan> = Arc::new(DeltaScanExec::new(
             Arc::clone(&exec.scan_plan),
             grouped_input,
             Arc::clone(&exec.transforms),
-            dv_state,
-            Arc::clone(&exec.public_file_ids),
+            PhysicalScanContext {
+                deletion_vectors: Arc::new(DeletionVectorIndex::try_new(entries)?),
+                public_file_ids: Arc::clone(&exec.public_file_ids),
+                physical_file_identities: Arc::new(identities),
+                physical_input_contract: Arc::new(grouped_contract),
+            },
             exec.partition_stats.clone(),
             ExecutionPlanMetricsSet::new(),
         ));
@@ -2120,6 +2737,49 @@ mod tests {
         ];
         assert_batches_sorted_eq!(&expected, &first?);
         assert_batches_sorted_eq!(&expected, &second?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_uses_hidden_physical_row_positions() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        let explain = datafusion::physical_plan::displayable(scan.as_ref())
+            .indent(false)
+            .to_string();
+        assert!(explain.contains("dv_mode=physical_position"), "{explain}");
+        assert!(explain.contains("physical_row_index=true"), "{explain}");
+        let input_schema = exec.input.schema();
+        let hidden_position = input_schema
+            .fields()
+            .iter()
+            .find(|field| field.name().starts_with("__delta_rs_physical_row_position"))
+            .expect("physical child must materialize a hidden row position");
+        let hidden_position_name = hidden_position.name().clone();
+        assert_eq!(hidden_position.data_type(), &DataType::Int64);
+        assert!(
+            exec.schema()
+                .fields()
+                .iter()
+                .all(|field| field.name() != &hidden_position_name)
+        );
+
+        let batches = collect(scan, session.task_ctx()).await?;
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+        assert!(batches.iter().all(|batch| {
+            batch
+                .schema()
+                .fields()
+                .iter()
+                .all(|field| field.name() != &hidden_position_name)
+        }));
 
         Ok(())
     }
@@ -2236,10 +2896,6 @@ mod tests {
     ) -> DeltaScanStream {
         use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 
-        let input_schema = input_batches
-            .first()
-            .map(|b| b.schema())
-            .unwrap_or_else(|| Arc::clone(&scan_plan.contract.output_schema));
         let input_file_id_column = scan_plan.contract.file_id_field.name().clone();
         let mut public_file_ids = super::super::PublicFileIdMap::default();
         for file_id in selection_vectors.keys() {
@@ -2255,6 +2911,77 @@ mod tests {
             }
         }
 
+        let has_deletion_vectors = !selection_vectors.is_empty();
+        let mut physical_input_contract = Arc::new(super::super::PhysicalInputContract::new(
+            &scan_plan.parquet_read_schema,
+            scan_plan.contract.file_id_field.clone(),
+            has_deletion_vectors,
+        ));
+        let mut next_position_by_file = HashMap::<String, i64>::new();
+        let input_batches = input_batches
+            .into_iter()
+            .map(|batch| {
+                if !has_deletion_vectors {
+                    return batch;
+                }
+                append_test_physical_positions(
+                    batch,
+                    &physical_input_contract,
+                    &input_file_id_column,
+                    &mut next_position_by_file,
+                )
+            })
+            .collect::<Vec<_>>();
+        let deletion_entries: HashMap<String, super::super::deletion_vector::DeletionVectorEntry> =
+            selection_vectors
+                .iter()
+                .map(|selection| {
+                    let observed = next_position_by_file
+                        .get(selection.0)
+                        .copied()
+                        .unwrap_or_default();
+                    let physical_record_count = u64::try_from(observed)
+                        .unwrap()
+                        .max(u64::try_from(selection.1.len()).unwrap());
+                    let deleted_cardinality =
+                        u64::try_from(selection.1.iter().filter(|keep| !**keep).count()).unwrap();
+                    (
+                        selection.0.clone(),
+                        super::super::deletion_vector::DeletionVectorEntry {
+                            keep_mask: selection.1.clone(),
+                            physical_record_count,
+                            deleted_cardinality,
+                        },
+                    )
+                })
+                .collect();
+        let mut selected = next_position_by_file
+            .iter()
+            .map(|(id, count)| (id.clone(), Some(*count as u64)))
+            .collect::<HashMap<_, _>>();
+        for (id, entry) in &deletion_entries {
+            selected.insert(id.clone(), Some(entry.physical_record_count));
+        }
+        Arc::make_mut(&mut physical_input_contract).footer_bounds = selected
+            .iter()
+            .map(|(id, count)| {
+                (
+                    id.clone(),
+                    Arc::new(std::sync::OnceLock::from(count.unwrap())),
+                )
+            })
+            .collect();
+        let deletion_vectors = Arc::new(
+            DeletionVectorIndex::try_new(deletion_entries)
+                .unwrap()
+                .with_selected_files(selected)
+                .expect("valid test deletion vectors"),
+        );
+        let input_schema = input_batches
+            .first()
+            .map(|batch| batch.schema())
+            .unwrap_or_else(|| physical_input_contract.table_schema.table_schema().clone());
+
         let input = Box::pin(RecordBatchStreamAdapter::new(
             input_schema,
             futures::stream::iter(input_batches.into_iter().map(Ok)),
@@ -2269,15 +2996,42 @@ mod tests {
             input,
             baseline_metrics: BaselineMetrics::new(&ExecutionPlanMetricsSet::new(), 0),
             transforms: Arc::new(HashMap::new()),
-            selection_vectors,
+            deletion_vectors,
+            physical_input_contract,
+            dv_rows_checked: Count::new(),
+            dv_rows_removed: Count::new(),
             public_file_ids: Arc::new(public_file_ids),
-            input_file_id_column,
             file_id_column,
             row_index_field,
             row_index_by_file: HashMap::new(),
             pending: VecDeque::new(),
             schema_adapter,
         }
+    }
+
+    fn append_test_physical_positions(
+        batch: RecordBatch,
+        physical_input_contract: &super::super::PhysicalInputContract,
+        input_file_id_column: &str,
+        next_position_by_file: &mut HashMap<String, i64>,
+    ) -> RecordBatch {
+        let file_id_idx =
+            file_id_column_idx(&batch, input_file_id_column).expect("valid compact file-id column");
+        let mut positions = Vec::with_capacity(batch.num_rows());
+        for (file_id, run) in
+            split_by_file_id_runs(&batch, file_id_idx).expect("valid compact file-id runs")
+        {
+            let next = next_position_by_file.entry(file_id).or_default();
+            positions.extend(*next..*next + i64::try_from(run.num_rows()).unwrap());
+            *next += i64::try_from(run.num_rows()).unwrap();
+        }
+        let mut columns = batch.columns().to_vec();
+        columns.push(Arc::new(arrow_array::Int64Array::from(positions)));
+        RecordBatch::try_new(
+            physical_input_contract.table_schema.table_schema().clone(),
+            columns,
+        )
+        .expect("test physical input batch")
     }
 
     fn retain_row_index(scan_plan: Arc<KernelScanPlan>, column: &str) -> Arc<KernelScanPlan> {
@@ -2325,8 +3079,12 @@ mod tests {
             retain_row_index(scan_plan, "row_ordinal"),
             Arc::clone(&exec.input),
             Arc::clone(&exec.transforms),
-            exec.dv_state.clone(),
-            Arc::clone(&exec.public_file_ids),
+            PhysicalScanContext {
+                deletion_vectors: Arc::clone(&exec.deletion_vectors),
+                public_file_ids: Arc::clone(&exec.public_file_ids),
+                physical_file_identities: Arc::clone(&exec.physical_file_identities),
+                physical_input_contract: Arc::clone(&exec.physical_input_contract),
+            },
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -2363,8 +3121,12 @@ mod tests {
             retain_row_index(scan_plan, "row_ordinal"),
             repartitioned_input,
             Arc::clone(&exec.transforms),
-            exec.dv_state.clone(),
-            Arc::clone(&exec.public_file_ids),
+            PhysicalScanContext {
+                deletion_vectors: Arc::clone(&exec.deletion_vectors),
+                public_file_ids: Arc::clone(&exec.public_file_ids),
+                physical_file_identities: Arc::clone(&exec.physical_file_identities),
+                physical_input_contract: Arc::clone(&exec.physical_input_contract),
+            },
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -2396,12 +3158,21 @@ mod tests {
         let mut public_file_ids = super::super::PublicFileIdMap::default();
         public_file_ids.insert("f1".to_string(), "f1".to_string());
         public_file_ids.insert("f2".to_string(), "f2".to_string());
+        let physical_input_contract = Arc::new(super::super::PhysicalInputContract::new(
+            &scan_plan.parquet_read_schema,
+            scan_plan.contract.file_id_field.clone(),
+            false,
+        ));
         let exec = DeltaScanExec::new(
             scan_plan,
             input,
             Arc::new(HashMap::new()),
-            DvExecutionState::None,
-            Arc::new(public_file_ids),
+            PhysicalScanContext {
+                deletion_vectors: Arc::new(DeletionVectorIndex::default()),
+                public_file_ids: Arc::new(public_file_ids),
+                physical_file_identities: Arc::new(super::super::PhysicalFileIdentityMap::default()),
+                physical_input_contract,
+            },
             HashMap::new(),
             ExecutionPlanMetricsSet::new(),
         );
@@ -2519,6 +3290,12 @@ mod tests {
             None,
         );
 
+        let batch = append_test_physical_positions(
+            batch,
+            &stream.physical_input_contract,
+            FILE_ID_COLUMN_DEFAULT,
+            &mut HashMap::new(),
+        );
         let outputs = stream.batch_project(batch)?;
         assert_eq!(outputs.len(), 2);
 
@@ -2585,6 +3362,12 @@ mod tests {
             None,
         );
 
+        let batch = append_test_physical_positions(
+            batch,
+            &stream.physical_input_contract,
+            FILE_ID_COLUMN_DEFAULT,
+            &mut HashMap::new(),
+        );
         let outputs = stream.batch_project(batch)?;
         let kept: Vec<i32> = outputs
             .iter()
@@ -2614,9 +3397,20 @@ mod tests {
             Vec::new(),
             None,
         );
-        let batches = stream.batch_project(RecordBatch::new_empty(Arc::clone(
-            &scan_plan.contract.output_schema,
-        )))?;
+        assert!(
+            stream
+                .batch_project(RecordBatch::new_empty(
+                    scan_plan.contract.output_schema.clone()
+                ))
+                .is_err()
+        );
+        let batches = stream.batch_project(RecordBatch::new_empty(
+            stream
+                .physical_input_contract
+                .table_schema
+                .table_schema()
+                .clone(),
+        ))?;
         let columns = batches[0].columns();
 
         assert_eq!(batches[0].schema(), scan_plan.contract.output_schema);
@@ -2639,9 +3433,20 @@ mod tests {
             None,
         );
 
-        let batches = stream.batch_project(RecordBatch::new_empty(Arc::clone(
-            &scan_plan.contract.output_schema,
-        )))?;
+        assert!(
+            stream
+                .batch_project(RecordBatch::new_empty(
+                    scan_plan.contract.output_schema.clone()
+                ))
+                .is_err()
+        );
+        let batches = stream.batch_project(RecordBatch::new_empty(
+            stream
+                .physical_input_contract
+                .table_schema
+                .table_schema()
+                .clone(),
+        ))?;
 
         assert_eq!(batches[0].schema(), scan_plan.contract.output_schema);
         let schema = batches[0].schema();
@@ -2834,123 +3639,5 @@ mod tests {
         }
 
         Ok(())
-    }
-
-    #[test]
-    fn test_dv_short_mask_drain_and_pad() {
-        use super::{DvMaskResult, consume_dv_mask};
-
-        let mut sv = vec![true, false, true];
-        let result = consume_dv_mask(&mut sv, 5);
-
-        assert_eq!(
-            result,
-            DvMaskResult {
-                selection: Some(vec![true, false, true, true, true]),
-                should_remove: true,
-            }
-        );
-        assert!(sv.is_empty());
-    }
-
-    #[test]
-    fn test_dv_mask_exhaustion_across_batches() {
-        use super::{DvMaskResult, consume_dv_mask};
-
-        let file_id = "test_file.parquet".to_string();
-        let mut selection_vectors = HashMap::from([(file_id.clone(), vec![false, true])]);
-
-        let result1 = consume_dv_mask(selection_vectors.get_mut(&file_id).unwrap(), 5);
-        assert_eq!(
-            result1,
-            DvMaskResult {
-                selection: Some(vec![false, true, true, true, true]),
-                should_remove: true,
-            }
-        );
-        if result1.should_remove {
-            selection_vectors.remove(&file_id);
-        }
-
-        let result2 = if let Some(sv) = selection_vectors.get_mut(&file_id) {
-            consume_dv_mask(sv, 5)
-        } else {
-            DvMaskResult {
-                selection: None,
-                should_remove: false,
-            }
-        };
-        assert_eq!(
-            result2,
-            DvMaskResult {
-                selection: None,
-                should_remove: false,
-            }
-        );
-    }
-
-    #[test]
-    fn test_dv_normal_mask_drains_exactly() {
-        use super::{DvMaskResult, consume_dv_mask};
-
-        let mut sv = vec![
-            true, false, true, false, true, true, false, true, false, true,
-        ];
-
-        let result1 = consume_dv_mask(&mut sv, 3);
-        assert_eq!(
-            result1,
-            DvMaskResult {
-                selection: Some(vec![true, false, true]),
-                should_remove: false,
-            }
-        );
-        assert_eq!(sv.len(), 7);
-
-        let result2 = consume_dv_mask(&mut sv, 3);
-        assert_eq!(
-            result2,
-            DvMaskResult {
-                selection: Some(vec![false, true, true]),
-                should_remove: false,
-            }
-        );
-        assert_eq!(sv, vec![false, true, false, true]);
-
-        let result3 = consume_dv_mask(&mut sv, 5);
-        assert_eq!(
-            result3,
-            DvMaskResult {
-                selection: Some(vec![false, true, false, true, true]),
-                should_remove: true,
-            }
-        );
-        assert!(sv.is_empty());
-
-        let result4 = consume_dv_mask(&mut sv, 5);
-        assert_eq!(
-            result4,
-            DvMaskResult {
-                selection: None,
-                should_remove: true,
-            }
-        );
-    }
-
-    #[test]
-    fn test_dv_long_mask_retains_remainder_for_next_batch() {
-        use super::{DvMaskResult, consume_dv_mask};
-
-        let mut sv = vec![true, false, false, true];
-        let result = consume_dv_mask(&mut sv, 2);
-
-        assert_eq!(
-            result,
-            DvMaskResult {
-                selection: Some(vec![true, false]),
-                should_remove: false,
-            }
-        );
-        assert_eq!(sv, vec![false, true]);
     }
 }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -2080,12 +2080,9 @@ mod tests {
                     .with_file_groups(groups.into_iter().map(FileGroup::new).collect())
                     .build(),
             );
-            assert!(
-                Arc::new(exec.clone())
-                    .with_new_children(vec![replacement])
-                    .is_err(),
-                "must reject changed per-file {change}"
-            );
+            #[expect(deprecated, reason = "qualify both supported child-replacement APIs")]
+            let replaced = Arc::new(exec.clone()).with_new_children(vec![replacement]);
+            assert!(replaced.is_err(), "must reject changed per-file {change}");
         }
 
         let mut fragment = config.file_groups[0][0].clone();

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -9,24 +9,20 @@ use std::sync::{Arc, LazyLock};
 use std::task::{Context, Poll};
 
 use arrow::array::RecordBatch;
-use arrow::compute::filter_record_batch;
 use arrow::datatypes::SchemaRef;
-use arrow_array::{BooleanArray, RecordBatchOptions};
+use arrow_array::RecordBatchOptions;
 use arrow_schema::{FieldRef, Fields, Schema};
-use dashmap::DashMap;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::error::{DataFusionError, Result};
 use datafusion::common::tree_node::TreeNodeRecursion;
-use datafusion::common::{HashMap, internal_datafusion_err, stats::Precision};
+use datafusion::common::{HashMap, stats::Precision};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::{
     Boundedness, CardinalityEffect, EmissionType, PlanProperties,
 };
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
-use datafusion::physical_plan::metrics::{
-    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
-};
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::statistics::StatisticsArgs;
 use datafusion::physical_plan::{
     ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
@@ -36,8 +32,8 @@ use delta_kernel::schema::{Schema as KernelSchema, SchemaRef as KernelSchemaRef}
 use delta_kernel::{EvaluationHandler, ExpressionRef};
 use futures::stream::Stream;
 use itertools::Itertools as _;
-use tracing::debug;
 
+use super::deletion_vector::DeletionVectorIndex;
 use crate::delta_datafusion::table_provider::next::KernelScanPlan;
 use crate::kernel::ARROW_HANDLER;
 use crate::kernel::arrow::engine_ext::ExpressionEvaluatorExt;
@@ -71,7 +67,7 @@ pub(crate) struct DeltaScanMetaExec {
     /// Transforms to be applied to data eminating from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Deletion vectors for the table
-    selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+    deletion_vectors: Arc<DeletionVectorIndex>,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
     /// Execution metrics
@@ -130,7 +126,7 @@ impl DeltaScanMetaExec {
         scan_plan: Arc<KernelScanPlan>,
         input: Vec<VecDeque<(String, usize)>>,
         transforms: Arc<HashMap<String, ExpressionRef>>,
-        selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+        deletion_vectors: Arc<DeletionVectorIndex>,
         public_file_ids: Arc<super::PublicFileIdMap>,
         file_id_field: Option<FieldRef>,
         metrics: ExecutionPlanMetricsSet,
@@ -141,7 +137,7 @@ impl DeltaScanMetaExec {
             scan_plan,
             input,
             transforms,
-            selection_vectors,
+            deletion_vectors,
             public_file_ids,
             metrics,
             file_id_field,
@@ -150,9 +146,8 @@ impl DeltaScanMetaExec {
     }
 
     fn effective_row_count_for_file(&self, file_id: &str, row_count: usize) -> Result<usize> {
-        if let Some(selection) = self.selection_vectors.get(file_id) {
-            let (kept_rows, _) = effective_row_count(row_count, selection.value(), file_id)?;
-            Ok(kept_rows)
+        if self.deletion_vectors.has_vectors() {
+            self.deletion_vectors.live_row_count(file_id, row_count)
         } else {
             Ok(row_count)
         }
@@ -272,10 +267,8 @@ impl ExecutionPlan for DeltaScanMetaExec {
             scan_plan: Arc::clone(&self.scan_plan),
             input: self.input[partition].clone(),
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
-            dv_short_mask_padded_files_total: MetricBuilder::new(&self.metrics)
-                .counter("dv_short_mask_padded_files_total", partition),
             transforms: Arc::clone(&self.transforms),
-            selection_vectors: Arc::clone(&self.selection_vectors),
+            deletion_vectors: Arc::clone(&self.deletion_vectors),
             public_file_ids: Arc::clone(&self.public_file_ids),
             file_id_field: self.file_id_field.clone(),
             schema_adapter: super::SchemaAdapter::new(Arc::clone(
@@ -357,12 +350,10 @@ struct DeltaScanMetaStream {
     input: VecDeque<(String, usize)>,
     /// Execution metrics
     baseline_metrics: BaselineMetrics,
-    /// Count of file batches where short deletion-vector masks required padding.
-    dv_short_mask_padded_files_total: Count,
     /// Transforms to be applied to data read from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Selection vectors to be applied to data read from individual files
-    selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+    deletion_vectors: Arc<DeletionVectorIndex>,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
     /// Column name for the file id
@@ -381,29 +372,16 @@ impl DeltaScanMetaStream {
 
         let _timer = self.baseline_metrics.elapsed_compute().timer();
 
+        let live_row_count = if self.deletion_vectors.has_vectors() {
+            self.deletion_vectors.live_row_count(&file_id, row_count)?
+        } else {
+            row_count
+        };
         let batch = RecordBatch::try_new_with_options(
             EMPTY_SCHEMA.clone(),
             vec![],
-            &RecordBatchOptions::new().with_row_count(Some(row_count)),
+            &RecordBatchOptions::new().with_row_count(Some(live_row_count)),
         )?;
-
-        let batch = if let Some(selection) = self.selection_vectors.get(&file_id) {
-            let mask_len = selection.len();
-            let (batch, padded_rows) = apply_selection_vector(batch, selection.value(), &file_id)?;
-            if padded_rows > 0 {
-                self.dv_short_mask_padded_files_total.add(1);
-                debug!(
-                    file_id = file_id.as_str(),
-                    mask_len,
-                    row_count,
-                    padded_rows,
-                    "Padded short deletion-vector keep-mask in metadata scan"
-                );
-            }
-            batch
-        } else {
-            batch
-        };
 
         let result = if self
             .scan_plan
@@ -452,43 +430,6 @@ impl DeltaScanMetaStream {
     }
 }
 
-fn apply_selection_vector(
-    batch: RecordBatch,
-    selection: &[bool],
-    file_id: &str,
-) -> Result<(RecordBatch, usize)> {
-    let (_, n_rows_to_pad) = effective_row_count(batch.num_rows(), selection, file_id)?;
-    // Delta Kernel may emit short keep-masks; missing trailing entries are
-    // implicitly `true` (row is kept).
-    let filter = BooleanArray::from_iter(
-        selection
-            .iter()
-            .copied()
-            .chain(std::iter::repeat_n(true, n_rows_to_pad)),
-    );
-    Ok((filter_record_batch(&batch, &filter)?, n_rows_to_pad))
-}
-
-fn effective_row_count(
-    row_count: usize,
-    selection: &[bool],
-    file_id: &str,
-) -> Result<(usize, usize)> {
-    if selection.len() > row_count {
-        return Err(internal_datafusion_err!(
-            "Selection vector length ({}) exceeds row count ({}) for file '{}'. \
-             This indicates a bug in deletion vector processing.",
-            selection.len(),
-            row_count,
-            file_id
-        ));
-    }
-
-    let n_rows_to_pad = row_count - selection.len();
-    let kept_rows = selection.iter().filter(|keep| **keep).count() + n_rows_to_pad;
-    Ok((kept_rows, n_rows_to_pad))
-}
-
 impl Stream for DeltaScanMetaStream {
     type Item = Result<RecordBatch>;
 
@@ -518,8 +459,8 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::array::RecordBatch;
-    use arrow_array::{Int64Array, RecordBatchOptions, StringArray};
-    use arrow_schema::{DataType, Field, Fields, Schema};
+    use arrow_array::{Int64Array, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
     use datafusion::{
         catalog::TableProvider,
         common::stats::Precision,
@@ -772,54 +713,6 @@ mod tests {
         );
 
         Ok(())
-    }
-
-    #[test]
-    fn test_apply_selection_vector_short_mask_pads_with_true() {
-        let batch = RecordBatch::try_new_with_options(
-            Arc::new(Schema::new(Fields::empty())),
-            vec![],
-            &RecordBatchOptions::new().with_row_count(Some(4)),
-        )
-        .unwrap();
-
-        // Short masks are valid: missing trailing entries are implicitly true.
-        let (filtered, padded_rows) =
-            apply_selection_vector(batch, &[false, true], "file:///f.parquet").unwrap();
-        assert_eq!(filtered.num_rows(), 3);
-        assert_eq!(padded_rows, 2);
-    }
-
-    #[test]
-    fn test_apply_selection_vector_no_padding_when_lengths_match() {
-        let batch = RecordBatch::try_new_with_options(
-            Arc::new(Schema::new(Fields::empty())),
-            vec![],
-            &RecordBatchOptions::new().with_row_count(Some(2)),
-        )
-        .unwrap();
-
-        let (filtered, padded_rows) =
-            apply_selection_vector(batch, &[true, false], "file:///f.parquet").unwrap();
-        assert_eq!(filtered.num_rows(), 1);
-        assert_eq!(padded_rows, 0);
-    }
-
-    #[test]
-    fn test_apply_selection_vector_longer_than_batch_errors() {
-        let batch = RecordBatch::try_new_with_options(
-            Arc::new(Schema::new(Fields::empty())),
-            vec![],
-            &RecordBatchOptions::new().with_row_count(Some(2)),
-        )
-        .unwrap();
-
-        let err = apply_selection_vector(batch, &[true, true, true], "file:///f.parquet")
-            .expect_err("selection vector longer than row count must error");
-        assert!(
-            err.to_string().contains("Selection vector length"),
-            "unexpected error: {err}"
-        );
     }
 
     #[tokio::test]
@@ -1145,8 +1038,22 @@ mod tests {
             .downcast_ref::<DeltaScanMetaExec>()
             .expect("expected metadata-only scan");
 
-        let selection_vectors: Arc<DashMap<String, Vec<bool>>> = Arc::new(DashMap::new());
-        selection_vectors.insert("f2".to_string(), vec![true, false, true, false]);
+        let deletion_vectors = Arc::new(
+            DeletionVectorIndex::try_new(HashMap::from([(
+                "f2".to_string(),
+                super::super::deletion_vector::DeletionVectorEntry {
+                    keep_mask: vec![true, false, true, false],
+                    physical_record_count: 4,
+                    deleted_cardinality: 2,
+                },
+            )]))?
+            .with_selected_files(HashMap::from([
+                ("f1".into(), Some(10)),
+                ("f2".into(), Some(4)),
+                ("f3".into(), Some(6)),
+                ("f4".into(), Some(2)),
+            ]))?,
+        );
         let public_file_ids = Arc::new(
             [
                 ("f1".to_string(), "f1".to_string()),
@@ -1167,7 +1074,7 @@ mod tests {
                 ("f4".to_string(), 2usize),
             ])],
             Arc::clone(&template.transforms),
-            selection_vectors,
+            deletion_vectors,
             public_file_ids,
             template.file_id_field.clone(),
             ExecutionPlanMetricsSet::new(),

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/metadata_cache.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/metadata_cache.rs
@@ -1,0 +1,188 @@
+//! Store-qualified views of the session cache. The backing cache owns the single
+//! retention allowance, including entries from concurrent, independently planned scans.
+
+use std::{
+    any::Any,
+    sync::{Arc, Weak},
+    time::Duration,
+};
+
+use datafusion::{
+    common::{HashMap, Result, TableReference},
+    execution::cache::{
+        Cache, CacheEntryInfo,
+        cache_manager::{CachedFileMetadataEntry, FileMetadata, FileMetadataCache},
+    },
+};
+use object_store::{ObjectMeta, ObjectStore, path::Path};
+
+#[derive(Debug)]
+pub(super) struct StoreMetadataCache {
+    backing: Arc<FileMetadataCache>,
+    store: Arc<dyn ObjectStore>,
+    object: ObjectMeta,
+}
+
+struct TaggedMetadata {
+    // Weak retains the allocation identity, preventing address reuse without
+    // retaining an unregistered store's data for the cache entry's lifetime.
+    store: Weak<dyn ObjectStore>,
+    value: Arc<dyn FileMetadata>,
+    object: ObjectMeta,
+    footer: Option<std::result::Result<super::reader::FooterEvidence, String>>,
+}
+
+impl FileMetadata for TaggedMetadata {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn memory_size(&self) -> usize {
+        self.value.memory_size()
+            + std::mem::size_of::<Self>()
+            + self.object.location.as_ref().len()
+            + self.object.e_tag.as_ref().map_or(0, String::len)
+            + self.object.version.as_ref().map_or(0, String::len)
+            + self
+                .footer
+                .as_ref()
+                .and_then(|proof| proof.as_ref().err())
+                .map_or(0, String::len)
+    }
+    fn extra_info(&self) -> HashMap<String, String> {
+        self.value.extra_info()
+    }
+}
+
+impl StoreMetadataCache {
+    pub(super) fn new(
+        backing: Arc<FileMetadataCache>,
+        store: Arc<dyn ObjectStore>,
+        object: ObjectMeta,
+    ) -> Self {
+        Self {
+            backing,
+            store,
+            object,
+        }
+    }
+
+    pub(super) fn footer_evidence(
+        &self,
+        metadata: &Arc<parquet::file::metadata::ParquetMetaData>,
+    ) -> std::result::Result<super::reader::FooterEvidence, String> {
+        if let Some(entry) = self.backing.get(&self.key(&self.object.location))
+            && let Some(tagged) = entry.file_metadata.as_any().downcast_ref::<TaggedMetadata>()
+            && Weak::ptr_eq(&Arc::downgrade(&self.store), &tagged.store)
+            && tagged.object == self.object
+            && let Some(cached) = tagged.value.as_any().downcast_ref::<datafusion::datasource::physical_plan::parquet::metadata::CachedParquetMetaData>()
+            && Arc::ptr_eq(cached.parquet_metadata(), metadata)
+            && let Some(evidence) = &tagged.footer
+        {
+            return evidence.clone();
+        }
+        super::reader::validate_footer(metadata)
+    }
+
+    fn key(&self, path: &Path) -> Path {
+        // The store allocation and canonical path qualify each key. Tagged values
+        // distinguish these entries from bare-path entries and verify full identity.
+        let address = Arc::as_ptr(&self.store) as *const () as usize;
+        Path::from(format!("__delta_rs_metadata/{address:x}/{}", path.as_ref()))
+    }
+
+    fn untag(&self, entry: CachedFileMetadataEntry) -> Option<CachedFileMetadataEntry> {
+        let tagged = entry
+            .file_metadata
+            .as_any()
+            .downcast_ref::<TaggedMetadata>()?;
+        if !Weak::ptr_eq(&tagged.store, &Arc::downgrade(&self.store))
+            || tagged.object != self.object
+        {
+            return None;
+        }
+        Some(CachedFileMetadataEntry::new(
+            tagged.object.clone(),
+            Arc::clone(&tagged.value),
+        ))
+    }
+}
+
+impl Cache<Path, CachedFileMetadataEntry> for StoreMetadataCache {
+    fn get(&self, path: &Path) -> Option<CachedFileMetadataEntry> {
+        if path != &self.object.location {
+            return None;
+        }
+        self.untag(self.backing.get(&self.key(path))?)
+    }
+    fn put(&self, path: &Path, value: CachedFileMetadataEntry) -> Option<CachedFileMetadataEntry> {
+        if path != &self.object.location || value.meta != self.object {
+            return None;
+        }
+        let footer = value.file_metadata.as_any().downcast_ref::<datafusion::datasource::physical_plan::parquet::metadata::CachedParquetMetaData>().map(|v| super::reader::validate_footer(v.parquet_metadata()));
+        let tagged = Arc::new(TaggedMetadata {
+            footer,
+            store: Arc::downgrade(&self.store),
+            object: value.meta.clone(),
+            value: value.file_metadata,
+        });
+        self.backing
+            .put(
+                &self.key(path),
+                CachedFileMetadataEntry::new(value.meta, tagged),
+            )
+            .and_then(|v| self.untag(v))
+    }
+    fn remove(&self, path: &Path) -> Option<CachedFileMetadataEntry> {
+        self.backing
+            .remove(&self.key(path))
+            .and_then(|v| self.untag(v))
+    }
+    fn contains_key(&self, path: &Path) -> bool {
+        self.get(path).is_some()
+    }
+    fn len(&self) -> usize {
+        self.list_entries().len()
+    }
+    fn clear(&self) {
+        self.remove(&self.object.location);
+    }
+    fn name(&self) -> String {
+        self.backing.name()
+    }
+    fn cache_limit(&self) -> usize {
+        self.backing.cache_limit()
+    }
+    fn update_cache_limit(&self, limit: usize) {
+        self.backing.update_cache_limit(limit);
+    }
+    fn cache_ttl(&self) -> Option<Duration> {
+        self.backing.cache_ttl()
+    }
+    fn update_cache_ttl(&self, ttl: Option<Duration>) {
+        self.backing.update_cache_ttl(ttl);
+    }
+    fn drop_table_entries(&self, table: &TableReference) -> Result<()> {
+        self.backing.drop_table_entries(table)
+    }
+    fn list_entries(&self) -> HashMap<Path, CacheEntryInfo<CachedFileMetadataEntry>> {
+        self.backing
+            .list_entries()
+            .into_iter()
+            .filter_map(|(key, info)| {
+                if key != self.key(&self.object.location) {
+                    return None;
+                }
+                let value = self.untag(info.value)?;
+                Some((
+                    self.object.location.clone(),
+                    CacheEntryInfo {
+                        value,
+                        size_bytes: info.size_bytes,
+                        hits: info.hits,
+                        expires: info.expires,
+                    },
+                ))
+            })
+            .collect()
+    }
+}

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -27,7 +27,6 @@ use arrow_array::{
 use arrow_cast::{CastOptions, cast_with_options};
 use arrow_schema::{DataType, FieldRef, Schema, SchemaBuilder, SchemaRef};
 use chrono::{TimeZone as _, Utc};
-use dashmap::DashMap;
 use datafusion::{
     catalog::Session,
     common::{
@@ -65,6 +64,7 @@ use tracing::debug;
 use url::Url;
 
 pub use self::exec::DeltaScanExec;
+use self::exec::DvExecutionState;
 use self::exec_meta::DeltaScanMetaExec;
 use self::expr_adapter::{DeltaPhysicalExprAdapterFactory, relax_schema_nested_nullability};
 pub(crate) use self::plan::{KernelScanPlan, ProjectedScanContract, supports_filters_pushdown};
@@ -89,10 +89,10 @@ mod replay;
 
 type ScanMetadataStream = Pin<Box<dyn Stream<Item = Result<ScanMetadata, DeltaTableError>> + Send>>;
 type PublicFileIdMap = HashMap<String, String>;
-pub(crate) type PhysicalFileIdentityMap = HashMap<String, PhysicalFileIdentity>;
+type PhysicalFileIdentityMap = HashMap<String, PhysicalFileIdentity>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct PhysicalFileIdentity {
+struct PhysicalFileIdentity {
     object_store_url: ObjectStoreUrl,
     location: Path,
 }
@@ -100,7 +100,7 @@ pub(crate) struct PhysicalFileIdentity {
 struct ReplayedScanFiles {
     files: Vec<ScanFileContext>,
     transforms: HashMap<String, Arc<Expression>>,
-    dvs: DashMap<String, Vec<bool>>,
+    dvs: HashMap<String, Vec<bool>>,
     public_file_ids: PublicFileIdMap,
     metrics: ExecutionPlanMetricsSet,
 }
@@ -160,7 +160,7 @@ pub(super) async fn execution_plan(
                 Arc::new(scan_plan),
                 vec![file_rows],
                 Arc::new(transforms),
-                Arc::new(dvs),
+                Arc::new(dvs.into_iter().collect()),
                 Arc::new(public_file_ids),
                 retain_file_id.then_some(file_id_field),
                 metrics,
@@ -202,7 +202,7 @@ pub(super) async fn replay_deletion_vectors(
     let dv_stream = stream.dv_stream.build();
     // Only files with `dv_info.has_vector()` spawn tasks, so every item should carry a DV.
     // Guard with a typed error (instead of panic) in case that invariant drifts.
-    let dvs: DashMap<_, _> = dv_stream
+    let dvs: HashMap<_, _> = dv_stream
         .and_then(|(url, dv, num_records)| {
             ready(match dv {
                 Some(keep_mask) => normalize_dv_keep_mask_for_api(keep_mask, num_records, &url)
@@ -421,19 +421,27 @@ async fn get_data_scan_plan(
     let has_deletion_vectors = !dvs.is_empty();
     let mut partition_stats = HashMap::new();
 
-    let physical_file_identities = files
-        .iter()
-        .enumerate()
-        .map(|(file_index, file)| {
-            Ok((
-                compact_internal_file_id(file_index),
-                PhysicalFileIdentity {
-                    object_store_url: file.file_url.as_object_store_url(),
-                    location: Path::from_url_path(file.file_url.path())?,
-                },
-            ))
-        })
-        .try_collect::<_, PhysicalFileIdentityMap, DataFusionError>()?;
+    let dv_state = if has_deletion_vectors {
+        let physical_file_identities = files
+            .iter()
+            .enumerate()
+            .map(|(file_index, file)| {
+                Ok((
+                    compact_internal_file_id(file_index),
+                    PhysicalFileIdentity {
+                        object_store_url: file.file_url.as_object_store_url(),
+                        location: Path::from_url_path(file.file_url.path())?,
+                    },
+                ))
+            })
+            .try_collect::<_, PhysicalFileIdentityMap, DataFusionError>()?;
+        DvExecutionState::Sequential {
+            selection_vectors: Arc::new(dvs),
+            physical_file_identities: Arc::new(physical_file_identities),
+        }
+    } else {
+        DvExecutionState::None
+    };
 
     // Convert files into DataFusion `PartitionedFile`s grouped by object store.
     // Create one `DataSourceExec` plan for each store.
@@ -459,10 +467,7 @@ async fn get_data_scan_plan(
         // on `partition_values`, so partition values must be set first.
         partitioned_file.partition_values = vec![file_value.clone()];
         partitioned_file = partitioned_file.with_statistics(Arc::new(f.stats));
-        Ok::<_, DataFusionError>((
-            f.file_url.as_object_store_url(),
-            (partitioned_file, None::<Vec<bool>>),
-        ))
+        Ok::<_, DataFusionError>((f.file_url.as_object_store_url(), partitioned_file))
     };
 
     // Group the files by their object store url. Since datafusion assumes that all files in a
@@ -473,41 +478,40 @@ async fn get_data_scan_plan(
         .map(to_partitioned_file)
         .try_collect::<_, Vec<_>, _>()?;
 
-    let files_by_store = partitioned_files.into_iter().into_group_map();
+    let files_by_store = partitioned_files
+        .into_iter()
+        .into_group_map()
+        .into_iter()
+        .map(|(store, files)| (store, files, has_deletion_vectors));
 
     // TODO(roeap); not sure exactly how row tracking is implemented in kernel right now
     // so leaving predicate as None for now until we are sure this is safe to do.
     let table_config = scan_plan.table_configuration();
-    let predicate =
-        if table_config.is_feature_enabled(&TableFeature::RowTracking) || has_deletion_vectors {
-            None
-        } else {
-            scan_plan.parquet_predicate.as_ref()
-        };
-    let parquet_limit = if has_deletion_vectors { None } else { limit };
+    let predicate = if table_config.is_feature_enabled(&TableFeature::RowTracking) {
+        None
+    } else {
+        scan_plan.parquet_predicate.as_ref()
+    };
     let file_id_field = scan_plan.contract.file_id_field.clone();
     let pq_plan = get_read_plan(
         session,
         files_by_store,
         &scan_plan.parquet_read_schema,
         &scan_plan.parquet_predicate_schema,
-        parquet_limit,
+        limit,
         &file_id_field,
         predicate,
-        has_deletion_vectors,
     )
     .await?;
 
     let transforms = Arc::new(transforms);
-    let dvs = Arc::new(dvs);
     let public_file_ids = Arc::new(public_file_ids);
     let exec = DeltaScanExec::new(
         Arc::new(scan_plan),
         pq_plan,
         Arc::clone(&transforms),
-        Arc::clone(&dvs),
+        dv_state,
         Arc::clone(&public_file_ids),
-        Arc::new(physical_file_identities),
         partition_stats,
         metrics,
     );
@@ -551,7 +555,7 @@ fn update_partition_stats(
     Ok(())
 }
 
-type FilesByStore = (ObjectStoreUrl, Vec<(PartitionedFile, Option<Vec<bool>>)>);
+type FilesByStore = (ObjectStoreUrl, Vec<PartitionedFile>, bool);
 
 fn compact_internal_file_id(file_index: usize) -> String {
     file_index.to_string()
@@ -560,8 +564,8 @@ fn compact_internal_file_id(file_index: usize) -> String {
 fn remap_deletion_vectors_to_internal_file_ids(
     files: &[ScanFileContext],
     mut dvs_by_url: HashMap<String, Vec<bool>>,
-) -> Result<DashMap<String, Vec<bool>>> {
-    let dvs = DashMap::new();
+) -> Result<HashMap<String, Vec<bool>>> {
+    let mut dvs = HashMap::new();
     for (file_index, file) in files.iter().enumerate() {
         if dvs_by_url.is_empty() {
             break;
@@ -668,13 +672,6 @@ fn partitioned_files_to_file_groups_with_limit(
     file_groups
 }
 
-fn lock_dv_file_group_layout(
-    builder: FileScanConfigBuilder,
-    file_group_count: usize,
-) -> FileScanConfigBuilder {
-    builder.with_output_partitioning(Some(Partitioning::UnknownPartitioning(file_group_count)))
-}
-
 async fn get_read_plan(
     state: &dyn Session,
     files_by_store: impl IntoIterator<Item = FilesByStore>,
@@ -689,7 +686,6 @@ async fn get_read_plan(
     limit: Option<usize>,
     file_id_field: &FieldRef,
     predicate: Option<&Expr>,
-    has_deletion_vectors: bool,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut plans = Vec::new();
 
@@ -711,7 +707,7 @@ async fn get_read_plan(
     let parquet_predicate_df_schema = parquet_predicate_schema.clone().to_dfschema()?;
     let adapter_factory = Arc::new(DeltaPhysicalExprAdapterFactory);
 
-    for (store_url, files) in files_by_store.into_iter() {
+    for (store_url, files, has_deletion_vectors) in files_by_store.into_iter() {
         let reader_factory = Arc::new(CachedParquetFileReaderFactory::new(
             state.runtime_env().object_store(&store_url)?,
             state.runtime_env().cache_manager.get_file_metadata_cache(),
@@ -771,7 +767,7 @@ async fn get_read_plan(
             }
         }
 
-        let file_groups = partitioned_files_to_file_groups(files.into_iter().map(|file| file.0));
+        let file_groups = partitioned_files_to_file_groups(files);
         let (file_groups, statistics) =
             compute_all_files_statistics(file_groups, full_table_schema, true, false)?;
 
@@ -782,7 +778,8 @@ async fn get_read_plan(
             .with_limit(if has_deletion_vectors { None } else { limit })
             .with_expr_adapter(Some(adapter_factory.clone() as _));
         let builder = if has_deletion_vectors {
-            lock_dv_file_group_layout(builder, file_group_count)
+            builder
+                .with_output_partitioning(Some(Partitioning::UnknownPartitioning(file_group_count)))
         } else {
             builder
         };
@@ -1407,10 +1404,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_data.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -1425,7 +1419,6 @@ mod tests {
             None,
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1449,7 +1442,6 @@ mod tests {
             Some(1),
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1478,7 +1470,6 @@ mod tests {
             Some(1),
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1538,10 +1529,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_data.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -1556,7 +1544,6 @@ mod tests {
             None,
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1595,7 +1582,6 @@ mod tests {
             None,
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1766,14 +1752,8 @@ mod tests {
             .push(wrap_file_id_value("second:///test_data.parquet"));
 
         let files_by_store = vec![
-            (
-                store_url_1.as_object_store_url(),
-                vec![(file_1, None::<Vec<bool>>)],
-            ),
-            (
-                store_url_2.as_object_store_url(),
-                vec![(file_2, None::<Vec<bool>>)],
-            ),
+            (store_url_1.as_object_store_url(), vec![file_1], false),
+            (store_url_2.as_object_store_url(), vec![file_2], false),
         ];
 
         let file_id_field =
@@ -1789,7 +1769,6 @@ mod tests {
             None,
             &file_id_field,
             None,
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1838,10 +1817,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_data.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -1857,7 +1833,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1905,10 +1880,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_rewrite_failure.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -1924,7 +1896,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1985,10 +1956,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_view_literal.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -2004,7 +1972,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2062,10 +2029,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_sql_literal.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -2081,7 +2045,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2140,10 +2103,7 @@ mod tests {
             "memory:///test_column_mapping_pushdown.parquet",
         ));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -2159,7 +2119,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2230,10 +2189,7 @@ mod tests {
         file.partition_values
             .push(wrap_file_id_value("memory:///test_binary_view.parquet"));
 
-        let files_by_store = vec![(
-            store_url.as_object_store_url(),
-            vec![(file, None::<Vec<bool>>)],
-        )];
+        let files_by_store = vec![(store_url.as_object_store_url(), vec![file], false)];
 
         let file_id_field =
             crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
@@ -2249,7 +2205,6 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
-            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -38,6 +38,7 @@ use datafusion::{
     datasource::physical_plan::{ParquetSource, parquet::CachedParquetFileReaderFactory},
     error::DataFusionError,
     execution::object_store::ObjectStoreUrl,
+    physical_expr::Partitioning,
     physical_plan::{
         ExecutionPlan,
         empty::EmptyExec,
@@ -88,6 +89,13 @@ mod replay;
 
 type ScanMetadataStream = Pin<Box<dyn Stream<Item = Result<ScanMetadata, DeltaTableError>> + Send>>;
 type PublicFileIdMap = HashMap<String, String>;
+pub(crate) type PhysicalFileIdentityMap = HashMap<String, PhysicalFileIdentity>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PhysicalFileIdentity {
+    object_store_url: ObjectStoreUrl,
+    location: Path,
+}
 
 struct ReplayedScanFiles {
     files: Vec<ScanFileContext>,
@@ -410,7 +418,22 @@ async fn get_data_scan_plan(
         public_file_ids,
         metrics,
     } = replayed;
+    let has_deletion_vectors = !dvs.is_empty();
     let mut partition_stats = HashMap::new();
+
+    let physical_file_identities = files
+        .iter()
+        .enumerate()
+        .map(|(file_index, file)| {
+            Ok((
+                compact_internal_file_id(file_index),
+                PhysicalFileIdentity {
+                    object_store_url: file.file_url.as_object_store_url(),
+                    location: Path::from_url_path(file.file_url.path())?,
+                },
+            ))
+        })
+        .try_collect::<_, PhysicalFileIdentityMap, DataFusionError>()?;
 
     // Convert files into DataFusion `PartitionedFile`s grouped by object store.
     // Create one `DataSourceExec` plan for each store.
@@ -455,20 +478,23 @@ async fn get_data_scan_plan(
     // TODO(roeap); not sure exactly how row tracking is implemented in kernel right now
     // so leaving predicate as None for now until we are sure this is safe to do.
     let table_config = scan_plan.table_configuration();
-    let predicate = if table_config.is_feature_enabled(&TableFeature::RowTracking) {
-        None
-    } else {
-        scan_plan.parquet_predicate.as_ref()
-    };
+    let predicate =
+        if table_config.is_feature_enabled(&TableFeature::RowTracking) || has_deletion_vectors {
+            None
+        } else {
+            scan_plan.parquet_predicate.as_ref()
+        };
+    let parquet_limit = if has_deletion_vectors { None } else { limit };
     let file_id_field = scan_plan.contract.file_id_field.clone();
     let pq_plan = get_read_plan(
         session,
         files_by_store,
         &scan_plan.parquet_read_schema,
         &scan_plan.parquet_predicate_schema,
-        limit,
+        parquet_limit,
         &file_id_field,
         predicate,
+        has_deletion_vectors,
     )
     .await?;
 
@@ -481,6 +507,7 @@ async fn get_data_scan_plan(
         Arc::clone(&transforms),
         Arc::clone(&dvs),
         Arc::clone(&public_file_ids),
+        Arc::new(physical_file_identities),
         partition_stats,
         metrics,
     );
@@ -641,6 +668,13 @@ fn partitioned_files_to_file_groups_with_limit(
     file_groups
 }
 
+fn lock_dv_file_group_layout(
+    builder: FileScanConfigBuilder,
+    file_group_count: usize,
+) -> FileScanConfigBuilder {
+    builder.with_output_partitioning(Some(Partitioning::UnknownPartitioning(file_group_count)))
+}
+
 async fn get_read_plan(
     state: &dyn Session,
     files_by_store: impl IntoIterator<Item = FilesByStore>,
@@ -655,6 +689,7 @@ async fn get_read_plan(
     limit: Option<usize>,
     file_id_field: &FieldRef,
     predicate: Option<&Expr>,
+    has_deletion_vectors: bool,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut plans = Vec::new();
 
@@ -696,8 +731,7 @@ async fn get_read_plan(
         // TODO(roeap); we might be able to also push selection vectors into the read plan
         // by creating parquet access plans. However we need to make sure this does not
         // interfere with other delta features like row ids.
-        let has_selection_vectors = files.iter().any(|(_, sv)| sv.is_some());
-        if !has_selection_vectors && let Some(pred) = predicate {
+        if !has_deletion_vectors && let Some(pred) = predicate {
             match state.create_physical_expr(pred.clone(), &parquet_predicate_df_schema) {
                 Ok(physical) => match adapter_factory
                     .create(parquet_predicate_schema.clone(), full_read_schema.clone())
@@ -741,12 +775,18 @@ async fn get_read_plan(
         let (file_groups, statistics) =
             compute_all_files_statistics(file_groups, full_table_schema, true, false)?;
 
-        let config = FileScanConfigBuilder::new(store_url, Arc::new(file_source))
+        let file_group_count = file_groups.len();
+        let builder = FileScanConfigBuilder::new(store_url, Arc::new(file_source))
             .with_file_groups(file_groups)
             .with_statistics(statistics)
-            .with_limit(limit)
-            .with_expr_adapter(Some(adapter_factory.clone() as _))
-            .build();
+            .with_limit(if has_deletion_vectors { None } else { limit })
+            .with_expr_adapter(Some(adapter_factory.clone() as _));
+        let builder = if has_deletion_vectors {
+            lock_dv_file_group_layout(builder, file_group_count)
+        } else {
+            builder
+        };
+        let config = builder.build();
 
         plans.push(DataSourceExec::from_data_source(config) as Arc<dyn ExecutionPlan>);
     }
@@ -1385,6 +1425,7 @@ mod tests {
             None,
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1408,6 +1449,7 @@ mod tests {
             Some(1),
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1436,6 +1478,7 @@ mod tests {
             Some(1),
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1513,6 +1556,7 @@ mod tests {
             None,
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1551,6 +1595,7 @@ mod tests {
             None,
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1744,6 +1789,7 @@ mod tests {
             None,
             &file_id_field,
             None,
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1811,6 +1857,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1877,6 +1924,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -1956,6 +2004,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2032,6 +2081,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2109,6 +2159,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;
@@ -2198,6 +2249,7 @@ mod tests {
             None,
             &file_id_field,
             Some(&predicate),
+            false,
         )
         .await?;
         let batches = collect(plan, session.task_ctx()).await?;

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -639,19 +639,26 @@ async fn get_data_scan_plan(
         scan_plan.parquet_predicate.as_ref()
     };
     let file_id_field = scan_plan.contract.file_id_field.clone();
-    let known_logical: Schema = table_config.logical_schema().as_ref().try_into_arrow()?;
-    let known_physical: Schema = table_config.physical_schema().as_ref().try_into_arrow()?;
+    // Complete schemas are needed only to choose a collision-free hidden position
+    // field. Avoid converting them again on scans without a positional consumer.
+    let known_schemas = if has_deletion_vectors {
+        let logical: Schema = table_config.logical_schema().as_ref().try_into_arrow()?;
+        let physical: Schema = table_config.physical_schema().as_ref().try_into_arrow()?;
+        vec![
+            Arc::new(logical),
+            Arc::new(physical),
+            scan_plan.contract.scan_schema.clone(),
+            scan_plan.contract.output_schema.clone(),
+            scan_plan.parquet_predicate_schema.clone(),
+        ]
+    } else {
+        Vec::new()
+    };
     let mut physical_input_contract = PhysicalInputContract::try_new(
         &scan_plan.parquet_read_schema,
         file_id_field,
         has_deletion_vectors,
-        &[
-            Arc::new(known_logical),
-            Arc::new(known_physical),
-            scan_plan.contract.scan_schema.clone(),
-            scan_plan.contract.output_schema.clone(),
-            scan_plan.parquet_predicate_schema.clone(),
-        ],
+        &known_schemas,
     )?;
     physical_input_contract.log_counts = log_counts;
     physical_input_contract.store_bindings = store_bindings;

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -25,7 +25,7 @@ use arrow_array::{
     ArrayRef, DictionaryArray, RecordBatch, StringArray, StringViewArray, UInt16Array,
 };
 use arrow_cast::{CastOptions, cast_with_options};
-use arrow_schema::{DataType, FieldRef, Schema, SchemaBuilder, SchemaRef};
+use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
 use chrono::{TimeZone as _, Utc};
 use datafusion::{
     catalog::Session,
@@ -34,7 +34,7 @@ use datafusion::{
         plan_err, stats::Precision,
     },
     config::TableParquetOptions,
-    datasource::physical_plan::{ParquetSource, parquet::CachedParquetFileReaderFactory},
+    datasource::physical_plan::ParquetSource,
     error::DataFusionError,
     execution::object_store::ObjectStoreUrl,
     physical_expr::Partitioning,
@@ -54,21 +54,24 @@ use datafusion_physical_expr_adapter::{
     BatchAdapter, BatchAdapterFactory, PhysicalExprAdapterFactory,
 };
 use delta_kernel::{
-    Engine, Expression, engine::arrow_data::ArrowEngineData, expressions::StructData,
-    scan::ScanMetadata, table_features::TableFeature,
+    Engine, Expression,
+    engine::{arrow_conversion::TryIntoArrow as _, arrow_data::ArrowEngineData},
+    expressions::StructData,
+    scan::ScanMetadata,
+    table_features::TableFeature,
 };
 use futures::{Stream, TryStreamExt as _, future::ready};
 use itertools::Itertools as _;
 use object_store::{ObjectMeta, path::Path};
+use parquet::arrow::RowNumber;
 use tracing::debug;
 use url::Url;
 
 pub use self::exec::DeltaScanExec;
-use self::exec::DvExecutionState;
 use self::exec_meta::DeltaScanMetaExec;
 use self::expr_adapter::{DeltaPhysicalExprAdapterFactory, relax_schema_nested_nullability};
 pub(crate) use self::plan::{KernelScanPlan, ProjectedScanContract, supports_filters_pushdown};
-use self::replay::{ScanFileContext, ScanFileStream};
+use self::replay::{LoadedDeletionVector, ScanFileContext, ScanFileStream};
 use super::{FileSelection, ResolvedFileSelection};
 use crate::{
     DeltaTableError,
@@ -80,16 +83,23 @@ use crate::{
     },
     kernel::LogicalFileView,
 };
+use deletion_vector::{DeletionVectorEntry, DeletionVectorIndex};
 
+mod deletion_vector;
 mod exec;
 mod exec_meta;
 mod expr_adapter;
+mod metadata_cache;
 mod plan;
+mod reader;
 mod replay;
+#[cfg(test)]
+mod test_support;
 
 type ScanMetadataStream = Pin<Box<dyn Stream<Item = Result<ScanMetadata, DeltaTableError>> + Send>>;
 type PublicFileIdMap = HashMap<String, String>;
 type PhysicalFileIdentityMap = HashMap<String, PhysicalFileIdentity>;
+type StoreBindings = HashMap<ObjectStoreUrl, Option<Arc<dyn object_store::ObjectStore>>>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct PhysicalFileIdentity {
@@ -97,10 +107,127 @@ struct PhysicalFileIdentity {
     location: Path,
 }
 
+#[derive(Clone, Debug)]
+struct PhysicalInputContract {
+    store_bindings: StoreBindings,
+    log_counts: HashMap<String, Option<u64>>,
+    footer_bounds: HashMap<String, Arc<std::sync::OnceLock<u64>>>,
+    sources: Vec<datafusion_datasource::file_scan_config::FileScanConfig>,
+    planned_files: HashMap<String, PartitionedFile>,
+    table_schema: TableSchema,
+    file_id_field: FieldRef,
+    physical_row_position_field: Option<FieldRef>,
+    file_id_index: usize,
+    physical_row_position_index: Option<usize>,
+}
+
+impl PhysicalInputContract {
+    fn try_new(
+        parquet_read_schema: &SchemaRef,
+        file_id_field: FieldRef,
+        include_physical_row_position: bool,
+        known_schemas: &[SchemaRef],
+    ) -> Result<Self> {
+        if parquet_read_schema
+            .field_with_name(file_id_field.name())
+            .is_ok()
+        {
+            return plan_err!("compact file-id field collides with physical schema");
+        }
+        let parquet_read_schema = Arc::new(relax_schema_nested_nullability(parquet_read_schema));
+        let physical_row_position_field = include_physical_row_position.then(|| {
+            let base_name = "__delta_rs_physical_row_position";
+            let mut name = base_name.to_string();
+            let mut suffix = 0;
+            while parquet_read_schema.field_with_name(&name).is_ok()
+                || file_id_field.name() == &name
+                || known_schemas
+                    .iter()
+                    .any(|s| s.field_with_name(&name).is_ok())
+            {
+                suffix += 1;
+                name = format!("{base_name}_{suffix}");
+            }
+            Arc::new(Field::new(name, DataType::Int64, true).with_extension_type(RowNumber))
+        });
+        let mut builder = TableSchema::builder(parquet_read_schema)
+            .with_table_partition_cols(vec![file_id_field.clone()]);
+        if let Some(field) = &physical_row_position_field {
+            builder = builder.with_virtual_columns(vec![field.clone()]);
+        }
+        let table_schema = builder.build();
+        let file_id_index = table_schema.table_schema().index_of(file_id_field.name())?;
+        let physical_row_position_index = physical_row_position_field
+            .as_ref()
+            .map(|field| table_schema.table_schema().index_of(field.name()))
+            .transpose()?;
+        Ok(Self {
+            sources: Vec::new(),
+            planned_files: HashMap::new(),
+            store_bindings: HashMap::new(),
+            log_counts: HashMap::new(),
+            footer_bounds: HashMap::new(),
+            table_schema,
+            file_id_field,
+            physical_row_position_field,
+            file_id_index,
+            physical_row_position_index,
+        })
+    }
+
+    #[cfg(test)]
+    fn new(schema: &SchemaRef, file_id: FieldRef, positions: bool) -> Self {
+        Self::try_new(schema, file_id, positions, &[]).unwrap()
+    }
+
+    fn bind_sources(&mut self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
+        if let Some(source) = input.downcast_ref::<DataSourceExec>() {
+            let config = source
+                .data_source()
+                .downcast_ref::<datafusion_datasource::file_scan_config::FileScanConfig>()
+                .ok_or_else(|| internal_datafusion_err!("expected native file scan"))?;
+            if config
+                .file_groups
+                .iter()
+                .flat_map(|g| g.iter())
+                .any(|f| !f.extensions.is_empty())
+            {
+                return plan_err!("unplanned reader-affecting file extensions");
+            }
+            for file in config.file_groups.iter().flat_map(|group| group.iter()) {
+                let Some(datafusion::scalar::ScalarValue::Dictionary(_, value)) =
+                    file.partition_values.first()
+                else {
+                    return plan_err!("planned file is missing compact identity");
+                };
+                let datafusion::scalar::ScalarValue::Utf8(Some(id)) = value.as_ref() else {
+                    return plan_err!("planned file has invalid compact identity");
+                };
+                if self
+                    .planned_files
+                    .insert(id.clone(), file.clone())
+                    .is_some()
+                {
+                    return plan_err!("duplicate planned compact file identity");
+                }
+            }
+            self.sources.push(config.clone());
+        } else if let Some(union) = input.downcast_ref::<UnionExec>() {
+            for child in union.inputs() {
+                self.bind_sources(child)?;
+            }
+        } else if input.downcast_ref::<EmptyExec>().is_none() {
+            return plan_err!("unsupported initial physical input");
+        }
+        Ok(())
+    }
+}
+
 struct ReplayedScanFiles {
+    store_bindings: StoreBindings,
     files: Vec<ScanFileContext>,
     transforms: HashMap<String, Arc<Expression>>,
-    dvs: HashMap<String, Vec<bool>>,
+    dvs: DeletionVectorIndex,
     public_file_ids: PublicFileIdMap,
     metrics: ExecutionPlanMetricsSet,
 }
@@ -118,11 +245,19 @@ pub(super) async fn execution_plan(
         && selection.active_file_ids.is_empty()
     {
         return Ok(Arc::new(EmptyExec::new(
-            scan_plan.contract.result_schema.clone(),
+            scan_plan.contract.output_schema.clone(),
         )));
     }
 
-    let replayed = replay_files(engine, &scan_plan, config.clone(), stream, file_selection).await?;
+    let replayed = replay_files(
+        session,
+        engine,
+        &scan_plan,
+        config.clone(),
+        stream,
+        file_selection,
+    )
+    .await?;
 
     let file_id_field = scan_plan.contract.file_id_field.clone();
     if scan_plan.is_metadata_only() && !scan_plan.contract.retain_row_index {
@@ -160,7 +295,7 @@ pub(super) async fn execution_plan(
                 Arc::new(scan_plan),
                 vec![file_rows],
                 Arc::new(transforms),
-                Arc::new(dvs.into_iter().collect()),
+                Arc::new(dvs),
                 Arc::new(public_file_ids),
                 retain_file_id.then_some(file_id_field),
                 metrics,
@@ -174,15 +309,8 @@ pub(super) async fn execution_plan(
 
 /// Materialize deletion vector keep masks for every file in the scan that has one.
 ///
-/// Deletion vectors are loaded as a side-effect of consuming [`ScanFileStream`].  We drain the
-/// full stream here (discarding file contexts, stats, and partition values) because the DV
-/// loading tasks are spawned lazily during stream poll.  A dedicated DV-only stream that skips
-/// stats parsing is possible but not yet warranted — this path is not latency-sensitive and the
-/// file-list is typically small.
-///
-/// [`ReceiverStreamBuilder::build`] returns a merged stream that includes a JoinSet checker;
-/// `.try_collect().await` below will not complete until every spawned DV-loading task has
-/// finished, so no results are lost.
+/// The complete selected-file registry is captured first, then its expected
+/// descriptors are loaded. The merged receiver waits for every loading task.
 pub(super) async fn replay_deletion_vectors(
     engine: Arc<dyn Engine>,
     scan_plan: &KernelScanPlan,
@@ -191,23 +319,27 @@ pub(super) async fn replay_deletion_vectors(
     file_selection: Option<&ResolvedFileSelection>,
 ) -> Result<Vec<DeletionVectorSelection>> {
     let mut stream = ScanFileStream::new(
-        engine,
         &scan_plan.scan,
         config.clone(),
         file_selection.map(|selection| &selection.active_file_ids),
         stream,
     );
-    while stream.try_next().await?.is_some() {}
-
-    let dv_stream = stream.dv_stream.build();
+    let mut files = Vec::new();
+    while let Some(batch) = stream.try_next().await? {
+        files.extend(batch);
+    }
+    let dv_stream =
+        replay::load_deletion_vectors(engine, scan_plan.scan.table_root(), &files).build();
     // Only files with `dv_info.has_vector()` spawn tasks, so every item should carry a DV.
     // Guard with a typed error (instead of panic) in case that invariant drifts.
     let dvs: HashMap<_, _> = dv_stream
-        .and_then(|(url, dv, num_records)| {
-            ready(match dv {
-                Some(keep_mask) => normalize_dv_keep_mask_for_api(keep_mask, num_records, &url)
-                    .map(|mask| (url.to_string(), mask))
-                    .map_err(DeltaTableError::from),
+        .and_then(|loaded| {
+            ready(match loaded.keep_mask {
+                Some(keep_mask) => {
+                    normalize_dv_keep_mask_for_api(keep_mask, loaded.num_records, &loaded.file_url)
+                        .map(|mask| (loaded.file_url.to_string(), mask))
+                        .map_err(DeltaTableError::from)
+                }
                 None => Err(DeltaTableError::generic(
                     "Invariant violation: DV task spawned for file without deletion vector",
                 )),
@@ -309,6 +441,7 @@ async fn collect_selected_active_file_ids(
 }
 
 async fn replay_files(
+    session: &dyn Session,
     engine: Arc<dyn Engine>,
     scan_plan: &KernelScanPlan,
     scan_config: DeltaScanConfig,
@@ -316,7 +449,6 @@ async fn replay_files(
     file_selection: Option<&ResolvedFileSelection>,
 ) -> Result<ReplayedScanFiles> {
     let mut stream = ScanFileStream::new(
-        engine,
         &scan_plan.scan,
         scan_config,
         file_selection.map(|selection| &selection.active_file_ids),
@@ -347,12 +479,23 @@ async fn replay_files(
         })
         .collect();
 
-    let dv_stream = stream.dv_stream.build();
-    let dvs_by_url: HashMap<_, _> = dv_stream
-        .try_filter_map(|(url, dv, _)| ready(Ok(dv.map(|dv| (url.to_string(), dv)))))
-        .try_collect()
-        .await?;
-    let dvs = remap_deletion_vectors_to_internal_file_ids(&files, dvs_by_url)?;
+    let mut store_bindings = StoreBindings::new();
+    for file in &files {
+        let url = file.file_url.as_object_store_url();
+        store_bindings
+            .entry(url.clone())
+            .or_insert_with(|| session.runtime_env().object_store(&url).ok());
+    }
+    let dv_stream =
+        replay::load_deletion_vectors(engine, scan_plan.scan.table_root(), &files).build();
+    let loaded = dv_stream.try_collect::<Vec<_>>().await?;
+    let mut dvs_by_url = HashMap::new();
+    for dv in loaded {
+        if dvs_by_url.insert(dv.selected_id, dv).is_some() {
+            return plan_err!("duplicate deletion-vector loading result");
+        }
+    }
+    let dvs = build_deletion_vector_index(&files, dvs_by_url)?;
 
     let metrics = ExecutionPlanMetricsSet::new();
     MetricBuilder::new(&metrics)
@@ -360,6 +503,7 @@ async fn replay_files(
         .add(stream.metrics.num_scanned);
 
     Ok(ReplayedScanFiles {
+        store_bindings,
         files,
         transforms,
         dvs,
@@ -374,8 +518,8 @@ async fn replay_files(
 /// full mask per file, to do this we pad trailing entries with `true` up to `numRecords`. If `numRecords`
 /// is missing we fail, because we cannot know the correct full length.
 ///
-/// This is API only. Scan execution does per batch normalization in `exec::consume_dv_mask` and
-/// `exec_meta::apply_selection_vector`.
+/// This is API only. Scan execution keeps the sparse representation and performs immutable
+/// lookups by absolute physical Parquet row position.
 fn normalize_dv_keep_mask_for_api(
     mut mask: Vec<bool>,
     num_records: Option<u64>,
@@ -412,36 +556,38 @@ async fn get_data_scan_plan(
     limit: Option<usize>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let ReplayedScanFiles {
+        store_bindings,
         files,
         transforms,
         dvs,
         public_file_ids,
         metrics,
     } = replayed;
-    let has_deletion_vectors = !dvs.is_empty();
+    let has_deletion_vectors = dvs.has_vectors();
     let mut partition_stats = HashMap::new();
+    let log_counts = files
+        .iter()
+        .filter(|_| has_deletion_vectors)
+        .enumerate()
+        .map(|(i, file)| (compact_internal_file_id(i), file.num_records))
+        .collect();
 
-    let dv_state = if has_deletion_vectors {
-        let physical_file_identities = files
-            .iter()
-            .enumerate()
-            .map(|(file_index, file)| {
-                Ok((
-                    compact_internal_file_id(file_index),
-                    PhysicalFileIdentity {
-                        object_store_url: file.file_url.as_object_store_url(),
-                        location: Path::from_url_path(file.file_url.path())?,
-                    },
-                ))
-            })
-            .try_collect::<_, PhysicalFileIdentityMap, DataFusionError>()?;
-        DvExecutionState::Sequential {
-            selection_vectors: Arc::new(dvs),
-            physical_file_identities: Arc::new(physical_file_identities),
-        }
-    } else {
-        DvExecutionState::None
-    };
+    let physical_file_identities = files
+        .iter()
+        .filter(|_| has_deletion_vectors)
+        .enumerate()
+        .map(|(file_index, file)| {
+            Ok((
+                compact_internal_file_id(file_index),
+                PhysicalFileIdentity {
+                    object_store_url: file.file_url.as_object_store_url(),
+                    location: Path::from_url_path(file.file_url.path())?,
+                },
+            ))
+        })
+        .try_collect::<_, PhysicalFileIdentityMap, DataFusionError>()?;
+    let dvs = Arc::new(dvs);
+    let parquet_limit = if has_deletion_vectors { None } else { limit };
 
     // Convert files into DataFusion `PartitionedFile`s grouped by object store.
     // Create one `DataSourceExec` plan for each store.
@@ -493,29 +639,55 @@ async fn get_data_scan_plan(
         scan_plan.parquet_predicate.as_ref()
     };
     let file_id_field = scan_plan.contract.file_id_field.clone();
-    let pq_plan = get_read_plan(
+    let known_logical: Schema = table_config.logical_schema().as_ref().try_into_arrow()?;
+    let known_physical: Schema = table_config.physical_schema().as_ref().try_into_arrow()?;
+    let mut physical_input_contract = PhysicalInputContract::try_new(
+        &scan_plan.parquet_read_schema,
+        file_id_field,
+        has_deletion_vectors,
+        &[
+            Arc::new(known_logical),
+            Arc::new(known_physical),
+            scan_plan.contract.scan_schema.clone(),
+            scan_plan.contract.output_schema.clone(),
+            scan_plan.parquet_predicate_schema.clone(),
+        ],
+    )?;
+    physical_input_contract.log_counts = log_counts;
+    physical_input_contract.store_bindings = store_bindings;
+    physical_input_contract.footer_bounds = physical_file_identities
+        .keys()
+        .map(|id| (id.clone(), Arc::new(std::sync::OnceLock::new())))
+        .collect();
+    let pq_plan = get_read_plan_with_contract(
         session,
         files_by_store,
-        &scan_plan.parquet_read_schema,
+        &physical_input_contract,
         &scan_plan.parquet_predicate_schema,
-        limit,
-        &file_id_field,
+        parquet_limit,
         predicate,
     )
     .await?;
+    if has_deletion_vectors {
+        physical_input_contract.bind_sources(&pq_plan)?;
+    }
+    let physical_input_contract = Arc::new(physical_input_contract);
 
     let transforms = Arc::new(transforms);
     let public_file_ids = Arc::new(public_file_ids);
-    let exec = DeltaScanExec::new(
+    let exec = DeltaScanExec::try_new(
         Arc::new(scan_plan),
         pq_plan,
         Arc::clone(&transforms),
-        dv_state,
-        Arc::clone(&public_file_ids),
+        exec::PhysicalScanContext {
+            deletion_vectors: Arc::clone(&dvs),
+            public_file_ids: Arc::clone(&public_file_ids),
+            physical_file_identities: Arc::new(physical_file_identities),
+            physical_input_contract,
+        },
         partition_stats,
         metrics,
-    );
-
+    )?;
     Ok(Arc::new(exec))
 }
 
@@ -561,28 +733,68 @@ fn compact_internal_file_id(file_index: usize) -> String {
     file_index.to_string()
 }
 
-fn remap_deletion_vectors_to_internal_file_ids(
+fn build_deletion_vector_index(
     files: &[ScanFileContext],
-    mut dvs_by_url: HashMap<String, Vec<bool>>,
-) -> Result<HashMap<String, Vec<bool>>> {
-    let mut dvs = HashMap::new();
+    mut dvs_by_url: HashMap<usize, LoadedDeletionVector>,
+) -> Result<DeletionVectorIndex> {
+    let mut entries = HashMap::new();
     for (file_index, file) in files.iter().enumerate() {
-        if dvs_by_url.is_empty() {
-            break;
+        if !file.expected_dv.has_vector() {
+            if dvs_by_url.contains_key(&file_index) {
+                return plan_err!("unexpected deletion vector for explicitly all-live file");
+            }
+            continue;
         }
-        if let Some(dv) = dvs_by_url.remove(file.file_url.as_str()) {
-            dvs.insert(compact_internal_file_id(file_index), dv);
+        let loaded = dvs_by_url.remove(&file_index).ok_or_else(|| {
+            internal_datafusion_err!("missing expected deletion-vector loading result")
+        })?;
+        if loaded.file_url != file.file_url
+            || loaded.descriptor != file.expected_dv
+            || loaded.num_records != file.num_records
+            || loaded.deleted_cardinality != file.dv_cardinality
+        {
+            return plan_err!("deletion-vector loading metadata differs from selected file");
         }
+        let num_records = loaded.num_records.ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "numRecords is required for deletion-vector file {}",
+                super::redact_url_for_error(&file.file_url)
+            ))
+        })?;
+        let deleted_cardinality = loaded.deleted_cardinality.ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "deletion-vector cardinality is required for file {}",
+                super::redact_url_for_error(&file.file_url)
+            ))
+        })?;
+        let keep_mask = loaded.keep_mask.ok_or_else(|| {
+            internal_datafusion_err!("missing keep-mask for selected deletion-vector file")
+        })?;
+        entries.insert(
+            compact_internal_file_id(file_index),
+            DeletionVectorEntry {
+                keep_mask,
+                physical_record_count: num_records,
+                deleted_cardinality,
+            },
+        );
     }
-    if let Some(file_url) = dvs_by_url.keys().next() {
-        let redacted_url = Url::parse(file_url)
-            .map(|url| super::redact_url_for_error(&url))
-            .unwrap_or_else(|_| file_url.clone());
+    if let Some(loaded) = dvs_by_url.values().next() {
         return Err(internal_datafusion_err!(
-            "missing internal file id mapping for file with deletion vector: {redacted_url}"
+            "missing internal file id mapping for file with deletion vector: {}",
+            super::redact_url_for_error(&loaded.file_url)
         ));
     }
-    Ok(dvs)
+    if entries.is_empty() {
+        return Ok(DeletionVectorIndex::default());
+    }
+    DeletionVectorIndex::try_new(entries)?.with_selected_files(
+        files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (compact_internal_file_id(i), f.num_records))
+            .collect(),
+    )
 }
 
 fn public_file_id<'a>(
@@ -672,53 +884,98 @@ fn partitioned_files_to_file_groups_with_limit(
     file_groups
 }
 
-async fn get_read_plan(
+async fn get_read_plan_with_contract(
     state: &dyn Session,
     files_by_store: impl IntoIterator<Item = FilesByStore>,
-    // Schema of physical file columns to read from Parquet (no Delta partitions, no file-id).
-    //
-    // This is also the schema used for Parquet pruning/pushdown. It may include view types
-    // (e.g. Utf8View/BinaryView) depending on `DeltaScanConfig`.
-    parquet_read_schema: &SchemaRef,
+    physical_input_contract: &PhysicalInputContract,
     // Predicate binding schema used to bind Parquet predicates, including the synthetic file id
     // column when the provider exposes it.
     parquet_predicate_schema: &SchemaRef,
     limit: Option<usize>,
-    file_id_field: &FieldRef,
     predicate: Option<&Expr>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut plans = Vec::new();
-
-    // Relax nested-field nullability on the schema handed to the parquet source:
-    // Delta's `nullable = false` is a write-time invariant, and Spark-written files
-    // may mark nested fields optional. The logical schema is restored above the
-    // parquet scan by DeltaScanExec's transforms.
-    let parquet_read_schema = Arc::new(relax_schema_nested_nullability(parquet_read_schema));
-    let parquet_read_schema = &parquet_read_schema;
 
     let pq_options = TableParquetOptions {
         global: state.config().options().execution.parquet.clone(),
         ..Default::default()
     };
 
-    let mut full_read_schema = SchemaBuilder::from(parquet_read_schema.as_ref().clone());
-    full_read_schema.push(file_id_field.as_ref().clone().with_nullable(true));
-    let full_read_schema = Arc::new(full_read_schema.finish());
+    let full_read_schema = physical_input_contract
+        .table_schema
+        .schema_without_virtual_columns()
+        .clone();
     let parquet_predicate_df_schema = parquet_predicate_schema.clone().to_dfschema()?;
     let adapter_factory = Arc::new(DeltaPhysicalExprAdapterFactory);
 
     for (store_url, files, has_deletion_vectors) in files_by_store.into_iter() {
-        let reader_factory = Arc::new(CachedParquetFileReaderFactory::new(
-            state.runtime_env().object_store(&store_url)?,
+        fn file_id(value: &datafusion::scalar::ScalarValue) -> Option<&str> {
+            match value {
+                datafusion::scalar::ScalarValue::Dictionary(_, v) => file_id(v),
+                datafusion::scalar::ScalarValue::Utf8(Some(v)) => Some(v),
+                _ => None,
+            }
+        }
+        let mut expected_files = HashMap::new();
+        for file in &files {
+            let count = file
+                .partition_values
+                .first()
+                .and_then(file_id)
+                .and_then(|id| physical_input_contract.log_counts.get(id).copied())
+                .flatten();
+            let value = (file.object_meta.clone(), count);
+            if let Some(previous) =
+                expected_files.insert(file.object_meta.location.clone(), value.clone())
+                && previous != value
+            {
+                return plan_err!(
+                    "inconsistent metadata for selected logical files sharing a physical object"
+                );
+            }
+        }
+        let mut footer_bounds = HashMap::<Path, Vec<Arc<std::sync::OnceLock<u64>>>>::new();
+        for file in &files {
+            if let Some(bound) = file
+                .partition_values
+                .first()
+                .and_then(file_id)
+                .and_then(|id| physical_input_contract.footer_bounds.get(id))
+            {
+                footer_bounds
+                    .entry(file.object_meta.location.clone())
+                    .or_default()
+                    .push(bound.clone());
+            }
+        }
+        let reader_factory = Arc::new(reader::BoundParquetReaderFactory::new(
+            match physical_input_contract.store_bindings.get(&store_url) {
+                Some(Some(store)) => store.clone(),
+                Some(None) => {
+                    return plan_err!(
+                        "selected file's store was unavailable when the registry was captured"
+                    );
+                }
+                None => state.runtime_env().object_store(&store_url)?,
+            },
             state.runtime_env().cache_manager.get_file_metadata_cache(),
+            expected_files,
+            physical_input_contract
+                .physical_row_position_field
+                .as_ref()
+                .map(|f| {
+                    (
+                        f.name().clone(),
+                        physical_input_contract.file_id_field.name().clone(),
+                    )
+                }),
+            footer_bounds,
         ));
 
         // NOTE: In the "next" provider, DataFusion's Parquet scan partition fields are file-id
         // only. Delta partition columns/values are injected via kernel transforms and handled
         // above Parquet, so they are not part of the Parquet partition schema here.
-        let table_schema = TableSchema::builder(parquet_read_schema.clone())
-            .with_table_partition_cols(vec![file_id_field.clone()])
-            .build();
+        let table_schema = physical_input_contract.table_schema.clone();
         let full_table_schema = table_schema.table_schema().clone();
         let mut file_source = ParquetSource::new(table_schema)
             .with_table_parquet_options(pq_options.clone())
@@ -789,10 +1046,35 @@ async fn get_read_plan(
     }
 
     Ok(match plans.len() {
-        0 => Arc::new(EmptyExec::new(full_read_schema.clone())),
+        0 => Arc::new(EmptyExec::new(
+            physical_input_contract.table_schema.table_schema().clone(),
+        )),
         1 => plans.remove(0),
         _ => UnionExec::try_new(plans)?,
     })
+}
+
+#[cfg(test)]
+async fn get_read_plan(
+    state: &dyn Session,
+    files_by_store: impl IntoIterator<Item = FilesByStore>,
+    parquet_read_schema: &SchemaRef,
+    parquet_predicate_schema: &SchemaRef,
+    limit: Option<usize>,
+    file_id_field: &FieldRef,
+    predicate: Option<&Expr>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let physical_input_contract =
+        PhysicalInputContract::new(parquet_read_schema, file_id_field.clone(), false);
+    get_read_plan_with_contract(
+        state,
+        files_by_store,
+        &physical_input_contract,
+        parquet_predicate_schema,
+        limit,
+        predicate,
+    )
+    .await
 }
 
 // Small helper to reuse some code between exec and exec_meta
@@ -911,6 +1193,7 @@ mod tests {
     };
     use object_store::{ObjectStoreExt as _, memory::InMemory};
     use parquet::arrow::ArrowWriter;
+    use parquet::file::properties::WriterProperties;
     use url::Url;
 
     use crate::{
@@ -926,6 +1209,100 @@ mod tests {
     };
 
     use super::{plan::build_parquet_predicate_schema, *};
+
+    fn registry_fixture(dv: bool, records: Option<u64>) -> ScanFileContext {
+        use delta_kernel::actions::deletion_vector::{
+            DeletionVectorDescriptor, DeletionVectorStorageType,
+        };
+        let expected_dv = if dv {
+            delta_kernel::scan::state::DvInfo::from(DeletionVectorDescriptor {
+                storage_type: DeletionVectorStorageType::Inline,
+                path_or_inline_dv: "fixture".into(),
+                offset: None,
+                size_in_bytes: 1,
+                cardinality: 1,
+            })
+        } else {
+            Default::default()
+        };
+        ScanFileContext {
+            file_url: Url::parse("memory:///file.parquet").unwrap(),
+            size: 100,
+            transform: None,
+            stats: Statistics::new_unknown(&Schema::empty()),
+            partitions: None,
+            num_records: records,
+            expected_dv,
+            dv_cardinality: dv.then_some(1),
+        }
+    }
+
+    fn registry_load(file: &ScanFileContext) -> LoadedDeletionVector {
+        LoadedDeletionVector {
+            selected_id: 0,
+            descriptor: file.expected_dv.clone(),
+            file_url: file.file_url.clone(),
+            keep_mask: Some(vec![false]),
+            num_records: file.num_records,
+            deleted_cardinality: file.dv_cardinality,
+        }
+    }
+
+    #[test]
+    fn registry_rejects_missing_and_unexpected_dv_results() {
+        let file = registry_fixture(true, Some(3));
+        assert!(build_deletion_vector_index(&[file], HashMap::new()).is_err());
+        let live = registry_fixture(false, None);
+        let load = registry_load(&registry_fixture(true, Some(3)));
+        assert!(build_deletion_vector_index(&[live], HashMap::from([(0, load)])).is_err());
+        let unknown = registry_load(&registry_fixture(true, Some(3)));
+        assert!(build_deletion_vector_index(&[], HashMap::from([(0, unknown)])).is_err());
+    }
+
+    #[test]
+    fn registry_accepts_non_dv_files_without_log_statistics() -> TestResult {
+        let live = registry_fixture(false, None);
+        assert!(!build_deletion_vector_index(&[live], HashMap::new())?.has_vectors());
+        let dv = registry_fixture(true, Some(3));
+        let load = registry_load(&dv);
+        let index = build_deletion_vector_index(
+            &[dv, registry_fixture(false, None)],
+            HashMap::from([(0, load)]),
+        )?;
+        assert_eq!(
+            index
+                .selection_for_positions("1", &Int64Array::from(vec![0, 9]))?
+                .true_count(),
+            2
+        );
+        assert_eq!(
+            index
+                .selection_for_positions("0", &Int64Array::from(vec![0, 1]))?
+                .true_count(),
+            1
+        );
+        assert!(
+            index
+                .selection_for_positions("2", &Int64Array::from(vec![0]))
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn registry_rejects_descriptor_count_and_mask_mismatches() {
+        for mutation in 0..4 {
+            let file = registry_fixture(true, Some(3));
+            let mut loaded = registry_load(&file);
+            match mutation {
+                0 => loaded.num_records = Some(4),
+                1 => loaded.deleted_cardinality = Some(0),
+                2 => loaded.keep_mask = None,
+                _ => loaded.keep_mask = Some(vec![true]),
+            }
+            assert!(build_deletion_vector_index(&[file], HashMap::from([(0, loaded)])).is_err());
+        }
+    }
 
     #[test]
     fn test_partitioned_files_to_file_groups_respects_dictionary_cardinality_limit() {
@@ -1074,59 +1451,6 @@ mod tests {
         assert!(filtered[0].schema().column_with_name("file_id").is_none());
 
         Ok(())
-    }
-
-    fn scan_file_context(file_url: &str) -> ScanFileContext {
-        ScanFileContext {
-            file_url: Url::parse(file_url).expect("valid test URL"),
-            size: 0,
-            transform: None,
-            stats: Statistics::new_unknown(&Schema::empty()),
-            partitions: None,
-        }
-    }
-
-    #[test]
-    fn test_remap_deletion_vectors_to_internal_file_ids_uses_compact_keys() -> TestResult {
-        let files = vec![
-            scan_file_context("s3://bucket/very/long/path/first.parquet"),
-            scan_file_context("s3://bucket/very/long/path/second.parquet"),
-        ];
-        let mut dvs_by_url = HashMap::new();
-        dvs_by_url.insert(files[1].file_url.to_string(), vec![true, false, true]);
-
-        let dvs = remap_deletion_vectors_to_internal_file_ids(&files, dvs_by_url)?;
-
-        assert!(dvs.contains_key("1"));
-        assert!(!dvs.contains_key(files[1].file_url.as_str()));
-        assert_eq!(
-            dvs.get("1").expect("compact dv key").as_slice(),
-            &[true, false, true]
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_remap_deletion_vectors_to_internal_file_ids_errors_for_unknown_url() {
-        let files = vec![scan_file_context(
-            "s3://bucket/very/long/path/first.parquet",
-        )];
-        let mut dvs_by_url = HashMap::new();
-        dvs_by_url.insert(
-            "s3://bucket/very/long/path/missing.parquet?X-Amz-Signature=secret-token".to_string(),
-            vec![true],
-        );
-
-        let err = remap_deletion_vectors_to_internal_file_ids(&files, dvs_by_url).unwrap_err();
-        let err = err.to_string();
-        assert!(
-            err.contains("missing internal file id mapping for file with deletion vector"),
-            "unexpected error: {err}"
-        );
-        assert!(
-            !err.contains("secret-token"),
-            "error should redact URL query secrets: {err}"
-        );
     }
 
     #[cfg(debug_assertions)]
@@ -1483,6 +1807,89 @@ mod tests {
         assert_batches_sorted_eq!(&expected, &batches);
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_row_number_retains_absolute_position_after_row_group_pruning() -> TestResult {
+        let store = Arc::new(InMemory::new());
+        let store_url = Url::parse("memory:///")?;
+        let session = Arc::new(create_session().into_inner());
+        session
+            .runtime_env()
+            .register_object_store(&store_url, store.clone());
+
+        let arrow_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let data = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![0, 1, 2, 3, 4, 5]))],
+        )?;
+        let properties = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(2))
+            .build();
+        let mut buffer = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buffer, arrow_schema.clone(), Some(properties))?;
+        writer.write(&data)?;
+        writer.close()?;
+
+        let path = Path::from("absolute_positions.parquet");
+        store.put(&path, buffer.into()).await?;
+        let mut file: PartitionedFile = store.head(&path).await?.into();
+        file.partition_values
+            .push(wrap_file_id_value("memory:///absolute_positions.parquet"));
+
+        let file_id_field =
+            crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+        let predicate_schema = build_parquet_predicate_schema(&arrow_schema, &file_id_field);
+        let contract = PhysicalInputContract::new(&arrow_schema, file_id_field, true);
+        let predicate = col("id").gt_eq(lit(4i32));
+        let plan = get_read_plan_with_contract(
+            &session.state(),
+            vec![(store_url.as_object_store_url(), vec![file], false)],
+            &contract,
+            &predicate_schema,
+            None,
+            Some(&predicate),
+        )
+        .await?;
+
+        let batches = collect(plan, session.task_ctx()).await?;
+        let positions = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(contract.physical_row_position_index.unwrap())
+                    .as_primitive::<arrow::datatypes::Int64Type>()
+                    .values()
+                    .iter()
+                    .copied()
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(positions, vec![4, 5]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_physical_input_contract_avoids_hidden_name_collisions() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "__delta_rs_physical_row_position",
+            DataType::Int64,
+            true,
+        )]));
+        let file_id_field =
+            crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+
+        let contract = PhysicalInputContract::new(&schema, file_id_field, true);
+
+        assert_eq!(
+            contract
+                .physical_row_position_field
+                .as_ref()
+                .expect("physical position field")
+                .name(),
+            "__delta_rs_physical_row_position_1"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/reader.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/reader.rs
@@ -1,0 +1,406 @@
+//! Bound Parquet readers and evidence for physical coordinates from the full footer.
+
+use std::{ops::Range, sync::Arc};
+
+use bytes::Bytes;
+use datafusion::{
+    common::{HashMap, Result, plan_err},
+    datasource::physical_plan::parquet::{
+        CachedParquetFileReaderFactory, ParquetFileReaderFactory,
+    },
+    execution::cache::cache_manager::FileMetadataCache,
+    physical_plan::metrics::{ExecutionPlanMetricsSet, Gauge, MetricBuilder},
+};
+use datafusion_datasource::PartitionedFile;
+use futures::future::BoxFuture;
+use object_store::{ObjectStore, path::Path};
+use parquet::{
+    arrow::{arrow_reader::ArrowReaderOptions, async_reader::AsyncFileReader},
+    errors::ParquetError,
+    file::metadata::ParquetMetaData,
+};
+
+use super::metadata_cache::StoreMetadataCache;
+
+#[derive(Clone, Debug)]
+pub(super) struct FooterEvidence {
+    pub records: u64,
+}
+
+pub(super) fn validate_footer(
+    metadata: &ParquetMetaData,
+) -> std::result::Result<FooterEvidence, String> {
+    let records = u64::try_from(metadata.file_metadata().num_rows())
+        .map_err(|_| "negative footer row count")?;
+    let mut total = 0_u64;
+    let missing_ordinals = metadata
+        .row_groups()
+        .iter()
+        .all(|group| group.ordinal().is_none());
+    for (index, group) in metadata.row_groups().iter().enumerate() {
+        if !missing_ordinals && group.ordinal().and_then(|n| usize::try_from(n).ok()) != Some(index)
+        {
+            return Err("inconsistent row-group ordinals in complete footer".into());
+        }
+        let count = u64::try_from(group.num_rows()).map_err(|_| "negative row-group count")?;
+        total = total
+            .checked_add(count)
+            .ok_or("row-group population overflows u64")?;
+    }
+    if total != records {
+        return Err("row-group population differs from footer row count".into());
+    }
+    Ok(FooterEvidence { records })
+}
+
+#[derive(Debug)]
+pub(super) struct BoundParquetReaderFactory {
+    store: Arc<dyn ObjectStore>,
+    cache: Arc<FileMetadataCache>,
+    files: HashMap<Path, (object_store::ObjectMeta, Option<u64>)>,
+    hidden_position: Option<(String, String)>,
+    footer_bounds: HashMap<Path, Vec<Arc<std::sync::OnceLock<u64>>>>,
+}
+
+impl BoundParquetReaderFactory {
+    pub(super) fn new(
+        store: Arc<dyn ObjectStore>,
+        cache: Arc<FileMetadataCache>,
+        files: HashMap<Path, (object_store::ObjectMeta, Option<u64>)>,
+        hidden_position: Option<(String, String)>,
+        footer_bounds: HashMap<Path, Vec<Arc<std::sync::OnceLock<u64>>>>,
+    ) -> Self {
+        Self {
+            store,
+            cache,
+            files,
+            hidden_position,
+            footer_bounds,
+        }
+    }
+}
+
+impl ParquetFileReaderFactory for BoundParquetReaderFactory {
+    fn create_reader(
+        &self,
+        partition_index: usize,
+        file: PartitionedFile,
+        metadata_size_hint: Option<usize>,
+        metrics: &ExecutionPlanMetricsSet,
+    ) -> Result<Box<dyn AsyncFileReader + Send>> {
+        let Some((expected, count)) = self.files.get(&file.object_meta.location) else {
+            return plan_err!("unplanned file in bound Parquet reader");
+        };
+        if &file.object_meta != expected || !file.extensions.is_empty() {
+            return plan_err!(
+                "changed file metadata or reader-affecting extensions in bound Parquet reader"
+            );
+        }
+        let cache = Arc::new(StoreMetadataCache::new(
+            Arc::clone(&self.cache),
+            Arc::clone(&self.store),
+            expected.clone(),
+        ));
+        let footer_bounds = self
+            .footer_bounds
+            .get(&file.object_meta.location)
+            .cloned()
+            .unwrap_or_default();
+        let reader = CachedParquetFileReaderFactory::new(Arc::clone(&self.store), cache.clone())
+            .create_reader(partition_index, file, metadata_size_hint, metrics)?;
+        Ok(Box::new(BoundReader {
+            active_metadata: MetricBuilder::new(metrics)
+                .gauge("active_footer_reference_bytes", partition_index),
+            reader,
+            cache,
+            count: *count,
+            hidden_position: self.hidden_position.clone(),
+            footer_bounds,
+        }))
+    }
+}
+
+struct BoundReader {
+    // A sum over live reader references, not unique allocations or an RSS bound.
+    // Parquet's estimator includes shared substructures and excludes allocator overhead.
+    active_metadata: Gauge,
+    reader: Box<dyn AsyncFileReader + Send>,
+    cache: Arc<StoreMetadataCache>,
+    count: Option<u64>,
+    hidden_position: Option<(String, String)>,
+    footer_bounds: Vec<Arc<std::sync::OnceLock<u64>>>,
+}
+
+impl Drop for BoundReader {
+    fn drop(&mut self) {
+        self.active_metadata.set(0);
+    }
+}
+
+impl AsyncFileReader for BoundReader {
+    fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, parquet::errors::Result<Bytes>> {
+        self.reader.get_bytes(range)
+    }
+    fn get_byte_ranges(
+        &mut self,
+        ranges: Vec<Range<u64>>,
+    ) -> BoxFuture<'_, parquet::errors::Result<Vec<Bytes>>> {
+        self.reader.get_byte_ranges(ranges)
+    }
+    fn get_metadata<'a>(
+        &'a mut self,
+        options: Option<&'a ArrowReaderOptions>,
+    ) -> BoxFuture<'a, parquet::errors::Result<Arc<ParquetMetaData>>> {
+        Box::pin(async move {
+            let metadata = self.reader.get_metadata(options).await?;
+            self.active_metadata.set(metadata.memory_size());
+            if let Some((hidden, file_id)) = &self.hidden_position {
+                let evidence = self
+                    .cache
+                    .footer_evidence(&metadata)
+                    .map_err(ParquetError::General)?;
+                if self.count.is_some_and(|count| count != evidence.records) {
+                    return Err(ParquetError::General(
+                        "log-declared numRecords differs from full footer".into(),
+                    ));
+                }
+                for bound in &self.footer_bounds {
+                    let count = bound.get_or_init(|| evidence.records);
+                    if *count != evidence.records {
+                        return Err(ParquetError::General(
+                            "physical file population changed after planning".into(),
+                        ));
+                    }
+                }
+                if metadata
+                    .file_metadata()
+                    .schema_descr()
+                    .root_schema()
+                    .get_fields()
+                    .iter()
+                    .any(|field| field.name() == hidden || field.name() == file_id)
+                {
+                    return Err(ParquetError::General(
+                        "on-disk field collides with physical input support column".into(),
+                    ));
+                }
+            }
+            Ok(metadata)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Int32Array, RecordBatch};
+    use arrow_schema::{DataType, Field, Schema};
+    use chrono::{TimeZone, Utc};
+    use datafusion::execution::cache::default_cache::DefaultCache;
+    use object_store::{ObjectStoreExt, memory::InMemory};
+    use parquet::arrow::ArrowWriter;
+
+    async fn fixture(name: &str) -> (Arc<dyn ObjectStore>, object_store::ObjectMeta) {
+        let schema = Arc::new(Schema::new(vec![Field::new(name, DataType::Int32, false)]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1, 2]))])
+                .unwrap();
+        let mut bytes = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut bytes, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("same.parquet");
+        store.put(&path, bytes.into()).await.unwrap();
+        let mut meta = store.head(&path).await.unwrap();
+        meta.last_modified = Utc.timestamp_opt(0, 0).unwrap();
+        meta.e_tag = None;
+        meta.version = None;
+        (store, meta)
+    }
+
+    async fn footer(
+        store: Arc<dyn ObjectStore>,
+        meta: object_store::ObjectMeta,
+        cache: Arc<FileMetadataCache>,
+    ) -> Arc<ParquetMetaData> {
+        let factory = BoundParquetReaderFactory::new(
+            store,
+            cache,
+            HashMap::from([(meta.location.clone(), (meta.clone(), Some(2)))]),
+            Some(("position".into(), "__file_id".into())),
+            HashMap::new(),
+        );
+        let mut reader = factory
+            .create_reader(0, meta.into(), None, &ExecutionPlanMetricsSet::new())
+            .unwrap();
+        reader.get_metadata(None).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn equal_validation_attributes_in_different_stores_do_not_alias() {
+        let (a, meta_a) = fixture("aa").await;
+        let (b, meta_b) = fixture("bb").await;
+        assert_eq!(
+            meta_a, meta_b,
+            "fixture must defeat bare-path size/mtime validation"
+        );
+        let cache: Arc<FileMetadataCache> = Arc::new(DefaultCache::new(1 << 20));
+        let first = footer(a.clone(), meta_a.clone(), cache.clone()).await;
+        let second = footer(b, meta_b, cache.clone()).await;
+        assert_eq!(
+            first
+                .file_metadata()
+                .schema_descr()
+                .root_schema()
+                .get_fields()[0]
+                .name(),
+            "aa"
+        );
+        assert_eq!(
+            second
+                .file_metadata()
+                .schema_descr()
+                .root_schema()
+                .get_fields()[0]
+                .name(),
+            "bb"
+        );
+        let fresh_query = footer(a, meta_a, cache).await;
+        assert!(
+            Arc::ptr_eq(&first, &fresh_query),
+            "separately planned readers should reuse immutable metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_fresh_readers_share_one_retention_allowance() {
+        let cache: Arc<FileMetadataCache> = Arc::new(DefaultCache::new(4096));
+        let mut tasks = tokio::task::JoinSet::new();
+        for _ in 0..16 {
+            let cache = cache.clone();
+            tasks.spawn(async move {
+                let (store, meta) = fixture("aa").await;
+                footer(store, meta, cache).await
+            });
+        }
+        let mut active_metadata = Vec::new();
+        while let Some(result) = tasks.join_next().await {
+            active_metadata.push(result.unwrap());
+        }
+        let retained: usize = cache
+            .list_entries()
+            .values()
+            .map(|entry| entry.size_bytes)
+            .sum();
+        assert!(retained <= cache.cache_limit());
+        assert!(
+            cache.len() < active_metadata.len(),
+            "fixture must evict while readers retain metadata"
+        );
+        assert!(
+            active_metadata
+                .iter()
+                .all(|m| m.file_metadata().num_rows() == 2)
+        );
+    }
+
+    #[tokio::test]
+    async fn footer_evidence_rejects_bad_populations_and_ordinals() {
+        let (store, meta) = fixture("aa").await;
+        let original = footer(store, meta, Arc::new(DefaultCache::new(1 << 20))).await;
+        let group = original.row_group(0);
+        let missing = parquet::file::metadata::RowGroupMetaData::builder(group.schema_descr_ptr())
+            .set_column_metadata(group.columns().to_vec())
+            .set_num_rows(1)
+            .build()
+            .unwrap();
+        let omitted = ParquetMetaData::new(
+            original.file_metadata().clone(),
+            vec![missing.clone(), missing.clone()],
+        );
+        assert_eq!(validate_footer(&omitted).unwrap().records, 2);
+        let explicit = missing
+            .clone()
+            .into_builder()
+            .set_ordinal(0)
+            .build()
+            .unwrap();
+        let duplicate = ParquetMetaData::new(
+            original.file_metadata().clone(),
+            vec![explicit.clone(), explicit],
+        );
+        assert!(
+            validate_footer(&duplicate)
+                .unwrap_err()
+                .contains("ordinals")
+        );
+        let mixed = ParquetMetaData::new(
+            original.file_metadata().clone(),
+            vec![
+                missing.clone(),
+                missing
+                    .clone()
+                    .into_builder()
+                    .set_ordinal(1)
+                    .build()
+                    .unwrap(),
+            ],
+        );
+        assert!(validate_footer(&mixed).is_err());
+        let wrong_total = ParquetMetaData::new(original.file_metadata().clone(), vec![missing]);
+        assert!(
+            validate_footer(&wrong_total)
+                .unwrap_err()
+                .contains("population")
+        );
+    }
+
+    #[tokio::test]
+    async fn reader_rejects_unexpected_on_disk_support_fields() {
+        for name in ["position", "__file_id"] {
+            let (store, meta) = fixture(name).await;
+            let factory = BoundParquetReaderFactory::new(
+                store,
+                Arc::new(DefaultCache::new(1 << 20)),
+                HashMap::from([(meta.location.clone(), (meta.clone(), Some(2)))]),
+                Some(("position".into(), "__file_id".into())),
+                HashMap::new(),
+            );
+            let mut reader = factory
+                .create_reader(0, meta.into(), None, &ExecutionPlanMetricsSet::new())
+                .unwrap();
+            assert!(
+                reader
+                    .get_metadata(None)
+                    .await
+                    .unwrap_err()
+                    .to_string()
+                    .contains("support column")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn positional_reader_rejects_log_footer_count_mismatch() {
+        let (store, meta) = fixture("aa").await;
+        let factory = BoundParquetReaderFactory::new(
+            store,
+            Arc::new(DefaultCache::new(1 << 20)),
+            HashMap::from([(meta.location.clone(), (meta.clone(), Some(3)))]),
+            Some(("position".into(), "__file_id".into())),
+            HashMap::new(),
+        );
+        let mut reader = factory
+            .create_reader(0, meta.into(), None, &ExecutionPlanMetricsSet::new())
+            .unwrap();
+        assert!(
+            reader
+                .get_metadata(None)
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("numRecords")
+        );
+    }
+}

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/reader.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/reader.rs
@@ -91,7 +91,10 @@ impl ParquetFileReaderFactory for BoundParquetReaderFactory {
         let Some((expected, count)) = self.files.get(&file.object_meta.location) else {
             return plan_err!("unplanned file in bound Parquet reader");
         };
-        if &file.object_meta != expected || !file.extensions.is_empty() {
+        if &file.object_meta != expected
+            || !file.extensions.is_empty()
+            || file.arrow_schema.is_some()
+        {
             return plan_err!(
                 "changed file metadata or reader-affecting extensions in bound Parquet reader"
             );

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
@@ -62,13 +62,11 @@ pin_project! {
     /// [`ScanFileContext`] entries enriched with:
     ///
     /// - **File statistics**: Row counts, min/max values, null counts
-    /// - **Deletion vectors**: Asynchronously loaded and cached
+    /// - **Deletion vectors**: Expected descriptors captured before loading
     /// - **Partition values**: Extracted from file metadata
     /// - **Transforms**: Column mapping expressions for physical-to-logical translation
     pub(crate) struct ScanFileStream<'a, S> {
         pub(crate) metrics: ReplayStats,
-
-        engine: Arc<dyn Engine>,
 
         table_root: Url,
 
@@ -78,16 +76,57 @@ pin_project! {
 
         file_selection: Option<&'a HashSet<String>>,
 
-        pub(crate) dv_stream: ReceiverStreamBuilder<(Url, Option<Vec<bool>>, Option<u64>)>,
-
         #[pin]
         stream: S,
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct LoadedDeletionVector {
+    pub selected_id: usize,
+    pub descriptor: DvInfo,
+    pub file_url: Url,
+    pub keep_mask: Option<Vec<bool>>,
+    pub num_records: Option<u64>,
+    pub deleted_cardinality: Option<u64>,
+}
+
+/// Start loads only after the caller captures the complete selected population.
+pub(super) fn load_deletion_vectors(
+    engine: Arc<dyn Engine>,
+    table_root: &Url,
+    files: &[ScanFileContext],
+) -> ReceiverStreamBuilder<LoadedDeletionVector> {
+    let mut stream = ReceiverStreamBuilder::new(100);
+    for (selected_id, file) in files.iter().enumerate() {
+        if !file.expected_dv.has_vector() {
+            continue;
+        }
+        let engine = engine.clone();
+        let descriptor = file.expected_dv.clone();
+        let file_url = file.file_url.clone();
+        let num_records = file.num_records;
+        let deleted_cardinality = file.dv_cardinality;
+        let table_root = table_root.clone();
+        let tx = stream.tx();
+        stream.spawn_blocking(move || {
+            let keep_mask = descriptor.get_selection_vector(engine.as_ref(), &table_root)?;
+            let _ = tx.blocking_send(Ok(LoadedDeletionVector {
+                selected_id,
+                descriptor,
+                file_url,
+                keep_mask,
+                num_records,
+                deleted_cardinality,
+            }));
+            Ok(())
+        });
+    }
+    stream
+}
+
 impl<'a, S> ScanFileStream<'a, S> {
     pub(crate) fn new(
-        engine: Arc<dyn Engine>,
         scan: &Arc<Scan>,
         scan_config: DeltaScanConfig,
         file_selection: Option<&'a HashSet<String>>,
@@ -95,8 +134,6 @@ impl<'a, S> ScanFileStream<'a, S> {
     ) -> Self {
         Self {
             metrics: ReplayStats::new(),
-            dv_stream: ReceiverStreamBuilder::<(Url, Option<Vec<bool>>, Option<u64>)>::new(100),
-            engine,
             table_root: scan.table_root().clone(),
             kernel_scan: scan.inner().clone(),
             stream,
@@ -135,7 +172,7 @@ where
                     scan_data
                 };
 
-                let ctx = match scan_data
+                let mut ctx = match scan_data
                     .visit_scan_files(ScanContext::new(this.table_root.clone()), visit_scan_file)
                     .map_err(|err| DataFusionError::from(DeltaTableError::from(err)))
                     .and_then(ScanContext::error_or)
@@ -144,31 +181,36 @@ where
                     Err(err) => return Poll::Ready(Some(Err(err.into()))),
                 };
 
-                // Spawn tasks to read the deletion vectors from disk.
-                for file in &ctx.files {
-                    if file.dv_info.has_vector() {
-                        let engine = this.engine.clone();
-                        let dv_info = file.dv_info.clone();
-                        let file_url = file.file_url.clone();
-                        let num_records = file.num_records;
-                        let table_root = this.table_root.clone();
-                        let tx = this.dv_stream.tx();
-
-                        let load_dv = move || {
-                            let dv = dv_info.get_selection_vector(engine.as_ref(), &table_root)?;
-                            let _ = tx.blocking_send(Ok((file_url, dv, num_records)));
-                            Ok(())
-                        };
-                        this.dv_stream.spawn_blocking(load_dv);
-                    }
-                }
-
                 this.metrics.num_scanned += ctx.count;
 
                 let (data, selection_vector) = scan_data.scan_files.into_parts();
                 let batch = ArrowEngineData::try_from_engine_data(data)?.into();
                 let scan_files =
                     filter_record_batch(&batch, &BooleanArray::from(selection_vector))?;
+
+                if ctx.files.len() != scan_files.num_rows() {
+                    return Poll::Ready(Some(Err(DeltaTableError::from(
+                        DataFusionError::Internal(format!(
+                            "scan replay produced {} file contexts for {} selected metadata rows",
+                            ctx.files.len(),
+                            scan_files.num_rows()
+                        )),
+                    ))));
+                }
+
+                for (file, row) in ctx.files.iter_mut().zip(0..scan_files.num_rows()) {
+                    file.dv_cardinality = LogicalFileView::new(scan_files.clone(), row)
+                        .deletion_vector_descriptor()
+                        .map(|descriptor| {
+                            u64::try_from(descriptor.cardinality).map_err(|_| {
+                                DataFusionError::Plan(
+                                    "deletion-vector descriptor has negative cardinality"
+                                        .to_string(),
+                                )
+                            })
+                        })
+                        .transpose()?;
+                }
 
                 let stats_projection = match StatsProjection::for_scan(this.kernel_scan.as_ref()) {
                     Ok(projection) => projection,
@@ -372,6 +414,9 @@ pub(crate) struct ScanFileContext {
     pub stats: Statistics,
     /// Partition values for the file.
     pub partitions: Option<StructData>,
+    pub num_records: Option<u64>,
+    pub expected_dv: DvInfo,
+    pub dv_cardinality: Option<u64>,
 }
 
 impl ScanFileContext {
@@ -383,6 +428,9 @@ impl ScanFileContext {
             transform: inner.transform,
             stats,
             partitions,
+            num_records: inner.num_records,
+            expected_dv: inner.dv_info,
+            dv_cardinality: inner.dv_cardinality,
         }
     }
 }
@@ -397,6 +445,8 @@ struct ScanFileContextInner {
     pub transform: Option<ExpressionRef>,
     /// Number of records in the file from Add-file stats.
     pub num_records: Option<u64>,
+
+    pub dv_cardinality: Option<u64>,
 
     pub dv_info: DvInfo,
 }
@@ -492,6 +542,7 @@ fn visit_scan_file(ctx: &mut ScanContext, scan_file: ScanFile) {
         file_url,
         size: scan_file.size as u64,
         num_records: scan_file.stats.map(|stats| stats.num_records),
+        dv_cardinality: None,
     });
     ctx.count += 1;
 }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/test_support.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/test_support.rs
@@ -1,0 +1,182 @@
+//! Deterministic fixture coordinates shared by qualification and the Criterion harness.
+//! Expected visibility comes from the generator's declared positions, never reader output.
+
+use arrow_array::{Int64Array, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use delta_kernel::actions::deletion_vector_writer::{
+    KernelDeletionVector, StreamingDeletionVectorWriter,
+};
+use parquet::{arrow::ArrowWriter, file::properties::WriterProperties};
+use serde_json::{Value, json};
+use std::{collections::BTreeSet, error::Error, fs, sync::Arc};
+use tempfile::TempDir;
+use url::Url;
+
+type FixtureResult<T> = Result<T, Box<dyn Error>>;
+
+pub struct FileSpec {
+    pub rows: usize,
+    pub groups: Vec<usize>,
+    pub deleted: Option<BTreeSet<u64>>,
+    pub log_stats: bool,
+}
+
+pub struct Fixture {
+    pub directory: TempDir,
+    pub coordinates: Vec<(usize, u64, i64, i64)>,
+    pub deleted: Vec<Option<BTreeSet<u64>>>,
+    adds: Vec<Value>,
+    version: usize,
+}
+
+impl Fixture {
+    pub fn new(specs: Vec<FileSpec>, page_rows: usize) -> FixtureResult<Self> {
+        let directory = tempfile::tempdir()?;
+        fs::create_dir(directory.path().join("_delta_log"))?;
+        let has_dvs = specs.iter().any(|f| f.deleted.is_some());
+        let protocol = if has_dvs {
+            json!({"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["deletionVectors"],"writerFeatures":["deletionVectors"]}})
+        } else {
+            json!({"protocol":{"minReaderVersion":1,"minWriterVersion":2}})
+        };
+        let logical_schema = json!({"type":"struct","fields":[{"name":"id","type":"long","nullable":false,"metadata":{}},{"name":"value","type":"long","nullable":false,"metadata":{}}]});
+        let metadata = json!({"metaData":{"id":"c75e5410-d53e-4fb3-b848-2e595cda0001","format":{"provider":"parquet","options":{}},"schemaString":logical_schema.to_string(),"partitionColumns":[],"configuration":{}}});
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("value", DataType::Int64, false),
+        ]));
+        let mut fixture = Self {
+            directory,
+            coordinates: Vec::new(),
+            deleted: Vec::new(),
+            adds: Vec::new(),
+            version: 0,
+        };
+        let mut global_id = 0_i64;
+        for (file_id, spec) in specs.into_iter().enumerate() {
+            let path = format!("part-{file_id}.parquet");
+            let file = fs::File::create(fixture.directory.path().join(&path))?;
+            let properties = WriterProperties::builder()
+                .set_max_row_group_row_count(None)
+                .set_data_page_row_count_limit(page_rows)
+                .set_write_batch_size(page_rows.min(4))
+                .build();
+            let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(properties))?;
+            let first_id = global_id;
+            let mut position = 0;
+            let mut group = 0;
+            while position < spec.rows {
+                let count = spec.groups[group % spec.groups.len()].min(spec.rows - position);
+                let mut ids = Vec::with_capacity(count);
+                let mut values = Vec::with_capacity(count);
+                for row in position..position + count {
+                    ids.push(global_id);
+                    let value = -(row as i64);
+                    values.push(value);
+                    fixture
+                        .coordinates
+                        .push((file_id, row as u64, global_id, value));
+                    global_id += 1;
+                }
+                writer.write(&RecordBatch::try_new(
+                    schema.clone(),
+                    vec![
+                        Arc::new(Int64Array::from(ids)),
+                        Arc::new(Int64Array::from(values)),
+                    ],
+                )?)?;
+                writer.flush()?;
+                position += count;
+                group += 1;
+            }
+            writer.close()?;
+            let size = fs::metadata(fixture.directory.path().join(&path))?.len();
+            let mut add = json!({"path":path,"partitionValues":{},"size":size,"modificationTime":0,"dataChange":true});
+            if spec.log_stats {
+                add["stats"] = json!(json!({"numRecords":spec.rows,"minValues":{"id":first_id,"value":-(spec.rows as i64 - 1)},"maxValues":{"id":global_id - 1,"value":0},"nullCount":{"id":0,"value":0}}).to_string());
+            }
+            if let Some(deleted) = &spec.deleted {
+                add["deletionVector"] = fixture.write_dv(file_id, 0, deleted)?;
+            }
+            fixture.deleted.push(spec.deleted);
+            fixture.adds.push(add);
+        }
+        let mut actions = vec![protocol, metadata];
+        actions.extend(fixture.adds.iter().map(|add| json!({"add":add})));
+        fixture.write_log(0, actions)?;
+        Ok(fixture)
+    }
+
+    pub fn url(&self) -> Url {
+        Url::from_directory_path(self.directory.path()).unwrap()
+    }
+
+    pub fn live_coordinates(&self) -> Vec<(usize, u64, i64, i64)> {
+        self.coordinates
+            .iter()
+            .copied()
+            .filter(|(file, position, _, _)| {
+                !self.deleted[*file]
+                    .as_ref()
+                    .is_some_and(|deleted| deleted.contains(position))
+            })
+            .collect()
+    }
+
+    pub fn replace_visibility(
+        &mut self,
+        file_id: usize,
+        deleted: BTreeSet<u64>,
+    ) -> FixtureResult<()> {
+        self.version += 1;
+        let old = self.adds[file_id].clone();
+        let mut remove = old.clone();
+        remove["deletionTimestamp"] = json!(self.version);
+        remove["extendedFileMetadata"] = json!(true);
+        let mut add = old;
+        add["deletionVector"] = self.write_dv(file_id, self.version, &deleted)?;
+        self.write_log(
+            self.version,
+            vec![json!({"remove":remove}), json!({"add":add})],
+        )?;
+        self.adds[file_id] = add;
+        self.deleted[file_id] = Some(deleted);
+        Ok(())
+    }
+
+    fn write_dv(
+        &self,
+        file: usize,
+        version: usize,
+        positions: &BTreeSet<u64>,
+    ) -> FixtureResult<Value> {
+        let path = self
+            .directory
+            .path()
+            .join(format!("dv-{file}-{version}.bin"));
+        let mut output = fs::File::create(&path)?;
+        let mut writer = StreamingDeletionVectorWriter::new(&mut output);
+        let mut dv = KernelDeletionVector::new();
+        dv.add_deleted_row_indexes(positions.iter().copied());
+        let written = writer.write_deletion_vector(dv)?;
+        writer.finalize()?;
+        Ok(
+            json!({"storageType":"p","pathOrInlineDv":Url::from_file_path(path).unwrap().as_str(),"offset":written.offset,"sizeInBytes":written.size_in_bytes,"cardinality":positions.len()}),
+        )
+    }
+
+    fn write_log(&self, version: usize, actions: Vec<Value>) -> FixtureResult<()> {
+        fs::write(
+            self.directory
+                .path()
+                .join("_delta_log")
+                .join(format!("{version:020}.json")),
+            actions
+                .iter()
+                .map(Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )?;
+        Ok(())
+    }
+}

--- a/docs/development/physical-position-deletion-vectors.md
+++ b/docs/development/physical-position-deletion-vectors.md
@@ -1,0 +1,69 @@
+# Physical-position deletion-vector scans
+
+The first change replaces execution-order mask consumption with immutable lookup by
+`(compact file identity, absolute physical Parquet row position)`. The complete
+selected population and store bindings are captured before asynchronous DV loading.
+Missing, duplicate, unexpected, or inconsistent loading results are errors. An
+explicitly selected file without a DV is all-live; an unknown identity is an error.
+One `Arc<DeletionVectorIndex>` owns the masks across executions and streams. A new
+snapshot creates independent visibility even when immutable footer metadata is reused.
+
+There are three separate count proofs:
+
+| Count | Evidence |
+| --- | --- |
+| Log-declared physical population | Valid selected action `numRecords`; required for a DV, optional otherwise. |
+| Footer-verified physical population | Complete footer and consistent row groups/ordinals, compared with applicable log metadata before positional decoding. |
+| Exact visible population | Complete selected population and matching validated DV state; metadata-only execution uses the log/DV protocol contract without opening Parquet. |
+
+Sparse masks have an implicit live tail, bounded by the physical population. Reader
+coordinates are never reconstructed by counting returned batches. Hidden position
+fields use Parquet's nullable Int64 `RowNumber`; their definitions, lineage, and
+on-disk collisions are checked. Filtering applies to payload and identity together
+before Kernel transformations and strips support fields at the output boundary.
+
+The session's existing metadata cache supplies one retention allowance across stores
+and concurrent scans. Private namespaced views tag entries with store-allocation
+identity, full object metadata, and footer-validation evidence. Weak store references
+prevent allocation identity reuse without retaining unregistered stores. Namespace and
+validation storage are charged to the backing cache. Eviction does not release
+metadata still held by an active reader. `active_footer_reference_bytes` reports
+Parquet's memory estimate summed over live reader references; shared allocations may
+be counted more than once and allocator overhead is excluded. It is not RSS.
+
+The correctness change retains DV predicate, file-layout, repartitioning, and
+fetch/LIMIT containment. MERGE still uses a one-based surviving-row ordinal. Its
+migration is a separate follow-up: indexed visibility alone does not permit moving
+predicates or truncation before ordinal assignment. RowTracking restrictions are
+independent as well. No public metadata function, durable row identity, decoder-level
+DV selection, or physical serialization codec is introduced.
+
+## Qualification and repeatable measurement
+
+The fixture generator's original coordinates and declared deleted-position sets form
+the oracle. Reader identity and final logical output are checked separately. Private
+reader tests cover the optimizer matrix while production plans remain contained:
+page index and row filter on/off, batches 1/7/8192, partitions 1/2/4/8, and file
+repartitioning on/off. Fixtures have unequal groups and verified multiple pages.
+Additional cases cover malformed counts/ordinals, missing statistics, cache collisions
+with equal validation attributes, concurrent snapshots, old-plan reuse, cancellation,
+and logical serialization. Native FFI qualification is recorded separately from
+Python integration.
+
+Run the scan suite, complete core suite, formatting, strict all-target Clippy, and
+incremental diff whitespace checks at the final source head. Python contribution
+checks, build, unit tests, and documentation are separate gates. An inherited failure
+or unavailable prerequisite remains an unmet gate; it is not a successful check.
+Record source/parent SHAs, lock hash, toolchain/target, features/profile, fixture and
+harness revisions, commands, and terminal statuses with each result.
+
+`cargo bench --locked -p deltalake-core --features datafusion --bench dv_physical_position`
+runs the shared Criterion harness. It covers no/sparse/dense DVs, large and many-small
+files, selective predicates, partitions 1/2/4/8, prepared/reset and fresh plans, and
+cold/warm metadata, with ten samples per case. Set `DV_BENCH_TELEMETRY` to a JSONL
+path for planning/first-read/stream times, I/O requests and bytes, pruning metrics,
+cache retention, and sampled active footer references. Capture process peak RSS with
+an external process monitor. Use separate processes and identical locks, fixtures,
+profiles, and settings for parent and follow-ups. Keep distributions/confidence and
+investigate repeatable no-DV regressions above 5%; do not infer an RSS bound from the
+cache allowance. Benchmark-only overlays on the parent must be recorded explicitly.


### PR DESCRIPTION
Deletion-vector visibility now uses `(compact file identity, absolute physical Parquet row position)`. A complete selected-file registry is captured before DV loading, and one immutable `Arc<DeletionVectorIndex>` owns the validated masks across executions. Missing expected vectors, unknown identities, inconsistent counts and invalid positions fail closed. Payload and identity are filtered together before Kernel transformations.

This PR retains DV predicate, file-layout, partition/repartition and LIMIT/fetch containment. MERGE keeps its one-based surviving-row ordinal; migrating that ordinal is a separate follow-up. No public metadata functions, decoder-level DV selection, durable RowTracking or physical serialization codec are added.

The private reader contract checks hidden fields, bound stores/readers/adapters, footer counts and coordinate metadata. A store-qualified adapter uses the existing session metadata cache, sharing one retention allowance across stores and concurrent scans. Snapshot visibility is separate from reusable file metadata. Metadata-only exact counts rely on validated log/DV protocol metadata; they are not presented as footer-verified reads. Non-DV files without statistics remain readable.

### Stack and review range

Depends on open #4692 at `42ef7613dc6a9f40a6a65b9475cb24dd28ad7b1a`. Landing order is #4692 → this correctness follow-up → optimizer follow-up. Suitable upstream stacking branches are unavailable, so this draft targets `main` and GitHub's displayed diff is cumulative.

Review the immutable [correctness-base → PR1 diff](https://github.com/ethan-tyler/delta-rs/compare/42ef7613dc6a9f40a6a65b9475cb24dd28ad7b1a...fbe01a93a9e647ded3f9fbc247bb03ad43ff8f51). The optimizer follow-up is being qualified separately; this PR does not claim to eliminate every ordering restriction discussed in #4115.

### Local qualification

Source `fbe01a93a9e647ded3f9fbc247bb03ad43ff8f51`; incremental parent `42ef7613dc6a9f40a6a65b9475cb24dd28ad7b1a`. Rust 1.94.1, `aarch64-apple-darwin`, `datafusion` feature, dev/test profile.

Controlled lock SHA-256: `661bc498f84e4cee03885a2445cb0dc6ef5427ca8a88662d3a7c53cb160e6435`. Graph: DataFusion 55.0.0, Arrow/Parquet 59.3.0, buoyant Kernel 0.25.1, object_store 0.13.2, Tokio 1.53.1. Normal resolution and the effective Arrow/Parquet 59.2.0 lower-bound lanes each pass all 124 scan tests; those runs belong to `84c3fa6d`, whose production code matches this head (subsequent changes affect tests/harness only).

- Final-head `make setup-dat`, focused scan suite (124 tests), full core suite (1181 library + 194 integration + 19 doctests), formatting and incremental whitespace checks pass.
- The 96-case private reader matrix proves real pages, pruning and ranged coordinates against generator-derived identities. Additional tests cover malformed registries/coordinates, collisions, optional counts, repeatability, cancellation and concurrent snapshots with old-plan reuse. Production DV plans remain contained here.
- Final editable Python build/default suite: 701 passed, 5 skipped, 5 xfailed, 3 xpassed. Contribution checks and documentation pass; unchanged Python-source checks have explicit reuse rationale in local evidence.
- Native DataFusion 55 FFI roundtrip, direct exported execution/Arrow C Data stream, concurrency and cancellation pass. This is separate from Python integration.

**Unmet gates:** strict all-target Clippy reports 16 errors reproduced on the exact parent; non-strict all-target lint has no diagnostics in changed scan modules or the harness. The parent's Python DataFusion-54 guard conflicts with Rust DataFusion 55. Exact-parent opt-in integration with Python 54 reproduced a Bus error; a Python 55 distribution was unavailable from the configured index. The proposed guard/dependency patch is isolated and unapplied. No guard bypass or successful Python DataFusion integration is claimed. This remains a draft, not a fully qualified merge candidate.

### Controlled performance and memory

The reusable Criterion harness covers 192 cases: no/sparse/dense DVs, large/many-small files, predicates, partitions 1/2/4/8, prepared/reset versus fresh planning, cold/warm metadata. Parent and PR1 use identical harness/fixtures/lock/profile, separate processes and at least ten samples; `CARGO_PROFILE_BENCH_DEBUG=0`. Fresh planning uses an already registered snapshot/provider.

Median PR1/parent elapsed-time ratios across each 64-case group: no DV **0.962**, sparse DV **1.214**, dense DV **1.288**. This contained correctness step has a measured DV cost; optimizer recovery belongs to PR2. Two initially elevated no-DV cases did not repeat above 5% in two longer alternating 20-sample rounds.

Measured max RSS: parent 514,441,216 bytes; PR1 519,929,856 bytes. Maximum observed cache retention: 257,088 / 272,054 bytes against the same 50 MiB allowance. PR1's maximum sampled active footer-reference estimate was 112,392 bytes; shared allocations may be counted repeatedly and this is not RSS. Per-case timing, I/O, pruning, cache and active-reference evidence is retained locally. Earlier superseded harness measurements are not used for these claims.

Fixture SHA-256 `b7c6657beb46174ffd92cb849c14d41f0fb1266ba9b8a0f2a42c17c148cc2443`; harness SHA-256 `1fa1efab2556768caa8c1418beb1cc835f6ccf57be743cf196172f479e484156`. Raw logs and source/dependency/toolchain/command tuples are retained in the task evidence directory. Exact-head remote CI and CI dependency resolution are pending publication and will be reported separately from synthetic merge checks.

Implemented and qualified with OpenAI Codex assistance. Local self-review is not independent maintainer approval. New commits have verified DCO trailers.
