### PR TITLE
fix(python): align DataFusion FFI integration with version 55

### DIFF
--- a/.github/workflows/python_build.yml
+++ b/.github/workflows/python_build.yml
@@ -112,9 +112,8 @@ jobs:
       - name: Build and install deltalake
         run: make develop
 
-      - name: Assert DataFusion major version
-        run: uv run --no-sync python -c "from importlib.metadata import version; v=version('datafusion'); assert v.split('.')[0]=='53', f'Expected 53.x, got {v}'"
-
+      # Restore the DataFusion dependency and major-version assertion when 55.x wheels
+      # are published. Until then, the integration test skips without a matching consumer.
       - name: Run DataFusion integration test
         run: DELTALAKE_RUN_DATAFUSION_TESTS=1 uv run --no-sync pytest -v tests/test_datafusion.py -m datafusion
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -111,7 +111,6 @@ dev = [
 ]
 opentelemetry = ["opentelemetry-sdk>=1.20.0", "opentelemetry-api>=1.20.0"]
 polars = ["polars==1.32"]
-datafusion = ["datafusion==53.*"]
 lakefs = ["lakefs==0.8.0"]
 pyspark = [
     "pyspark==4.0.1",
@@ -128,4 +127,5 @@ other = [
 ]
 
 [tool.uv]
-default-groups = ["dev", "opentelemetry", "polars", "datafusion", "lakefs", "docs", "other"]
+# Re-enable a Python DataFusion dependency group once DataFusion 55 wheels are published.
+default-groups = ["dev", "opentelemetry", "polars", "lakefs", "docs", "other"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -157,7 +157,7 @@ struct RawDeltaTableMetaData {
 
 type StringVec = Vec<String>;
 
-const REQUIRED_DATAFUSION_PY_MAJOR: u32 = 54;
+const REQUIRED_DATAFUSION_PY_MAJOR: u32 = 55;
 static FALLBACK_TASK_CTX_PROVIDER: OnceLock<Arc<SessionContext>> = OnceLock::new();
 const MAX_OPTIMIZE_TARGET_SIZE: u64 = i64::MAX as u64;
 

--- a/python/tests/test_datafusion.py
+++ b/python/tests/test_datafusion.py
@@ -14,35 +14,33 @@ def _datafusion_major_version() -> int | None:
         return None
 
 
-def test_datafusion_table_provider_incompatible_version_errors(tmp_path, monkeypatch):
-    # Force the runtime check to behave like an incompatible pre-53 datafusion install.
-    call_count = {"count": 0}
+@pytest.mark.parametrize("installed", ["53.0.0", "54.0.0", "56.0.0", "invalid"])
+def test_datafusion_table_provider_incompatible_version_errors(
+    tmp_path, monkeypatch, installed
+):
+    calls = []
 
     def fake_version(pkg: str) -> str:
-        assert pkg == "datafusion"
-        call_count["count"] += 1
-        if call_count["count"] == 1:
-            return "53.0.0"
-        return "54.0.0"
+        calls.append(pkg)
+        return installed
 
     monkeypatch.setattr("importlib.metadata.version", fake_version)
-
     table = Table(
         {"id": Array([1, 2, 3], Field("id", type=DataType.int64(), nullable=True))}
     )
     write_deltalake(tmp_path, table)
     dt = DeltaTable(tmp_path)
 
-    # Call the FFI export hook directly; DO NOT call SessionContext.register_* (that is what segfaults).
-    with pytest.raises(RuntimeError) as exc_info:
-        dt.__datafusion_table_provider__()  # type: ignore[attr-defined]
+    # Reject incompatible consumers before exporting a capsule or reading a session capsule.
+    class UnreachableSession:
+        def __datafusion_task_context_provider__(self):
+            pytest.fail(
+                "incompatible consumers must be rejected before accessing their session"
+            )
 
-    assert call_count["count"] == 1
-
-    msg = str(exc_info.value)
-    assert "datafusion" in msg
-    assert "datafusion==54" in msg
-    assert "QueryBuilder" in msg
+    with pytest.raises(RuntimeError, match="datafusion==55"):
+        dt.__datafusion_table_provider__(session=UnreachableSession())
+    assert calls == ["datafusion"]
 
 
 def test_datafusion_table_provider_not_installed_errors(tmp_path, monkeypatch):
@@ -71,7 +69,7 @@ def test_datafusion_table_provider_accepts_session_keyword_argument(
 ):
     def fake_version(pkg: str) -> str:
         assert pkg == "datafusion"
-        return "54.0.0"
+        return "55.0.0"
 
     monkeypatch.setattr("importlib.metadata.version", fake_version)
 
@@ -93,7 +91,7 @@ def test_datafusion_table_provider_invalid_task_ctx_capsule_name_errors(
 
     def fake_version(pkg: str) -> str:
         assert pkg == "datafusion"
-        return "54.0.0"
+        return "55.0.0"
 
     monkeypatch.setattr("importlib.metadata.version", fake_version)
 
@@ -124,13 +122,10 @@ def test_datafusion_table_provider(tmp_path):
             "DataFusion Python integration tests are disabled by default; set DELTALAKE_RUN_DATAFUSION_TESTS=1"
         )
 
-    # This deltalake build exports a DataFusion 54.x FFI TableProvider; the
-    # installed datafusion-python wheel must match that major or the runtime
-    # guard rejects it. datafusion-python has no 54.x release yet, so skip until
-    # one is published rather than fail.
+    # Skip until matching wheels are available; the runtime guard requires major 55.
     datafusion_major = _datafusion_major_version()
-    if datafusion_major != 54:
-        pytest.skip("DataFusion Python integration requires datafusion==54.x wheels")
+    if datafusion_major != 55:
+        pytest.skip("DataFusion Python integration requires datafusion==55.x wheels")
     nrows = 5
     table = Table(
         {


### PR DESCRIPTION
The workspace uses Rust DataFusion 55, but the Python FFI guard accepts 54 and the development dependency installs 53. Require a matching 55 consumer and reject incompatible or malformed versions before accessing session capsules.

Keep the optional consumer out of default development dependencies and skip the Python integration test when a matching 55 consumer is unavailable, following the earlier release-gap approach. Restore the dependency group and CI major-version assertion once DataFusion 55 wheels are published.

Validation:
- All 8 DataFusion Python tests passed on macOS with Python 3.13 using the existing local DataFusion 55 development consumer and deltalake wheel.
- Confirmed that missing, mismatched, and malformed consumer versions skip the integration test before accessing the consumer.
- Actionlint, Ruff lint/format, and diff whitespace checks passed.
