### PR TITLE
refactor: apply deletion vectors by physical row position

### DIFF
--- a/crates/core/src/datafile/reader.rs
+++ b/crates/core/src/datafile/reader.rs
@@ -15,11 +15,12 @@
 
 use std::sync::Arc;
 
+use crate::logstore::parquet_reader::ParquetObjectReader;
 use delta_kernel::table_features::ColumnMappingMode;
 use futures::stream::{StreamExt as _, TryStreamExt as _};
 use object_store::ObjectStore;
 use object_store::path::Path;
-use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
+use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
 
 use crate::DeltaTable;
 use crate::errors::{DeltaResult, DeltaTableError};

--- a/crates/core/src/delta_datafusion/cdf/scan_utils.rs
+++ b/crates/core/src/delta_datafusion/cdf/scan_utils.rs
@@ -104,6 +104,10 @@ pub fn create_spec_partition_values<F: FileAction>(
     spec_partition_values
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Keep the existing CDF pair expansion interface explicit"
+)]
 pub async fn extend_groups_with_pairs(
     schema: SchemaRef,
     pairs: Vec<ResolvedPair>,
@@ -135,7 +139,7 @@ pub async fn extend_groups_with_pairs(
             &pair,
             &table_partition_values,
             Arc::clone(&cache),
-            &metrics,
+            metrics,
         )
         .await?;
         push_pair_selection(
@@ -145,7 +149,7 @@ pub async fn extend_groups_with_pairs(
             &pair,
             &table_partition_values,
             Arc::clone(&cache),
-            &metrics,
+            metrics,
         )
         .await?;
     }
@@ -339,6 +343,7 @@ impl TryInto<DeletionVectorDescriptor> for crate::kernel::DeletionVectorDescript
 /// 1. Marking the rows up until the index as kept or omitted depending on the action
 /// 2. Marking the row itself for the opposite
 /// 3. Marking the tail end rows up until the row group end as kept or omitted depending on the action
+///
 /// This then builds the final access plan for the individual row group.
 fn row_group_access(
     marked: &roaring::RoaringTreemap,

--- a/crates/core/src/delta_datafusion/cdf/scan_utils.rs
+++ b/crates/core/src/delta_datafusion/cdf/scan_utils.rs
@@ -106,7 +106,7 @@ pub fn create_spec_partition_values<F: FileAction>(
 
 #[expect(
     clippy::too_many_arguments,
-    reason = "Keep the existing CDF pair expansion interface explicit"
+    reason = "Pass the CDF pair expansion inputs together"
 )]
 pub async fn extend_groups_with_pairs(
     schema: SchemaRef,

--- a/crates/core/src/delta_datafusion/data_validation.rs
+++ b/crates/core/src/delta_datafusion/data_validation.rs
@@ -2340,7 +2340,7 @@ mod tests {
         // Confirm that two DataValidation nodes built from identical inputs compare Equal under
         // both PartialEq and PartialOrd — proving validated_schema is deterministic from
         // input + validations, so the PartialOrd filter guard is always a no-op in practice.
-        use datafusion::common::{DFSchema, ToDFSchema};
+        use datafusion::common::ToDFSchema;
         use datafusion::logical_expr::{EmptyRelation, LogicalPlan};
         use datafusion::prelude::col;
 

--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -634,18 +634,14 @@ mod tests {
     };
     use crate::writer::test_utils::get_delta_schema;
     use arrow::array::StructArray;
-    use arrow::datatypes::{Field, Schema};
+    use arrow::datatypes::Field;
     use datafusion::assert_batches_sorted_eq;
-    use datafusion::physical_plan::empty::EmptyExec;
     use datafusion::prelude::SessionConfig;
-    use datafusion_proto::physical_plan::AsExecutionPlan;
-    use datafusion_proto::protobuf;
     use delta_kernel::schema::ArrayType;
     use futures::{StreamExt, TryStreamExt};
     use object_store::ObjectStoreExt as _;
     use serde_json::json;
     use std::ops::Range;
-    use url::Url;
 
     use super::*;
     use crate::delta_datafusion::table_provider::next::{FileSelection, MissingSelectedFilePolicy};
@@ -1432,7 +1428,7 @@ mod tests {
         assert_eq!(1, files.len());
         let object_store = table.object_store();
         let file_meta = object_store.head(&files[0]).await.unwrap();
-        let file_reader = parquet::arrow::async_reader::ParquetObjectReader::new(
+        let file_reader = crate::logstore::parquet_reader::ParquetObjectReader::new(
             object_store,
             file_meta.location.clone(),
         )

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/deletion_vector.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/deletion_vector.rs
@@ -1,0 +1,301 @@
+//! Immutable deletion-vector lookup by absolute physical Parquet row position.
+
+use arrow_array::{BooleanArray, Int64Array};
+use datafusion::common::{HashMap, Result, exec_err, plan_err};
+
+#[derive(Debug)]
+#[cfg_attr(test, derive(Clone))]
+pub(super) struct DeletionVectorEntry {
+    pub keep_mask: Vec<bool>,
+    pub physical_record_count: u64,
+    pub deleted_cardinality: u64,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct DeletionVectorIndex {
+    pub(super) entries: HashMap<String, DeletionVectorEntry>,
+    selected: HashMap<String, Option<u64>>,
+}
+
+impl DeletionVectorIndex {
+    pub fn try_new(entries: HashMap<String, DeletionVectorEntry>) -> Result<Self> {
+        for (file_id, entry) in &entries {
+            if entry.physical_record_count > i64::MAX as u64 {
+                return plan_err!("numRecords exceeds Parquet Int64 coordinates");
+            }
+            let mask_len = u64::try_from(entry.keep_mask.len()).map_err(|_| {
+                datafusion::common::DataFusionError::Plan(format!(
+                    "deletion-vector mask length overflows u64 for compact file id '{file_id}'"
+                ))
+            })?;
+            if mask_len > entry.physical_record_count {
+                return plan_err!(
+                    "deletion-vector mask length {mask_len} exceeds numRecords {} for compact file id '{file_id}'",
+                    entry.physical_record_count
+                );
+            }
+            let actual_deleted = u64::try_from(
+                entry.keep_mask.iter().filter(|keep| !**keep).count(),
+            )
+            .map_err(|_| {
+                datafusion::common::DataFusionError::Plan(format!(
+                    "deletion-vector cardinality overflows u64 for compact file id '{file_id}'"
+                ))
+            })?;
+            if actual_deleted != entry.deleted_cardinality {
+                return plan_err!(
+                    "deletion-vector cardinality mismatch for compact file id '{file_id}': descriptor={}, actual={actual_deleted}",
+                    entry.deleted_cardinality
+                );
+            }
+            if entry.deleted_cardinality > entry.physical_record_count {
+                return plan_err!(
+                    "deletion-vector cardinality {} exceeds numRecords {} for compact file id '{file_id}'",
+                    entry.deleted_cardinality,
+                    entry.physical_record_count
+                );
+            }
+        }
+        let selected = entries
+            .iter()
+            .map(|(id, entry)| (id.clone(), Some(entry.physical_record_count)))
+            .collect();
+        Ok(Self { entries, selected })
+    }
+
+    pub fn with_selected_files(mut self, selected: HashMap<String, Option<u64>>) -> Result<Self> {
+        for (id, entry) in &self.entries {
+            if selected.get(id) != Some(&Some(entry.physical_record_count)) {
+                return plan_err!(
+                    "selected-file count does not match deletion vector for compact file id '{id}'"
+                );
+            }
+        }
+        self.selected = selected;
+        Ok(self)
+    }
+
+    pub fn has_vectors(&self) -> bool {
+        !self.entries.is_empty()
+    }
+
+    pub fn file_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn has_vector(&self, compact_file_id: &str) -> bool {
+        self.entries.contains_key(compact_file_id)
+    }
+
+    pub fn selection_for_positions(
+        &self,
+        compact_file_id: &str,
+        positions: &Int64Array,
+    ) -> Result<BooleanArray> {
+        let count = self.selected.get(compact_file_id).ok_or_else(|| {
+            datafusion::common::DataFusionError::Execution(format!(
+                "unknown selected compact file id '{compact_file_id}'"
+            ))
+        })?;
+        let entry = self.entries.get(compact_file_id);
+        positions
+            .iter()
+            .map(|position| {
+                let Some(position) = position else {
+                    return exec_err!(
+                        "null physical row position for compact file id '{compact_file_id}'"
+                    );
+                };
+                let position = u64::try_from(position).map_err(|_| {
+                    datafusion::common::DataFusionError::Execution(format!(
+                        "negative physical row position for compact file id '{compact_file_id}'"
+                    ))
+                })?;
+                if let Some(count) = count && position >= *count {
+                    return exec_err!(
+                        "physical row position {position} exceeds numRecords {} for compact file id '{compact_file_id}'",
+                        count
+                    );
+                }
+                // The implicit-live tail is not an index into the materialized mask.
+                let keep = match entry {
+                    Some(entry) if position < entry.keep_mask.len() as u64 => {
+                        let index = usize::try_from(position).map_err(|_| datafusion::common::DataFusionError::Execution("materialized position overflows usize".into()))?;
+                        entry.keep_mask[index]
+                    }
+                    _ => true,
+                };
+                Ok(keep)
+            })
+            .collect::<Result<BooleanArray>>()
+    }
+
+    pub fn live_row_count(
+        &self,
+        compact_file_id: &str,
+        physical_record_count: usize,
+    ) -> Result<usize> {
+        let Some(count) = self.selected.get(compact_file_id) else {
+            return exec_err!("unknown selected compact file id '{compact_file_id}'");
+        };
+        if count.is_some_and(|count| count != physical_record_count as u64) {
+            return exec_err!(
+                "physical record count mismatch for compact file id '{compact_file_id}'"
+            );
+        }
+        let Some(entry) = self.entries.get(compact_file_id) else {
+            return Ok(physical_record_count);
+        };
+        let supplied_record_count = u64::try_from(physical_record_count).map_err(|_| {
+            datafusion::common::DataFusionError::Execution(format!(
+                "physical record count overflows u64 for compact file id '{compact_file_id}'"
+            ))
+        })?;
+        if supplied_record_count != entry.physical_record_count {
+            return exec_err!(
+                "physical record count mismatch for compact file id '{compact_file_id}': expected {}, got {supplied_record_count}",
+                entry.physical_record_count
+            );
+        }
+        usize::try_from(entry.physical_record_count - entry.deleted_cardinality).map_err(|_| {
+            datafusion::common::DataFusionError::Execution(format!(
+                "live row count overflows usize for compact file id '{compact_file_id}'"
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_array::Int64Array;
+    use datafusion::common::HashMap;
+
+    use super::*;
+
+    fn index(mask: Vec<bool>, records: u64, deleted: u64) -> Result<DeletionVectorIndex> {
+        DeletionVectorIndex::try_new(HashMap::from([(
+            "7".to_string(),
+            DeletionVectorEntry {
+                keep_mask: mask,
+                physical_record_count: records,
+                deleted_cardinality: deleted,
+            },
+        )]))
+    }
+
+    #[test]
+    fn unknown_file_cannot_be_counted_as_all_live() -> Result<()> {
+        let index = index(vec![false], 3, 1)?;
+        assert!(index.live_row_count("unknown", 3).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn large_implicit_tail_needs_no_materialized_mask() -> Result<()> {
+        let index = index(vec![false], (1_u64 << 40) + 1, 1)?;
+        assert_eq!(
+            index
+                .selection_for_positions("7", &Int64Array::from(vec![1_i64 << 40]))?
+                .true_count(),
+            1
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn selects_by_absolute_position_and_keeps_sparse_tail() -> Result<()> {
+        let index = index(vec![true, false, true], 6, 1)?;
+        let positions = Int64Array::from(vec![5, 1, 3, 0, 2]);
+
+        let selection = index.selection_for_positions("7", &positions)?;
+
+        assert_eq!(
+            selection.iter().collect::<Vec<_>>(),
+            vec![Some(true), Some(false), Some(true), Some(true), Some(true),]
+        );
+        assert_eq!(index.live_row_count("7", 6)?, 5);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_invalid_positions() -> Result<()> {
+        let index = index(vec![true, false], 3, 1)?;
+
+        for positions in [
+            Int64Array::from(vec![Some(0), None]),
+            Int64Array::from(vec![-1]),
+            Int64Array::from(vec![3]),
+        ] {
+            assert!(index.selection_for_positions("7", &positions).is_err());
+        }
+        assert!(
+            index
+                .selection_for_positions("unknown", &Int64Array::from(vec![0]))
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_invalid_planning_metadata() {
+        assert!(index(vec![true, false, true], 2, 1).is_err());
+        assert!(index(vec![true, false], 2, 0).is_err());
+        assert!(index(vec![true, false], 2, 2).is_err());
+    }
+
+    #[test]
+    fn all_live_and_all_deleted_masks_remain_valid() -> Result<()> {
+        let all_live = index(Vec::new(), 3, 0)?;
+        assert_eq!(all_live.live_row_count("7", 3)?, 3);
+
+        let all_deleted = index(vec![false, false, false], 3, 3)?;
+        let selection =
+            all_deleted.selection_for_positions("7", &Int64Array::from(vec![0, 1, 2]))?;
+        assert_eq!(selection.true_count(), 0);
+        assert_eq!(all_deleted.live_row_count("7", 3)?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn indexed_lookup_matches_reference_for_reordered_predicate_results() -> Result<()> {
+        let mut state = 0x5eed_cafe_u64;
+        for record_count in 1..=64_u64 {
+            let mut full_mask = Vec::with_capacity(record_count as usize);
+            let mut deleted_positions = std::collections::HashSet::new();
+            for position in 0..record_count {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                if state.is_multiple_of(5) {
+                    deleted_positions.insert(position as i64);
+                }
+                full_mask.push(!state.is_multiple_of(5));
+            }
+            let deleted = full_mask.iter().filter(|keep| !**keep).count() as u64;
+            let sparse_len = full_mask
+                .iter()
+                .rposition(|keep| !*keep)
+                .map_or(0, |position| position + 1);
+            let sparse_mask = full_mask[..sparse_len].to_vec();
+            let index = index(sparse_mask.clone(), record_count, deleted)?;
+
+            let mut positions = (0..record_count as i64)
+                .filter(|position| position % 3 != 1)
+                .collect::<Vec<_>>();
+            positions.reverse();
+            let selection =
+                index.selection_for_positions("7", &Int64Array::from(positions.clone()))?;
+
+            let actual = positions
+                .into_iter()
+                .zip(selection.values())
+                .filter_map(|(position, keep)| keep.then_some(position))
+                .collect::<Vec<_>>();
+            let expected = (0..record_count as i64)
+                .filter(|position| position % 3 != 1)
+                .rev()
+                .filter(|position| !deleted_positions.contains(position))
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected, "record_count={record_count}");
+        }
+        Ok(())
+    }
+}

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/deletion_vector.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/deletion_vector.rs
@@ -1,4 +1,4 @@
-//! Immutable deletion-vector lookup by absolute physical Parquet row position.
+//! Immutable deletion vector lookup by absolute physical Parquet row position.
 
 use arrow_array::{BooleanArray, Int64Array};
 use datafusion::common::{HashMap, Result, exec_err, plan_err};
@@ -18,19 +18,27 @@ pub(super) struct DeletionVectorIndex {
 }
 
 impl DeletionVectorIndex {
-    pub fn try_new(entries: HashMap<String, DeletionVectorEntry>) -> Result<Self> {
+    pub fn try_new(
+        entries: HashMap<String, DeletionVectorEntry>,
+        selected: HashMap<String, Option<u64>>,
+    ) -> Result<Self> {
         for (file_id, entry) in &entries {
+            if selected.get(file_id) != Some(&Some(entry.physical_record_count)) {
+                return plan_err!(
+                    "selected file row count does not match deletion vector for compact file id '{file_id}'"
+                );
+            }
             if entry.physical_record_count > i64::MAX as u64 {
                 return plan_err!("numRecords exceeds Parquet Int64 coordinates");
             }
             let mask_len = u64::try_from(entry.keep_mask.len()).map_err(|_| {
                 datafusion::common::DataFusionError::Plan(format!(
-                    "deletion-vector mask length overflows u64 for compact file id '{file_id}'"
+                    "deletion vector mask length overflows u64 for compact file id '{file_id}'"
                 ))
             })?;
             if mask_len > entry.physical_record_count {
                 return plan_err!(
-                    "deletion-vector mask length {mask_len} exceeds numRecords {} for compact file id '{file_id}'",
+                    "deletion vector mask length {mask_len} exceeds numRecords {} for compact file id '{file_id}'",
                     entry.physical_record_count
                 );
             }
@@ -39,40 +47,17 @@ impl DeletionVectorIndex {
             )
             .map_err(|_| {
                 datafusion::common::DataFusionError::Plan(format!(
-                    "deletion-vector cardinality overflows u64 for compact file id '{file_id}'"
+                    "deletion vector cardinality overflows u64 for compact file id '{file_id}'"
                 ))
             })?;
             if actual_deleted != entry.deleted_cardinality {
                 return plan_err!(
-                    "deletion-vector cardinality mismatch for compact file id '{file_id}': descriptor={}, actual={actual_deleted}",
+                    "deletion vector cardinality mismatch for compact file id '{file_id}': descriptor={}, actual={actual_deleted}",
                     entry.deleted_cardinality
                 );
             }
-            if entry.deleted_cardinality > entry.physical_record_count {
-                return plan_err!(
-                    "deletion-vector cardinality {} exceeds numRecords {} for compact file id '{file_id}'",
-                    entry.deleted_cardinality,
-                    entry.physical_record_count
-                );
-            }
         }
-        let selected = entries
-            .iter()
-            .map(|(id, entry)| (id.clone(), Some(entry.physical_record_count)))
-            .collect();
         Ok(Self { entries, selected })
-    }
-
-    pub fn with_selected_files(mut self, selected: HashMap<String, Option<u64>>) -> Result<Self> {
-        for (id, entry) in &self.entries {
-            if selected.get(id) != Some(&Some(entry.physical_record_count)) {
-                return plan_err!(
-                    "selected-file count does not match deletion vector for compact file id '{id}'"
-                );
-            }
-        }
-        self.selected = selected;
-        Ok(self)
     }
 
     pub fn has_vectors(&self) -> bool {
@@ -117,7 +102,7 @@ impl DeletionVectorIndex {
                         count
                     );
                 }
-                // The implicit-live tail is not an index into the materialized mask.
+                // Rows past the end of the mask are kept.
                 let keep = match entry {
                     Some(entry) if position < entry.keep_mask.len() as u64 => {
                         let index = usize::try_from(position).map_err(|_| datafusion::common::DataFusionError::Execution("materialized position overflows usize".into()))?;
@@ -138,7 +123,12 @@ impl DeletionVectorIndex {
         let Some(count) = self.selected.get(compact_file_id) else {
             return exec_err!("unknown selected compact file id '{compact_file_id}'");
         };
-        if count.is_some_and(|count| count != physical_record_count as u64) {
+        let supplied_record_count = u64::try_from(physical_record_count).map_err(|_| {
+            datafusion::common::DataFusionError::Execution(format!(
+                "physical record count overflows u64 for compact file id '{compact_file_id}'"
+            ))
+        })?;
+        if count.is_some_and(|count| count != supplied_record_count) {
             return exec_err!(
                 "physical record count mismatch for compact file id '{compact_file_id}'"
             );
@@ -146,17 +136,6 @@ impl DeletionVectorIndex {
         let Some(entry) = self.entries.get(compact_file_id) else {
             return Ok(physical_record_count);
         };
-        let supplied_record_count = u64::try_from(physical_record_count).map_err(|_| {
-            datafusion::common::DataFusionError::Execution(format!(
-                "physical record count overflows u64 for compact file id '{compact_file_id}'"
-            ))
-        })?;
-        if supplied_record_count != entry.physical_record_count {
-            return exec_err!(
-                "physical record count mismatch for compact file id '{compact_file_id}': expected {}, got {supplied_record_count}",
-                entry.physical_record_count
-            );
-        }
         usize::try_from(entry.physical_record_count - entry.deleted_cardinality).map_err(|_| {
             datafusion::common::DataFusionError::Execution(format!(
                 "live row count overflows usize for compact file id '{compact_file_id}'"
@@ -173,14 +152,17 @@ mod tests {
     use super::*;
 
     fn index(mask: Vec<bool>, records: u64, deleted: u64) -> Result<DeletionVectorIndex> {
-        DeletionVectorIndex::try_new(HashMap::from([(
-            "7".to_string(),
-            DeletionVectorEntry {
-                keep_mask: mask,
-                physical_record_count: records,
-                deleted_cardinality: deleted,
-            },
-        )]))
+        DeletionVectorIndex::try_new(
+            HashMap::from([(
+                "7".to_string(),
+                DeletionVectorEntry {
+                    keep_mask: mask,
+                    physical_record_count: records,
+                    deleted_cardinality: deleted,
+                },
+            )]),
+            HashMap::from([("7".to_string(), Some(records))]),
+        )
     }
 
     #[test]
@@ -214,6 +196,8 @@ mod tests {
             vec![Some(true), Some(false), Some(true), Some(true), Some(true),]
         );
         assert_eq!(index.live_row_count("7", 6)?, 5);
+        assert!(index.live_row_count("7", 5).is_err());
+        assert!(index.live_row_count("7", 7).is_err());
         Ok(())
     }
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -345,7 +345,13 @@ impl DeltaScanExec {
                     if planned_file.partition_values != file.partition_values {
                         return plan_err!("unplanned partition constants");
                     }
-                    if planned_file.object_meta != file.object_meta {
+                    if planned_file.object_meta != file.object_meta
+                        || planned_file.arrow_schema != file.arrow_schema
+                        || planned_file.statistics != file.statistics
+                        || planned_file.ordering != file.ordering
+                        || planned_file.metadata_size_hint != file.metadata_size_hint
+                        || planned_file.table_reference != file.table_reference
+                    {
                         return plan_err!("immutable planned file metadata changed");
                     }
                     if file.range.is_some() {
@@ -2047,6 +2053,38 @@ mod tests {
             .downcast_ref::<FileScanConfig>()
             .expect("DataSourceExec must hold a parquet FileScanConfig");
 
+        for change in ["schema", "statistics", "ordering", "hint"] {
+            let mut groups = config
+                .file_groups
+                .iter()
+                .map(|group| group.iter().cloned().collect::<Vec<_>>())
+                .collect::<Vec<_>>();
+            let file = &mut groups[0][0];
+            match change {
+                "schema" => file.arrow_schema = Some(Arc::new(arrow_schema::Schema::empty())),
+                "statistics" => file.statistics = None,
+                "ordering" => {
+                    file.ordering = Some(
+                        datafusion::physical_expr::LexOrdering::new(vec![
+                            datafusion::physical_expr::PhysicalSortExpr::new_default(Arc::new(
+                                Column::new("value", 0),
+                            )),
+                        ])
+                        .unwrap(),
+                    )
+                }
+                _ => file.metadata_size_hint = Some(1),
+            }
+            let replacement = DataSourceExec::from_data_source(
+                FileScanConfigBuilder::from(config.clone())
+                    .with_file_groups(groups.into_iter().map(FileGroup::new).collect())
+                    .build(),
+            );
+            #[expect(deprecated, reason = "qualify both supported child-replacement APIs")]
+            let replaced = Arc::new(exec.clone()).with_new_children(vec![replacement]);
+            assert!(replaced.is_err(), "must reject changed per-file {change}");
+        }
+
         let mut fragment = config.file_groups[0][0].clone();
         fragment.range = Some(FileRange {
             start: 0,
@@ -2415,6 +2453,157 @@ mod tests {
             fixture_rows(&collect(first_plan, session.task_ctx()).await?),
             expected_first
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_cancellation_after_partial_consumption_preserves_visibility() -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture};
+        use datafusion::physical_plan::execution_plan::reset_plan_states;
+        let fixture = Fixture::new(
+            vec![FileSpec {
+                rows: 161,
+                groups: vec![37, 53, 71],
+                deleted: Some([0, 36, 37, 89, 90, 160].into_iter().collect()),
+                log_stats: true,
+            }],
+            8,
+        )?;
+        let table = crate::open_table(fixture.url()).await?;
+        let session = datafusion::prelude::SessionContext::new_with_config(
+            SessionConfig::new().with_batch_size(7),
+        );
+        session.register_table("t", table.table_provider().await?)?;
+        let plan = session
+            .sql("select * from t")
+            .await?
+            .create_physical_plan()
+            .await?;
+        let expected = fixture
+            .live_coordinates()
+            .into_iter()
+            .map(|r| (r.2, r.3))
+            .collect::<Vec<_>>();
+        let mut cancelled = plan.execute(0, session.task_ctx())?;
+        let first = cancelled.next().await.unwrap()?;
+        assert!(first.num_rows() > 0 && first.num_rows() < expected.len());
+        assert!(
+            first.num_rows() <= 7,
+            "fixture must force multiple output batches"
+        );
+        drop(cancelled);
+        assert_eq!(
+            fixture_rows(&collect(reset_plan_states(plan.clone())?, session.task_ctx()).await?),
+            expected
+        );
+        assert_eq!(
+            fixture_rows(&collect(plan, session.task_ctx()).await?),
+            expected
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_cancellation_during_pending_object_store_read() -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture, PausedStore};
+        use std::sync::atomic::Ordering;
+        use std::time::Duration;
+        let fixture = Fixture::new(
+            vec![FileSpec {
+                rows: 161,
+                groups: vec![37, 53, 71],
+                deleted: Some([0, 37, 90].into_iter().collect()),
+                log_stats: true,
+            }],
+            8,
+        )?;
+        let store = Arc::new(PausedStore::new(Arc::new(
+            object_store::local::LocalFileSystem::new(),
+        )));
+        let table = crate::DeltaTableBuilder::from_url(fixture.url())?
+            .with_storage_backend(store.clone(), fixture.url())
+            .load()
+            .await?;
+        let session = datafusion::prelude::SessionContext::new_with_config(
+            SessionConfig::new().with_batch_size(7),
+        );
+        session
+            .runtime_env()
+            .register_object_store(&url::Url::parse("file:///")?, store.clone());
+        let plan = table
+            .table_provider()
+            .await?
+            .scan(&session.state(), None, &[], None)
+            .await?;
+        store.paused.store(true, Ordering::SeqCst);
+        let mut cancelled = plan.execute(0, session.task_ctx())?;
+        let mut next = Box::pin(cancelled.next());
+        tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::select! {
+                _ = store.entered.notified() => {},
+                result = &mut next => panic!("read completed before cancellation: {result:?}"),
+            }
+        })
+        .await?;
+        assert_eq!(store.active.load(Ordering::SeqCst), 1);
+        drop(next);
+        drop(cancelled);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let changed = store.changed.notified();
+                if store.active.load(Ordering::SeqCst) == 0 {
+                    break;
+                }
+                changed.await;
+            }
+        })
+        .await?;
+        store.paused.store(false, Ordering::SeqCst);
+        let expected = fixture
+            .live_coordinates()
+            .into_iter()
+            .map(|r| (r.2, r.3))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            fixture_rows(&collect(plan, session.task_ctx()).await?),
+            expected
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_without_on_disk_row_group_ordinals() -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture};
+        let mut fixture = Fixture::new(
+            vec![FileSpec {
+                rows: 161,
+                groups: vec![37, 53, 71],
+                deleted: Some([0, 36, 37, 89, 90, 160].into_iter().collect()),
+                log_stats: true,
+            }],
+            8,
+        )?;
+        fixture.remove_row_group_ordinals(0)?;
+        let expected = fixture
+            .live_coordinates()
+            .into_iter()
+            .map(|r| (r.2, r.3))
+            .collect::<Vec<_>>();
+        let table = crate::open_table(fixture.url()).await?;
+        for batch_size in [1, 7, 8192] {
+            let session = datafusion::prelude::SessionContext::new_with_config(
+                SessionConfig::new().with_batch_size(batch_size),
+            );
+            let plan = table
+                .table_provider()
+                .await?
+                .scan(&session.state(), None, &[], None)
+                .await?;
+            assert_eq!(
+                fixture_rows(&collect(plan, session.task_ctx()).await?),
+                expected
+            );
+        }
         Ok(())
     }
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -12,7 +12,7 @@ use arrow::array::{RecordBatch, StringArray};
 use arrow::compute::filter_record_batch;
 use arrow::datatypes::{FieldRef, Schema, SchemaRef, UInt16Type};
 use arrow_array::StringViewArray;
-use arrow_array::{Array, ArrayRef, BooleanArray, UInt64Array};
+use arrow_array::{Array, ArrayRef, UInt64Array};
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::error::{DataFusionError, Result};
 use datafusion::common::tree_node::TreeNodeRecursion;
@@ -25,7 +25,9 @@ use datafusion::physical_expr::utils::collect_columns;
 use datafusion::physical_expr::{Distribution, EquivalenceProperties};
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, PlanProperties};
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
-use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+};
 use datafusion::physical_plan::statistics::{ChildStats, StatisticsArgs};
 use datafusion::physical_plan::{
     ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan,
@@ -40,6 +42,7 @@ use delta_kernel::table_features::TableFeature;
 use delta_kernel::{EvaluationHandler, ExpressionRef};
 use futures::stream::{Stream, StreamExt};
 
+use super::deletion_vector::DeletionVectorIndex;
 use super::expr_adapter::DeltaPhysicalExprAdapterFactory;
 use super::plan::KernelScanPlan;
 use crate::delta_datafusion::file_id::file_id_field;
@@ -49,89 +52,6 @@ use crate::kernel::arrow::engine_ext::ExpressionEvaluatorExt;
 const DELTA_MATERIALIZED_PUSHDOWN_SENTINEL: &str =
     "__delta_rs_unpushable_delta_materialized_filter";
 
-/// Deletion-vector inputs for [`DeltaScanExec`].
-#[derive(Clone, Debug)]
-pub(super) enum DvExecutionState {
-    NotPresent,
-    Sequential {
-        /// Keep masks shared by plan clones. Each execution copies and consumes them.
-        selection_vectors: Arc<HashMap<String, Vec<bool>>>,
-        /// Expected object store and path for each file ID in the child plan.
-        physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
-    },
-}
-
-impl DvExecutionState {
-    fn is_sequential(&self) -> bool {
-        matches!(self, Self::Sequential { .. })
-    }
-
-    fn selection_vectors(&self) -> Option<&HashMap<String, Vec<bool>>> {
-        match self {
-            Self::NotPresent => None,
-            Self::Sequential {
-                selection_vectors, ..
-            } => Some(selection_vectors),
-        }
-    }
-
-    fn physical_file_identities(&self) -> Option<&super::PhysicalFileIdentityMap> {
-        match self {
-            Self::NotPresent => None,
-            Self::Sequential {
-                physical_file_identities,
-                ..
-            } => Some(physical_file_identities),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub(crate) struct DvMaskResult {
-    pub selection: Option<Vec<bool>>,
-    pub should_remove: bool,
-}
-
-/// Consume the per-file deletion-vector keep-mask for the current batch.
-///
-/// The keep-mask is stored once per file and consumed incrementally as parquet
-/// batches are produced:
-/// - If the mask is shorter than the batch, missing trailing entries are
-///   treated as `true` (keep row).
-/// - If the mask is longer than the batch, the remainder is preserved for the
-///   next batch from the same file.
-///
-/// This function intentionally does not error when `selection_vector.len()` is
-/// greater than `batch_num_rows`; that is expected when one file spans multiple
-/// input batches.
-pub(crate) fn consume_dv_mask(
-    selection_vector: &mut Vec<bool>,
-    batch_num_rows: usize,
-) -> DvMaskResult {
-    if selection_vector.is_empty() {
-        return DvMaskResult {
-            selection: None,
-            should_remove: true,
-        };
-    }
-
-    if selection_vector.len() >= batch_num_rows {
-        let sv: Vec<bool> = selection_vector.drain(0..batch_num_rows).collect();
-        let is_empty = selection_vector.is_empty();
-        DvMaskResult {
-            selection: Some(sv),
-            should_remove: is_empty,
-        }
-    } else {
-        let mut sv: Vec<bool> = std::mem::take(selection_vector);
-        sv.resize(batch_num_rows, true);
-        DvMaskResult {
-            selection: Some(sv),
-            should_remove: true,
-        }
-    }
-}
-
 /// Physical execution plan for scanning Delta tables.
 ///
 /// Wraps a Parquet reader execution plan and applies Delta Lake protocol transformations
@@ -139,14 +59,14 @@ pub(crate) fn consume_dv_mask(
 ///
 /// - **Column mapping**: Translates physical column names to logical names
 /// - **Partition values**: Materializes partition column values from file paths
-/// - **Deletion vectors**: Filters out deleted rows using per-file selection vectors
+/// - **Deletion vectors**: Filters deleted rows by immutable physical Parquet row position
 /// - **Schema evolution**: Handles missing columns and type coercion
 ///
 /// # Data Flow
 ///
 /// 1. Inner [`input`](Self::input) plan reads raw Parquet data
 /// 2. Per-file [`transforms`](Self::transforms) convert physical to logical schema
-/// 3. The scan applies deletion vectors before it returns rows
+/// 3. [`deletion_vectors`](Self::deletion_vectors) filter deleted rows
 /// 4. Result is cast to the projected scan contract's result schema
 #[derive(Clone, Debug)]
 pub struct DeltaScanExec {
@@ -155,20 +75,29 @@ pub struct DeltaScanExec {
     input: Arc<dyn ExecutionPlan>,
     /// Transforms to be applied to data eminating from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
-    /// The planner records deletion vector masks and physical file ownership here.
-    dv_state: DvExecutionState,
+    /// Immutable deletion vectors keyed by compact scan file id.
+    deletion_vectors: Arc<DeletionVectorIndex>,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
+    /// Expected physical file ownership keyed by compact scan file id.
+    physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
+    /// Authoritative hidden physical input schema and resolved support-column indices.
+    physical_input_contract: Arc<super::PhysicalInputContract>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
-    /// File id column name carried by the input batches for per file correlation.
-    input_file_id_column: String,
     /// User-visible file-id column name when projected in the output.
     file_id_column: Option<String>,
     /// plan properties
     properties: Arc<PlanProperties>,
     /// Aggregated partition column statistics
     partition_stats: HashMap<String, ColumnStatistics>,
+}
+
+pub(super) struct PhysicalScanContext {
+    pub(super) deletion_vectors: Arc<DeletionVectorIndex>,
+    pub(super) public_file_ids: Arc<super::PublicFileIdMap>,
+    pub(super) physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
+    pub(super) physical_input_contract: Arc<super::PhysicalInputContract>,
 }
 
 impl DisplayAs for DeltaScanExec {
@@ -185,6 +114,19 @@ impl DisplayAs for DeltaScanExec {
                 if let Some(row_index_field) = self.scan_plan.contract.retained_row_index_field() {
                     write!(f, ": row_index_column={}", row_index_field.name())?;
                 }
+                write!(
+                    f,
+                    ": dv_mode={}, physical_row_index={}, file_group_layout_locked={}",
+                    if self.has_deletion_vectors() {
+                        "physical_position"
+                    } else {
+                        "none"
+                    },
+                    self.physical_input_contract
+                        .physical_row_position_field
+                        .is_some(),
+                    self.has_deletion_vectors()
+                )?;
                 Ok(())
             }
         }
@@ -192,65 +134,112 @@ impl DisplayAs for DeltaScanExec {
 }
 
 impl DeltaScanExec {
-    pub(super) fn new(
+    fn register_dv_file_metric(
+        metrics: &ExecutionPlanMetricsSet,
+        deletion_vectors: &DeletionVectorIndex,
+    ) {
+        if deletion_vectors.has_vectors() {
+            MetricBuilder::new(metrics)
+                .global_counter("dv_files")
+                .add(deletion_vectors.file_count());
+        }
+    }
+
+    pub(super) fn try_new(
         scan_plan: Arc<KernelScanPlan>,
         input: Arc<dyn ExecutionPlan>,
         transforms: Arc<HashMap<String, ExpressionRef>>,
-        dv_state: DvExecutionState,
-        public_file_ids: Arc<super::PublicFileIdMap>,
+        context: PhysicalScanContext,
         partition_stats: HashMap<String, ColumnStatistics>,
         metrics: ExecutionPlanMetricsSet,
-    ) -> Self {
-        let input_file_id_column = scan_plan.contract.file_id_field.name().to_owned();
+    ) -> Result<Self> {
+        let PhysicalScanContext {
+            deletion_vectors,
+            public_file_ids,
+            physical_file_identities,
+            physical_input_contract,
+        } = context;
+        Self::register_dv_file_metric(&metrics, &deletion_vectors);
         let file_id_column = scan_plan
             .contract
             .retain_file_id
             .then(|| scan_plan.contract.file_id_field.name().to_owned());
         let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(Arc::clone(&scan_plan.contract.output_schema)),
-            input.properties().partitioning.clone(),
+            datafusion::physical_expr::Partitioning::UnknownPartitioning(
+                input.properties().partitioning.partition_count(),
+            ),
             input.properties().emission_type,
             input.properties().boundedness,
         ));
-        Self {
+        let exec = Self {
             scan_plan,
             input,
             transforms,
-            dv_state,
+            deletion_vectors,
             public_file_ids,
+            physical_file_identities,
+            physical_input_contract,
             partition_stats,
             metrics,
-            input_file_id_column,
             file_id_column,
             properties,
+        };
+        if exec.has_deletion_vectors() {
+            exec.validate_dv_child_topology(&exec.input)?;
         }
+        Ok(exec)
+    }
+
+    #[cfg(test)]
+    fn new(
+        scan_plan: Arc<KernelScanPlan>,
+        input: Arc<dyn ExecutionPlan>,
+        transforms: Arc<HashMap<String, ExpressionRef>>,
+        context: PhysicalScanContext,
+        stats: HashMap<String, ColumnStatistics>,
+        metrics: ExecutionPlanMetricsSet,
+    ) -> Self {
+        Self::try_new(scan_plan, input, transforms, context, stats, metrics).unwrap()
     }
 
     fn with_new_input_same_properties(&self, input: Arc<dyn ExecutionPlan>) -> Self {
+        let metrics = ExecutionPlanMetricsSet::new();
+        Self::register_dv_file_metric(&metrics, &self.deletion_vectors);
+        let properties = self.properties.as_ref().clone().with_partitioning(
+            datafusion::physical_expr::Partitioning::UnknownPartitioning(
+                input.properties().partitioning.partition_count(),
+            ),
+        );
         Self {
             input,
-            metrics: ExecutionPlanMetricsSet::new(),
+            metrics,
+            properties: Arc::new(properties),
             ..Self::clone(self)
         }
     }
 
-    fn with_new_input(&self, input: Arc<dyn ExecutionPlan>) -> Self {
-        Self::new(
+    fn with_new_input(&self, input: Arc<dyn ExecutionPlan>) -> Result<Self> {
+        Self::try_new(
             Arc::clone(&self.scan_plan),
             input,
             Arc::clone(&self.transforms),
-            self.dv_state.clone(),
-            Arc::clone(&self.public_file_ids),
+            PhysicalScanContext {
+                deletion_vectors: Arc::clone(&self.deletion_vectors),
+                public_file_ids: Arc::clone(&self.public_file_ids),
+                physical_file_identities: Arc::clone(&self.physical_file_identities),
+                physical_input_contract: Arc::clone(&self.physical_input_contract),
+            },
             self.partition_stats.clone(),
             ExecutionPlanMetricsSet::new(),
         )
     }
 
     fn has_deletion_vectors(&self) -> bool {
-        self.dv_state.is_sequential()
+        self.deletion_vectors.has_vectors()
     }
 
-    fn validate_dv_child_topology(&self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
+    pub(super) fn validate_dv_child_topology(&self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
         fn scalar_file_id(value: &ScalarValue) -> Option<&str> {
             match value {
                 ScalarValue::Dictionary(_, value) => scalar_file_id(value),
@@ -265,6 +254,7 @@ impl DeltaScanExec {
             plan: &Arc<dyn ExecutionPlan>,
             expected: &super::PhysicalFileIdentityMap,
             observed: &mut HashSet<String>,
+            contract: &super::PhysicalInputContract,
         ) -> Result<()> {
             if let Some(fetch) = plan.fetch() {
                 return plan_err!(
@@ -272,25 +262,56 @@ impl DeltaScanExec {
                 );
             }
             if let Some(coalesce) = plan.downcast_ref::<CoalescePartitionsExec>() {
-                return visit(coalesce.input(), expected, observed);
+                return visit(coalesce.input(), expected, observed, contract);
             }
             if let Some(union) = plan.downcast_ref::<UnionExec>() {
                 for input in union.inputs() {
-                    visit(input, expected, observed)?;
+                    visit(input, expected, observed, contract)?;
                 }
                 return Ok(());
             }
             let Some(source_exec) = plan.downcast_ref::<DataSourceExec>() else {
                 return plan_err!(
-                    "DeltaScanExec rejects node {} during sequential deletion vector scans",
+                    "DeltaScanExec deletion-vector topology contains unsupported node {}",
                     plan.name()
                 );
             };
             let Some(config) = source_exec.data_source().downcast_ref::<FileScanConfig>() else {
                 return plan_err!(
-                    "DeltaScanExec requires FileScanConfig leaves during sequential deletion vector scans"
+                    "DeltaScanExec deletion-vector topology requires FileScanConfig leaves"
                 );
             };
+            let source = config
+                .file_source
+                .downcast_ref::<datafusion::datasource::physical_plan::ParquetSource>()
+                .ok_or_else(|| internal_datafusion_err!("expected native Parquet source"))?;
+            let expected_source = contract
+                .sources
+                .iter()
+                .find(|planned| planned.object_store_url == config.object_store_url)
+                .ok_or_else(|| internal_datafusion_err!("unplanned store binding"))?;
+            let original = expected_source
+                .file_source
+                .downcast_ref::<datafusion::datasource::physical_plan::ParquetSource>()
+                .ok_or_else(|| internal_datafusion_err!("lost planned Parquet source"))?;
+            let same_reader = source
+                .parquet_file_reader_factory()
+                .zip(original.parquet_file_reader_factory())
+                .is_some_and(|(a, b)| Arc::ptr_eq(a, b));
+            let same_adapter = config
+                .expr_adapter_factory
+                .as_ref()
+                .zip(expected_source.expr_adapter_factory.as_ref())
+                .is_some_and(|(a, b)| Arc::ptr_eq(a, b));
+            if !Arc::ptr_eq(&config.file_source, &expected_source.file_source)
+                || !same_reader
+                || !same_adapter
+                || plan.schema() != *contract.table_schema.table_schema()
+            {
+                return plan_err!(
+                    "physical input reader, adapter, or support-field lineage changed"
+                );
+            }
             if !matches!(
                 config.output_partitioning,
                 Some(datafusion::physical_expr::Partitioning::UnknownPartitioning(partitions))
@@ -308,32 +329,45 @@ impl DeltaScanExec {
 
             for group in &config.file_groups {
                 for file in group.iter() {
+                    if !file.extensions.is_empty() {
+                        return plan_err!("unplanned reader-affecting file extensions");
+                    }
                     let Some(file_id) = file.partition_values.first().and_then(scalar_file_id)
                     else {
                         return plan_err!(
-                            "A sequential deletion vector file lacks a compact file id"
+                            "DeltaScanExec deletion-vector file is missing a compact file id"
                         );
                     };
+                    let planned_file = contract
+                        .planned_files
+                        .get(file_id)
+                        .ok_or_else(|| internal_datafusion_err!("unplanned partition constants"))?;
+                    if planned_file.partition_values != file.partition_values {
+                        return plan_err!("unplanned partition constants");
+                    }
+                    if planned_file.object_meta != file.object_meta {
+                        return plan_err!("immutable planned file metadata changed");
+                    }
                     if file.range.is_some() {
                         return plan_err!(
-                            "Sequential deletion vector file id '{file_id}' uses a byte range"
+                            "DeltaScanExec deletion-vector file id '{file_id}' has a byte range"
                         );
                     }
                     let Some(expected_file) = expected.get(file_id) else {
                         return plan_err!(
-                            "Sequential deletion vector scan received unknown file id '{file_id}'"
+                            "DeltaScanExec deletion-vector topology contains unknown file id '{file_id}'"
                         );
                     };
                     if expected_file.object_store_url != config.object_store_url
                         || expected_file.location != file.object_meta.location
                     {
                         return plan_err!(
-                            "Sequential deletion vector file id '{file_id}' has an unexpected store or location"
+                            "DeltaScanExec deletion-vector topology has an inconsistent mapping for file id '{file_id}'"
                         );
                     }
                     if !observed.insert(file_id.to_owned()) {
                         return plan_err!(
-                            "Sequential deletion vector file id '{file_id}' belongs to multiple child files"
+                            "DeltaScanExec deletion-vector topology has duplicate ownership for file id '{file_id}'"
                         );
                     }
                 }
@@ -341,15 +375,15 @@ impl DeltaScanExec {
             Ok(())
         }
 
-        let expected = self.dv_state.physical_file_identities().ok_or_else(|| {
-            internal_datafusion_err!(
-                "DeltaScanExec deletion vector topology validation requires sequential state"
-            )
-        })?;
         let mut observed = HashSet::new();
-        visit(input, expected, &mut observed)?;
-        if observed.len() != expected.len() {
-            return plan_err!("DeltaScanExec sequential deletion vector scan lacks selected files");
+        visit(
+            input,
+            &self.physical_file_identities,
+            &mut observed,
+            &self.physical_input_contract,
+        )?;
+        if observed.len() != self.physical_file_identities.len() {
+            return plan_err!("DeltaScanExec deletion-vector topology is missing selected files");
         }
         Ok(())
     }
@@ -411,8 +445,8 @@ impl DeltaScanExec {
 
         stats.column_statistics = new_stats;
         if self.has_deletion_vectors() {
-            // Child statistics describe physical Parquet rows. This node reports conservative
-            // bounds unless the DV index contains numRecords.
+            // Child statistics describe physical Parquet rows. Keep them conservative;
+            // metadata-only execution derives exact visible counts separately.
             stats = stats.to_inexact();
         }
         Ok(stats)
@@ -469,8 +503,8 @@ impl ExecutionPlan for DeltaScanExec {
         if self.scan_plan.contract.retained_row_index_field().is_some()
             || self.has_deletion_vectors()
         {
-            // DeltaScanExec requires one stream to preserve physical row order for retained row
-            // indexes and sequential DV masks.
+            // Retained row indexes require ordered, stream-local state. Physical-position DVs
+            // retain the PR 0 single-partition containment until the PR 2 optimizer unlock.
             InputDistributionRequirements::new(vec![Distribution::SinglePartition])
         } else {
             InputDistributionRequirements::new(vec![Distribution::UnspecifiedDistribution])
@@ -498,7 +532,7 @@ impl ExecutionPlan for DeltaScanExec {
             ChildrenPropertiesMode::Keep => {
                 Ok(Arc::new(self.with_new_input_same_properties(input)))
             }
-            ChildrenPropertiesMode::Recompute => Ok(Arc::new(self.with_new_input(input))),
+            ChildrenPropertiesMode::Recompute => Ok(Arc::new(self.with_new_input(input)?)),
         }
     }
 
@@ -520,13 +554,13 @@ impl ExecutionPlan for DeltaScanExec {
         if self.scan_plan.contract.retained_row_index_field().is_some()
             || self.has_deletion_vectors()
         {
-            // A DeltaScanStream stores row ordinals and DV cursors for one execution partition.
-            // DataFusion can split a file across streams after repartitioning.
+            // Row ordinals retain stream-local counters. Physical-position DVs retain the PR 0
+            // repartition barrier until the PR 2 optimizer unlock is qualified.
             return Ok(None);
         }
 
         if let Some(input) = self.input.repartitioned(target_partitions, config)? {
-            Ok(Some(Arc::new(self.with_new_input(input))))
+            Ok(Some(Arc::new(self.with_new_input(input)?)))
         } else {
             Ok(None)
         }
@@ -541,6 +575,9 @@ impl ExecutionPlan for DeltaScanExec {
         // callers that build DeltaScanExec directly or replace its child plan.
         let retains_row_index = self.scan_plan.contract.retained_row_index_field().is_some();
         let has_deletion_vectors = self.has_deletion_vectors();
+        if has_deletion_vectors {
+            self.validate_dv_child_topology(&self.input)?;
+        }
         if retains_row_index || has_deletion_vectors {
             let input_partition_count = self.input.properties().partitioning.partition_count();
             if input_partition_count > 1 {
@@ -550,10 +587,15 @@ impl ExecutionPlan for DeltaScanExec {
                     );
                 }
                 return plan_err!(
-                    "DeltaScanExec sequential deletion vectors require a single input partition, got {input_partition_count}"
+                    "DeltaScanExec contained deletion-vector scans require a single input partition, got {input_partition_count}"
                 );
             }
         }
+
+        let dv_rows_checked =
+            MetricBuilder::new(&self.metrics).counter("dv_rows_checked", partition);
+        let dv_rows_removed =
+            MetricBuilder::new(&self.metrics).counter("dv_rows_removed", partition);
 
         Ok(Box::pin(DeltaScanStream {
             scan_plan: Arc::clone(&self.scan_plan),
@@ -561,15 +603,11 @@ impl ExecutionPlan for DeltaScanExec {
             input: self.input.execute(partition, context)?,
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
             transforms: Arc::clone(&self.transforms),
-            // Each stream consumes its masks as it reads batches. Deep-copy the masks
-            // once per execution to isolate repeated or concurrent scans.
-            selection_vectors: self
-                .dv_state
-                .selection_vectors()
-                .cloned()
-                .unwrap_or_default(),
+            deletion_vectors: Arc::clone(&self.deletion_vectors),
+            physical_input_contract: Arc::clone(&self.physical_input_contract),
+            dv_rows_checked,
+            dv_rows_removed,
             public_file_ids: Arc::clone(&self.public_file_ids),
-            input_file_id_column: self.input_file_id_column.clone(),
             file_id_column: self.file_id_column.clone(),
             row_index_field: self.scan_plan.contract.retained_row_index_field(),
             row_index_by_file: HashMap::new(),
@@ -723,12 +761,14 @@ struct DeltaScanStream {
     baseline_metrics: BaselineMetrics,
     /// Transforms to be applied to data read from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
-    /// Selection vectors to be applied to data read from individual files
-    selection_vectors: HashMap<String, Vec<bool>>,
+    /// Immutable deletion-vector lookup by physical row position.
+    deletion_vectors: Arc<DeletionVectorIndex>,
+    physical_input_contract: Arc<super::PhysicalInputContract>,
+    dv_rows_checked: Count,
+    dv_rows_removed: Count,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
     /// File id column name carried by the input batches for per file correlation.
-    input_file_id_column: String,
     /// User-visible file-id column name when projected in the output.
     file_id_column: Option<String>,
     /// Row index field included in projected output.
@@ -750,11 +790,16 @@ impl DeltaScanStream {
         let elapsed = self.baseline_metrics.elapsed_compute().clone();
         let _timer = elapsed.timer();
 
+        let file_id_idx = self.physical_input_contract.file_id_index;
+        if batch.schema() != *self.physical_input_contract.table_schema.table_schema() {
+            return internal_err!(
+                "physical input schema does not preserve compact file-id field '{}' and its support fields",
+                self.physical_input_contract.file_id_field.name()
+            );
+        }
         if batch.num_rows() == 0 {
             return Ok(vec![RecordBatch::new_empty(self.schema())]);
         }
-
-        let file_id_idx = file_id_column_idx(&batch, &self.input_file_id_column)?;
         let file_runs = split_by_file_id_runs(&batch, file_id_idx)?;
 
         let mut results = Vec::with_capacity(file_runs.len());
@@ -770,25 +815,73 @@ impl DeltaScanStream {
         file_id: String,
         file_id_idx: usize,
     ) -> Result<RecordBatch> {
-        let dv_result = if let Some(selection_vector) = self.selection_vectors.get_mut(&file_id) {
-            consume_dv_mask(selection_vector, batch.num_rows())
-        } else {
-            DvMaskResult {
-                selection: None,
-                should_remove: false,
+        let input_row_count = batch.num_rows();
+        let has_deletion_vector = self.deletion_vectors.has_vector(&file_id);
+        let mut batch = if self
+            .physical_input_contract
+            .physical_row_position_index
+            .is_some()
+        {
+            let position_idx = self
+                .physical_input_contract
+                .physical_row_position_index
+                .ok_or_else(|| {
+                    internal_datafusion_err!(
+                        "physical-position DV mode is missing its row-position field"
+                    )
+                })?;
+            let positions = batch
+                .column(position_idx)
+                .as_any()
+                .downcast_ref::<arrow_array::Int64Array>()
+                .ok_or_else(|| {
+                    internal_datafusion_err!(
+                        "physical row-position column is not a nullable Int64 array"
+                    )
+                })?;
+            if !has_deletion_vector {
+                let count = self
+                    .physical_input_contract
+                    .footer_bounds
+                    .get(&file_id)
+                    .and_then(|bound| bound.get())
+                    .ok_or_else(|| {
+                        internal_datafusion_err!("missing reader-verified physical bounds")
+                    })?;
+                for position in positions.iter() {
+                    if !position.is_some_and(|position| position >= 0 && (position as u64) < *count)
+                    {
+                        return internal_err!(
+                            "physical position outside reader-verified file population"
+                        );
+                    }
+                }
             }
-        };
-
-        if dv_result.should_remove {
-            self.selection_vectors.remove(&file_id);
-        }
-
-        let mut batch = if let Some(selection) = dv_result.selection {
-            filter_record_batch(&batch, &BooleanArray::from(selection))?
+            let selection = self
+                .deletion_vectors
+                .selection_for_positions(&file_id, positions)?;
+            match selection.true_count() {
+                count if count == batch.num_rows() => batch,
+                0 => batch.slice(0, 0),
+                _ => filter_record_batch(&batch, &selection)?,
+            }
         } else {
             batch
         };
-        batch.remove_column(file_id_idx);
+        if has_deletion_vector {
+            self.dv_rows_checked.add(input_row_count);
+            self.dv_rows_removed
+                .add(input_row_count.saturating_sub(batch.num_rows()));
+        }
+
+        let mut hidden_indices = vec![file_id_idx];
+        if let Some(position_idx) = self.physical_input_contract.physical_row_position_index {
+            hidden_indices.push(position_idx);
+        }
+        hidden_indices.sort_unstable_by(|left, right| right.cmp(left));
+        for index in hidden_indices {
+            batch.remove_column(index);
+        }
 
         let result = if let Some(transform) = self.transforms.get(&file_id) {
             let evaluator = ARROW_HANDLER
@@ -915,6 +1008,7 @@ impl RecordBatchStream for DeltaScanStream {
 }
 
 #[inline]
+#[cfg(test)]
 fn file_id_column_idx(batch: &RecordBatch, file_id_column: &str) -> Result<usize> {
     batch
         .schema_ref()
@@ -1427,6 +1521,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_gather_filters_for_pushdown_rejects_dv_data_filters() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        assert!(
+            exec.deletion_vectors.has_vectors(),
+            "fixture must select at least one deletion vector"
+        );
+        let int_idx = exec.schema().index_of("int")?;
+        let int: Arc<dyn PhysicalExpr> = Arc::new(Column::new("int", int_idx));
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![int],
+            physical_lit(true),
+        ));
+
+        let description = exec.gather_filters_for_pushdown(
+            FilterPushdownPhase::Post,
+            vec![filter],
+            session.state().config().options(),
+        )?;
+
+        let child_filters = description.parent_filters();
+        assert_eq!(child_filters.len(), 1);
+        assert_eq!(child_filters[0].len(), 1);
+        assert!(matches!(child_filters[0][0].discriminant, PushedDown::No));
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_gather_filters_for_pushdown_skips_column_mapping_parent_filters() -> TestResult {
         let mut table = open_fs_path("../test/tests/data/table_with_column_mapping");
         table.load().await?;
@@ -1866,6 +1995,7 @@ mod tests {
             .downcast_ref::<DeltaScanExec>()
             .expect("planner must return DeltaScanExec");
 
+        assert!(exec.deletion_vectors.has_vectors());
         assert!(!exec.supports_limit_pushdown());
         assert!(matches!(
             exec.cardinality_effect(),
@@ -1969,6 +2099,508 @@ mod tests {
         Ok(())
     }
 
+    fn fixture_rows(batches: &[RecordBatch]) -> Vec<(i64, i64)> {
+        let mut rows = batches
+            .iter()
+            .flat_map(|batch| {
+                let ids = batch
+                    .column(batch.schema().index_of("id").unwrap())
+                    .as_any()
+                    .downcast_ref::<arrow_array::Int64Array>()
+                    .unwrap();
+                let values = batch
+                    .column(batch.schema().index_of("value").unwrap())
+                    .as_any()
+                    .downcast_ref::<arrow_array::Int64Array>()
+                    .unwrap();
+                ids.values()
+                    .iter()
+                    .copied()
+                    .zip(values.values().iter().copied())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        rows.sort_unstable();
+        rows
+    }
+
+    #[tokio::test]
+    async fn test_optimized_plan_reset_preserves_shared_visibility() -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture};
+        use datafusion::physical_plan::execution_plan::reset_plan_states;
+        let fixture = Fixture::new(
+            vec![FileSpec {
+                rows: 161,
+                groups: vec![37, 53, 71],
+                deleted: Some([0, 1, 37, 90].into_iter().collect()),
+                log_stats: true,
+            }],
+            8,
+        )?;
+        let table = crate::open_table(fixture.url()).await?;
+        let context = datafusion::prelude::SessionContext::new();
+        context.register_table("t", table.table_provider().await?)?;
+        let plan = context
+            .sql("select * from t where id > 0")
+            .await?
+            .create_physical_plan()
+            .await?;
+        fn visibility(plan: &Arc<dyn ExecutionPlan>) -> Arc<DeletionVectorIndex> {
+            if let Some(scan) = plan.downcast_ref::<DeltaScanExec>() {
+                return scan.deletion_vectors.clone();
+            }
+            for child in plan.children() {
+                if child.name().contains("DeltaScan") || !child.children().is_empty() {
+                    return visibility(child);
+                }
+            }
+            panic!("missing Delta scan");
+        }
+        let index = visibility(&plan);
+        let expected = fixture
+            .live_coordinates()
+            .into_iter()
+            .map(|r| (r.2, r.3))
+            .collect::<Vec<_>>();
+        for _ in 0..3 {
+            let reset = reset_plan_states(plan.clone())?;
+            assert!(Arc::ptr_eq(&index, &visibility(&reset)));
+            assert_eq!(
+                fixture_rows(&collect(reset, context.task_ctx()).await?),
+                expected
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_reader_coordinate_matrix_against_generator_oracle() -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture};
+        let fixture = Fixture::new(
+            vec![FileSpec {
+                rows: 161,
+                groups: vec![37, 53, 71],
+                deleted: Some([0, 36, 37, 42, 89, 90, 144, 160].into_iter().collect()),
+                log_stats: true,
+            }],
+            8,
+        )?;
+        let table = crate::open_table(fixture.url()).await?;
+        let provider = table.table_provider().await?;
+        let session = create_session().into_inner();
+        let base_plan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = base_plan.downcast_ref::<DeltaScanExec>().unwrap();
+        let source_exec = exec.input.downcast_ref::<DataSourceExec>().unwrap();
+        let original = source_exec
+            .data_source()
+            .downcast_ref::<FileScanConfig>()
+            .unwrap();
+        let source = original
+            .file_source
+            .downcast_ref::<ParquetSource>()
+            .unwrap();
+        let expected = fixture
+            .live_coordinates()
+            .into_iter()
+            .filter(|row| row.2 >= 40 && row.2 < 145)
+            .collect::<Vec<_>>();
+        let footer =
+            parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new_with_options(
+                std::fs::File::open(fixture.directory.path().join("part-0.parquet"))?,
+                parquet::arrow::arrow_reader::ArrowReaderOptions::new()
+                    .with_page_index_policy(parquet::file::metadata::PageIndexPolicy::Required),
+            )?;
+        assert_eq!(
+            footer
+                .metadata()
+                .row_groups()
+                .iter()
+                .map(|g| g.num_rows())
+                .collect::<Vec<_>>(),
+            [37, 53, 71]
+        );
+        assert!(
+            footer
+                .metadata()
+                .offset_index()
+                .unwrap()
+                .iter()
+                .all(|group| group.iter().all(|column| column.page_locations().len() > 1))
+        );
+        let mut cases = 0;
+        let mut observed_ranges = false;
+        let mut observed_group_pruning = false;
+        let mut observed_page_pruning = false;
+        for pages in [false, true] {
+            for row_filter in [false, true] {
+                for batch_size in [1, 7, 8192] {
+                    for partitions in [1, 2, 4, 8] {
+                        for repartition in [false, true] {
+                            let mut options = SessionConfig::new()
+                                .with_batch_size(batch_size)
+                                .with_target_partitions(partitions);
+                            options.options_mut().optimizer.repartition_file_scans = repartition;
+                            options.options_mut().optimizer.repartition_file_min_size = 0;
+                            options.options_mut().execution.parquet.enable_page_index = pages;
+                            options.options_mut().execution.parquet.pushdown_filters = row_filter;
+                            let context = datafusion::prelude::SessionContext::new_with_config_rt(
+                                options,
+                                session.runtime_env(),
+                            );
+                            let predicate = context.state().create_physical_expr(
+                                col("id").gt_eq(lit(40_i64)).and(col("id").lt(lit(145_i64))),
+                                &exec.input.schema().to_dfschema()?,
+                            )?;
+                            let native = source
+                                .with_predicate(predicate)
+                                .with_pushdown_filters(row_filter)
+                                .with_enable_page_index(pages);
+                            let config = FileScanConfigBuilder::from(original.clone())
+                                .with_source(Arc::new(native))
+                                .with_output_partitioning(None)
+                                .build();
+                            let input: Arc<dyn ExecutionPlan> =
+                                DataSourceExec::from_data_source(config);
+                            let optimized = DefaultPhysicalPlanner::default()
+                                .optimize_physical_plan(input, &context.state(), |_, _| {})?;
+                            if let Some(source) = optimized.downcast_ref::<DataSourceExec>() {
+                                let config = source
+                                    .data_source()
+                                    .downcast_ref::<FileScanConfig>()
+                                    .unwrap();
+                                observed_ranges |= config
+                                    .file_groups
+                                    .iter()
+                                    .flat_map(|g| g.iter())
+                                    .any(|file| file.range.is_some());
+                            }
+                            let batches = collect(optimized.clone(), context.task_ctx()).await?;
+                            if let Some(metrics) = optimized.metrics() {
+                                for metric in metrics.iter() {
+                                    let name = metric.value().name();
+                                    if let datafusion::physical_plan::metrics::MetricValue::PruningMetrics { pruning_metrics, .. } = metric.value() {
+                                        observed_group_pruning |= name == "row_groups_pruned_statistics" && pruning_metrics.pruned() > 0;
+                                        observed_page_pruning |= name == "page_index_rows_pruned" && pruning_metrics.pruned() > 0;
+                                    }
+                                }
+                            }
+                            let mut visible = Vec::new();
+                            for batch in batches {
+                                let positions = batch
+                                    .column(
+                                        exec.physical_input_contract
+                                            .physical_row_position_index
+                                            .unwrap(),
+                                    )
+                                    .as_any()
+                                    .downcast_ref::<arrow_array::Int64Array>()
+                                    .unwrap();
+                                let ids = batch
+                                    .column(batch.schema().index_of("id")?)
+                                    .as_any()
+                                    .downcast_ref::<arrow_array::Int64Array>()
+                                    .unwrap();
+                                let keep = exec
+                                    .deletion_vectors
+                                    .selection_for_positions("0", positions)?;
+                                for ((id, position), keep) in ids
+                                    .values()
+                                    .iter()
+                                    .zip(positions.values())
+                                    .zip(keep.values())
+                                {
+                                    assert_eq!(
+                                        id, position,
+                                        "reader coordinate differs from generated coordinate: pages={pages}, row_filter={row_filter}, batch={batch_size}, partitions={partitions}, repartition={repartition}"
+                                    );
+                                    if keep && *id >= 40 && *id < 145 {
+                                        visible.push((0, *position as u64, *id, -*id));
+                                    }
+                                }
+                            }
+                            visible.sort_unstable();
+                            assert_eq!(
+                                visible, expected,
+                                "pages={pages}, row_filter={row_filter}, batch={batch_size}, partitions={partitions}, repartition={repartition}"
+                            );
+                            cases += 1;
+                        }
+                    }
+                }
+            }
+        }
+        assert_eq!(cases, 96);
+        assert!(
+            observed_group_pruning,
+            "fixture must execute row-group pruning"
+        );
+        assert!(
+            observed_page_pruning,
+            "fixture must execute page-index pruning"
+        );
+        assert!(
+            observed_ranges,
+            "private coordinate qualification must execute native ranged reads"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_visibility_is_frozen_across_concurrent_plans_and_advancement()
+    -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture};
+        let mut fixture = Fixture::new(
+            vec![FileSpec {
+                rows: 161,
+                groups: vec![37, 53, 71],
+                deleted: Some([1].into_iter().collect()),
+                log_stats: true,
+            }],
+            8,
+        )?;
+        let session = create_session().into_inner();
+        let first_table = crate::open_table(fixture.url()).await?;
+        let first_provider = first_table.table_provider().await?;
+        let first_plan = first_provider
+            .scan(&session.state(), None, &[], None)
+            .await?;
+        use datafusion_proto::logical_plan::LogicalExtensionCodec;
+        let codec = crate::delta_datafusion::DeltaLogicalCodec {};
+        let table_ref = datafusion::common::TableReference::bare("snapshot");
+        let mut encoded = Vec::new();
+        codec.try_encode_table_provider(&table_ref, first_provider.clone(), &mut encoded)?;
+        let decoded = codec.try_decode_table_provider(
+            &encoded,
+            &table_ref,
+            first_provider.schema(),
+            &session.task_ctx(),
+        )?;
+        let expected_first = fixture
+            .live_coordinates()
+            .into_iter()
+            .map(|(_, _, id, value)| (id, value))
+            .collect::<Vec<_>>();
+        fixture.replace_visibility(0, [2].into_iter().collect())?;
+        let second_table = crate::open_table(fixture.url()).await?;
+        let second_provider = second_table.table_provider().await?;
+        let second_plan = second_provider
+            .scan(&session.state(), None, &[], None)
+            .await?;
+        let expected_second = fixture
+            .live_coordinates()
+            .into_iter()
+            .map(|(_, _, id, value)| (id, value))
+            .collect::<Vec<_>>();
+        let (a, b) = tokio::join!(
+            collect(first_plan.clone(), session.task_ctx()),
+            collect(second_plan, session.task_ctx())
+        );
+        assert_eq!(fixture_rows(&a?), expected_first);
+        assert_eq!(fixture_rows(&b?), expected_second);
+        fixture.replace_visibility(0, [3, 4].into_iter().collect())?;
+        let mut advanced = first_table;
+        advanced.update_state().await?;
+        assert_eq!(
+            fixture_rows(&collect(first_plan.clone(), session.task_ctx()).await?),
+            expected_first
+        );
+        let decoded_plan = decoded.scan(&session.state(), None, &[], None).await?;
+        assert_eq!(
+            fixture_rows(&collect(decoded_plan, session.task_ctx()).await?),
+            expected_first
+        );
+        // Cancellation must not consume visibility shared by subsequent streams.
+        drop(first_plan.execute(0, session.task_ctx())?);
+        assert_eq!(
+            fixture_rows(&collect(first_plan, session.task_ctx()).await?),
+            expected_first
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_generated_mixed_scan_checks_coordinates_and_logical_rows_independently()
+    -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture};
+        let fixture = Fixture::new(
+            vec![
+                FileSpec {
+                    rows: 161,
+                    groups: vec![37, 53, 71],
+                    deleted: Some([0, 36, 37, 89, 90, 160].into_iter().collect()),
+                    log_stats: true,
+                },
+                FileSpec {
+                    rows: 107,
+                    groups: vec![41, 66],
+                    deleted: None,
+                    log_stats: false,
+                },
+            ],
+            8,
+        )?;
+        let table = crate::open_table(fixture.url()).await?;
+        let provider = table.table_provider().await?;
+        let session = create_session().into_inner();
+        let plan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = plan.downcast_ref::<DeltaScanExec>().unwrap();
+        let physical = collect(exec.input.clone(), session.task_ctx()).await?;
+        let expected_by_id = fixture
+            .coordinates
+            .iter()
+            .map(|row| (row.2, *row))
+            .collect::<HashMap<_, _>>();
+        let mut actual_visible = Vec::new();
+        for batch in physical {
+            let positions = batch
+                .column(
+                    exec.physical_input_contract
+                        .physical_row_position_index
+                        .unwrap(),
+                )
+                .as_any()
+                .downcast_ref::<arrow_array::Int64Array>()
+                .unwrap();
+            let ids = batch
+                .column(batch.schema().index_of("id")?)
+                .as_any()
+                .downcast_ref::<arrow_array::Int64Array>()
+                .unwrap();
+            for (id, position) in ids.values().iter().zip(positions.values()) {
+                assert_eq!(*position as u64, expected_by_id[id].1);
+            }
+            for (file_id, run) in
+                split_by_file_id_runs(&batch, exec.physical_input_contract.file_id_index)?
+            {
+                let positions = run
+                    .column(
+                        exec.physical_input_contract
+                            .physical_row_position_index
+                            .unwrap(),
+                    )
+                    .as_any()
+                    .downcast_ref::<arrow_array::Int64Array>()
+                    .unwrap();
+                let selection = exec
+                    .deletion_vectors
+                    .selection_for_positions(&file_id, positions)?;
+                let ids = run
+                    .column(run.schema().index_of("id")?)
+                    .as_any()
+                    .downcast_ref::<arrow_array::Int64Array>()
+                    .unwrap();
+                for (id, keep) in ids.values().iter().zip(selection.values()) {
+                    if keep {
+                        actual_visible.push(expected_by_id[id]);
+                    }
+                }
+            }
+        }
+        actual_visible.sort_unstable();
+        assert_eq!(actual_visible, fixture.live_coordinates());
+        let expected = fixture
+            .live_coordinates()
+            .iter()
+            .map(|row| (row.2, row.3))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            fixture_rows(&collect(plan.clone(), session.task_ctx()).await?),
+            expected
+        );
+        assert_eq!(
+            fixture_rows(&collect(plan, session.task_ctx()).await?),
+            expected
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[expect(deprecated, reason = "qualify both supported child replacement APIs")]
+    async fn test_dv_provenance_rejects_extensions_and_fabricated_positions() -> TestResult {
+        use datafusion::datasource::physical_plan::parquet::ParquetAccessPlan;
+        use datafusion::physical_plan::projection::ProjectionExec;
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan.downcast_ref::<DeltaScanExec>().unwrap();
+        let source = exec.input.downcast_ref::<DataSourceExec>().unwrap();
+        let config = source
+            .data_source()
+            .downcast_ref::<FileScanConfig>()
+            .unwrap();
+        let mut files = config.file_groups[0].iter().cloned().collect::<Vec<_>>();
+        files[0].extensions.insert(ParquetAccessPlan::new_all(1));
+        let injected = DataSourceExec::from_data_source(
+            FileScanConfigBuilder::from(config.clone())
+                .with_file_groups(vec![FileGroup::new(files)])
+                .build(),
+        );
+        assert!(
+            Arc::new(exec.clone())
+                .with_new_children(vec![injected.clone()])
+                .is_err()
+        );
+        assert!(
+            Arc::new(exec.clone())
+                .replace_children(
+                    vec![injected],
+                    ReplaceChildrenOptions::new(ChildrenPropertiesMode::Keep)
+                )
+                .is_err()
+        );
+        let position = exec
+            .physical_input_contract
+            .physical_row_position_index
+            .unwrap();
+        for computed in [false, true] {
+            let expressions = exec
+                .input
+                .schema()
+                .fields()
+                .iter()
+                .enumerate()
+                .map(|(index, field)| {
+                    let column: Arc<dyn PhysicalExpr> = Arc::new(Column::new(field.name(), index));
+                    let expression = if index == position {
+                        if computed {
+                            Arc::new(BinaryExpr::new(column, Operator::Plus, physical_lit(0_i64)))
+                                as Arc<dyn PhysicalExpr>
+                        } else {
+                            physical_lit(ScalarValue::Int64(None))
+                        }
+                    } else {
+                        column
+                    };
+                    (expression, field.name().clone())
+                })
+                .collect::<Vec<_>>();
+            let fabricated: Arc<dyn ExecutionPlan> =
+                Arc::new(ProjectionExec::try_new(expressions, exec.input.clone())?);
+            for (actual, expected) in fabricated
+                .schema()
+                .fields()
+                .iter()
+                .zip(exec.input.schema().fields())
+            {
+                assert_eq!(
+                    (actual.name(), actual.data_type(), actual.is_nullable()),
+                    (
+                        expected.name(),
+                        expected.data_type(),
+                        expected.is_nullable()
+                    )
+                );
+            }
+            assert!(
+                Arc::new(exec.clone())
+                    .with_new_children(vec![fabricated])
+                    .is_err()
+            );
+        }
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_dv_scan_downgrades_all_exact_physical_statistics() -> TestResult {
         let table = open_fs_path(DV_TABLE_PATH);
@@ -2023,26 +2655,10 @@ mod tests {
             .downcast_ref::<FileScanConfig>()
             .expect("DataSourceExec must hold a parquet FileScanConfig");
         let original_file = source_config.file_groups[0][0].clone();
-        let original_file_id = exec
-            .dv_state
-            .selection_vectors()
-            .and_then(|vectors| vectors.keys().next().cloned())
-            .expect("fixture must have one deletion vector mask");
+        let original_file_id = exec.deletion_vectors.entries.keys().next().unwrap().clone();
 
         let duplicate_file_id = "duplicate".to_string();
-        let source_url = url::Url::parse(&format!(
-            "{}{}",
-            source_config.object_store_url.as_str(),
-            original_file.object_meta.location.as_ref()
-        ))?;
-        let source_path = source_url.to_file_path().map_err(|_| {
-            std::io::Error::other(format!("fixture requires a file URL: {source_url}"))
-        })?;
-        let temp_dir = tempfile::tempdir()?;
-        let duplicate_path = temp_dir.path().join("duplicate.parquet");
-        std::fs::copy(&source_path, &duplicate_path)?;
-        let duplicate_location = object_store::path::Path::from_filesystem_path(&duplicate_path)?;
-
+        let duplicate_location = original_file.object_meta.location.clone();
         let mut duplicate_file = original_file.clone();
         duplicate_file.object_meta.location = duplicate_location.clone();
         duplicate_file.partition_values =
@@ -2056,19 +2672,19 @@ mod tests {
             ])
             .with_output_partitioning(Some(Partitioning::UnknownPartitioning(2)))
             .build();
-        let grouped_input = DataSourceExec::from_data_source(grouped_config);
+        let grouped_input: Arc<dyn ExecutionPlan> =
+            DataSourceExec::from_data_source(grouped_config);
+        let mut grouped_contract = exec.physical_input_contract.as_ref().clone();
+        grouped_contract.sources.clear();
+        grouped_contract.planned_files.clear();
+        grouped_contract.bind_sources(&grouped_input)?;
 
-        let mut selection_vectors = exec.dv_state.selection_vectors().unwrap().clone();
-        let duplicate_mask = selection_vectors
-            .get(&original_file_id)
-            .expect("fixture must provide the original mask")
-            .clone();
-        selection_vectors.insert(duplicate_file_id.clone(), duplicate_mask);
-        let mut identities = exec
-            .dv_state
-            .physical_file_identities()
-            .expect("fixture must provide sequential DV identities")
-            .clone();
+        let mut entries = exec.deletion_vectors.entries.clone();
+        entries.insert(
+            duplicate_file_id.clone(),
+            entries[&original_file_id].clone(),
+        );
+        let mut identities = exec.physical_file_identities.as_ref().clone();
         identities.insert(
             duplicate_file_id.clone(),
             super::super::PhysicalFileIdentity {
@@ -2076,17 +2692,16 @@ mod tests {
                 location: duplicate_location,
             },
         );
-        let dv_state = DvExecutionState::Sequential {
-            selection_vectors: Arc::new(selection_vectors),
-            physical_file_identities: Arc::new(identities),
-        };
-
         let grouped_scan: Arc<dyn ExecutionPlan> = Arc::new(DeltaScanExec::new(
             Arc::clone(&exec.scan_plan),
             grouped_input,
             Arc::clone(&exec.transforms),
-            dv_state,
-            Arc::clone(&exec.public_file_ids),
+            PhysicalScanContext {
+                deletion_vectors: Arc::new(DeletionVectorIndex::try_new(entries)?),
+                public_file_ids: Arc::clone(&exec.public_file_ids),
+                physical_file_identities: Arc::new(identities),
+                physical_input_contract: Arc::new(grouped_contract),
+            },
             exec.partition_stats.clone(),
             ExecutionPlanMetricsSet::new(),
         ));
@@ -2121,6 +2736,49 @@ mod tests {
         ];
         assert_batches_sorted_eq!(&expected, &first?);
         assert_batches_sorted_eq!(&expected, &second?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_uses_hidden_physical_row_positions() -> TestResult {
+        let table = open_fs_path(DV_TABLE_PATH);
+        let provider = table.table_provider().await?;
+        let session = Arc::new(create_session().into_inner());
+        let scan = provider.scan(&session.state(), None, &[], None).await?;
+        let exec = scan
+            .downcast_ref::<DeltaScanExec>()
+            .expect("expected DeltaScanExec");
+
+        let explain = datafusion::physical_plan::displayable(scan.as_ref())
+            .indent(false)
+            .to_string();
+        assert!(explain.contains("dv_mode=physical_position"), "{explain}");
+        assert!(explain.contains("physical_row_index=true"), "{explain}");
+        let input_schema = exec.input.schema();
+        let hidden_position = input_schema
+            .fields()
+            .iter()
+            .find(|field| field.name().starts_with("__delta_rs_physical_row_position"))
+            .expect("physical child must materialize a hidden row position");
+        let hidden_position_name = hidden_position.name().clone();
+        assert_eq!(hidden_position.data_type(), &DataType::Int64);
+        assert!(
+            exec.schema()
+                .fields()
+                .iter()
+                .all(|field| field.name() != &hidden_position_name)
+        );
+
+        let batches = collect(scan, session.task_ctx()).await?;
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+        assert!(batches.iter().all(|batch| {
+            batch
+                .schema()
+                .fields()
+                .iter()
+                .all(|field| field.name() != &hidden_position_name)
+        }));
 
         Ok(())
     }
@@ -2237,10 +2895,6 @@ mod tests {
     ) -> DeltaScanStream {
         use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 
-        let input_schema = input_batches
-            .first()
-            .map(|b| b.schema())
-            .unwrap_or_else(|| Arc::clone(&scan_plan.contract.output_schema));
         let input_file_id_column = scan_plan.contract.file_id_field.name().clone();
         let mut public_file_ids = super::super::PublicFileIdMap::default();
         for file_id in selection_vectors.keys() {
@@ -2256,6 +2910,77 @@ mod tests {
             }
         }
 
+        let has_deletion_vectors = !selection_vectors.is_empty();
+        let mut physical_input_contract = Arc::new(super::super::PhysicalInputContract::new(
+            &scan_plan.parquet_read_schema,
+            scan_plan.contract.file_id_field.clone(),
+            has_deletion_vectors,
+        ));
+        let mut next_position_by_file = HashMap::<String, i64>::new();
+        let input_batches = input_batches
+            .into_iter()
+            .map(|batch| {
+                if !has_deletion_vectors {
+                    return batch;
+                }
+                append_test_physical_positions(
+                    batch,
+                    &physical_input_contract,
+                    &input_file_id_column,
+                    &mut next_position_by_file,
+                )
+            })
+            .collect::<Vec<_>>();
+        let deletion_entries: HashMap<String, super::super::deletion_vector::DeletionVectorEntry> =
+            selection_vectors
+                .iter()
+                .map(|selection| {
+                    let observed = next_position_by_file
+                        .get(selection.0)
+                        .copied()
+                        .unwrap_or_default();
+                    let physical_record_count = u64::try_from(observed)
+                        .unwrap()
+                        .max(u64::try_from(selection.1.len()).unwrap());
+                    let deleted_cardinality =
+                        u64::try_from(selection.1.iter().filter(|keep| !**keep).count()).unwrap();
+                    (
+                        selection.0.clone(),
+                        super::super::deletion_vector::DeletionVectorEntry {
+                            keep_mask: selection.1.clone(),
+                            physical_record_count,
+                            deleted_cardinality,
+                        },
+                    )
+                })
+                .collect();
+        let mut selected = next_position_by_file
+            .iter()
+            .map(|(id, count)| (id.clone(), Some(*count as u64)))
+            .collect::<HashMap<_, _>>();
+        for (id, entry) in &deletion_entries {
+            selected.insert(id.clone(), Some(entry.physical_record_count));
+        }
+        Arc::make_mut(&mut physical_input_contract).footer_bounds = selected
+            .iter()
+            .map(|(id, count)| {
+                (
+                    id.clone(),
+                    Arc::new(std::sync::OnceLock::from(count.unwrap())),
+                )
+            })
+            .collect();
+        let deletion_vectors = Arc::new(
+            DeletionVectorIndex::try_new(deletion_entries)
+                .unwrap()
+                .with_selected_files(selected)
+                .expect("valid test deletion vectors"),
+        );
+        let input_schema = input_batches
+            .first()
+            .map(|batch| batch.schema())
+            .unwrap_or_else(|| physical_input_contract.table_schema.table_schema().clone());
+
         let input = Box::pin(RecordBatchStreamAdapter::new(
             input_schema,
             futures::stream::iter(input_batches.into_iter().map(Ok)),
@@ -2270,15 +2995,42 @@ mod tests {
             input,
             baseline_metrics: BaselineMetrics::new(&ExecutionPlanMetricsSet::new(), 0),
             transforms: Arc::new(HashMap::new()),
-            selection_vectors,
+            deletion_vectors,
+            physical_input_contract,
+            dv_rows_checked: Count::new(),
+            dv_rows_removed: Count::new(),
             public_file_ids: Arc::new(public_file_ids),
-            input_file_id_column,
             file_id_column,
             row_index_field,
             row_index_by_file: HashMap::new(),
             pending: VecDeque::new(),
             schema_adapter,
         }
+    }
+
+    fn append_test_physical_positions(
+        batch: RecordBatch,
+        physical_input_contract: &super::super::PhysicalInputContract,
+        input_file_id_column: &str,
+        next_position_by_file: &mut HashMap<String, i64>,
+    ) -> RecordBatch {
+        let file_id_idx =
+            file_id_column_idx(&batch, input_file_id_column).expect("valid compact file-id column");
+        let mut positions = Vec::with_capacity(batch.num_rows());
+        for (file_id, run) in
+            split_by_file_id_runs(&batch, file_id_idx).expect("valid compact file-id runs")
+        {
+            let next = next_position_by_file.entry(file_id).or_default();
+            positions.extend(*next..*next + i64::try_from(run.num_rows()).unwrap());
+            *next += i64::try_from(run.num_rows()).unwrap();
+        }
+        let mut columns = batch.columns().to_vec();
+        columns.push(Arc::new(arrow_array::Int64Array::from(positions)));
+        RecordBatch::try_new(
+            physical_input_contract.table_schema.table_schema().clone(),
+            columns,
+        )
+        .expect("test physical input batch")
     }
 
     fn retain_row_index(scan_plan: Arc<KernelScanPlan>, column: &str) -> Arc<KernelScanPlan> {
@@ -2326,8 +3078,12 @@ mod tests {
             retain_row_index(scan_plan, "row_ordinal"),
             Arc::clone(&exec.input),
             Arc::clone(&exec.transforms),
-            exec.dv_state.clone(),
-            Arc::clone(&exec.public_file_ids),
+            PhysicalScanContext {
+                deletion_vectors: Arc::clone(&exec.deletion_vectors),
+                public_file_ids: Arc::clone(&exec.public_file_ids),
+                physical_file_identities: Arc::clone(&exec.physical_file_identities),
+                physical_input_contract: Arc::clone(&exec.physical_input_contract),
+            },
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -2364,8 +3120,12 @@ mod tests {
             retain_row_index(scan_plan, "row_ordinal"),
             repartitioned_input,
             Arc::clone(&exec.transforms),
-            exec.dv_state.clone(),
-            Arc::clone(&exec.public_file_ids),
+            PhysicalScanContext {
+                deletion_vectors: Arc::clone(&exec.deletion_vectors),
+                public_file_ids: Arc::clone(&exec.public_file_ids),
+                physical_file_identities: Arc::clone(&exec.physical_file_identities),
+                physical_input_contract: Arc::clone(&exec.physical_input_contract),
+            },
             exec.partition_stats.clone(),
             exec.metrics.clone(),
         );
@@ -2397,12 +3157,21 @@ mod tests {
         let mut public_file_ids = super::super::PublicFileIdMap::default();
         public_file_ids.insert("f1".to_string(), "f1".to_string());
         public_file_ids.insert("f2".to_string(), "f2".to_string());
+        let physical_input_contract = Arc::new(super::super::PhysicalInputContract::new(
+            &scan_plan.parquet_read_schema,
+            scan_plan.contract.file_id_field.clone(),
+            false,
+        ));
         let exec = DeltaScanExec::new(
             scan_plan,
             input,
             Arc::new(HashMap::new()),
-            DvExecutionState::NotPresent,
-            Arc::new(public_file_ids),
+            PhysicalScanContext {
+                deletion_vectors: Arc::new(DeletionVectorIndex::default()),
+                public_file_ids: Arc::new(public_file_ids),
+                physical_file_identities: Arc::new(super::super::PhysicalFileIdentityMap::default()),
+                physical_input_contract,
+            },
             HashMap::new(),
             ExecutionPlanMetricsSet::new(),
         );
@@ -2520,6 +3289,12 @@ mod tests {
             None,
         );
 
+        let batch = append_test_physical_positions(
+            batch,
+            &stream.physical_input_contract,
+            FILE_ID_COLUMN_DEFAULT,
+            &mut HashMap::new(),
+        );
         let outputs = stream.batch_project(batch)?;
         assert_eq!(outputs.len(), 2);
 
@@ -2586,6 +3361,12 @@ mod tests {
             None,
         );
 
+        let batch = append_test_physical_positions(
+            batch,
+            &stream.physical_input_contract,
+            FILE_ID_COLUMN_DEFAULT,
+            &mut HashMap::new(),
+        );
         let outputs = stream.batch_project(batch)?;
         let kept: Vec<i32> = outputs
             .iter()
@@ -2615,9 +3396,20 @@ mod tests {
             Vec::new(),
             None,
         );
-        let batches = stream.batch_project(RecordBatch::new_empty(Arc::clone(
-            &scan_plan.contract.output_schema,
-        )))?;
+        assert!(
+            stream
+                .batch_project(RecordBatch::new_empty(
+                    scan_plan.contract.output_schema.clone()
+                ))
+                .is_err()
+        );
+        let batches = stream.batch_project(RecordBatch::new_empty(
+            stream
+                .physical_input_contract
+                .table_schema
+                .table_schema()
+                .clone(),
+        ))?;
         let columns = batches[0].columns();
 
         assert_eq!(batches[0].schema(), scan_plan.contract.output_schema);
@@ -2640,9 +3432,20 @@ mod tests {
             None,
         );
 
-        let batches = stream.batch_project(RecordBatch::new_empty(Arc::clone(
-            &scan_plan.contract.output_schema,
-        )))?;
+        assert!(
+            stream
+                .batch_project(RecordBatch::new_empty(
+                    scan_plan.contract.output_schema.clone()
+                ))
+                .is_err()
+        );
+        let batches = stream.batch_project(RecordBatch::new_empty(
+            stream
+                .physical_input_contract
+                .table_schema
+                .table_schema()
+                .clone(),
+        ))?;
 
         assert_eq!(batches[0].schema(), scan_plan.contract.output_schema);
         let schema = batches[0].schema();
@@ -2835,123 +3638,5 @@ mod tests {
         }
 
         Ok(())
-    }
-
-    #[test]
-    fn test_dv_short_mask_drain_and_pad() {
-        use super::{DvMaskResult, consume_dv_mask};
-
-        let mut sv = vec![true, false, true];
-        let result = consume_dv_mask(&mut sv, 5);
-
-        assert_eq!(
-            result,
-            DvMaskResult {
-                selection: Some(vec![true, false, true, true, true]),
-                should_remove: true,
-            }
-        );
-        assert!(sv.is_empty());
-    }
-
-    #[test]
-    fn test_dv_mask_exhaustion_across_batches() {
-        use super::{DvMaskResult, consume_dv_mask};
-
-        let file_id = "test_file.parquet".to_string();
-        let mut selection_vectors = HashMap::from([(file_id.clone(), vec![false, true])]);
-
-        let result1 = consume_dv_mask(selection_vectors.get_mut(&file_id).unwrap(), 5);
-        assert_eq!(
-            result1,
-            DvMaskResult {
-                selection: Some(vec![false, true, true, true, true]),
-                should_remove: true,
-            }
-        );
-        if result1.should_remove {
-            selection_vectors.remove(&file_id);
-        }
-
-        let result2 = if let Some(sv) = selection_vectors.get_mut(&file_id) {
-            consume_dv_mask(sv, 5)
-        } else {
-            DvMaskResult {
-                selection: None,
-                should_remove: false,
-            }
-        };
-        assert_eq!(
-            result2,
-            DvMaskResult {
-                selection: None,
-                should_remove: false,
-            }
-        );
-    }
-
-    #[test]
-    fn test_dv_normal_mask_drains_exactly() {
-        use super::{DvMaskResult, consume_dv_mask};
-
-        let mut sv = vec![
-            true, false, true, false, true, true, false, true, false, true,
-        ];
-
-        let result1 = consume_dv_mask(&mut sv, 3);
-        assert_eq!(
-            result1,
-            DvMaskResult {
-                selection: Some(vec![true, false, true]),
-                should_remove: false,
-            }
-        );
-        assert_eq!(sv.len(), 7);
-
-        let result2 = consume_dv_mask(&mut sv, 3);
-        assert_eq!(
-            result2,
-            DvMaskResult {
-                selection: Some(vec![false, true, true]),
-                should_remove: false,
-            }
-        );
-        assert_eq!(sv, vec![false, true, false, true]);
-
-        let result3 = consume_dv_mask(&mut sv, 5);
-        assert_eq!(
-            result3,
-            DvMaskResult {
-                selection: Some(vec![false, true, false, true, true]),
-                should_remove: true,
-            }
-        );
-        assert!(sv.is_empty());
-
-        let result4 = consume_dv_mask(&mut sv, 5);
-        assert_eq!(
-            result4,
-            DvMaskResult {
-                selection: None,
-                should_remove: true,
-            }
-        );
-    }
-
-    #[test]
-    fn test_dv_long_mask_retains_remainder_for_next_batch() {
-        use super::{DvMaskResult, consume_dv_mask};
-
-        let mut sv = vec![true, false, false, true];
-        let result = consume_dv_mask(&mut sv, 2);
-
-        assert_eq!(
-            result,
-            DvMaskResult {
-                selection: Some(vec![true, false]),
-                should_remove: false,
-            }
-        );
-        assert_eq!(sv, vec![false, true]);
     }
 }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec.rs
@@ -54,38 +54,31 @@ const DELTA_MATERIALIZED_PUSHDOWN_SENTINEL: &str =
 
 /// Physical execution plan for scanning Delta tables.
 ///
-/// Wraps a Parquet reader execution plan and applies Delta Lake protocol transformations
-/// to produce the logical table data. This includes:
-///
-/// - **Column mapping**: Translates physical column names to logical names
-/// - **Partition values**: Materializes partition column values from file paths
-/// - **Deletion vectors**: Filters deleted rows by immutable physical Parquet row position
-/// - **Schema evolution**: Handles missing columns and type coercion
+/// Reads Parquet data, filters deleted rows by physical row position, and applies
+/// column mapping, partition values, and schema evolution.
 ///
 /// # Data Flow
 ///
 /// 1. Inner [`input`](Self::input) plan reads raw Parquet data
-/// 2. Per-file [`transforms`](Self::transforms) convert physical to logical schema
-/// 3. [`deletion_vectors`](Self::deletion_vectors) filter deleted rows
-/// 4. Result is cast to the projected scan contract's result schema
+/// 2. [`deletion_vectors`](Self::deletion_vectors) filter deleted rows
+/// 3. File [`transforms`](Self::transforms) convert the physical schema to the logical schema
+/// 4. The result is cast to the projected scan schema
 #[derive(Clone, Debug)]
 pub struct DeltaScanExec {
     scan_plan: Arc<KernelScanPlan>,
     /// Execution plan yielding the raw data read from data files.
     input: Arc<dyn ExecutionPlan>,
-    /// Transforms to be applied to data eminating from individual files
+    /// Transforms applied to data read from individual files.
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Immutable deletion vectors keyed by compact scan file id.
     deletion_vectors: Arc<DeletionVectorIndex>,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
-    /// Expected physical file ownership keyed by compact scan file id.
-    physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
-    /// Authoritative hidden physical input schema and resolved support-column indices.
+    /// Physical input schema and indices of the hidden file id and row position columns.
     physical_input_contract: Arc<super::PhysicalInputContract>,
     /// Execution metrics
     metrics: ExecutionPlanMetricsSet,
-    /// User-visible file-id column name when projected in the output.
+    /// Public file id column name when projected in the output.
     file_id_column: Option<String>,
     /// plan properties
     properties: Arc<PlanProperties>,
@@ -96,7 +89,6 @@ pub struct DeltaScanExec {
 pub(super) struct PhysicalScanContext {
     pub(super) deletion_vectors: Arc<DeletionVectorIndex>,
     pub(super) public_file_ids: Arc<super::PublicFileIdMap>,
-    pub(super) physical_file_identities: Arc<super::PhysicalFileIdentityMap>,
     pub(super) physical_input_contract: Arc<super::PhysicalInputContract>,
 }
 
@@ -156,7 +148,6 @@ impl DeltaScanExec {
         let PhysicalScanContext {
             deletion_vectors,
             public_file_ids,
-            physical_file_identities,
             physical_input_contract,
         } = context;
         Self::register_dv_file_metric(&metrics, &deletion_vectors);
@@ -178,7 +169,6 @@ impl DeltaScanExec {
             transforms,
             deletion_vectors,
             public_file_ids,
-            physical_file_identities,
             physical_input_contract,
             partition_stats,
             metrics,
@@ -227,7 +217,6 @@ impl DeltaScanExec {
             PhysicalScanContext {
                 deletion_vectors: Arc::clone(&self.deletion_vectors),
                 public_file_ids: Arc::clone(&self.public_file_ids),
-                physical_file_identities: Arc::clone(&self.physical_file_identities),
                 physical_input_contract: Arc::clone(&self.physical_input_contract),
             },
             self.partition_stats.clone(),
@@ -239,7 +228,7 @@ impl DeltaScanExec {
         self.deletion_vectors.has_vectors()
     }
 
-    pub(super) fn validate_dv_child_topology(&self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
+    fn validate_dv_child_topology(&self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
         fn scalar_file_id(value: &ScalarValue) -> Option<&str> {
             match value {
                 ScalarValue::Dictionary(_, value) => scalar_file_id(value),
@@ -252,7 +241,6 @@ impl DeltaScanExec {
 
         fn visit(
             plan: &Arc<dyn ExecutionPlan>,
-            expected: &super::PhysicalFileIdentityMap,
             observed: &mut HashSet<String>,
             contract: &super::PhysicalInputContract,
         ) -> Result<()> {
@@ -262,55 +250,41 @@ impl DeltaScanExec {
                 );
             }
             if let Some(coalesce) = plan.downcast_ref::<CoalescePartitionsExec>() {
-                return visit(coalesce.input(), expected, observed, contract);
+                return visit(coalesce.input(), observed, contract);
             }
             if let Some(union) = plan.downcast_ref::<UnionExec>() {
                 for input in union.inputs() {
-                    visit(input, expected, observed, contract)?;
+                    visit(input, observed, contract)?;
                 }
                 return Ok(());
             }
             let Some(source_exec) = plan.downcast_ref::<DataSourceExec>() else {
                 return plan_err!(
-                    "DeltaScanExec deletion-vector topology contains unsupported node {}",
+                    "DeltaScanExec deletion vector topology contains unsupported node {}",
                     plan.name()
                 );
             };
             let Some(config) = source_exec.data_source().downcast_ref::<FileScanConfig>() else {
                 return plan_err!(
-                    "DeltaScanExec deletion-vector topology requires FileScanConfig leaves"
+                    "DeltaScanExec deletion vector topology requires FileScanConfig leaves"
                 );
             };
-            let source = config
-                .file_source
-                .downcast_ref::<datafusion::datasource::physical_plan::ParquetSource>()
-                .ok_or_else(|| internal_datafusion_err!("expected native Parquet source"))?;
             let expected_source = contract
                 .sources
                 .iter()
+                .filter_map(|source| source.downcast_ref::<FileScanConfig>())
                 .find(|planned| planned.object_store_url == config.object_store_url)
                 .ok_or_else(|| internal_datafusion_err!("unplanned store binding"))?;
-            let original = expected_source
-                .file_source
-                .downcast_ref::<datafusion::datasource::physical_plan::ParquetSource>()
-                .ok_or_else(|| internal_datafusion_err!("lost planned Parquet source"))?;
-            let same_reader = source
-                .parquet_file_reader_factory()
-                .zip(original.parquet_file_reader_factory())
-                .is_some_and(|(a, b)| Arc::ptr_eq(a, b));
             let same_adapter = config
                 .expr_adapter_factory
                 .as_ref()
                 .zip(expected_source.expr_adapter_factory.as_ref())
                 .is_some_and(|(a, b)| Arc::ptr_eq(a, b));
             if !Arc::ptr_eq(&config.file_source, &expected_source.file_source)
-                || !same_reader
                 || !same_adapter
                 || plan.schema() != *contract.table_schema.table_schema()
             {
-                return plan_err!(
-                    "physical input reader, adapter, or support-field lineage changed"
-                );
+                return plan_err!("physical input reader, adapter, or support fields changed");
             }
             if !matches!(
                 config.output_partitioning,
@@ -330,15 +304,15 @@ impl DeltaScanExec {
             for group in &config.file_groups {
                 for file in group.iter() {
                     if !file.extensions.is_empty() {
-                        return plan_err!("unplanned reader-affecting file extensions");
+                        return plan_err!("unplanned file extensions that affect the reader");
                     }
                     let Some(file_id) = file.partition_values.first().and_then(scalar_file_id)
                     else {
                         return plan_err!(
-                            "DeltaScanExec deletion-vector file is missing a compact file id"
+                            "DeltaScanExec deletion vector file is missing a compact file id"
                         );
                     };
-                    let planned_file = contract
+                    let (expected_store, planned_file) = contract
                         .planned_files
                         .get(file_id)
                         .ok_or_else(|| internal_datafusion_err!("unplanned partition constants"))?;
@@ -356,24 +330,17 @@ impl DeltaScanExec {
                     }
                     if file.range.is_some() {
                         return plan_err!(
-                            "DeltaScanExec deletion-vector file id '{file_id}' has a byte range"
+                            "DeltaScanExec deletion vector file id '{file_id}' has a byte range"
                         );
                     }
-                    let Some(expected_file) = expected.get(file_id) else {
+                    if expected_store != &config.object_store_url {
                         return plan_err!(
-                            "DeltaScanExec deletion-vector topology contains unknown file id '{file_id}'"
-                        );
-                    };
-                    if expected_file.object_store_url != config.object_store_url
-                        || expected_file.location != file.object_meta.location
-                    {
-                        return plan_err!(
-                            "DeltaScanExec deletion-vector topology has an inconsistent mapping for file id '{file_id}'"
+                            "DeltaScanExec deletion vector topology has an inconsistent mapping for file id '{file_id}'"
                         );
                     }
                     if !observed.insert(file_id.to_owned()) {
                         return plan_err!(
-                            "DeltaScanExec deletion-vector topology has duplicate ownership for file id '{file_id}'"
+                            "DeltaScanExec deletion vector topology has duplicate ownership for file id '{file_id}'"
                         );
                     }
                 }
@@ -382,14 +349,9 @@ impl DeltaScanExec {
         }
 
         let mut observed = HashSet::new();
-        visit(
-            input,
-            &self.physical_file_identities,
-            &mut observed,
-            &self.physical_input_contract,
-        )?;
-        if observed.len() != self.physical_file_identities.len() {
-            return plan_err!("DeltaScanExec deletion-vector topology is missing selected files");
+        visit(input, &mut observed, &self.physical_input_contract)?;
+        if observed.len() != self.physical_input_contract.planned_files.len() {
+            return plan_err!("DeltaScanExec deletion vector topology is missing selected files");
         }
         Ok(())
     }
@@ -451,8 +413,8 @@ impl DeltaScanExec {
 
         stats.column_statistics = new_stats;
         if self.has_deletion_vectors() {
-            // Child statistics describe physical Parquet rows. Keep them conservative;
-            // metadata-only execution derives exact visible counts separately.
+            // Child statistics include deleted rows. Exact visible counts are available
+            // in metadata scans.
             stats = stats.to_inexact();
         }
         Ok(stats)
@@ -509,8 +471,8 @@ impl ExecutionPlan for DeltaScanExec {
         if self.scan_plan.contract.retained_row_index_field().is_some()
             || self.has_deletion_vectors()
         {
-            // Retained row indexes require ordered, stream-local state. Physical-position DVs
-            // retain the PR 0 single-partition containment until the PR 2 optimizer unlock.
+            // Row indexes use a counter per stream and require ordered input.
+            // Scans with deletion vectors still require a single input partition.
             InputDistributionRequirements::new(vec![Distribution::SinglePartition])
         } else {
             InputDistributionRequirements::new(vec![Distribution::UnspecifiedDistribution])
@@ -560,8 +522,7 @@ impl ExecutionPlan for DeltaScanExec {
         if self.scan_plan.contract.retained_row_index_field().is_some()
             || self.has_deletion_vectors()
         {
-            // Row ordinals retain stream-local counters. Physical-position DVs retain the PR 0
-            // repartition barrier until the PR 2 optimizer unlock is qualified.
+            // Repartitioning is disabled for row indexes and deletion vectors.
             return Ok(None);
         }
 
@@ -593,7 +554,7 @@ impl ExecutionPlan for DeltaScanExec {
                     );
                 }
                 return plan_err!(
-                    "DeltaScanExec contained deletion-vector scans require a single input partition, got {input_partition_count}"
+                    "DeltaScanExec scans with deletion vectors require a single input partition, got {input_partition_count}"
                 );
             }
         }
@@ -767,7 +728,7 @@ struct DeltaScanStream {
     baseline_metrics: BaselineMetrics,
     /// Transforms to be applied to data read from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
-    /// Immutable deletion-vector lookup by physical row position.
+    /// Immutable deletion vector lookup by physical row position.
     deletion_vectors: Arc<DeletionVectorIndex>,
     physical_input_contract: Arc<super::PhysicalInputContract>,
     dv_rows_checked: Count,
@@ -799,7 +760,7 @@ impl DeltaScanStream {
         let file_id_idx = self.physical_input_contract.file_id_index;
         if batch.schema() != *self.physical_input_contract.table_schema.table_schema() {
             return internal_err!(
-                "physical input schema does not preserve compact file-id field '{}' and its support fields",
+                "physical input schema does not preserve compact file id field '{}' and its support fields",
                 self.physical_input_contract.file_id_field.name()
             );
         }
@@ -823,26 +784,16 @@ impl DeltaScanStream {
     ) -> Result<RecordBatch> {
         let input_row_count = batch.num_rows();
         let has_deletion_vector = self.deletion_vectors.has_vector(&file_id);
-        let mut batch = if self
-            .physical_input_contract
-            .physical_row_position_index
-            .is_some()
+        let mut batch = if let Some(position_idx) =
+            self.physical_input_contract.physical_row_position_index
         {
-            let position_idx = self
-                .physical_input_contract
-                .physical_row_position_index
-                .ok_or_else(|| {
-                    internal_datafusion_err!(
-                        "physical-position DV mode is missing its row-position field"
-                    )
-                })?;
             let positions = batch
                 .column(position_idx)
                 .as_any()
                 .downcast_ref::<arrow_array::Int64Array>()
                 .ok_or_else(|| {
                     internal_datafusion_err!(
-                        "physical row-position column is not a nullable Int64 array"
+                        "physical row position column is not a nullable Int64 array"
                     )
                 })?;
             if !has_deletion_vector {
@@ -852,13 +803,13 @@ impl DeltaScanStream {
                     .get(&file_id)
                     .and_then(|bound| bound.get())
                     .ok_or_else(|| {
-                        internal_datafusion_err!("missing reader-verified physical bounds")
+                        internal_datafusion_err!("reader has not verified the physical row count")
                     })?;
                 for position in positions.iter() {
                     if !position.is_some_and(|position| position >= 0 && (position as u64) < *count)
                     {
                         return internal_err!(
-                            "physical position outside reader-verified file population"
+                            "physical position outside file bounds verified by the reader"
                         );
                     }
                 }
@@ -2053,7 +2004,16 @@ mod tests {
             .downcast_ref::<FileScanConfig>()
             .expect("DataSourceExec must hold a parquet FileScanConfig");
 
-        for change in ["schema", "statistics", "ordering", "hint"] {
+        for change in [
+            "schema",
+            "statistics",
+            "ordering",
+            "hint",
+            "missing",
+            "duplicate",
+            "location",
+            "identity",
+        ] {
             let mut groups = config
                 .file_groups
                 .iter()
@@ -2073,16 +2033,30 @@ mod tests {
                         .unwrap(),
                     )
                 }
-                _ => file.metadata_size_hint = Some(1),
+                "hint" => file.metadata_size_hint = Some(1),
+                "missing" => groups[0].clear(),
+                "duplicate" => {
+                    let duplicate = file.clone();
+                    groups[0].push(duplicate);
+                }
+                "location" => {
+                    file.object_meta.location = object_store::path::Path::from("other.parquet")
+                }
+                _ => {
+                    file.partition_values =
+                        vec![crate::delta_datafusion::file_id::wrap_file_id_value(
+                            "unknown",
+                        )]
+                }
             }
             let replacement = DataSourceExec::from_data_source(
                 FileScanConfigBuilder::from(config.clone())
                     .with_file_groups(groups.into_iter().map(FileGroup::new).collect())
                     .build(),
             );
-            #[expect(deprecated, reason = "qualify both supported child-replacement APIs")]
+            #[expect(deprecated, reason = "test both supported APIs for replacing children")]
             let replaced = Arc::new(exec.clone()).with_new_children(vec![replacement]);
-            assert!(replaced.is_err(), "must reject changed per-file {change}");
+            assert!(replaced.is_err(), "must reject changed file {change}");
         }
 
         let mut fragment = config.file_groups[0][0].clone();
@@ -2166,15 +2140,11 @@ mod tests {
     async fn test_optimized_plan_reset_preserves_shared_visibility() -> TestResult {
         use super::super::test_support::{FileSpec, Fixture};
         use datafusion::physical_plan::execution_plan::reset_plan_states;
-        let fixture = Fixture::new(
-            vec![FileSpec {
-                rows: 161,
-                groups: vec![37, 53, 71],
-                deleted: Some([0, 1, 37, 90].into_iter().collect()),
-                log_stats: true,
-            }],
-            8,
-        )?;
+        let fixture = Fixture::new(vec![FileSpec {
+            groups: vec![37, 53, 71],
+            deleted: Some([0, 1, 37, 90].into_iter().collect()),
+            log_stats: true,
+        }])?;
         let table = crate::open_table(fixture.url()).await?;
         let context = datafusion::prelude::SessionContext::new();
         context.register_table("t", table.table_provider().await?)?;
@@ -2214,15 +2184,11 @@ mod tests {
     #[tokio::test]
     async fn test_reader_coordinate_matrix_against_generator_oracle() -> TestResult {
         use super::super::test_support::{FileSpec, Fixture};
-        let fixture = Fixture::new(
-            vec![FileSpec {
-                rows: 161,
-                groups: vec![37, 53, 71],
-                deleted: Some([0, 36, 37, 42, 89, 90, 144, 160].into_iter().collect()),
-                log_stats: true,
-            }],
-            8,
-        )?;
+        let fixture = Fixture::new(vec![FileSpec {
+            groups: vec![37, 53, 71],
+            deleted: Some([0, 36, 37, 42, 89, 90, 144, 160].into_iter().collect()),
+            log_stats: true,
+        }])?;
         let table = crate::open_table(fixture.url()).await?;
         let provider = table.table_provider().await?;
         let session = create_session().into_inner();
@@ -2370,16 +2336,13 @@ mod tests {
         assert_eq!(cases, 96);
         assert!(
             observed_group_pruning,
-            "fixture must execute row-group pruning"
+            "fixture must execute row group pruning"
         );
         assert!(
             observed_page_pruning,
-            "fixture must execute page-index pruning"
+            "fixture must execute page index pruning"
         );
-        assert!(
-            observed_ranges,
-            "private coordinate qualification must execute native ranged reads"
-        );
+        assert!(observed_ranges, "fixture must read byte ranges");
         Ok(())
     }
 
@@ -2387,15 +2350,11 @@ mod tests {
     async fn test_snapshot_visibility_is_frozen_across_concurrent_plans_and_advancement()
     -> TestResult {
         use super::super::test_support::{FileSpec, Fixture};
-        let mut fixture = Fixture::new(
-            vec![FileSpec {
-                rows: 161,
-                groups: vec![37, 53, 71],
-                deleted: Some([1].into_iter().collect()),
-                log_stats: true,
-            }],
-            8,
-        )?;
+        let mut fixture = Fixture::new(vec![FileSpec {
+            groups: vec![37, 53, 71],
+            deleted: Some([1].into_iter().collect()),
+            log_stats: true,
+        }])?;
         let session = create_session().into_inner();
         let first_table = crate::open_table(fixture.url()).await?;
         let first_provider = first_table.table_provider().await?;
@@ -2447,7 +2406,7 @@ mod tests {
             fixture_rows(&collect(decoded_plan, session.task_ctx()).await?),
             expected_first
         );
-        // Cancellation must not consume visibility shared by subsequent streams.
+        // Cancelling a stream must leave deletion masks unchanged for later scans.
         drop(first_plan.execute(0, session.task_ctx())?);
         assert_eq!(
             fixture_rows(&collect(first_plan, session.task_ctx()).await?),
@@ -2460,15 +2419,11 @@ mod tests {
     async fn test_dv_cancellation_after_partial_consumption_preserves_visibility() -> TestResult {
         use super::super::test_support::{FileSpec, Fixture};
         use datafusion::physical_plan::execution_plan::reset_plan_states;
-        let fixture = Fixture::new(
-            vec![FileSpec {
-                rows: 161,
-                groups: vec![37, 53, 71],
-                deleted: Some([0, 36, 37, 89, 90, 160].into_iter().collect()),
-                log_stats: true,
-            }],
-            8,
-        )?;
+        let fixture = Fixture::new(vec![FileSpec {
+            groups: vec![37, 53, 71],
+            deleted: Some([0, 36, 37, 89, 90, 160].into_iter().collect()),
+            log_stats: true,
+        }])?;
         let table = crate::open_table(fixture.url()).await?;
         let session = datafusion::prelude::SessionContext::new_with_config(
             SessionConfig::new().with_batch_size(7),
@@ -2508,15 +2463,11 @@ mod tests {
         use super::super::test_support::{FileSpec, Fixture, PausedStore};
         use std::sync::atomic::Ordering;
         use std::time::Duration;
-        let fixture = Fixture::new(
-            vec![FileSpec {
-                rows: 161,
-                groups: vec![37, 53, 71],
-                deleted: Some([0, 37, 90].into_iter().collect()),
-                log_stats: true,
-            }],
-            8,
-        )?;
+        let fixture = Fixture::new(vec![FileSpec {
+            groups: vec![37, 53, 71],
+            deleted: Some([0, 37, 90].into_iter().collect()),
+            log_stats: true,
+        }])?;
         let store = Arc::new(PausedStore::new(Arc::new(
             object_store::local::LocalFileSystem::new(),
         )));
@@ -2574,15 +2525,11 @@ mod tests {
     #[tokio::test]
     async fn test_dv_scan_without_on_disk_row_group_ordinals() -> TestResult {
         use super::super::test_support::{FileSpec, Fixture};
-        let mut fixture = Fixture::new(
-            vec![FileSpec {
-                rows: 161,
-                groups: vec![37, 53, 71],
-                deleted: Some([0, 36, 37, 89, 90, 160].into_iter().collect()),
-                log_stats: true,
-            }],
-            8,
-        )?;
+        let mut fixture = Fixture::new(vec![FileSpec {
+            groups: vec![37, 53, 71],
+            deleted: Some([0, 36, 37, 89, 90, 160].into_iter().collect()),
+            log_stats: true,
+        }])?;
         fixture.remove_row_group_ordinals(0)?;
         let expected = fixture
             .live_coordinates()
@@ -2611,23 +2558,18 @@ mod tests {
     async fn test_generated_mixed_scan_checks_coordinates_and_logical_rows_independently()
     -> TestResult {
         use super::super::test_support::{FileSpec, Fixture};
-        let fixture = Fixture::new(
-            vec![
-                FileSpec {
-                    rows: 161,
-                    groups: vec![37, 53, 71],
-                    deleted: Some([0, 36, 37, 89, 90, 160].into_iter().collect()),
-                    log_stats: true,
-                },
-                FileSpec {
-                    rows: 107,
-                    groups: vec![41, 66],
-                    deleted: None,
-                    log_stats: false,
-                },
-            ],
-            8,
-        )?;
+        let fixture = Fixture::new(vec![
+            FileSpec {
+                groups: vec![37, 53, 71],
+                deleted: Some([0, 36, 37, 89, 90, 160].into_iter().collect()),
+                log_stats: true,
+            },
+            FileSpec {
+                groups: vec![41, 66],
+                deleted: None,
+                log_stats: false,
+            },
+        ])?;
         let table = crate::open_table(fixture.url()).await?;
         let provider = table.table_provider().await?;
         let session = create_session().into_inner();
@@ -2704,7 +2646,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[expect(deprecated, reason = "qualify both supported child replacement APIs")]
+    #[expect(deprecated, reason = "test both supported child replacement APIs")]
     async fn test_dv_provenance_rejects_extensions_and_fabricated_positions() -> TestResult {
         use datafusion::datasource::physical_plan::parquet::ParquetAccessPlan;
         use datafusion::physical_plan::projection::ProjectionExec;
@@ -2847,13 +2789,19 @@ mod tests {
         let original_file_id = exec.deletion_vectors.entries.keys().next().unwrap().clone();
 
         let duplicate_file_id = "duplicate".to_string();
-        let duplicate_location = original_file.object_meta.location.clone();
         let mut duplicate_file = original_file.clone();
-        duplicate_file.object_meta.location = duplicate_location.clone();
         duplicate_file.partition_values =
             vec![crate::delta_datafusion::file_id::wrap_file_id_value(
                 duplicate_file_id.clone(),
             )];
+        let mut grouped_contract = exec.physical_input_contract.as_ref().clone();
+        grouped_contract.planned_files.insert(
+            duplicate_file_id.clone(),
+            (
+                source_config.object_store_url.clone(),
+                duplicate_file.clone(),
+            ),
+        );
         let grouped_config = FileScanConfigBuilder::from(source_config.clone())
             .with_file_groups(vec![
                 FileGroup::new(vec![original_file]),
@@ -2863,9 +2811,7 @@ mod tests {
             .build();
         let grouped_input: Arc<dyn ExecutionPlan> =
             DataSourceExec::from_data_source(grouped_config);
-        let mut grouped_contract = exec.physical_input_contract.as_ref().clone();
         grouped_contract.sources.clear();
-        grouped_contract.planned_files.clear();
         grouped_contract.bind_sources(&grouped_input)?;
 
         let mut entries = exec.deletion_vectors.entries.clone();
@@ -2873,22 +2819,17 @@ mod tests {
             duplicate_file_id.clone(),
             entries[&original_file_id].clone(),
         );
-        let mut identities = exec.physical_file_identities.as_ref().clone();
-        identities.insert(
-            duplicate_file_id.clone(),
-            super::super::PhysicalFileIdentity {
-                object_store_url: source_config.object_store_url.clone(),
-                location: duplicate_location,
-            },
-        );
+        let selected = entries
+            .iter()
+            .map(|(id, entry)| (id.clone(), Some(entry.physical_record_count)))
+            .collect();
         let grouped_scan: Arc<dyn ExecutionPlan> = Arc::new(DeltaScanExec::new(
             Arc::clone(&exec.scan_plan),
             grouped_input,
             Arc::clone(&exec.transforms),
             PhysicalScanContext {
-                deletion_vectors: Arc::new(DeletionVectorIndex::try_new(entries)?),
+                deletion_vectors: Arc::new(DeletionVectorIndex::try_new(entries, selected)?),
                 public_file_ids: Arc::clone(&exec.public_file_ids),
-                physical_file_identities: Arc::new(identities),
                 physical_input_contract: Arc::new(grouped_contract),
             },
             exec.partition_stats.clone(),
@@ -3160,9 +3101,7 @@ mod tests {
             })
             .collect();
         let deletion_vectors = Arc::new(
-            DeletionVectorIndex::try_new(deletion_entries)
-                .unwrap()
-                .with_selected_files(selected)
+            DeletionVectorIndex::try_new(deletion_entries, selected)
                 .expect("valid test deletion vectors"),
         );
         let input_schema = input_batches
@@ -3204,10 +3143,10 @@ mod tests {
         next_position_by_file: &mut HashMap<String, i64>,
     ) -> RecordBatch {
         let file_id_idx =
-            file_id_column_idx(&batch, input_file_id_column).expect("valid compact file-id column");
+            file_id_column_idx(&batch, input_file_id_column).expect("valid compact file id column");
         let mut positions = Vec::with_capacity(batch.num_rows());
         for (file_id, run) in
-            split_by_file_id_runs(&batch, file_id_idx).expect("valid compact file-id runs")
+            split_by_file_id_runs(&batch, file_id_idx).expect("valid compact file id runs")
         {
             let next = next_position_by_file.entry(file_id).or_default();
             positions.extend(*next..*next + i64::try_from(run.num_rows()).unwrap());
@@ -3270,7 +3209,6 @@ mod tests {
             PhysicalScanContext {
                 deletion_vectors: Arc::clone(&exec.deletion_vectors),
                 public_file_ids: Arc::clone(&exec.public_file_ids),
-                physical_file_identities: Arc::clone(&exec.physical_file_identities),
                 physical_input_contract: Arc::clone(&exec.physical_input_contract),
             },
             exec.partition_stats.clone(),
@@ -3312,7 +3250,6 @@ mod tests {
             PhysicalScanContext {
                 deletion_vectors: Arc::clone(&exec.deletion_vectors),
                 public_file_ids: Arc::clone(&exec.public_file_ids),
-                physical_file_identities: Arc::clone(&exec.physical_file_identities),
                 physical_input_contract: Arc::clone(&exec.physical_input_contract),
             },
             exec.partition_stats.clone(),
@@ -3358,7 +3295,6 @@ mod tests {
             PhysicalScanContext {
                 deletion_vectors: Arc::new(DeletionVectorIndex::default()),
                 public_file_ids: Arc::new(public_file_ids),
-                physical_file_identities: Arc::new(super::super::PhysicalFileIdentityMap::default()),
                 physical_input_contract,
             },
             HashMap::new(),
@@ -3386,6 +3322,55 @@ mod tests {
             .map(RecordBatch::num_rows)
             .sum::<usize>();
         assert_eq!(row_count, 2, "repartitioned plan must return two rows");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dv_scan_assigns_surviving_row_ordinals_across_batches_and_files() -> TestResult {
+        use super::super::test_support::{FileSpec, Fixture};
+        let fixture = Fixture::new(vec![
+            FileSpec {
+                groups: vec![3, 3],
+                deleted: Some([0, 2, 4].into_iter().collect()),
+                log_stats: true,
+            },
+            FileSpec {
+                groups: vec![3],
+                deleted: Some([0].into_iter().collect()),
+                log_stats: true,
+            },
+        ])?;
+        let table = crate::open_table(fixture.url()).await?;
+        let provider = crate::delta_datafusion::table_provider::next::DeltaScan::builder()
+            .with_log_store(table.log_store())
+            .with_row_index_column("row_ordinal")
+            .await?;
+        let session = datafusion::prelude::SessionContext::new_with_config(
+            SessionConfig::new().with_batch_size(2),
+        );
+        session.register_table("t", provider)?;
+        let plan = session
+            .sql("select id, row_ordinal from t")
+            .await?
+            .create_physical_plan()
+            .await?;
+        for _ in 0..2 {
+            let batches = collect(plan.clone(), session.task_ctx()).await?;
+            assert_batches_sorted_eq!(
+                [
+                    "+----+-------------+",
+                    "| id | row_ordinal |",
+                    "+----+-------------+",
+                    "| 1  | 1           |",
+                    "| 3  | 2           |",
+                    "| 5  | 3           |",
+                    "| 7  | 1           |",
+                    "| 8  | 2           |",
+                    "+----+-------------+",
+                ],
+                &batches
+            );
+        }
         Ok(())
     }
 

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -9,24 +9,20 @@ use std::sync::{Arc, LazyLock};
 use std::task::{Context, Poll};
 
 use arrow::array::RecordBatch;
-use arrow::compute::filter_record_batch;
 use arrow::datatypes::SchemaRef;
-use arrow_array::{BooleanArray, RecordBatchOptions};
+use arrow_array::RecordBatchOptions;
 use arrow_schema::{FieldRef, Fields, Schema};
-use dashmap::DashMap;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::error::{DataFusionError, Result};
 use datafusion::common::tree_node::TreeNodeRecursion;
-use datafusion::common::{HashMap, internal_datafusion_err, stats::Precision};
+use datafusion::common::{HashMap, stats::Precision};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::execution_plan::{
     Boundedness, CardinalityEffect, EmissionType, PlanProperties,
 };
 use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdownPhase};
-use datafusion::physical_plan::metrics::{
-    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
-};
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::statistics::StatisticsArgs;
 use datafusion::physical_plan::{
     ChildrenPropertiesMode, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
@@ -36,8 +32,8 @@ use delta_kernel::schema::{Schema as KernelSchema, SchemaRef as KernelSchemaRef}
 use delta_kernel::{EvaluationHandler, ExpressionRef};
 use futures::stream::Stream;
 use itertools::Itertools as _;
-use tracing::debug;
 
+use super::deletion_vector::DeletionVectorIndex;
 use crate::delta_datafusion::table_provider::next::KernelScanPlan;
 use crate::kernel::ARROW_HANDLER;
 use crate::kernel::arrow::engine_ext::ExpressionEvaluatorExt;
@@ -71,7 +67,7 @@ pub(crate) struct DeltaScanMetaExec {
     /// Transforms to be applied to data eminating from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Deletion vectors for the table
-    selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+    deletion_vectors: Arc<DeletionVectorIndex>,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
     /// Execution metrics
@@ -130,7 +126,7 @@ impl DeltaScanMetaExec {
         scan_plan: Arc<KernelScanPlan>,
         input: Vec<VecDeque<(String, usize)>>,
         transforms: Arc<HashMap<String, ExpressionRef>>,
-        selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+        deletion_vectors: Arc<DeletionVectorIndex>,
         public_file_ids: Arc<super::PublicFileIdMap>,
         file_id_field: Option<FieldRef>,
         metrics: ExecutionPlanMetricsSet,
@@ -141,7 +137,7 @@ impl DeltaScanMetaExec {
             scan_plan,
             input,
             transforms,
-            selection_vectors,
+            deletion_vectors,
             public_file_ids,
             metrics,
             file_id_field,
@@ -150,9 +146,8 @@ impl DeltaScanMetaExec {
     }
 
     fn effective_row_count_for_file(&self, file_id: &str, row_count: usize) -> Result<usize> {
-        if let Some(selection) = self.selection_vectors.get(file_id) {
-            let (kept_rows, _) = effective_row_count(row_count, selection.value(), file_id)?;
-            Ok(kept_rows)
+        if self.deletion_vectors.has_vectors() {
+            self.deletion_vectors.live_row_count(file_id, row_count)
         } else {
             Ok(row_count)
         }
@@ -272,10 +267,8 @@ impl ExecutionPlan for DeltaScanMetaExec {
             scan_plan: Arc::clone(&self.scan_plan),
             input: self.input[partition].clone(),
             baseline_metrics: BaselineMetrics::new(&self.metrics, partition),
-            dv_short_mask_padded_files_total: MetricBuilder::new(&self.metrics)
-                .counter("dv_short_mask_padded_files_total", partition),
             transforms: Arc::clone(&self.transforms),
-            selection_vectors: Arc::clone(&self.selection_vectors),
+            deletion_vectors: Arc::clone(&self.deletion_vectors),
             public_file_ids: Arc::clone(&self.public_file_ids),
             file_id_field: self.file_id_field.clone(),
             schema_adapter: super::SchemaAdapter::new(Arc::clone(
@@ -357,12 +350,10 @@ struct DeltaScanMetaStream {
     input: VecDeque<(String, usize)>,
     /// Execution metrics
     baseline_metrics: BaselineMetrics,
-    /// Count of file batches where short deletion-vector masks required padding.
-    dv_short_mask_padded_files_total: Count,
     /// Transforms to be applied to data read from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
     /// Selection vectors to be applied to data read from individual files
-    selection_vectors: Arc<DashMap<String, Vec<bool>>>,
+    deletion_vectors: Arc<DeletionVectorIndex>,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
     /// Column name for the file id
@@ -381,29 +372,16 @@ impl DeltaScanMetaStream {
 
         let _timer = self.baseline_metrics.elapsed_compute().timer();
 
+        let live_row_count = if self.deletion_vectors.has_vectors() {
+            self.deletion_vectors.live_row_count(&file_id, row_count)?
+        } else {
+            row_count
+        };
         let batch = RecordBatch::try_new_with_options(
             EMPTY_SCHEMA.clone(),
             vec![],
-            &RecordBatchOptions::new().with_row_count(Some(row_count)),
+            &RecordBatchOptions::new().with_row_count(Some(live_row_count)),
         )?;
-
-        let batch = if let Some(selection) = self.selection_vectors.get(&file_id) {
-            let mask_len = selection.len();
-            let (batch, padded_rows) = apply_selection_vector(batch, selection.value(), &file_id)?;
-            if padded_rows > 0 {
-                self.dv_short_mask_padded_files_total.add(1);
-                debug!(
-                    file_id = file_id.as_str(),
-                    mask_len,
-                    row_count,
-                    padded_rows,
-                    "Padded short deletion-vector keep-mask in metadata scan"
-                );
-            }
-            batch
-        } else {
-            batch
-        };
 
         let result = if self
             .scan_plan
@@ -452,43 +430,6 @@ impl DeltaScanMetaStream {
     }
 }
 
-fn apply_selection_vector(
-    batch: RecordBatch,
-    selection: &[bool],
-    file_id: &str,
-) -> Result<(RecordBatch, usize)> {
-    let (_, n_rows_to_pad) = effective_row_count(batch.num_rows(), selection, file_id)?;
-    // Delta Kernel may emit short keep-masks; missing trailing entries are
-    // implicitly `true` (row is kept).
-    let filter = BooleanArray::from_iter(
-        selection
-            .iter()
-            .copied()
-            .chain(std::iter::repeat_n(true, n_rows_to_pad)),
-    );
-    Ok((filter_record_batch(&batch, &filter)?, n_rows_to_pad))
-}
-
-fn effective_row_count(
-    row_count: usize,
-    selection: &[bool],
-    file_id: &str,
-) -> Result<(usize, usize)> {
-    if selection.len() > row_count {
-        return Err(internal_datafusion_err!(
-            "Selection vector length ({}) exceeds row count ({}) for file '{}'. \
-             This indicates a bug in deletion vector processing.",
-            selection.len(),
-            row_count,
-            file_id
-        ));
-    }
-
-    let n_rows_to_pad = row_count - selection.len();
-    let kept_rows = selection.iter().filter(|keep| **keep).count() + n_rows_to_pad;
-    Ok((kept_rows, n_rows_to_pad))
-}
-
 impl Stream for DeltaScanMetaStream {
     type Item = Result<RecordBatch>;
 
@@ -518,8 +459,8 @@ mod tests {
     use std::sync::Arc;
 
     use arrow::array::RecordBatch;
-    use arrow_array::{Int64Array, RecordBatchOptions, StringArray};
-    use arrow_schema::{DataType, Field, Fields, Schema};
+    use arrow_array::{Int64Array, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
     use datafusion::{
         catalog::TableProvider,
         common::stats::Precision,
@@ -772,54 +713,6 @@ mod tests {
         );
 
         Ok(())
-    }
-
-    #[test]
-    fn test_apply_selection_vector_short_mask_pads_with_true() {
-        let batch = RecordBatch::try_new_with_options(
-            Arc::new(Schema::new(Fields::empty())),
-            vec![],
-            &RecordBatchOptions::new().with_row_count(Some(4)),
-        )
-        .unwrap();
-
-        // Short masks are valid: missing trailing entries are implicitly true.
-        let (filtered, padded_rows) =
-            apply_selection_vector(batch, &[false, true], "file:///f.parquet").unwrap();
-        assert_eq!(filtered.num_rows(), 3);
-        assert_eq!(padded_rows, 2);
-    }
-
-    #[test]
-    fn test_apply_selection_vector_no_padding_when_lengths_match() {
-        let batch = RecordBatch::try_new_with_options(
-            Arc::new(Schema::new(Fields::empty())),
-            vec![],
-            &RecordBatchOptions::new().with_row_count(Some(2)),
-        )
-        .unwrap();
-
-        let (filtered, padded_rows) =
-            apply_selection_vector(batch, &[true, false], "file:///f.parquet").unwrap();
-        assert_eq!(filtered.num_rows(), 1);
-        assert_eq!(padded_rows, 0);
-    }
-
-    #[test]
-    fn test_apply_selection_vector_longer_than_batch_errors() {
-        let batch = RecordBatch::try_new_with_options(
-            Arc::new(Schema::new(Fields::empty())),
-            vec![],
-            &RecordBatchOptions::new().with_row_count(Some(2)),
-        )
-        .unwrap();
-
-        let err = apply_selection_vector(batch, &[true, true, true], "file:///f.parquet")
-            .expect_err("selection vector longer than row count must error");
-        assert!(
-            err.to_string().contains("Selection vector length"),
-            "unexpected error: {err}"
-        );
     }
 
     #[tokio::test]
@@ -1145,8 +1038,22 @@ mod tests {
             .downcast_ref::<DeltaScanMetaExec>()
             .expect("expected metadata-only scan");
 
-        let selection_vectors: Arc<DashMap<String, Vec<bool>>> = Arc::new(DashMap::new());
-        selection_vectors.insert("f2".to_string(), vec![true, false, true, false]);
+        let deletion_vectors = Arc::new(
+            DeletionVectorIndex::try_new(HashMap::from([(
+                "f2".to_string(),
+                super::super::deletion_vector::DeletionVectorEntry {
+                    keep_mask: vec![true, false, true, false],
+                    physical_record_count: 4,
+                    deleted_cardinality: 2,
+                },
+            )]))?
+            .with_selected_files(HashMap::from([
+                ("f1".into(), Some(10)),
+                ("f2".into(), Some(4)),
+                ("f3".into(), Some(6)),
+                ("f4".into(), Some(2)),
+            ]))?,
+        );
         let public_file_ids = Arc::new(
             [
                 ("f1".to_string(), "f1".to_string()),
@@ -1167,7 +1074,7 @@ mod tests {
                 ("f4".to_string(), 2usize),
             ])],
             Arc::clone(&template.transforms),
-            selection_vectors,
+            deletion_vectors,
             public_file_ids,
             template.file_id_field.clone(),
             ExecutionPlanMetricsSet::new(),

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/exec_meta.rs
@@ -352,7 +352,7 @@ struct DeltaScanMetaStream {
     baseline_metrics: BaselineMetrics,
     /// Transforms to be applied to data read from individual files
     transforms: Arc<HashMap<String, ExpressionRef>>,
-    /// Selection vectors to be applied to data read from individual files
+    /// Deletion vectors used to count visible rows in each file.
     deletion_vectors: Arc<DeletionVectorIndex>,
     /// Public file paths keyed by compact scan file id.
     public_file_ids: Arc<super::PublicFileIdMap>,
@@ -1038,22 +1038,22 @@ mod tests {
             .downcast_ref::<DeltaScanMetaExec>()
             .expect("expected metadata-only scan");
 
-        let deletion_vectors = Arc::new(
-            DeletionVectorIndex::try_new(HashMap::from([(
+        let deletion_vectors = Arc::new(DeletionVectorIndex::try_new(
+            HashMap::from([(
                 "f2".to_string(),
                 super::super::deletion_vector::DeletionVectorEntry {
                     keep_mask: vec![true, false, true, false],
                     physical_record_count: 4,
                     deleted_cardinality: 2,
                 },
-            )]))?
-            .with_selected_files(HashMap::from([
+            )]),
+            HashMap::from([
                 ("f1".into(), Some(10)),
                 ("f2".into(), Some(4)),
                 ("f3".into(), Some(6)),
                 ("f4".into(), Some(2)),
-            ]))?,
-        );
+            ]),
+        )?);
         let public_file_ids = Arc::new(
             [
                 ("f1".to_string(), "f1".to_string()),

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/metadata_cache.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/metadata_cache.rs
@@ -1,0 +1,188 @@
+//! Store-qualified views of the session cache. The backing cache owns the single
+//! retention allowance, including entries from concurrent, independently planned scans.
+
+use std::{
+    any::Any,
+    sync::{Arc, Weak},
+    time::Duration,
+};
+
+use datafusion::{
+    common::{HashMap, Result, TableReference},
+    execution::cache::{
+        Cache, CacheEntryInfo,
+        cache_manager::{CachedFileMetadataEntry, FileMetadata, FileMetadataCache},
+    },
+};
+use object_store::{ObjectMeta, ObjectStore, path::Path};
+
+#[derive(Debug)]
+pub(super) struct StoreMetadataCache {
+    backing: Arc<FileMetadataCache>,
+    store: Arc<dyn ObjectStore>,
+    object: ObjectMeta,
+}
+
+struct TaggedMetadata {
+    // Weak retains the allocation identity, preventing address reuse without
+    // retaining an unregistered store's data for the cache entry's lifetime.
+    store: Weak<dyn ObjectStore>,
+    value: Arc<dyn FileMetadata>,
+    object: ObjectMeta,
+    footer: Option<std::result::Result<super::reader::FooterEvidence, String>>,
+}
+
+impl FileMetadata for TaggedMetadata {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn memory_size(&self) -> usize {
+        self.value.memory_size()
+            + std::mem::size_of::<Self>()
+            + self.object.location.as_ref().len()
+            + self.object.e_tag.as_ref().map_or(0, String::len)
+            + self.object.version.as_ref().map_or(0, String::len)
+            + self
+                .footer
+                .as_ref()
+                .and_then(|proof| proof.as_ref().err())
+                .map_or(0, String::len)
+    }
+    fn extra_info(&self) -> HashMap<String, String> {
+        self.value.extra_info()
+    }
+}
+
+impl StoreMetadataCache {
+    pub(super) fn new(
+        backing: Arc<FileMetadataCache>,
+        store: Arc<dyn ObjectStore>,
+        object: ObjectMeta,
+    ) -> Self {
+        Self {
+            backing,
+            store,
+            object,
+        }
+    }
+
+    pub(super) fn footer_evidence(
+        &self,
+        metadata: &Arc<parquet::file::metadata::ParquetMetaData>,
+    ) -> std::result::Result<super::reader::FooterEvidence, String> {
+        if let Some(entry) = self.backing.get(&self.key(&self.object.location))
+            && let Some(tagged) = entry.file_metadata.as_any().downcast_ref::<TaggedMetadata>()
+            && Weak::ptr_eq(&Arc::downgrade(&self.store), &tagged.store)
+            && tagged.object == self.object
+            && let Some(cached) = tagged.value.as_any().downcast_ref::<datafusion::datasource::physical_plan::parquet::metadata::CachedParquetMetaData>()
+            && Arc::ptr_eq(cached.parquet_metadata(), metadata)
+            && let Some(evidence) = &tagged.footer
+        {
+            return evidence.clone();
+        }
+        super::reader::validate_footer(metadata)
+    }
+
+    fn key(&self, path: &Path) -> Path {
+        // The store allocation and canonical path qualify each key. Tagged values
+        // distinguish these entries from bare-path entries and verify full identity.
+        let address = Arc::as_ptr(&self.store) as *const () as usize;
+        Path::from(format!("__delta_rs_metadata/{address:x}/{}", path.as_ref()))
+    }
+
+    fn untag(&self, entry: CachedFileMetadataEntry) -> Option<CachedFileMetadataEntry> {
+        let tagged = entry
+            .file_metadata
+            .as_any()
+            .downcast_ref::<TaggedMetadata>()?;
+        if !Weak::ptr_eq(&tagged.store, &Arc::downgrade(&self.store))
+            || tagged.object != self.object
+        {
+            return None;
+        }
+        Some(CachedFileMetadataEntry::new(
+            tagged.object.clone(),
+            Arc::clone(&tagged.value),
+        ))
+    }
+}
+
+impl Cache<Path, CachedFileMetadataEntry> for StoreMetadataCache {
+    fn get(&self, path: &Path) -> Option<CachedFileMetadataEntry> {
+        if path != &self.object.location {
+            return None;
+        }
+        self.untag(self.backing.get(&self.key(path))?)
+    }
+    fn put(&self, path: &Path, value: CachedFileMetadataEntry) -> Option<CachedFileMetadataEntry> {
+        if path != &self.object.location || value.meta != self.object {
+            return None;
+        }
+        let footer = value.file_metadata.as_any().downcast_ref::<datafusion::datasource::physical_plan::parquet::metadata::CachedParquetMetaData>().map(|v| super::reader::validate_footer(v.parquet_metadata()));
+        let tagged = Arc::new(TaggedMetadata {
+            footer,
+            store: Arc::downgrade(&self.store),
+            object: value.meta.clone(),
+            value: value.file_metadata,
+        });
+        self.backing
+            .put(
+                &self.key(path),
+                CachedFileMetadataEntry::new(value.meta, tagged),
+            )
+            .and_then(|v| self.untag(v))
+    }
+    fn remove(&self, path: &Path) -> Option<CachedFileMetadataEntry> {
+        self.backing
+            .remove(&self.key(path))
+            .and_then(|v| self.untag(v))
+    }
+    fn contains_key(&self, path: &Path) -> bool {
+        self.get(path).is_some()
+    }
+    fn len(&self) -> usize {
+        self.list_entries().len()
+    }
+    fn clear(&self) {
+        self.remove(&self.object.location);
+    }
+    fn name(&self) -> String {
+        self.backing.name()
+    }
+    fn cache_limit(&self) -> usize {
+        self.backing.cache_limit()
+    }
+    fn update_cache_limit(&self, limit: usize) {
+        self.backing.update_cache_limit(limit);
+    }
+    fn cache_ttl(&self) -> Option<Duration> {
+        self.backing.cache_ttl()
+    }
+    fn update_cache_ttl(&self, ttl: Option<Duration>) {
+        self.backing.update_cache_ttl(ttl);
+    }
+    fn drop_table_entries(&self, table: &TableReference) -> Result<()> {
+        self.backing.drop_table_entries(table)
+    }
+    fn list_entries(&self) -> HashMap<Path, CacheEntryInfo<CachedFileMetadataEntry>> {
+        self.backing
+            .list_entries()
+            .into_iter()
+            .filter_map(|(key, info)| {
+                if key != self.key(&self.object.location) {
+                    return None;
+                }
+                let value = self.untag(info.value)?;
+                Some((
+                    self.object.location.clone(),
+                    CacheEntryInfo {
+                        value,
+                        size_bytes: info.size_bytes,
+                        hits: info.hits,
+                        expires: info.expires,
+                    },
+                ))
+            })
+            .collect()
+    }
+}

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/metadata_cache.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/metadata_cache.rs
@@ -1,5 +1,5 @@
-//! Store-qualified views of the session cache. The backing cache owns the single
-//! retention allowance, including entries from concurrent, independently planned scans.
+//! Parquet metadata cache keyed by object store and path.
+//! All scans share the session cache's capacity limit.
 
 use std::{
     any::Any,
@@ -24,8 +24,7 @@ pub(super) struct StoreMetadataCache {
 }
 
 struct TaggedMetadata {
-    // Weak retains the allocation identity, preventing address reuse without
-    // retaining an unregistered store's data for the cache entry's lifetime.
+    // Weak prevents reuse of the store's address while allowing the store to be dropped.
     store: Weak<dyn ObjectStore>,
     value: Arc<dyn FileMetadata>,
     object: ObjectMeta,
@@ -84,8 +83,8 @@ impl StoreMetadataCache {
     }
 
     fn key(&self, path: &Path) -> Path {
-        // The store allocation and canonical path qualify each key. Tagged values
-        // distinguish these entries from bare-path entries and verify full identity.
+        // Include the store address to distinguish identical paths in different stores.
+        // TaggedMetadata checks the store and object metadata when reading an entry.
         let address = Arc::as_ptr(&self.store) as *const () as usize;
         Path::from(format!("__delta_rs_metadata/{address:x}/{}", path.as_ref()))
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -59,7 +59,7 @@ use delta_kernel::{
     scan::ScanMetadata,
     table_features::TableFeature,
 };
-use futures::{Stream, TryStreamExt as _, future::ready};
+use futures::{Stream, TryStreamExt as _};
 use itertools::Itertools as _;
 use object_store::{ObjectMeta, path::Path};
 use parquet::arrow::RowNumber;
@@ -97,22 +97,16 @@ mod test_support;
 
 type ScanMetadataStream = Pin<Box<dyn Stream<Item = Result<ScanMetadata, DeltaTableError>> + Send>>;
 type PublicFileIdMap = HashMap<String, String>;
-type PhysicalFileIdentityMap = HashMap<String, PhysicalFileIdentity>;
 type StoreBindings = HashMap<ObjectStoreUrl, Option<Arc<dyn object_store::ObjectStore>>>;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct PhysicalFileIdentity {
-    object_store_url: ObjectStoreUrl,
-    location: Path,
-}
 
 #[derive(Clone, Debug)]
 struct PhysicalInputContract {
     store_bindings: StoreBindings,
     log_counts: HashMap<String, Option<u64>>,
     footer_bounds: HashMap<String, Arc<std::sync::OnceLock<u64>>>,
-    sources: Vec<datafusion_datasource::file_scan_config::FileScanConfig>,
-    planned_files: HashMap<String, PartitionedFile>,
+    sources: Vec<Arc<dyn datafusion_datasource::source::DataSource>>,
+    /// Selected file metadata captured before constructing the child plan.
+    planned_files: HashMap<String, (ObjectStoreUrl, PartitionedFile)>,
     table_schema: TableSchema,
     file_id_field: FieldRef,
     physical_row_position_field: Option<FieldRef>,
@@ -131,7 +125,7 @@ impl PhysicalInputContract {
             .field_with_name(file_id_field.name())
             .is_ok()
         {
-            return plan_err!("compact file-id field collides with physical schema");
+            return plan_err!("compact file id field collides with physical schema");
         }
         let parquet_read_schema = Arc::new(relax_schema_nested_nullability(parquet_read_schema));
         let physical_row_position_field = include_physical_row_position.then(|| {
@@ -191,26 +185,9 @@ impl PhysicalInputContract {
                 .flat_map(|g| g.iter())
                 .any(|f| !f.extensions.is_empty())
             {
-                return plan_err!("unplanned reader-affecting file extensions");
+                return plan_err!("unplanned file extensions that affect the reader");
             }
-            for file in config.file_groups.iter().flat_map(|group| group.iter()) {
-                let Some(datafusion::scalar::ScalarValue::Dictionary(_, value)) =
-                    file.partition_values.first()
-                else {
-                    return plan_err!("planned file is missing compact identity");
-                };
-                let datafusion::scalar::ScalarValue::Utf8(Some(id)) = value.as_ref() else {
-                    return plan_err!("planned file has invalid compact identity");
-                };
-                if self
-                    .planned_files
-                    .insert(id.clone(), file.clone())
-                    .is_some()
-                {
-                    return plan_err!("duplicate planned compact file identity");
-                }
-            }
-            self.sources.push(config.clone());
+            self.sources.push(Arc::clone(source.data_source()));
         } else if let Some(union) = input.downcast_ref::<UnionExec>() {
             for child in union.inputs() {
                 self.bind_sources(child)?;
@@ -306,10 +283,10 @@ pub(super) async fn execution_plan(
     get_data_scan_plan(session, scan_plan, replayed, limit).await
 }
 
-/// Load deletion-vector keep masks for the selected files.
+/// Load deletion vector keep masks for the selected files.
 ///
-/// The complete selected-file registry is captured first, then its expected
-/// descriptors are loaded. The merged receiver waits for every loading task.
+/// Record all selected files before loading their deletion vectors.
+/// Wait for every loading task before returning the masks.
 pub(super) async fn replay_deletion_vectors(
     engine: Arc<dyn Engine>,
     scan_plan: &KernelScanPlan,
@@ -327,25 +304,19 @@ pub(super) async fn replay_deletion_vectors(
     while let Some(batch) = stream.try_next().await? {
         files.extend(batch);
     }
-    let dv_stream =
+    let mut dv_stream =
         replay::load_deletion_vectors(engine, scan_plan.scan.table_root(), &files).build();
-    // Only files with `dv_info.has_vector()` spawn tasks, so every item should carry a DV.
-    // Guard with a typed error (instead of panic) in case that invariant drifts.
-    let dvs: HashMap<_, _> = dv_stream
-        .and_then(|loaded| {
-            ready(match loaded.keep_mask {
-                Some(keep_mask) => {
-                    normalize_dv_keep_mask_for_api(keep_mask, loaded.num_records, &loaded.file_url)
-                        .map(|mask| (loaded.file_url.to_string(), mask))
-                        .map_err(DeltaTableError::from)
-                }
-                None => Err(DeltaTableError::generic(
-                    "Invariant violation: DV task spawned for file without deletion vector",
-                )),
-            })
-        })
-        .try_collect()
-        .await?;
+    let mut dvs = HashMap::new();
+    while let Some(loaded) = dv_stream.try_next().await? {
+        let file = files.get(loaded.selected_id).ok_or_else(|| {
+            internal_datafusion_err!("deletion vector result has unknown selected file id")
+        })?;
+        let keep_mask = loaded.keep_mask.ok_or_else(|| {
+            internal_datafusion_err!("missing keep mask for selected deletion vector file")
+        })?;
+        let mask = normalize_dv_keep_mask_for_api(keep_mask, file.num_records, &file.file_url)?;
+        dvs.insert(file.file_url.to_string(), mask);
+    }
 
     let mut vectors: Vec<_> = dvs
         .into_iter()
@@ -485,16 +456,15 @@ async fn replay_files(
             .entry(url.clone())
             .or_insert_with(|| session.runtime_env().object_store(&url).ok());
     }
-    let dv_stream =
+    let mut dv_stream =
         replay::load_deletion_vectors(engine, scan_plan.scan.table_root(), &files).build();
-    let loaded = dv_stream.try_collect::<Vec<_>>().await?;
-    let mut dvs_by_url = HashMap::new();
-    for dv in loaded {
-        if dvs_by_url.insert(dv.selected_id, dv).is_some() {
-            return plan_err!("duplicate deletion-vector loading result");
+    let mut dvs_by_id = HashMap::new();
+    while let Some(dv) = dv_stream.try_next().await? {
+        if dvs_by_id.insert(dv.selected_id, dv).is_some() {
+            return plan_err!("duplicate deletion vector loading result");
         }
     }
-    let dvs = build_deletion_vector_index(&files, dvs_by_url)?;
+    let dvs = build_deletion_vector_index(&files, dvs_by_id)?;
 
     let metrics = ExecutionPlanMetricsSet::new();
     MetricBuilder::new(&metrics)
@@ -513,12 +483,10 @@ async fn replay_files(
 
 /// Normalize a DV keep mask for `deletion_vectors()`.
 ///
-/// Kernel returns a sparse mask (up to the highest deleted row index). For API output we need one
-/// full mask per file, to do this we pad trailing entries with `true` up to `numRecords`. If `numRecords`
-/// is missing we fail, because we cannot know the correct full length.
+/// Kernel returns a mask ending at the highest deleted row index. Pad the mask
+/// with `true` up to `numRecords`. Return an error if `numRecords` is missing.
 ///
-/// This is API only. Scan execution keeps the sparse representation and performs immutable
-/// lookups by absolute physical Parquet row position.
+/// Scan execution uses the original mask and looks up rows by physical Parquet position.
 fn normalize_dv_keep_mask_for_api(
     mut mask: Vec<bool>,
     num_records: Option<u64>,
@@ -571,20 +539,6 @@ async fn get_data_scan_plan(
         .map(|(i, file)| (compact_internal_file_id(i), file.num_records))
         .collect();
 
-    let physical_file_identities = files
-        .iter()
-        .filter(|_| has_deletion_vectors)
-        .enumerate()
-        .map(|(file_index, file)| {
-            Ok((
-                compact_internal_file_id(file_index),
-                PhysicalFileIdentity {
-                    object_store_url: file.file_url.as_object_store_url(),
-                    location: Path::from_url_path(file.file_url.path())?,
-                },
-            ))
-        })
-        .try_collect::<_, PhysicalFileIdentityMap, DataFusionError>()?;
     let dvs = Arc::new(dvs);
     let parquet_limit = if has_deletion_vectors { None } else { limit };
 
@@ -592,6 +546,7 @@ async fn get_data_scan_plan(
     // Create one `DataSourceExec` plan for each store.
     // Add a compact scan file id as a partition value for file correlation.
     // The exec maps that id back to the public file path only when the file column is projected.
+    let mut planned_files = HashMap::new();
     let to_partitioned_file = |(file_index, f): (usize, ScanFileContext)| {
         if let Some(part_stata) = &f.partitions {
             update_partition_stats(part_stata, &f.stats, &mut partition_stats)?;
@@ -607,12 +562,17 @@ async fn get_data_scan_plan(
             version: None,
         }
         .into();
-        let file_value = wrap_file_id_value(compact_internal_file_id(file_index));
+        let file_id = compact_internal_file_id(file_index);
+        let file_value = wrap_file_id_value(file_id.clone());
         // NOTE: `PartitionedFile::with_statistics` appends exact stats for partition columns based
         // on `partition_values`, so partition values must be set first.
-        partitioned_file.partition_values = vec![file_value.clone()];
+        partitioned_file.partition_values = vec![file_value];
         partitioned_file = partitioned_file.with_statistics(Arc::new(f.stats));
-        Ok::<_, DataFusionError>((f.file_url.as_object_store_url(), partitioned_file))
+        let store = f.file_url.as_object_store_url();
+        if has_deletion_vectors {
+            planned_files.insert(file_id, (store.clone(), partitioned_file.clone()));
+        }
+        Ok::<_, DataFusionError>((store, partitioned_file))
     };
 
     // Group the files by their object store url. Since datafusion assumes that all files in a
@@ -638,8 +598,8 @@ async fn get_data_scan_plan(
         scan_plan.parquet_predicate.as_ref()
     };
     let file_id_field = scan_plan.contract.file_id_field.clone();
-    // Complete schemas are needed only to choose a collision-free hidden position
-    // field. Avoid converting them again on scans without a positional consumer.
+    // Check both schemas when choosing a hidden position field name to avoid collisions.
+    // Scans without deletion vectors do not need these conversions.
     let known_schemas = if has_deletion_vectors {
         let logical: Schema = table_config.logical_schema().as_ref().try_into_arrow()?;
         let physical: Schema = table_config.physical_schema().as_ref().try_into_arrow()?;
@@ -661,7 +621,9 @@ async fn get_data_scan_plan(
     )?;
     physical_input_contract.log_counts = log_counts;
     physical_input_contract.store_bindings = store_bindings;
-    physical_input_contract.footer_bounds = physical_file_identities
+    physical_input_contract.planned_files = planned_files;
+    physical_input_contract.footer_bounds = physical_input_contract
+        .planned_files
         .keys()
         .map(|id| (id.clone(), Arc::new(std::sync::OnceLock::new())))
         .collect();
@@ -688,7 +650,6 @@ async fn get_data_scan_plan(
         exec::PhysicalScanContext {
             deletion_vectors: Arc::clone(&dvs),
             public_file_ids: Arc::clone(&public_file_ids),
-            physical_file_identities: Arc::new(physical_file_identities),
             physical_input_contract,
         },
         partition_stats,
@@ -741,40 +702,33 @@ fn compact_internal_file_id(file_index: usize) -> String {
 
 fn build_deletion_vector_index(
     files: &[ScanFileContext],
-    mut dvs_by_url: HashMap<usize, LoadedDeletionVector>,
+    mut dvs_by_id: HashMap<usize, LoadedDeletionVector>,
 ) -> Result<DeletionVectorIndex> {
     let mut entries = HashMap::new();
     for (file_index, file) in files.iter().enumerate() {
         if !file.expected_dv.has_vector() {
-            if dvs_by_url.contains_key(&file_index) {
-                return plan_err!("unexpected deletion vector for explicitly all-live file");
+            if dvs_by_id.contains_key(&file_index) {
+                return plan_err!("loaded deletion vector for a file with no descriptor");
             }
             continue;
         }
-        let loaded = dvs_by_url.remove(&file_index).ok_or_else(|| {
-            internal_datafusion_err!("missing expected deletion-vector loading result")
+        let loaded = dvs_by_id.remove(&file_index).ok_or_else(|| {
+            internal_datafusion_err!("missing expected deletion vector loading result")
         })?;
-        if loaded.file_url != file.file_url
-            || loaded.descriptor != file.expected_dv
-            || loaded.num_records != file.num_records
-            || loaded.deleted_cardinality != file.dv_cardinality
-        {
-            return plan_err!("deletion-vector loading metadata differs from selected file");
-        }
-        let num_records = loaded.num_records.ok_or_else(|| {
+        let num_records = file.num_records.ok_or_else(|| {
             DataFusionError::Plan(format!(
-                "numRecords is required for deletion-vector file {}",
+                "numRecords is required for deletion vector file {}",
                 super::redact_url_for_error(&file.file_url)
             ))
         })?;
-        let deleted_cardinality = loaded.deleted_cardinality.ok_or_else(|| {
+        let deleted_cardinality = file.dv_cardinality.ok_or_else(|| {
             DataFusionError::Plan(format!(
-                "deletion-vector cardinality is required for file {}",
+                "deletion vector cardinality is required for file {}",
                 super::redact_url_for_error(&file.file_url)
             ))
         })?;
         let keep_mask = loaded.keep_mask.ok_or_else(|| {
-            internal_datafusion_err!("missing keep-mask for selected deletion-vector file")
+            internal_datafusion_err!("missing keep mask for selected deletion vector file")
         })?;
         entries.insert(
             compact_internal_file_id(file_index),
@@ -785,16 +739,16 @@ fn build_deletion_vector_index(
             },
         );
     }
-    if let Some(loaded) = dvs_by_url.values().next() {
+    if !dvs_by_id.is_empty() {
         return Err(internal_datafusion_err!(
-            "missing internal file id mapping for file with deletion vector: {}",
-            super::redact_url_for_error(&loaded.file_url)
+            "deletion vector result has unknown selected file id"
         ));
     }
     if entries.is_empty() {
         return Ok(DeletionVectorIndex::default());
     }
-    DeletionVectorIndex::try_new(entries)?.with_selected_files(
+    DeletionVectorIndex::try_new(
+        entries,
         files
             .iter()
             .enumerate()
@@ -1240,14 +1194,10 @@ mod tests {
         }
     }
 
-    fn registry_load(file: &ScanFileContext) -> LoadedDeletionVector {
+    fn registry_load() -> LoadedDeletionVector {
         LoadedDeletionVector {
             selected_id: 0,
-            descriptor: file.expected_dv.clone(),
-            file_url: file.file_url.clone(),
             keep_mask: Some(vec![false]),
-            num_records: file.num_records,
-            deleted_cardinality: file.dv_cardinality,
         }
     }
 
@@ -1256,9 +1206,9 @@ mod tests {
         let file = registry_fixture(true, Some(3));
         assert!(build_deletion_vector_index(&[file], HashMap::new()).is_err());
         let live = registry_fixture(false, None);
-        let load = registry_load(&registry_fixture(true, Some(3)));
+        let load = registry_load();
         assert!(build_deletion_vector_index(&[live], HashMap::from([(0, load)])).is_err());
-        let unknown = registry_load(&registry_fixture(true, Some(3)));
+        let unknown = registry_load();
         assert!(build_deletion_vector_index(&[], HashMap::from([(0, unknown)])).is_err());
     }
 
@@ -1267,7 +1217,7 @@ mod tests {
         let live = registry_fixture(false, None);
         assert!(!build_deletion_vector_index(&[live], HashMap::new())?.has_vectors());
         let dv = registry_fixture(true, Some(3));
-        let load = registry_load(&dv);
+        let load = registry_load();
         let index = build_deletion_vector_index(
             &[dv, registry_fixture(false, None)],
             HashMap::from([(0, load)]),
@@ -1293,16 +1243,13 @@ mod tests {
     }
 
     #[test]
-    fn registry_rejects_descriptor_count_and_mask_mismatches() {
-        for mutation in 0..4 {
+    fn registry_rejects_missing_and_inconsistent_masks() {
+        for keep_mask in [None, Some(vec![true])] {
             let file = registry_fixture(true, Some(3));
-            let mut loaded = registry_load(&file);
-            match mutation {
-                0 => loaded.num_records = Some(4),
-                1 => loaded.deleted_cardinality = Some(0),
-                2 => loaded.keep_mask = None,
-                _ => loaded.keep_mask = Some(vec![true]),
-            }
+            let loaded = LoadedDeletionVector {
+                selected_id: 0,
+                keep_mask,
+            };
             assert!(build_deletion_vector_index(&[file], HashMap::from([(0, loaded)])).is_err());
         }
     }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -25,16 +25,15 @@ use arrow_array::{
     ArrayRef, DictionaryArray, RecordBatch, StringArray, StringViewArray, UInt16Array,
 };
 use arrow_cast::{CastOptions, cast_with_options};
-use arrow_schema::{DataType, FieldRef, Schema, SchemaBuilder, SchemaRef};
+use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
 use chrono::{TimeZone as _, Utc};
-use dashmap::DashMap;
 use datafusion::{
     catalog::Session,
     common::{
         ColumnStatistics, HashMap, Result, Statistics, ToDFSchema, internal_datafusion_err,
         plan_err, stats::Precision,
     },
-    datasource::physical_plan::{ParquetSource, parquet::CachedParquetFileReaderFactory},
+    datasource::physical_plan::ParquetSource,
     error::DataFusionError,
     execution::object_store::ObjectStoreUrl,
     physical_expr::Partitioning,
@@ -54,21 +53,24 @@ use datafusion_physical_expr_adapter::{
     BatchAdapter, BatchAdapterFactory, PhysicalExprAdapterFactory,
 };
 use delta_kernel::{
-    Engine, Expression, engine::arrow_data::ArrowEngineData, expressions::StructData,
-    scan::ScanMetadata, table_features::TableFeature,
+    Engine, Expression,
+    engine::{arrow_conversion::TryIntoArrow as _, arrow_data::ArrowEngineData},
+    expressions::StructData,
+    scan::ScanMetadata,
+    table_features::TableFeature,
 };
 use futures::{Stream, TryStreamExt as _, future::ready};
 use itertools::Itertools as _;
 use object_store::{ObjectMeta, path::Path};
+use parquet::arrow::RowNumber;
 use tracing::debug;
 use url::Url;
 
 pub use self::exec::DeltaScanExec;
-use self::exec::DvExecutionState;
 use self::exec_meta::DeltaScanMetaExec;
 use self::expr_adapter::{DeltaPhysicalExprAdapterFactory, relax_schema_nested_nullability};
 pub(crate) use self::plan::{KernelScanPlan, ProjectedScanContract, supports_filters_pushdown};
-use self::replay::{ScanFileContext, ScanFileStream};
+use self::replay::{LoadedDeletionVector, ScanFileContext, ScanFileStream};
 use super::{FileSelection, ResolvedFileSelection};
 use crate::{
     DeltaTableError,
@@ -80,16 +82,23 @@ use crate::{
     },
     kernel::LogicalFileView,
 };
+use deletion_vector::{DeletionVectorEntry, DeletionVectorIndex};
 
+mod deletion_vector;
 mod exec;
 mod exec_meta;
 mod expr_adapter;
+mod metadata_cache;
 mod plan;
+mod reader;
 mod replay;
+#[cfg(test)]
+mod test_support;
 
 type ScanMetadataStream = Pin<Box<dyn Stream<Item = Result<ScanMetadata, DeltaTableError>> + Send>>;
 type PublicFileIdMap = HashMap<String, String>;
 type PhysicalFileIdentityMap = HashMap<String, PhysicalFileIdentity>;
+type StoreBindings = HashMap<ObjectStoreUrl, Option<Arc<dyn object_store::ObjectStore>>>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct PhysicalFileIdentity {
@@ -97,10 +106,127 @@ struct PhysicalFileIdentity {
     location: Path,
 }
 
+#[derive(Clone, Debug)]
+struct PhysicalInputContract {
+    store_bindings: StoreBindings,
+    log_counts: HashMap<String, Option<u64>>,
+    footer_bounds: HashMap<String, Arc<std::sync::OnceLock<u64>>>,
+    sources: Vec<datafusion_datasource::file_scan_config::FileScanConfig>,
+    planned_files: HashMap<String, PartitionedFile>,
+    table_schema: TableSchema,
+    file_id_field: FieldRef,
+    physical_row_position_field: Option<FieldRef>,
+    file_id_index: usize,
+    physical_row_position_index: Option<usize>,
+}
+
+impl PhysicalInputContract {
+    fn try_new(
+        parquet_read_schema: &SchemaRef,
+        file_id_field: FieldRef,
+        include_physical_row_position: bool,
+        known_schemas: &[SchemaRef],
+    ) -> Result<Self> {
+        if parquet_read_schema
+            .field_with_name(file_id_field.name())
+            .is_ok()
+        {
+            return plan_err!("compact file-id field collides with physical schema");
+        }
+        let parquet_read_schema = Arc::new(relax_schema_nested_nullability(parquet_read_schema));
+        let physical_row_position_field = include_physical_row_position.then(|| {
+            let base_name = "__delta_rs_physical_row_position";
+            let mut name = base_name.to_string();
+            let mut suffix = 0;
+            while parquet_read_schema.field_with_name(&name).is_ok()
+                || file_id_field.name() == &name
+                || known_schemas
+                    .iter()
+                    .any(|s| s.field_with_name(&name).is_ok())
+            {
+                suffix += 1;
+                name = format!("{base_name}_{suffix}");
+            }
+            Arc::new(Field::new(name, DataType::Int64, true).with_extension_type(RowNumber))
+        });
+        let mut builder = TableSchema::builder(parquet_read_schema)
+            .with_table_partition_cols(vec![file_id_field.clone()]);
+        if let Some(field) = &physical_row_position_field {
+            builder = builder.with_virtual_columns(vec![field.clone()]);
+        }
+        let table_schema = builder.build();
+        let file_id_index = table_schema.table_schema().index_of(file_id_field.name())?;
+        let physical_row_position_index = physical_row_position_field
+            .as_ref()
+            .map(|field| table_schema.table_schema().index_of(field.name()))
+            .transpose()?;
+        Ok(Self {
+            sources: Vec::new(),
+            planned_files: HashMap::new(),
+            store_bindings: HashMap::new(),
+            log_counts: HashMap::new(),
+            footer_bounds: HashMap::new(),
+            table_schema,
+            file_id_field,
+            physical_row_position_field,
+            file_id_index,
+            physical_row_position_index,
+        })
+    }
+
+    #[cfg(test)]
+    fn new(schema: &SchemaRef, file_id: FieldRef, positions: bool) -> Self {
+        Self::try_new(schema, file_id, positions, &[]).unwrap()
+    }
+
+    fn bind_sources(&mut self, input: &Arc<dyn ExecutionPlan>) -> Result<()> {
+        if let Some(source) = input.downcast_ref::<DataSourceExec>() {
+            let config = source
+                .data_source()
+                .downcast_ref::<datafusion_datasource::file_scan_config::FileScanConfig>()
+                .ok_or_else(|| internal_datafusion_err!("expected native file scan"))?;
+            if config
+                .file_groups
+                .iter()
+                .flat_map(|g| g.iter())
+                .any(|f| !f.extensions.is_empty())
+            {
+                return plan_err!("unplanned reader-affecting file extensions");
+            }
+            for file in config.file_groups.iter().flat_map(|group| group.iter()) {
+                let Some(datafusion::scalar::ScalarValue::Dictionary(_, value)) =
+                    file.partition_values.first()
+                else {
+                    return plan_err!("planned file is missing compact identity");
+                };
+                let datafusion::scalar::ScalarValue::Utf8(Some(id)) = value.as_ref() else {
+                    return plan_err!("planned file has invalid compact identity");
+                };
+                if self
+                    .planned_files
+                    .insert(id.clone(), file.clone())
+                    .is_some()
+                {
+                    return plan_err!("duplicate planned compact file identity");
+                }
+            }
+            self.sources.push(config.clone());
+        } else if let Some(union) = input.downcast_ref::<UnionExec>() {
+            for child in union.inputs() {
+                self.bind_sources(child)?;
+            }
+        } else if input.downcast_ref::<EmptyExec>().is_none() {
+            return plan_err!("unsupported initial physical input");
+        }
+        Ok(())
+    }
+}
+
 struct ReplayedScanFiles {
+    store_bindings: StoreBindings,
     files: Vec<ScanFileContext>,
     transforms: HashMap<String, Arc<Expression>>,
-    dvs: HashMap<String, Vec<bool>>,
+    dvs: DeletionVectorIndex,
     public_file_ids: PublicFileIdMap,
     metrics: ExecutionPlanMetricsSet,
 }
@@ -118,11 +244,19 @@ pub(super) async fn execution_plan(
         && selection.active_file_ids.is_empty()
     {
         return Ok(Arc::new(EmptyExec::new(
-            scan_plan.contract.result_schema.clone(),
+            scan_plan.contract.output_schema.clone(),
         )));
     }
 
-    let replayed = replay_files(engine, &scan_plan, config.clone(), stream, file_selection).await?;
+    let replayed = replay_files(
+        session,
+        engine,
+        &scan_plan,
+        config.clone(),
+        stream,
+        file_selection,
+    )
+    .await?;
 
     let file_id_field = scan_plan.contract.file_id_field.clone();
     if scan_plan.is_metadata_only() && !scan_plan.contract.retain_row_index {
@@ -160,7 +294,7 @@ pub(super) async fn execution_plan(
                 Arc::new(scan_plan),
                 vec![file_rows],
                 Arc::new(transforms),
-                Arc::new(dvs.into_iter().collect()),
+                Arc::new(dvs),
                 Arc::new(public_file_ids),
                 retain_file_id.then_some(file_id_field),
                 metrics,
@@ -174,9 +308,8 @@ pub(super) async fn execution_plan(
 
 /// Load deletion-vector keep masks for the selected files.
 ///
-/// Drain [`ScanFileStream`] to start the DV loading tasks, then collect their
-/// results through [`ReceiverStreamBuilder::build`]. A successful collection
-/// waits for all DV tasks to finish.
+/// The complete selected-file registry is captured first, then its expected
+/// descriptors are loaded. The merged receiver waits for every loading task.
 pub(super) async fn replay_deletion_vectors(
     engine: Arc<dyn Engine>,
     scan_plan: &KernelScanPlan,
@@ -185,22 +318,27 @@ pub(super) async fn replay_deletion_vectors(
     file_selection: Option<&ResolvedFileSelection>,
 ) -> Result<Vec<DeletionVectorSelection>> {
     let mut stream = ScanFileStream::new(
-        engine,
         &scan_plan.scan,
         config.clone(),
         file_selection.map(|selection| &selection.active_file_ids),
         stream,
     );
-    while stream.try_next().await?.is_some() {}
-
-    let dv_stream = stream.dv_stream.build();
-    // A DV task must return a keep mask.
-    let dvs: DashMap<_, _> = dv_stream
-        .and_then(|(url, dv, num_records)| {
-            ready(match dv {
-                Some(keep_mask) => normalize_dv_keep_mask_for_api(keep_mask, num_records, &url)
-                    .map(|mask| (url.to_string(), mask))
-                    .map_err(DeltaTableError::from),
+    let mut files = Vec::new();
+    while let Some(batch) = stream.try_next().await? {
+        files.extend(batch);
+    }
+    let dv_stream =
+        replay::load_deletion_vectors(engine, scan_plan.scan.table_root(), &files).build();
+    // Only files with `dv_info.has_vector()` spawn tasks, so every item should carry a DV.
+    // Guard with a typed error (instead of panic) in case that invariant drifts.
+    let dvs: HashMap<_, _> = dv_stream
+        .and_then(|loaded| {
+            ready(match loaded.keep_mask {
+                Some(keep_mask) => {
+                    normalize_dv_keep_mask_for_api(keep_mask, loaded.num_records, &loaded.file_url)
+                        .map(|mask| (loaded.file_url.to_string(), mask))
+                        .map_err(DeltaTableError::from)
+                }
                 None => Err(DeltaTableError::generic(
                     "Invariant violation: DV task spawned for file without deletion vector",
                 )),
@@ -302,6 +440,7 @@ async fn collect_selected_active_file_ids(
 }
 
 async fn replay_files(
+    session: &dyn Session,
     engine: Arc<dyn Engine>,
     scan_plan: &KernelScanPlan,
     scan_config: DeltaScanConfig,
@@ -309,7 +448,6 @@ async fn replay_files(
     file_selection: Option<&ResolvedFileSelection>,
 ) -> Result<ReplayedScanFiles> {
     let mut stream = ScanFileStream::new(
-        engine,
         &scan_plan.scan,
         scan_config,
         file_selection.map(|selection| &selection.active_file_ids),
@@ -340,12 +478,23 @@ async fn replay_files(
         })
         .collect();
 
-    let dv_stream = stream.dv_stream.build();
-    let dvs_by_url: HashMap<_, _> = dv_stream
-        .try_filter_map(|(url, dv, _)| ready(Ok(dv.map(|dv| (url.to_string(), dv)))))
-        .try_collect()
-        .await?;
-    let dvs = remap_deletion_vectors_to_internal_file_ids(&files, dvs_by_url)?;
+    let mut store_bindings = StoreBindings::new();
+    for file in &files {
+        let url = file.file_url.as_object_store_url();
+        store_bindings
+            .entry(url.clone())
+            .or_insert_with(|| session.runtime_env().object_store(&url).ok());
+    }
+    let dv_stream =
+        replay::load_deletion_vectors(engine, scan_plan.scan.table_root(), &files).build();
+    let loaded = dv_stream.try_collect::<Vec<_>>().await?;
+    let mut dvs_by_url = HashMap::new();
+    for dv in loaded {
+        if dvs_by_url.insert(dv.selected_id, dv).is_some() {
+            return plan_err!("duplicate deletion-vector loading result");
+        }
+    }
+    let dvs = build_deletion_vector_index(&files, dvs_by_url)?;
 
     let metrics = ExecutionPlanMetricsSet::new();
     MetricBuilder::new(&metrics)
@@ -353,6 +502,7 @@ async fn replay_files(
         .add(stream.metrics.num_scanned);
 
     Ok(ReplayedScanFiles {
+        store_bindings,
         files,
         transforms,
         dvs,
@@ -367,8 +517,8 @@ async fn replay_files(
 /// full mask per file, to do this we pad trailing entries with `true` up to `numRecords`. If `numRecords`
 /// is missing we fail, because we cannot know the correct full length.
 ///
-/// This is API only. Scan execution does per batch normalization in `exec::consume_dv_mask` and
-/// `exec_meta::apply_selection_vector`.
+/// This is API only. Scan execution keeps the sparse representation and performs immutable
+/// lookups by absolute physical Parquet row position.
 fn normalize_dv_keep_mask_for_api(
     mut mask: Vec<bool>,
     num_records: Option<u64>,
@@ -405,36 +555,38 @@ async fn get_data_scan_plan(
     limit: Option<usize>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let ReplayedScanFiles {
+        store_bindings,
         files,
         transforms,
         dvs,
         public_file_ids,
         metrics,
     } = replayed;
-    let has_deletion_vectors = !dvs.is_empty();
+    let has_deletion_vectors = dvs.has_vectors();
     let mut partition_stats = HashMap::new();
+    let log_counts = files
+        .iter()
+        .filter(|_| has_deletion_vectors)
+        .enumerate()
+        .map(|(i, file)| (compact_internal_file_id(i), file.num_records))
+        .collect();
 
-    let dv_state = if has_deletion_vectors {
-        let physical_file_identities = files
-            .iter()
-            .enumerate()
-            .map(|(file_index, file)| {
-                Ok((
-                    compact_internal_file_id(file_index),
-                    PhysicalFileIdentity {
-                        object_store_url: file.file_url.as_object_store_url(),
-                        location: Path::from_url_path(file.file_url.path())?,
-                    },
-                ))
-            })
-            .try_collect::<_, PhysicalFileIdentityMap, DataFusionError>()?;
-        DvExecutionState::Sequential {
-            selection_vectors: Arc::new(dvs),
-            physical_file_identities: Arc::new(physical_file_identities),
-        }
-    } else {
-        DvExecutionState::NotPresent
-    };
+    let physical_file_identities = files
+        .iter()
+        .filter(|_| has_deletion_vectors)
+        .enumerate()
+        .map(|(file_index, file)| {
+            Ok((
+                compact_internal_file_id(file_index),
+                PhysicalFileIdentity {
+                    object_store_url: file.file_url.as_object_store_url(),
+                    location: Path::from_url_path(file.file_url.path())?,
+                },
+            ))
+        })
+        .try_collect::<_, PhysicalFileIdentityMap, DataFusionError>()?;
+    let dvs = Arc::new(dvs);
+    let parquet_limit = if has_deletion_vectors { None } else { limit };
 
     // Convert files into DataFusion `PartitionedFile`s grouped by object store.
     // Create one `DataSourceExec` plan for each store.
@@ -486,29 +638,55 @@ async fn get_data_scan_plan(
         scan_plan.parquet_predicate.as_ref()
     };
     let file_id_field = scan_plan.contract.file_id_field.clone();
-    let pq_plan = get_read_plan(
+    let known_logical: Schema = table_config.logical_schema().as_ref().try_into_arrow()?;
+    let known_physical: Schema = table_config.physical_schema().as_ref().try_into_arrow()?;
+    let mut physical_input_contract = PhysicalInputContract::try_new(
+        &scan_plan.parquet_read_schema,
+        file_id_field,
+        has_deletion_vectors,
+        &[
+            Arc::new(known_logical),
+            Arc::new(known_physical),
+            scan_plan.contract.scan_schema.clone(),
+            scan_plan.contract.output_schema.clone(),
+            scan_plan.parquet_predicate_schema.clone(),
+        ],
+    )?;
+    physical_input_contract.log_counts = log_counts;
+    physical_input_contract.store_bindings = store_bindings;
+    physical_input_contract.footer_bounds = physical_file_identities
+        .keys()
+        .map(|id| (id.clone(), Arc::new(std::sync::OnceLock::new())))
+        .collect();
+    let pq_plan = get_read_plan_with_contract(
         session,
         files_by_store,
-        &scan_plan.parquet_read_schema,
+        &physical_input_contract,
         &scan_plan.parquet_predicate_schema,
-        limit,
-        &file_id_field,
+        parquet_limit,
         predicate,
     )
     .await?;
+    if has_deletion_vectors {
+        physical_input_contract.bind_sources(&pq_plan)?;
+    }
+    let physical_input_contract = Arc::new(physical_input_contract);
 
     let transforms = Arc::new(transforms);
     let public_file_ids = Arc::new(public_file_ids);
-    let exec = DeltaScanExec::new(
+    let exec = DeltaScanExec::try_new(
         Arc::new(scan_plan),
         pq_plan,
         Arc::clone(&transforms),
-        dv_state,
-        Arc::clone(&public_file_ids),
+        exec::PhysicalScanContext {
+            deletion_vectors: Arc::clone(&dvs),
+            public_file_ids: Arc::clone(&public_file_ids),
+            physical_file_identities: Arc::new(physical_file_identities),
+            physical_input_contract,
+        },
         partition_stats,
         metrics,
-    );
-
+    )?;
     Ok(Arc::new(exec))
 }
 
@@ -554,28 +732,68 @@ fn compact_internal_file_id(file_index: usize) -> String {
     file_index.to_string()
 }
 
-fn remap_deletion_vectors_to_internal_file_ids(
+fn build_deletion_vector_index(
     files: &[ScanFileContext],
-    mut dvs_by_url: HashMap<String, Vec<bool>>,
-) -> Result<HashMap<String, Vec<bool>>> {
-    let mut dvs = HashMap::new();
+    mut dvs_by_url: HashMap<usize, LoadedDeletionVector>,
+) -> Result<DeletionVectorIndex> {
+    let mut entries = HashMap::new();
     for (file_index, file) in files.iter().enumerate() {
-        if dvs_by_url.is_empty() {
-            break;
+        if !file.expected_dv.has_vector() {
+            if dvs_by_url.contains_key(&file_index) {
+                return plan_err!("unexpected deletion vector for explicitly all-live file");
+            }
+            continue;
         }
-        if let Some(dv) = dvs_by_url.remove(file.file_url.as_str()) {
-            dvs.insert(compact_internal_file_id(file_index), dv);
+        let loaded = dvs_by_url.remove(&file_index).ok_or_else(|| {
+            internal_datafusion_err!("missing expected deletion-vector loading result")
+        })?;
+        if loaded.file_url != file.file_url
+            || loaded.descriptor != file.expected_dv
+            || loaded.num_records != file.num_records
+            || loaded.deleted_cardinality != file.dv_cardinality
+        {
+            return plan_err!("deletion-vector loading metadata differs from selected file");
         }
+        let num_records = loaded.num_records.ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "numRecords is required for deletion-vector file {}",
+                super::redact_url_for_error(&file.file_url)
+            ))
+        })?;
+        let deleted_cardinality = loaded.deleted_cardinality.ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "deletion-vector cardinality is required for file {}",
+                super::redact_url_for_error(&file.file_url)
+            ))
+        })?;
+        let keep_mask = loaded.keep_mask.ok_or_else(|| {
+            internal_datafusion_err!("missing keep-mask for selected deletion-vector file")
+        })?;
+        entries.insert(
+            compact_internal_file_id(file_index),
+            DeletionVectorEntry {
+                keep_mask,
+                physical_record_count: num_records,
+                deleted_cardinality,
+            },
+        );
     }
-    if let Some(file_url) = dvs_by_url.keys().next() {
-        let redacted_url = Url::parse(file_url)
-            .map(|url| super::redact_url_for_error(&url))
-            .unwrap_or_else(|_| file_url.clone());
+    if let Some(loaded) = dvs_by_url.values().next() {
         return Err(internal_datafusion_err!(
-            "missing internal file id mapping for file with deletion vector: {redacted_url}"
+            "missing internal file id mapping for file with deletion vector: {}",
+            super::redact_url_for_error(&loaded.file_url)
         ));
     }
-    Ok(dvs)
+    if entries.is_empty() {
+        return Ok(DeletionVectorIndex::default());
+    }
+    DeletionVectorIndex::try_new(entries)?.with_selected_files(
+        files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (compact_internal_file_id(i), f.num_records))
+            .collect(),
+    )
 }
 
 fn public_file_id<'a>(
@@ -665,50 +883,95 @@ fn partitioned_files_to_file_groups_with_limit(
     file_groups
 }
 
-async fn get_read_plan(
+async fn get_read_plan_with_contract(
     state: &dyn Session,
     files_by_store: impl IntoIterator<Item = FilesByStore>,
-    // Schema of physical file columns to read from Parquet (no Delta partitions, no file-id).
-    //
-    // This is also the schema used for Parquet pruning/pushdown. It may include view types
-    // (e.g. Utf8View/BinaryView) depending on `DeltaScanConfig`.
-    parquet_read_schema: &SchemaRef,
+    physical_input_contract: &PhysicalInputContract,
     // Predicate binding schema used to bind Parquet predicates, including the synthetic file id
     // column when the provider exposes it.
     parquet_predicate_schema: &SchemaRef,
     limit: Option<usize>,
-    file_id_field: &FieldRef,
     predicate: Option<&Expr>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let mut plans = Vec::new();
 
-    // Relax nested-field nullability on the schema handed to the parquet source:
-    // Delta's `nullable = false` is a write-time invariant, and Spark-written files
-    // may mark nested fields optional. The logical schema is restored above the
-    // parquet scan by DeltaScanExec's transforms.
-    let parquet_read_schema = Arc::new(relax_schema_nested_nullability(parquet_read_schema));
-    let parquet_read_schema = &parquet_read_schema;
-
     let pq_options = crate::datafile::ReaderProperties::default().to_table_parquet_options(state);
 
-    let mut full_read_schema = SchemaBuilder::from(parquet_read_schema.as_ref().clone());
-    full_read_schema.push(file_id_field.as_ref().clone().with_nullable(true));
-    let full_read_schema = Arc::new(full_read_schema.finish());
+    let full_read_schema = physical_input_contract
+        .table_schema
+        .schema_without_virtual_columns()
+        .clone();
     let parquet_predicate_df_schema = parquet_predicate_schema.clone().to_dfschema()?;
     let adapter_factory = Arc::new(DeltaPhysicalExprAdapterFactory);
 
     for (store_url, files, has_deletion_vectors) in files_by_store.into_iter() {
-        let reader_factory = Arc::new(CachedParquetFileReaderFactory::new(
-            state.runtime_env().object_store(&store_url)?,
+        fn file_id(value: &datafusion::scalar::ScalarValue) -> Option<&str> {
+            match value {
+                datafusion::scalar::ScalarValue::Dictionary(_, v) => file_id(v),
+                datafusion::scalar::ScalarValue::Utf8(Some(v)) => Some(v),
+                _ => None,
+            }
+        }
+        let mut expected_files = HashMap::new();
+        for file in &files {
+            let count = file
+                .partition_values
+                .first()
+                .and_then(file_id)
+                .and_then(|id| physical_input_contract.log_counts.get(id).copied())
+                .flatten();
+            let value = (file.object_meta.clone(), count);
+            if let Some(previous) =
+                expected_files.insert(file.object_meta.location.clone(), value.clone())
+                && previous != value
+            {
+                return plan_err!(
+                    "inconsistent metadata for selected logical files sharing a physical object"
+                );
+            }
+        }
+        let mut footer_bounds = HashMap::<Path, Vec<Arc<std::sync::OnceLock<u64>>>>::new();
+        for file in &files {
+            if let Some(bound) = file
+                .partition_values
+                .first()
+                .and_then(file_id)
+                .and_then(|id| physical_input_contract.footer_bounds.get(id))
+            {
+                footer_bounds
+                    .entry(file.object_meta.location.clone())
+                    .or_default()
+                    .push(bound.clone());
+            }
+        }
+        let reader_factory = Arc::new(reader::BoundParquetReaderFactory::new(
+            match physical_input_contract.store_bindings.get(&store_url) {
+                Some(Some(store)) => store.clone(),
+                Some(None) => {
+                    return plan_err!(
+                        "selected file's store was unavailable when the registry was captured"
+                    );
+                }
+                None => state.runtime_env().object_store(&store_url)?,
+            },
             state.runtime_env().cache_manager.get_file_metadata_cache(),
+            expected_files,
+            physical_input_contract
+                .physical_row_position_field
+                .as_ref()
+                .map(|f| {
+                    (
+                        f.name().clone(),
+                        physical_input_contract.file_id_field.name().clone(),
+                    )
+                }),
+            footer_bounds,
         ));
 
         // NOTE: In the "next" provider, DataFusion's Parquet scan partition fields are file-id
         // only. Delta partition columns/values are injected via kernel transforms and handled
         // above Parquet, so they are not part of the Parquet partition schema here.
-        let table_schema = TableSchema::builder(parquet_read_schema.clone())
-            .with_table_partition_cols(vec![file_id_field.clone()])
-            .build();
+        let table_schema = physical_input_contract.table_schema.clone();
         let full_table_schema = table_schema.table_schema().clone();
         let mut file_source = ParquetSource::new(table_schema)
             .with_table_parquet_options(pq_options.clone())
@@ -779,10 +1042,35 @@ async fn get_read_plan(
     }
 
     Ok(match plans.len() {
-        0 => Arc::new(EmptyExec::new(full_read_schema.clone())),
+        0 => Arc::new(EmptyExec::new(
+            physical_input_contract.table_schema.table_schema().clone(),
+        )),
         1 => plans.remove(0),
         _ => UnionExec::try_new(plans)?,
     })
+}
+
+#[cfg(test)]
+async fn get_read_plan(
+    state: &dyn Session,
+    files_by_store: impl IntoIterator<Item = FilesByStore>,
+    parquet_read_schema: &SchemaRef,
+    parquet_predicate_schema: &SchemaRef,
+    limit: Option<usize>,
+    file_id_field: &FieldRef,
+    predicate: Option<&Expr>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let physical_input_contract =
+        PhysicalInputContract::new(parquet_read_schema, file_id_field.clone(), false);
+    get_read_plan_with_contract(
+        state,
+        files_by_store,
+        &physical_input_contract,
+        parquet_predicate_schema,
+        limit,
+        predicate,
+    )
+    .await
 }
 
 // Small helper to reuse some code between exec and exec_meta
@@ -901,6 +1189,7 @@ mod tests {
     };
     use object_store::{ObjectStoreExt as _, memory::InMemory};
     use parquet::arrow::ArrowWriter;
+    use parquet::file::properties::WriterProperties;
     use url::Url;
 
     use crate::{
@@ -916,6 +1205,100 @@ mod tests {
     };
 
     use super::{plan::build_parquet_predicate_schema, *};
+
+    fn registry_fixture(dv: bool, records: Option<u64>) -> ScanFileContext {
+        use delta_kernel::actions::deletion_vector::{
+            DeletionVectorDescriptor, DeletionVectorStorageType,
+        };
+        let expected_dv = if dv {
+            delta_kernel::scan::state::DvInfo::from(DeletionVectorDescriptor {
+                storage_type: DeletionVectorStorageType::Inline,
+                path_or_inline_dv: "fixture".into(),
+                offset: None,
+                size_in_bytes: 1,
+                cardinality: 1,
+            })
+        } else {
+            Default::default()
+        };
+        ScanFileContext {
+            file_url: Url::parse("memory:///file.parquet").unwrap(),
+            size: 100,
+            transform: None,
+            stats: Statistics::new_unknown(&Schema::empty()),
+            partitions: None,
+            num_records: records,
+            expected_dv,
+            dv_cardinality: dv.then_some(1),
+        }
+    }
+
+    fn registry_load(file: &ScanFileContext) -> LoadedDeletionVector {
+        LoadedDeletionVector {
+            selected_id: 0,
+            descriptor: file.expected_dv.clone(),
+            file_url: file.file_url.clone(),
+            keep_mask: Some(vec![false]),
+            num_records: file.num_records,
+            deleted_cardinality: file.dv_cardinality,
+        }
+    }
+
+    #[test]
+    fn registry_rejects_missing_and_unexpected_dv_results() {
+        let file = registry_fixture(true, Some(3));
+        assert!(build_deletion_vector_index(&[file], HashMap::new()).is_err());
+        let live = registry_fixture(false, None);
+        let load = registry_load(&registry_fixture(true, Some(3)));
+        assert!(build_deletion_vector_index(&[live], HashMap::from([(0, load)])).is_err());
+        let unknown = registry_load(&registry_fixture(true, Some(3)));
+        assert!(build_deletion_vector_index(&[], HashMap::from([(0, unknown)])).is_err());
+    }
+
+    #[test]
+    fn registry_accepts_non_dv_files_without_log_statistics() -> TestResult {
+        let live = registry_fixture(false, None);
+        assert!(!build_deletion_vector_index(&[live], HashMap::new())?.has_vectors());
+        let dv = registry_fixture(true, Some(3));
+        let load = registry_load(&dv);
+        let index = build_deletion_vector_index(
+            &[dv, registry_fixture(false, None)],
+            HashMap::from([(0, load)]),
+        )?;
+        assert_eq!(
+            index
+                .selection_for_positions("1", &Int64Array::from(vec![0, 9]))?
+                .true_count(),
+            2
+        );
+        assert_eq!(
+            index
+                .selection_for_positions("0", &Int64Array::from(vec![0, 1]))?
+                .true_count(),
+            1
+        );
+        assert!(
+            index
+                .selection_for_positions("2", &Int64Array::from(vec![0]))
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn registry_rejects_descriptor_count_and_mask_mismatches() {
+        for mutation in 0..4 {
+            let file = registry_fixture(true, Some(3));
+            let mut loaded = registry_load(&file);
+            match mutation {
+                0 => loaded.num_records = Some(4),
+                1 => loaded.deleted_cardinality = Some(0),
+                2 => loaded.keep_mask = None,
+                _ => loaded.keep_mask = Some(vec![true]),
+            }
+            assert!(build_deletion_vector_index(&[file], HashMap::from([(0, loaded)])).is_err());
+        }
+    }
 
     #[test]
     fn test_partitioned_files_to_file_groups_respects_dictionary_cardinality_limit() {
@@ -1064,59 +1447,6 @@ mod tests {
         assert!(filtered[0].schema().column_with_name("file_id").is_none());
 
         Ok(())
-    }
-
-    fn scan_file_context(file_url: &str) -> ScanFileContext {
-        ScanFileContext {
-            file_url: Url::parse(file_url).expect("valid test URL"),
-            size: 0,
-            transform: None,
-            stats: Statistics::new_unknown(&Schema::empty()),
-            partitions: None,
-        }
-    }
-
-    #[test]
-    fn test_remap_deletion_vectors_to_internal_file_ids_uses_compact_keys() -> TestResult {
-        let files = vec![
-            scan_file_context("s3://bucket/very/long/path/first.parquet"),
-            scan_file_context("s3://bucket/very/long/path/second.parquet"),
-        ];
-        let mut dvs_by_url = HashMap::new();
-        dvs_by_url.insert(files[1].file_url.to_string(), vec![true, false, true]);
-
-        let dvs = remap_deletion_vectors_to_internal_file_ids(&files, dvs_by_url)?;
-
-        assert!(dvs.contains_key("1"));
-        assert!(!dvs.contains_key(files[1].file_url.as_str()));
-        assert_eq!(
-            dvs.get("1").expect("compact dv key").as_slice(),
-            &[true, false, true]
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_remap_deletion_vectors_to_internal_file_ids_errors_for_unknown_url() {
-        let files = vec![scan_file_context(
-            "s3://bucket/very/long/path/first.parquet",
-        )];
-        let mut dvs_by_url = HashMap::new();
-        dvs_by_url.insert(
-            "s3://bucket/very/long/path/missing.parquet?X-Amz-Signature=secret-token".to_string(),
-            vec![true],
-        );
-
-        let err = remap_deletion_vectors_to_internal_file_ids(&files, dvs_by_url).unwrap_err();
-        let err = err.to_string();
-        assert!(
-            err.contains("missing internal file id mapping for file with deletion vector"),
-            "unexpected error: {err}"
-        );
-        assert!(
-            !err.contains("secret-token"),
-            "error should redact URL query secrets: {err}"
-        );
     }
 
     #[cfg(debug_assertions)]
@@ -1473,6 +1803,89 @@ mod tests {
         assert_batches_sorted_eq!(&expected, &batches);
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_row_number_retains_absolute_position_after_row_group_pruning() -> TestResult {
+        let store = Arc::new(InMemory::new());
+        let store_url = Url::parse("memory:///")?;
+        let session = Arc::new(create_session().into_inner());
+        session
+            .runtime_env()
+            .register_object_store(&store_url, store.clone());
+
+        let arrow_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let data = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![0, 1, 2, 3, 4, 5]))],
+        )?;
+        let properties = WriterProperties::builder()
+            .set_max_row_group_row_count(Some(2))
+            .build();
+        let mut buffer = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buffer, arrow_schema.clone(), Some(properties))?;
+        writer.write(&data)?;
+        writer.close()?;
+
+        let path = Path::from("absolute_positions.parquet");
+        store.put(&path, buffer.into()).await?;
+        let mut file: PartitionedFile = store.head(&path).await?.into();
+        file.partition_values
+            .push(wrap_file_id_value("memory:///absolute_positions.parquet"));
+
+        let file_id_field =
+            crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+        let predicate_schema = build_parquet_predicate_schema(&arrow_schema, &file_id_field);
+        let contract = PhysicalInputContract::new(&arrow_schema, file_id_field, true);
+        let predicate = col("id").gt_eq(lit(4i32));
+        let plan = get_read_plan_with_contract(
+            &session.state(),
+            vec![(store_url.as_object_store_url(), vec![file], false)],
+            &contract,
+            &predicate_schema,
+            None,
+            Some(&predicate),
+        )
+        .await?;
+
+        let batches = collect(plan, session.task_ctx()).await?;
+        let positions = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(contract.physical_row_position_index.unwrap())
+                    .as_primitive::<arrow::datatypes::Int64Type>()
+                    .values()
+                    .iter()
+                    .copied()
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(positions, vec![4, 5]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_physical_input_contract_avoids_hidden_name_collisions() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "__delta_rs_physical_row_position",
+            DataType::Int64,
+            true,
+        )]));
+        let file_id_field =
+            crate::delta_datafusion::file_id::file_id_field(Some(FILE_ID_COLUMN_DEFAULT));
+
+        let contract = PhysicalInputContract::new(&schema, file_id_field, true);
+
+        assert_eq!(
+            contract
+                .physical_row_position_field
+                .as_ref()
+                .expect("physical position field")
+                .name(),
+            "__delta_rs_physical_row_position_1"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/mod.rs
@@ -638,19 +638,26 @@ async fn get_data_scan_plan(
         scan_plan.parquet_predicate.as_ref()
     };
     let file_id_field = scan_plan.contract.file_id_field.clone();
-    let known_logical: Schema = table_config.logical_schema().as_ref().try_into_arrow()?;
-    let known_physical: Schema = table_config.physical_schema().as_ref().try_into_arrow()?;
+    // Complete schemas are needed only to choose a collision-free hidden position
+    // field. Avoid converting them again on scans without a positional consumer.
+    let known_schemas = if has_deletion_vectors {
+        let logical: Schema = table_config.logical_schema().as_ref().try_into_arrow()?;
+        let physical: Schema = table_config.physical_schema().as_ref().try_into_arrow()?;
+        vec![
+            Arc::new(logical),
+            Arc::new(physical),
+            scan_plan.contract.scan_schema.clone(),
+            scan_plan.contract.output_schema.clone(),
+            scan_plan.parquet_predicate_schema.clone(),
+        ]
+    } else {
+        Vec::new()
+    };
     let mut physical_input_contract = PhysicalInputContract::try_new(
         &scan_plan.parquet_read_schema,
         file_id_field,
         has_deletion_vectors,
-        &[
-            Arc::new(known_logical),
-            Arc::new(known_physical),
-            scan_plan.contract.scan_schema.clone(),
-            scan_plan.contract.output_schema.clone(),
-            scan_plan.parquet_predicate_schema.clone(),
-        ],
+        &known_schemas,
     )?;
     physical_input_contract.log_counts = log_counts;
     physical_input_contract.store_bindings = store_bindings;

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/reader.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/reader.rs
@@ -1,0 +1,406 @@
+//! Bound Parquet readers and evidence for physical coordinates from the full footer.
+
+use std::{ops::Range, sync::Arc};
+
+use bytes::Bytes;
+use datafusion::{
+    common::{HashMap, Result, plan_err},
+    datasource::physical_plan::parquet::{
+        CachedParquetFileReaderFactory, ParquetFileReaderFactory,
+    },
+    execution::cache::cache_manager::FileMetadataCache,
+    physical_plan::metrics::{ExecutionPlanMetricsSet, Gauge, MetricBuilder},
+};
+use datafusion_datasource::PartitionedFile;
+use futures::future::BoxFuture;
+use object_store::{ObjectStore, path::Path};
+use parquet::{
+    arrow::{arrow_reader::ArrowReaderOptions, async_reader::AsyncFileReader},
+    errors::ParquetError,
+    file::metadata::ParquetMetaData,
+};
+
+use super::metadata_cache::StoreMetadataCache;
+
+#[derive(Clone, Debug)]
+pub(super) struct FooterEvidence {
+    pub records: u64,
+}
+
+pub(super) fn validate_footer(
+    metadata: &ParquetMetaData,
+) -> std::result::Result<FooterEvidence, String> {
+    let records = u64::try_from(metadata.file_metadata().num_rows())
+        .map_err(|_| "negative footer row count")?;
+    let mut total = 0_u64;
+    let missing_ordinals = metadata
+        .row_groups()
+        .iter()
+        .all(|group| group.ordinal().is_none());
+    for (index, group) in metadata.row_groups().iter().enumerate() {
+        if !missing_ordinals && group.ordinal().and_then(|n| usize::try_from(n).ok()) != Some(index)
+        {
+            return Err("inconsistent row-group ordinals in complete footer".into());
+        }
+        let count = u64::try_from(group.num_rows()).map_err(|_| "negative row-group count")?;
+        total = total
+            .checked_add(count)
+            .ok_or("row-group population overflows u64")?;
+    }
+    if total != records {
+        return Err("row-group population differs from footer row count".into());
+    }
+    Ok(FooterEvidence { records })
+}
+
+#[derive(Debug)]
+pub(super) struct BoundParquetReaderFactory {
+    store: Arc<dyn ObjectStore>,
+    cache: Arc<FileMetadataCache>,
+    files: HashMap<Path, (object_store::ObjectMeta, Option<u64>)>,
+    hidden_position: Option<(String, String)>,
+    footer_bounds: HashMap<Path, Vec<Arc<std::sync::OnceLock<u64>>>>,
+}
+
+impl BoundParquetReaderFactory {
+    pub(super) fn new(
+        store: Arc<dyn ObjectStore>,
+        cache: Arc<FileMetadataCache>,
+        files: HashMap<Path, (object_store::ObjectMeta, Option<u64>)>,
+        hidden_position: Option<(String, String)>,
+        footer_bounds: HashMap<Path, Vec<Arc<std::sync::OnceLock<u64>>>>,
+    ) -> Self {
+        Self {
+            store,
+            cache,
+            files,
+            hidden_position,
+            footer_bounds,
+        }
+    }
+}
+
+impl ParquetFileReaderFactory for BoundParquetReaderFactory {
+    fn create_reader(
+        &self,
+        partition_index: usize,
+        file: PartitionedFile,
+        metadata_size_hint: Option<usize>,
+        metrics: &ExecutionPlanMetricsSet,
+    ) -> Result<Box<dyn AsyncFileReader + Send>> {
+        let Some((expected, count)) = self.files.get(&file.object_meta.location) else {
+            return plan_err!("unplanned file in bound Parquet reader");
+        };
+        if &file.object_meta != expected || !file.extensions.is_empty() {
+            return plan_err!(
+                "changed file metadata or reader-affecting extensions in bound Parquet reader"
+            );
+        }
+        let cache = Arc::new(StoreMetadataCache::new(
+            Arc::clone(&self.cache),
+            Arc::clone(&self.store),
+            expected.clone(),
+        ));
+        let footer_bounds = self
+            .footer_bounds
+            .get(&file.object_meta.location)
+            .cloned()
+            .unwrap_or_default();
+        let reader = CachedParquetFileReaderFactory::new(Arc::clone(&self.store), cache.clone())
+            .create_reader(partition_index, file, metadata_size_hint, metrics)?;
+        Ok(Box::new(BoundReader {
+            active_metadata: MetricBuilder::new(metrics)
+                .gauge("active_footer_reference_bytes", partition_index),
+            reader,
+            cache,
+            count: *count,
+            hidden_position: self.hidden_position.clone(),
+            footer_bounds,
+        }))
+    }
+}
+
+struct BoundReader {
+    // A sum over live reader references, not unique allocations or an RSS bound.
+    // Parquet's estimator includes shared substructures and excludes allocator overhead.
+    active_metadata: Gauge,
+    reader: Box<dyn AsyncFileReader + Send>,
+    cache: Arc<StoreMetadataCache>,
+    count: Option<u64>,
+    hidden_position: Option<(String, String)>,
+    footer_bounds: Vec<Arc<std::sync::OnceLock<u64>>>,
+}
+
+impl Drop for BoundReader {
+    fn drop(&mut self) {
+        self.active_metadata.set(0);
+    }
+}
+
+impl AsyncFileReader for BoundReader {
+    fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, parquet::errors::Result<Bytes>> {
+        self.reader.get_bytes(range)
+    }
+    fn get_byte_ranges(
+        &mut self,
+        ranges: Vec<Range<u64>>,
+    ) -> BoxFuture<'_, parquet::errors::Result<Vec<Bytes>>> {
+        self.reader.get_byte_ranges(ranges)
+    }
+    fn get_metadata<'a>(
+        &'a mut self,
+        options: Option<&'a ArrowReaderOptions>,
+    ) -> BoxFuture<'a, parquet::errors::Result<Arc<ParquetMetaData>>> {
+        Box::pin(async move {
+            let metadata = self.reader.get_metadata(options).await?;
+            self.active_metadata.set(metadata.memory_size());
+            if let Some((hidden, file_id)) = &self.hidden_position {
+                let evidence = self
+                    .cache
+                    .footer_evidence(&metadata)
+                    .map_err(ParquetError::General)?;
+                if self.count.is_some_and(|count| count != evidence.records) {
+                    return Err(ParquetError::General(
+                        "log-declared numRecords differs from full footer".into(),
+                    ));
+                }
+                for bound in &self.footer_bounds {
+                    let count = bound.get_or_init(|| evidence.records);
+                    if *count != evidence.records {
+                        return Err(ParquetError::General(
+                            "physical file population changed after planning".into(),
+                        ));
+                    }
+                }
+                if metadata
+                    .file_metadata()
+                    .schema_descr()
+                    .root_schema()
+                    .get_fields()
+                    .iter()
+                    .any(|field| field.name() == hidden || field.name() == file_id)
+                {
+                    return Err(ParquetError::General(
+                        "on-disk field collides with physical input support column".into(),
+                    ));
+                }
+            }
+            Ok(metadata)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Int32Array, RecordBatch};
+    use arrow_schema::{DataType, Field, Schema};
+    use chrono::{TimeZone, Utc};
+    use datafusion::execution::cache::default_cache::DefaultCache;
+    use object_store::{ObjectStoreExt, memory::InMemory};
+    use parquet::arrow::ArrowWriter;
+
+    async fn fixture(name: &str) -> (Arc<dyn ObjectStore>, object_store::ObjectMeta) {
+        let schema = Arc::new(Schema::new(vec![Field::new(name, DataType::Int32, false)]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1, 2]))])
+                .unwrap();
+        let mut bytes = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut bytes, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("same.parquet");
+        store.put(&path, bytes.into()).await.unwrap();
+        let mut meta = store.head(&path).await.unwrap();
+        meta.last_modified = Utc.timestamp_opt(0, 0).unwrap();
+        meta.e_tag = None;
+        meta.version = None;
+        (store, meta)
+    }
+
+    async fn footer(
+        store: Arc<dyn ObjectStore>,
+        meta: object_store::ObjectMeta,
+        cache: Arc<FileMetadataCache>,
+    ) -> Arc<ParquetMetaData> {
+        let factory = BoundParquetReaderFactory::new(
+            store,
+            cache,
+            HashMap::from([(meta.location.clone(), (meta.clone(), Some(2)))]),
+            Some(("position".into(), "__file_id".into())),
+            HashMap::new(),
+        );
+        let mut reader = factory
+            .create_reader(0, meta.into(), None, &ExecutionPlanMetricsSet::new())
+            .unwrap();
+        reader.get_metadata(None).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn equal_validation_attributes_in_different_stores_do_not_alias() {
+        let (a, meta_a) = fixture("aa").await;
+        let (b, meta_b) = fixture("bb").await;
+        assert_eq!(
+            meta_a, meta_b,
+            "fixture must defeat bare-path size/mtime validation"
+        );
+        let cache: Arc<FileMetadataCache> = Arc::new(DefaultCache::new(1 << 20));
+        let first = footer(a.clone(), meta_a.clone(), cache.clone()).await;
+        let second = footer(b, meta_b, cache.clone()).await;
+        assert_eq!(
+            first
+                .file_metadata()
+                .schema_descr()
+                .root_schema()
+                .get_fields()[0]
+                .name(),
+            "aa"
+        );
+        assert_eq!(
+            second
+                .file_metadata()
+                .schema_descr()
+                .root_schema()
+                .get_fields()[0]
+                .name(),
+            "bb"
+        );
+        let fresh_query = footer(a, meta_a, cache).await;
+        assert!(
+            Arc::ptr_eq(&first, &fresh_query),
+            "separately planned readers should reuse immutable metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_fresh_readers_share_one_retention_allowance() {
+        let cache: Arc<FileMetadataCache> = Arc::new(DefaultCache::new(4096));
+        let mut tasks = tokio::task::JoinSet::new();
+        for _ in 0..16 {
+            let cache = cache.clone();
+            tasks.spawn(async move {
+                let (store, meta) = fixture("aa").await;
+                footer(store, meta, cache).await
+            });
+        }
+        let mut active_metadata = Vec::new();
+        while let Some(result) = tasks.join_next().await {
+            active_metadata.push(result.unwrap());
+        }
+        let retained: usize = cache
+            .list_entries()
+            .values()
+            .map(|entry| entry.size_bytes)
+            .sum();
+        assert!(retained <= cache.cache_limit());
+        assert!(
+            cache.len() < active_metadata.len(),
+            "fixture must evict while readers retain metadata"
+        );
+        assert!(
+            active_metadata
+                .iter()
+                .all(|m| m.file_metadata().num_rows() == 2)
+        );
+    }
+
+    #[tokio::test]
+    async fn footer_evidence_rejects_bad_populations_and_ordinals() {
+        let (store, meta) = fixture("aa").await;
+        let original = footer(store, meta, Arc::new(DefaultCache::new(1 << 20))).await;
+        let group = original.row_group(0);
+        let missing = parquet::file::metadata::RowGroupMetaData::builder(group.schema_descr_ptr())
+            .set_column_metadata(group.columns().to_vec())
+            .set_num_rows(1)
+            .build()
+            .unwrap();
+        let omitted = ParquetMetaData::new(
+            original.file_metadata().clone(),
+            vec![missing.clone(), missing.clone()],
+        );
+        assert_eq!(validate_footer(&omitted).unwrap().records, 2);
+        let explicit = missing
+            .clone()
+            .into_builder()
+            .set_ordinal(0)
+            .build()
+            .unwrap();
+        let duplicate = ParquetMetaData::new(
+            original.file_metadata().clone(),
+            vec![explicit.clone(), explicit],
+        );
+        assert!(
+            validate_footer(&duplicate)
+                .unwrap_err()
+                .contains("ordinals")
+        );
+        let mixed = ParquetMetaData::new(
+            original.file_metadata().clone(),
+            vec![
+                missing.clone(),
+                missing
+                    .clone()
+                    .into_builder()
+                    .set_ordinal(1)
+                    .build()
+                    .unwrap(),
+            ],
+        );
+        assert!(validate_footer(&mixed).is_err());
+        let wrong_total = ParquetMetaData::new(original.file_metadata().clone(), vec![missing]);
+        assert!(
+            validate_footer(&wrong_total)
+                .unwrap_err()
+                .contains("population")
+        );
+    }
+
+    #[tokio::test]
+    async fn reader_rejects_unexpected_on_disk_support_fields() {
+        for name in ["position", "__file_id"] {
+            let (store, meta) = fixture(name).await;
+            let factory = BoundParquetReaderFactory::new(
+                store,
+                Arc::new(DefaultCache::new(1 << 20)),
+                HashMap::from([(meta.location.clone(), (meta.clone(), Some(2)))]),
+                Some(("position".into(), "__file_id".into())),
+                HashMap::new(),
+            );
+            let mut reader = factory
+                .create_reader(0, meta.into(), None, &ExecutionPlanMetricsSet::new())
+                .unwrap();
+            assert!(
+                reader
+                    .get_metadata(None)
+                    .await
+                    .unwrap_err()
+                    .to_string()
+                    .contains("support column")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn positional_reader_rejects_log_footer_count_mismatch() {
+        let (store, meta) = fixture("aa").await;
+        let factory = BoundParquetReaderFactory::new(
+            store,
+            Arc::new(DefaultCache::new(1 << 20)),
+            HashMap::from([(meta.location.clone(), (meta.clone(), Some(3)))]),
+            Some(("position".into(), "__file_id".into())),
+            HashMap::new(),
+        );
+        let mut reader = factory
+            .create_reader(0, meta.into(), None, &ExecutionPlanMetricsSet::new())
+            .unwrap();
+        assert!(
+            reader
+                .get_metadata(None)
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("numRecords")
+        );
+    }
+}

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/reader.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/reader.rs
@@ -91,7 +91,10 @@ impl ParquetFileReaderFactory for BoundParquetReaderFactory {
         let Some((expected, count)) = self.files.get(&file.object_meta.location) else {
             return plan_err!("unplanned file in bound Parquet reader");
         };
-        if &file.object_meta != expected || !file.extensions.is_empty() {
+        if &file.object_meta != expected
+            || !file.extensions.is_empty()
+            || file.arrow_schema.is_some()
+        {
             return plan_err!(
                 "changed file metadata or reader-affecting extensions in bound Parquet reader"
             );

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/reader.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/reader.rs
@@ -1,4 +1,4 @@
-//! Bound Parquet readers and evidence for physical coordinates from the full footer.
+//! Parquet readers that validate file metadata and row counts from the full footer.
 
 use std::{ops::Range, sync::Arc};
 
@@ -40,15 +40,15 @@ pub(super) fn validate_footer(
     for (index, group) in metadata.row_groups().iter().enumerate() {
         if !missing_ordinals && group.ordinal().and_then(|n| usize::try_from(n).ok()) != Some(index)
         {
-            return Err("inconsistent row-group ordinals in complete footer".into());
+            return Err("inconsistent row group ordinals in complete footer".into());
         }
-        let count = u64::try_from(group.num_rows()).map_err(|_| "negative row-group count")?;
+        let count = u64::try_from(group.num_rows()).map_err(|_| "negative row group count")?;
         total = total
             .checked_add(count)
-            .ok_or("row-group population overflows u64")?;
+            .ok_or("row group population overflows u64")?;
     }
     if total != records {
-        return Err("row-group population differs from footer row count".into());
+        return Err("row group population differs from footer row count".into());
     }
     Ok(FooterEvidence { records })
 }
@@ -96,7 +96,7 @@ impl ParquetFileReaderFactory for BoundParquetReaderFactory {
             || file.arrow_schema.is_some()
         {
             return plan_err!(
-                "changed file metadata or reader-affecting extensions in bound Parquet reader"
+                "bound Parquet reader received changed file metadata or reader extensions"
             );
         }
         let cache = Arc::new(StoreMetadataCache::new(
@@ -124,8 +124,8 @@ impl ParquetFileReaderFactory for BoundParquetReaderFactory {
 }
 
 struct BoundReader {
-    // A sum over live reader references, not unique allocations or an RSS bound.
-    // Parquet's estimator includes shared substructures and excludes allocator overhead.
+    // Estimated metadata bytes held by each reader. Shared allocations are counted
+    // once per reader. Allocator overhead is excluded; this does not bound process memory.
     active_metadata: Gauge,
     reader: Box<dyn AsyncFileReader + Send>,
     cache: Arc<StoreMetadataCache>,
@@ -164,7 +164,7 @@ impl AsyncFileReader for BoundReader {
                     .map_err(ParquetError::General)?;
                 if self.count.is_some_and(|count| count != evidence.records) {
                     return Err(ParquetError::General(
-                        "log-declared numRecords differs from full footer".into(),
+                        "numRecords in the log differs from the footer row count".into(),
                     ));
                 }
                 for bound in &self.footer_bounds {
@@ -184,7 +184,7 @@ impl AsyncFileReader for BoundReader {
                     .any(|field| field.name() == hidden || field.name() == file_id)
                 {
                     return Err(ParquetError::General(
-                        "on-disk field collides with physical input support column".into(),
+                        "Parquet field collides with physical input support column".into(),
                     ));
                 }
             }
@@ -246,7 +246,7 @@ mod tests {
         let (b, meta_b) = fixture("bb").await;
         assert_eq!(
             meta_a, meta_b,
-            "fixture must defeat bare-path size/mtime validation"
+            "fixture must match the path, size, and modification time"
         );
         let cache: Arc<FileMetadataCache> = Arc::new(DefaultCache::new(1 << 20));
         let first = footer(a.clone(), meta_a.clone(), cache.clone()).await;

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
@@ -58,13 +58,9 @@ impl ReplayStats {
 pin_project! {
     /// Stream that processes kernel scan metadata into file contexts with statistics.
     ///
-    /// This stream consumes [`ScanMetadata`] from Delta Kernel's scan and produces
-    /// [`ScanFileContext`] entries enriched with:
-    ///
-    /// - **File statistics**: Row counts, min/max values, null counts
-    /// - **Deletion vectors**: Expected descriptors captured before loading
-    /// - **Partition values**: Extracted from file metadata
-    /// - **Transforms**: Column mapping expressions for physical-to-logical translation
+    /// Converts Delta Kernel's [`ScanMetadata`] into [`ScanFileContext`] entries
+    /// containing file statistics, deletion vector descriptors, partition values,
+    /// and column mapping expressions. Deletion vectors are loaded after replay.
     pub(crate) struct ScanFileStream<'a, S> {
         pub(crate) metrics: ReplayStats,
 
@@ -82,16 +78,12 @@ pin_project! {
 }
 
 #[derive(Debug)]
-pub(crate) struct LoadedDeletionVector {
+pub(super) struct LoadedDeletionVector {
     pub selected_id: usize,
-    pub descriptor: DvInfo,
-    pub file_url: Url,
     pub keep_mask: Option<Vec<bool>>,
-    pub num_records: Option<u64>,
-    pub deleted_cardinality: Option<u64>,
 }
 
-/// Start loads only after the caller captures the complete selected population.
+/// Load deletion vectors after the caller records all selected files.
 pub(super) fn load_deletion_vectors(
     engine: Arc<dyn Engine>,
     table_root: &Url,
@@ -104,20 +96,13 @@ pub(super) fn load_deletion_vectors(
         }
         let engine = engine.clone();
         let descriptor = file.expected_dv.clone();
-        let file_url = file.file_url.clone();
-        let num_records = file.num_records;
-        let deleted_cardinality = file.dv_cardinality;
         let table_root = table_root.clone();
         let tx = stream.tx();
         stream.spawn_blocking(move || {
             let keep_mask = descriptor.get_selection_vector(engine.as_ref(), &table_root)?;
             let _ = tx.blocking_send(Ok(LoadedDeletionVector {
                 selected_id,
-                descriptor,
-                file_url,
                 keep_mask,
-                num_records,
-                deleted_cardinality,
             }));
             Ok(())
         });
@@ -204,7 +189,7 @@ where
                         .map(|descriptor| {
                             u64::try_from(descriptor.cardinality).map_err(|_| {
                                 DataFusionError::Plan(
-                                    "deletion-vector descriptor has negative cardinality"
+                                    "deletion vector descriptor has negative cardinality"
                                         .to_string(),
                                 )
                             })

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/replay.rs
@@ -62,13 +62,11 @@ pin_project! {
     /// [`ScanFileContext`] entries enriched with:
     ///
     /// - **File statistics**: Row counts, min/max values, null counts
-    /// - **Deletion vectors**: Asynchronously loaded and cached
+    /// - **Deletion vectors**: Expected descriptors captured before loading
     /// - **Partition values**: Extracted from file metadata
     /// - **Transforms**: Column mapping expressions for physical-to-logical translation
     pub(crate) struct ScanFileStream<'a, S> {
         pub(crate) metrics: ReplayStats,
-
-        engine: Arc<dyn Engine>,
 
         table_root: Url,
 
@@ -78,16 +76,57 @@ pin_project! {
 
         file_selection: Option<&'a HashSet<String>>,
 
-        pub(crate) dv_stream: ReceiverStreamBuilder<(Url, Option<Vec<bool>>, Option<u64>)>,
-
         #[pin]
         stream: S,
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct LoadedDeletionVector {
+    pub selected_id: usize,
+    pub descriptor: DvInfo,
+    pub file_url: Url,
+    pub keep_mask: Option<Vec<bool>>,
+    pub num_records: Option<u64>,
+    pub deleted_cardinality: Option<u64>,
+}
+
+/// Start loads only after the caller captures the complete selected population.
+pub(super) fn load_deletion_vectors(
+    engine: Arc<dyn Engine>,
+    table_root: &Url,
+    files: &[ScanFileContext],
+) -> ReceiverStreamBuilder<LoadedDeletionVector> {
+    let mut stream = ReceiverStreamBuilder::new(100);
+    for (selected_id, file) in files.iter().enumerate() {
+        if !file.expected_dv.has_vector() {
+            continue;
+        }
+        let engine = engine.clone();
+        let descriptor = file.expected_dv.clone();
+        let file_url = file.file_url.clone();
+        let num_records = file.num_records;
+        let deleted_cardinality = file.dv_cardinality;
+        let table_root = table_root.clone();
+        let tx = stream.tx();
+        stream.spawn_blocking(move || {
+            let keep_mask = descriptor.get_selection_vector(engine.as_ref(), &table_root)?;
+            let _ = tx.blocking_send(Ok(LoadedDeletionVector {
+                selected_id,
+                descriptor,
+                file_url,
+                keep_mask,
+                num_records,
+                deleted_cardinality,
+            }));
+            Ok(())
+        });
+    }
+    stream
+}
+
 impl<'a, S> ScanFileStream<'a, S> {
     pub(crate) fn new(
-        engine: Arc<dyn Engine>,
         scan: &Arc<Scan>,
         scan_config: DeltaScanConfig,
         file_selection: Option<&'a HashSet<String>>,
@@ -95,8 +134,6 @@ impl<'a, S> ScanFileStream<'a, S> {
     ) -> Self {
         Self {
             metrics: ReplayStats::new(),
-            dv_stream: ReceiverStreamBuilder::<(Url, Option<Vec<bool>>, Option<u64>)>::new(100),
-            engine,
             table_root: scan.table_root().clone(),
             kernel_scan: scan.inner().clone(),
             stream,
@@ -135,7 +172,7 @@ where
                     scan_data
                 };
 
-                let ctx = match scan_data
+                let mut ctx = match scan_data
                     .visit_scan_files(ScanContext::new(this.table_root.clone()), visit_scan_file)
                     .map_err(|err| DataFusionError::from(DeltaTableError::from(err)))
                     .and_then(ScanContext::error_or)
@@ -144,31 +181,36 @@ where
                     Err(err) => return Poll::Ready(Some(Err(err.into()))),
                 };
 
-                // Spawn tasks to read the deletion vectors from disk.
-                for file in &ctx.files {
-                    if file.dv_info.has_vector() {
-                        let engine = this.engine.clone();
-                        let dv_info = file.dv_info.clone();
-                        let file_url = file.file_url.clone();
-                        let num_records = file.num_records;
-                        let table_root = this.table_root.clone();
-                        let tx = this.dv_stream.tx();
-
-                        let load_dv = move || {
-                            let dv = dv_info.get_selection_vector(engine.as_ref(), &table_root)?;
-                            let _ = tx.blocking_send(Ok((file_url, dv, num_records)));
-                            Ok(())
-                        };
-                        this.dv_stream.spawn_blocking(load_dv);
-                    }
-                }
-
                 this.metrics.num_scanned += ctx.count;
 
                 let (data, selection_vector) = scan_data.scan_files.into_parts();
                 let batch = ArrowEngineData::try_from_engine_data(data)?.into();
                 let scan_files =
                     filter_record_batch(&batch, &BooleanArray::from(selection_vector))?;
+
+                if ctx.files.len() != scan_files.num_rows() {
+                    return Poll::Ready(Some(Err(DeltaTableError::from(
+                        DataFusionError::Internal(format!(
+                            "scan replay produced {} file contexts for {} selected metadata rows",
+                            ctx.files.len(),
+                            scan_files.num_rows()
+                        )),
+                    ))));
+                }
+
+                for (file, row) in ctx.files.iter_mut().zip(0..scan_files.num_rows()) {
+                    file.dv_cardinality = LogicalFileView::new(scan_files.clone(), row)
+                        .deletion_vector_descriptor()
+                        .map(|descriptor| {
+                            u64::try_from(descriptor.cardinality).map_err(|_| {
+                                DataFusionError::Plan(
+                                    "deletion-vector descriptor has negative cardinality"
+                                        .to_string(),
+                                )
+                            })
+                        })
+                        .transpose()?;
+                }
 
                 let stats_projection = match StatsProjection::for_scan(this.kernel_scan.as_ref()) {
                     Ok(projection) => projection,
@@ -372,6 +414,9 @@ pub(crate) struct ScanFileContext {
     pub stats: Statistics,
     /// Partition values for the file.
     pub partitions: Option<StructData>,
+    pub num_records: Option<u64>,
+    pub expected_dv: DvInfo,
+    pub dv_cardinality: Option<u64>,
 }
 
 impl ScanFileContext {
@@ -383,6 +428,9 @@ impl ScanFileContext {
             transform: inner.transform,
             stats,
             partitions,
+            num_records: inner.num_records,
+            expected_dv: inner.dv_info,
+            dv_cardinality: inner.dv_cardinality,
         }
     }
 }
@@ -397,6 +445,8 @@ struct ScanFileContextInner {
     pub transform: Option<ExpressionRef>,
     /// Number of records in the file from Add-file stats.
     pub num_records: Option<u64>,
+
+    pub dv_cardinality: Option<u64>,
 
     pub dv_info: DvInfo,
 }
@@ -492,6 +542,7 @@ fn visit_scan_file(ctx: &mut ScanContext, scan_file: ScanFile) {
         file_url,
         size: scan_file.size as u64,
         num_records: scan_file.stats.map(|stats| stats.num_records),
+        dv_cardinality: None,
     });
     ctx.count += 1;
 }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/test_support.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/test_support.rs
@@ -111,6 +111,62 @@ impl Fixture {
         Url::from_directory_path(self.directory.path()).unwrap()
     }
 
+    /// Rewrite only the footer, as a writer that omits the optional ordinals would.
+    pub fn remove_row_group_ordinals(&mut self, file_id: usize) -> FixtureResult<()> {
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        use parquet::file::metadata::{ParquetMetaData, ParquetMetaDataWriter, RowGroupMetaData};
+        use parquet::file::writer::TrackedWrite;
+        use std::io::Write;
+
+        let path = self
+            .directory
+            .path()
+            .join(format!("part-{file_id}.parquet"));
+        let bytes = fs::read(&path)?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes.clone()))?;
+        let original = reader.metadata();
+        let groups = original
+            .row_groups()
+            .iter()
+            .map(|group| {
+                let mut builder = RowGroupMetaData::builder(group.schema_descr_ptr())
+                    .set_column_metadata(group.columns().to_vec())
+                    .set_num_rows(group.num_rows())
+                    .set_total_byte_size(group.total_byte_size())
+                    .set_sorting_columns(group.sorting_columns().cloned());
+                if let Some(offset) = group.file_offset() {
+                    builder = builder.set_file_offset(offset);
+                }
+                builder.build()
+            })
+            .collect::<parquet::errors::Result<Vec<_>>>()?;
+        assert!(groups.iter().all(|group| group.ordinal().is_none()));
+        let metadata = ParquetMetaData::new(original.file_metadata().clone(), groups);
+        let footer_len =
+            u32::from_le_bytes(bytes[bytes.len() - 8..bytes.len() - 4].try_into()?) as usize;
+        let mut rewritten = Vec::new();
+        let mut output = TrackedWrite::new(&mut rewritten);
+        output.write_all(&bytes[..bytes.len() - 8 - footer_len])?;
+        ParquetMetaDataWriter::new_with_tracked(output, &metadata).finish()?;
+        fs::write(path, &rewritten)?;
+        self.adds[file_id]["size"] = json!(rewritten.len());
+        let log = self
+            .directory
+            .path()
+            .join("_delta_log/00000000000000000000.json");
+        let mut actions = fs::read_to_string(&log)?
+            .lines()
+            .map(serde_json::from_str::<Value>)
+            .collect::<Result<Vec<_>, _>>()?;
+        let path = format!("part-{file_id}.parquet");
+        for action in &mut actions {
+            if action.get("add").and_then(|add| add["path"].as_str()) == Some(&path) {
+                action["add"] = self.adds[file_id].clone();
+            }
+        }
+        self.write_log(0, actions)
+    }
+
     pub fn live_coordinates(&self) -> Vec<(usize, u64, i64, i64)> {
         self.coordinates
             .iter()
@@ -178,5 +234,104 @@ impl Fixture {
                 .join("\n"),
         )?;
         Ok(())
+    }
+}
+
+/// Pause real Parquet object-store requests until their futures are cancelled.
+#[derive(Debug)]
+pub struct PausedStore {
+    inner: Arc<dyn object_store::ObjectStore>,
+    pub paused: std::sync::atomic::AtomicBool,
+    pub active: std::sync::atomic::AtomicUsize,
+    pub entered: tokio::sync::Notify,
+    pub changed: tokio::sync::Notify,
+}
+
+impl PausedStore {
+    pub fn new(inner: Arc<dyn object_store::ObjectStore>) -> Self {
+        Self {
+            inner,
+            paused: false.into(),
+            active: 0.into(),
+            entered: Default::default(),
+            changed: Default::default(),
+        }
+    }
+}
+
+impl std::fmt::Display for PausedStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "paused test store")
+    }
+}
+
+struct PendingRead<'a>(&'a PausedStore);
+impl Drop for PendingRead<'_> {
+    fn drop(&mut self) {
+        self.0
+            .active
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        self.0.changed.notify_one();
+    }
+}
+
+#[async_trait::async_trait]
+impl object_store::ObjectStore for PausedStore {
+    async fn get_opts(
+        &self,
+        path: &object_store::path::Path,
+        options: object_store::GetOptions,
+    ) -> object_store::Result<object_store::GetResult> {
+        use std::sync::atomic::Ordering;
+        self.active.fetch_add(1, Ordering::SeqCst);
+        let _pending = PendingRead(self);
+        if path.as_ref().ends_with(".parquet")
+            && self.paused.load(std::sync::atomic::Ordering::SeqCst)
+        {
+            self.entered.notify_one();
+            std::future::pending::<()>().await;
+        }
+        self.inner.get_opts(path, options).await
+    }
+    async fn put_opts(
+        &self,
+        path: &object_store::path::Path,
+        payload: object_store::PutPayload,
+        options: object_store::PutOptions,
+    ) -> object_store::Result<object_store::PutResult> {
+        self.inner.put_opts(path, payload, options).await
+    }
+    async fn put_multipart_opts(
+        &self,
+        path: &object_store::path::Path,
+        options: object_store::PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+        self.inner.put_multipart_opts(path, options).await
+    }
+    fn delete_stream(
+        &self,
+        paths: futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>> {
+        self.inner.delete_stream(paths)
+    }
+    fn list(
+        &self,
+        path: Option<&object_store::path::Path>,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>> {
+        self.inner.list(path)
+    }
+    async fn list_with_delimiter(
+        &self,
+        path: Option<&object_store::path::Path>,
+    ) -> object_store::Result<object_store::ListResult> {
+        self.inner.list_with_delimiter(path).await
+    }
+    async fn copy_opts(
+        &self,
+        from: &object_store::path::Path,
+        to: &object_store::path::Path,
+        options: object_store::CopyOptions,
+    ) -> object_store::Result<()> {
+        self.inner.copy_opts(from, to, options).await
     }
 }

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/test_support.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/test_support.rs
@@ -1,5 +1,5 @@
-//! Deterministic fixture coordinates for scan regression tests.
-//! Expected visibility comes from the generator's declared positions, never reader output.
+//! Parquet fixtures with known row positions for scan regression tests.
+//! Expected rows are computed from the fixture definition.
 
 use arrow_array::{Int64Array, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
@@ -15,7 +15,6 @@ use url::Url;
 type FixtureResult<T> = Result<T, Box<dyn Error>>;
 
 pub struct FileSpec {
-    pub rows: usize,
     pub groups: Vec<usize>,
     pub deleted: Option<BTreeSet<u64>>,
     pub log_stats: bool,
@@ -30,7 +29,8 @@ pub struct Fixture {
 }
 
 impl Fixture {
-    pub fn new(specs: Vec<FileSpec>, page_rows: usize) -> FixtureResult<Self> {
+    pub fn new(specs: Vec<FileSpec>) -> FixtureResult<Self> {
+        const PAGE_ROWS: usize = 8;
         let directory = tempfile::tempdir()?;
         fs::create_dir(directory.path().join("_delta_log"))?;
         let has_dvs = specs.iter().any(|f| f.deleted.is_some());
@@ -58,15 +58,14 @@ impl Fixture {
             let file = fs::File::create(fixture.directory.path().join(&path))?;
             let properties = WriterProperties::builder()
                 .set_max_row_group_row_count(None)
-                .set_data_page_row_count_limit(page_rows)
-                .set_write_batch_size(page_rows.min(4))
+                .set_data_page_row_count_limit(PAGE_ROWS)
+                .set_write_batch_size(4)
                 .build();
             let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(properties))?;
             let first_id = global_id;
             let mut position = 0;
-            let mut group = 0;
-            while position < spec.rows {
-                let count = spec.groups[group % spec.groups.len()].min(spec.rows - position);
+            let rows: usize = spec.groups.iter().sum();
+            for count in spec.groups {
                 let mut ids = Vec::with_capacity(count);
                 let mut values = Vec::with_capacity(count);
                 for row in position..position + count {
@@ -87,13 +86,12 @@ impl Fixture {
                 )?)?;
                 writer.flush()?;
                 position += count;
-                group += 1;
             }
             writer.close()?;
             let size = fs::metadata(fixture.directory.path().join(&path))?.len();
             let mut add = json!({"path":path,"partitionValues":{},"size":size,"modificationTime":0,"dataChange":true});
             if spec.log_stats {
-                add["stats"] = json!(json!({"numRecords":spec.rows,"minValues":{"id":first_id,"value":-(spec.rows as i64 - 1)},"maxValues":{"id":global_id - 1,"value":0},"nullCount":{"id":0,"value":0}}).to_string());
+                add["stats"] = json!(json!({"numRecords":rows,"minValues":{"id":first_id,"value":-(rows as i64 - 1)},"maxValues":{"id":global_id - 1,"value":0},"nullCount":{"id":0,"value":0}}).to_string());
             }
             if let Some(deleted) = &spec.deleted {
                 add["deletionVector"] = fixture.write_dv(file_id, 0, deleted)?;
@@ -237,7 +235,7 @@ impl Fixture {
     }
 }
 
-/// Pause real Parquet object-store requests until their futures are cancelled.
+/// Pause Parquet requests until their futures are cancelled.
 #[derive(Debug)]
 pub struct PausedStore {
     inner: Arc<dyn object_store::ObjectStore>,

--- a/crates/core/src/delta_datafusion/table_provider/next/scan/test_support.rs
+++ b/crates/core/src/delta_datafusion/table_provider/next/scan/test_support.rs
@@ -1,0 +1,182 @@
+//! Deterministic fixture coordinates for scan regression tests.
+//! Expected visibility comes from the generator's declared positions, never reader output.
+
+use arrow_array::{Int64Array, RecordBatch};
+use arrow_schema::{DataType, Field, Schema};
+use delta_kernel::actions::deletion_vector_writer::{
+    KernelDeletionVector, StreamingDeletionVectorWriter,
+};
+use parquet::{arrow::ArrowWriter, file::properties::WriterProperties};
+use serde_json::{Value, json};
+use std::{collections::BTreeSet, error::Error, fs, sync::Arc};
+use tempfile::TempDir;
+use url::Url;
+
+type FixtureResult<T> = Result<T, Box<dyn Error>>;
+
+pub struct FileSpec {
+    pub rows: usize,
+    pub groups: Vec<usize>,
+    pub deleted: Option<BTreeSet<u64>>,
+    pub log_stats: bool,
+}
+
+pub struct Fixture {
+    pub directory: TempDir,
+    pub coordinates: Vec<(usize, u64, i64, i64)>,
+    pub deleted: Vec<Option<BTreeSet<u64>>>,
+    adds: Vec<Value>,
+    version: usize,
+}
+
+impl Fixture {
+    pub fn new(specs: Vec<FileSpec>, page_rows: usize) -> FixtureResult<Self> {
+        let directory = tempfile::tempdir()?;
+        fs::create_dir(directory.path().join("_delta_log"))?;
+        let has_dvs = specs.iter().any(|f| f.deleted.is_some());
+        let protocol = if has_dvs {
+            json!({"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["deletionVectors"],"writerFeatures":["deletionVectors"]}})
+        } else {
+            json!({"protocol":{"minReaderVersion":1,"minWriterVersion":2}})
+        };
+        let logical_schema = json!({"type":"struct","fields":[{"name":"id","type":"long","nullable":false,"metadata":{}},{"name":"value","type":"long","nullable":false,"metadata":{}}]});
+        let metadata = json!({"metaData":{"id":"c75e5410-d53e-4fb3-b848-2e595cda0001","format":{"provider":"parquet","options":{}},"schemaString":logical_schema.to_string(),"partitionColumns":[],"configuration":{}}});
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("value", DataType::Int64, false),
+        ]));
+        let mut fixture = Self {
+            directory,
+            coordinates: Vec::new(),
+            deleted: Vec::new(),
+            adds: Vec::new(),
+            version: 0,
+        };
+        let mut global_id = 0_i64;
+        for (file_id, spec) in specs.into_iter().enumerate() {
+            let path = format!("part-{file_id}.parquet");
+            let file = fs::File::create(fixture.directory.path().join(&path))?;
+            let properties = WriterProperties::builder()
+                .set_max_row_group_row_count(None)
+                .set_data_page_row_count_limit(page_rows)
+                .set_write_batch_size(page_rows.min(4))
+                .build();
+            let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(properties))?;
+            let first_id = global_id;
+            let mut position = 0;
+            let mut group = 0;
+            while position < spec.rows {
+                let count = spec.groups[group % spec.groups.len()].min(spec.rows - position);
+                let mut ids = Vec::with_capacity(count);
+                let mut values = Vec::with_capacity(count);
+                for row in position..position + count {
+                    ids.push(global_id);
+                    let value = -(row as i64);
+                    values.push(value);
+                    fixture
+                        .coordinates
+                        .push((file_id, row as u64, global_id, value));
+                    global_id += 1;
+                }
+                writer.write(&RecordBatch::try_new(
+                    schema.clone(),
+                    vec![
+                        Arc::new(Int64Array::from(ids)),
+                        Arc::new(Int64Array::from(values)),
+                    ],
+                )?)?;
+                writer.flush()?;
+                position += count;
+                group += 1;
+            }
+            writer.close()?;
+            let size = fs::metadata(fixture.directory.path().join(&path))?.len();
+            let mut add = json!({"path":path,"partitionValues":{},"size":size,"modificationTime":0,"dataChange":true});
+            if spec.log_stats {
+                add["stats"] = json!(json!({"numRecords":spec.rows,"minValues":{"id":first_id,"value":-(spec.rows as i64 - 1)},"maxValues":{"id":global_id - 1,"value":0},"nullCount":{"id":0,"value":0}}).to_string());
+            }
+            if let Some(deleted) = &spec.deleted {
+                add["deletionVector"] = fixture.write_dv(file_id, 0, deleted)?;
+            }
+            fixture.deleted.push(spec.deleted);
+            fixture.adds.push(add);
+        }
+        let mut actions = vec![protocol, metadata];
+        actions.extend(fixture.adds.iter().map(|add| json!({"add":add})));
+        fixture.write_log(0, actions)?;
+        Ok(fixture)
+    }
+
+    pub fn url(&self) -> Url {
+        Url::from_directory_path(self.directory.path()).unwrap()
+    }
+
+    pub fn live_coordinates(&self) -> Vec<(usize, u64, i64, i64)> {
+        self.coordinates
+            .iter()
+            .copied()
+            .filter(|(file, position, _, _)| {
+                !self.deleted[*file]
+                    .as_ref()
+                    .is_some_and(|deleted| deleted.contains(position))
+            })
+            .collect()
+    }
+
+    pub fn replace_visibility(
+        &mut self,
+        file_id: usize,
+        deleted: BTreeSet<u64>,
+    ) -> FixtureResult<()> {
+        self.version += 1;
+        let old = self.adds[file_id].clone();
+        let mut remove = old.clone();
+        remove["deletionTimestamp"] = json!(self.version);
+        remove["extendedFileMetadata"] = json!(true);
+        let mut add = old;
+        add["deletionVector"] = self.write_dv(file_id, self.version, &deleted)?;
+        self.write_log(
+            self.version,
+            vec![json!({"remove":remove}), json!({"add":add})],
+        )?;
+        self.adds[file_id] = add;
+        self.deleted[file_id] = Some(deleted);
+        Ok(())
+    }
+
+    fn write_dv(
+        &self,
+        file: usize,
+        version: usize,
+        positions: &BTreeSet<u64>,
+    ) -> FixtureResult<Value> {
+        let path = self
+            .directory
+            .path()
+            .join(format!("dv-{file}-{version}.bin"));
+        let mut output = fs::File::create(&path)?;
+        let mut writer = StreamingDeletionVectorWriter::new(&mut output);
+        let mut dv = KernelDeletionVector::new();
+        dv.add_deleted_row_indexes(positions.iter().copied());
+        let written = writer.write_deletion_vector(dv)?;
+        writer.finalize()?;
+        Ok(
+            json!({"storageType":"p","pathOrInlineDv":Url::from_file_path(path).unwrap().as_str(),"offset":written.offset,"sizeInBytes":written.size_in_bytes,"cardinality":positions.len()}),
+        )
+    }
+
+    fn write_log(&self, version: usize, actions: Vec<Value>) -> FixtureResult<()> {
+        fs::write(
+            self.directory
+                .path()
+                .join("_delta_log")
+                .join(format!("{version:020}.json")),
+            actions
+                .iter()
+                .map(Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )?;
+        Ok(())
+    }
+}

--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -776,12 +776,11 @@ impl From<&TableFeatures> for TableFeature {
 }
 
 impl TableFeatures {
-    /// Convert table feature to respective reader or/and write feature
+    /// Return the feature's reader and writer requirements.
     pub fn to_reader_writer_features(&self) -> (Option<TableFeature>, Option<TableFeature>) {
         let feature = TableFeature::from(self);
-        // Classify features based on their type
-        // Writer-only features
         match feature {
+            // Writer features
             TableFeature::AppendOnly
             | TableFeature::Invariants
             | TableFeature::CheckConstraints
@@ -796,7 +795,7 @@ impl TableFeatures {
             | TableFeature::ClusteredTable
             | TableFeature::MaterializePartitionColumns => (None, Some(feature)),
 
-            // ReaderWriter features
+            // Reader and writer features
             TableFeature::CatalogManaged
             | TableFeature::CatalogOwnedPreview
             | TableFeature::ColumnMapping
@@ -810,7 +809,7 @@ impl TableFeatures {
             | TableFeature::VariantTypePreview
             | TableFeature::VariantShreddingPreview => (Some(feature.clone()), Some(feature)),
 
-            // Optional ReaderWriter features
+            // Optional reader and writer features
             #[cfg(feature = "nanosecond-timestamps")]
             TableFeature::TimestampNanos => (Some(feature.clone()), Some(feature)),
 

--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -769,65 +769,56 @@ impl fmt::Display for TableFeatures {
     }
 }
 
-impl TryFrom<&TableFeatures> for TableFeature {
-    type Error = std::convert::Infallible;
-
-    fn try_from(value: &TableFeatures) -> Result<Self, Self::Error> {
-        TableFeature::try_from(value.as_ref())
+impl From<&TableFeatures> for TableFeature {
+    fn from(value: &TableFeatures) -> Self {
+        TableFeature::from(value.as_ref())
     }
 }
 
 impl TableFeatures {
     /// Convert table feature to respective reader or/and write feature
     pub fn to_reader_writer_features(&self) -> (Option<TableFeature>, Option<TableFeature>) {
-        let feature = TableFeature::try_from(self).ok();
+        let feature = TableFeature::from(self);
+        // Classify features based on their type
+        // Writer-only features
         match feature {
-            Some(feature) => {
-                // Classify features based on their type
-                // Writer-only features
-                match feature {
-                    TableFeature::AppendOnly
-                    | TableFeature::Invariants
-                    | TableFeature::CheckConstraints
-                    | TableFeature::ChangeDataFeed
-                    | TableFeature::GeneratedColumns
-                    | TableFeature::IdentityColumns
-                    | TableFeature::InCommitTimestamp
-                    | TableFeature::RowTracking
-                    | TableFeature::DomainMetadata
-                    | TableFeature::IcebergCompatV1
-                    | TableFeature::IcebergCompatV2
-                    | TableFeature::ClusteredTable
-                    | TableFeature::MaterializePartitionColumns => (None, Some(feature)),
+            TableFeature::AppendOnly
+            | TableFeature::Invariants
+            | TableFeature::CheckConstraints
+            | TableFeature::ChangeDataFeed
+            | TableFeature::GeneratedColumns
+            | TableFeature::IdentityColumns
+            | TableFeature::InCommitTimestamp
+            | TableFeature::RowTracking
+            | TableFeature::DomainMetadata
+            | TableFeature::IcebergCompatV1
+            | TableFeature::IcebergCompatV2
+            | TableFeature::ClusteredTable
+            | TableFeature::MaterializePartitionColumns => (None, Some(feature)),
 
-                    // ReaderWriter features
-                    TableFeature::CatalogManaged
-                    | TableFeature::CatalogOwnedPreview
-                    | TableFeature::ColumnMapping
-                    | TableFeature::DeletionVectors
-                    | TableFeature::TimestampWithoutTimezone
-                    | TableFeature::TypeWidening
-                    | TableFeature::TypeWideningPreview
-                    | TableFeature::V2Checkpoint
-                    | TableFeature::VacuumProtocolCheck
-                    | TableFeature::VariantType
-                    | TableFeature::VariantTypePreview
-                    | TableFeature::VariantShreddingPreview => {
-                        (Some(feature.clone()), Some(feature))
-                    }
+            // ReaderWriter features
+            TableFeature::CatalogManaged
+            | TableFeature::CatalogOwnedPreview
+            | TableFeature::ColumnMapping
+            | TableFeature::DeletionVectors
+            | TableFeature::TimestampWithoutTimezone
+            | TableFeature::TypeWidening
+            | TableFeature::TypeWideningPreview
+            | TableFeature::V2Checkpoint
+            | TableFeature::VacuumProtocolCheck
+            | TableFeature::VariantType
+            | TableFeature::VariantTypePreview
+            | TableFeature::VariantShreddingPreview => (Some(feature.clone()), Some(feature)),
 
-                    // Optional ReaderWriter features
-                    #[cfg(feature = "nanosecond-timestamps")]
-                    TableFeature::TimestampNanos => (Some(feature.clone()), Some(feature)),
+            // Optional ReaderWriter features
+            #[cfg(feature = "nanosecond-timestamps")]
+            TableFeature::TimestampNanos => (Some(feature.clone()), Some(feature)),
 
-                    // Unknown features
-                    TableFeature::Unknown(_) => (None, None),
-                    others => {
-                        panic!("This table has unsupported table features: {others:?}");
-                    }
-                }
+            // Unknown features
+            TableFeature::Unknown(_) => (None, None),
+            others => {
+                panic!("This table has unsupported table features: {others:?}");
             }
-            None => (None, None),
         }
     }
 }

--- a/crates/core/src/kernel/snapshot/stats_projection.rs
+++ b/crates/core/src/kernel/snapshot/stats_projection.rs
@@ -233,10 +233,8 @@ impl StatsProjection {
 
         let columns = requested_columns
             .iter()
-            .filter_map(|column| {
-                stats_schema_contains_data_column(stats_schema.as_ref(), column)
-                    .then(|| column.clone())
-            })
+            .filter(|&column| stats_schema_contains_data_column(stats_schema.as_ref(), column))
+            .cloned()
             .collect::<BTreeSet<_>>();
 
         if columns.is_empty() {

--- a/crates/core/src/kernel/transaction/mod.rs
+++ b/crates/core/src/kernel/transaction/mod.rs
@@ -516,11 +516,10 @@ impl CommitData {
                 let mut action: Value = serde_json::from_str(line)
                     .map_err(|e| TransactionError::SerializeLogJson { json_err: e })?;
 
-                if let Some(commit_info) = action.get_mut("commitInfo") {
-                    if let Some(Value::Object(metrics)) = commit_info.get_mut("operationMetrics") {
-                        metrics
-                            .insert("num_retries".to_string(), Value::Number(num_retries.into()));
-                    }
+                if let Some(commit_info) = action.get_mut("commitInfo")
+                    && let Some(Value::Object(metrics)) = commit_info.get_mut("operationMetrics")
+                {
+                    metrics.insert("num_retries".to_string(), Value::Number(num_retries.into()));
                 }
                 // Serialize just this updated line
                 let updated_line = serde_json::to_string(&action)

--- a/crates/core/src/logstore/parquet_reader.rs
+++ b/crates/core/src/logstore/parquet_reader.rs
@@ -152,14 +152,13 @@ impl AsyncFileReader for ParquetObjectReader {
                 .with_prefetch_hint(self.metadata_size_hint);
 
             // Override page index policies from ArrowReaderOptions if specified and not Skip.
-            if let Some(options) = options {
-                if options.column_index_policy() != PageIndexPolicy::Skip
-                    || options.offset_index_policy() != PageIndexPolicy::Skip
-                {
-                    metadata = metadata
-                        .with_column_index_policy(options.column_index_policy())
-                        .with_offset_index_policy(options.offset_index_policy());
-                }
+            if let Some(options) = options
+                && (options.column_index_policy() != PageIndexPolicy::Skip
+                    || options.offset_index_policy() != PageIndexPolicy::Skip)
+            {
+                metadata = metadata
+                    .with_column_index_policy(options.column_index_policy())
+                    .with_offset_index_policy(options.offset_index_policy());
             }
 
             let metadata = if let Some(file_size) = self.file_size {
@@ -170,16 +169,5 @@ impl AsyncFileReader for ParquetObjectReader {
 
             Ok(Arc::new(metadata))
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parquet_object_reader_new() {
-        // This test just verifies the struct can be instantiated
-        // Full integration tests are in the operations module
     }
 }

--- a/crates/core/src/operations/update/tests.rs
+++ b/crates/core/src/operations/update/tests.rs
@@ -99,7 +99,7 @@ async fn test_update_predicate_left_in_data() -> DeltaResult<()> {
         .with_predicate(col("value").eq(lit(10)))
         .await?;
 
-    use parquet::arrow::async_reader::ParquetObjectReader;
+    use crate::logstore::parquet_reader::ParquetObjectReader;
     use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
 
     for pq in table.get_files_by_partitions(&[]).await? {

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -825,6 +825,10 @@ fn is_skippable_root_prefix(path: &Path) -> bool {
 /// At the final level each child prefix is yielded immediately.
 /// Intermediate-level orphans are reported via `on_intermediate_orphan`.
 /// Every listed object increments `scanned`.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Traversal state and metrics are explicit in this existing vacuum interface"
+)]
 fn expand_partition_prefixes(
     store: Arc<dyn ObjectStore>,
     partition_depth: usize,
@@ -933,6 +937,10 @@ fn expand_partition_prefixes(
 /// not just orphans). Only objects that pass `consider_orphan_for_deletion`
 /// are yielded. Inputs are owned/`Arc` so the stream is `'static` and can be
 /// driven from concurrent `buffer_unordered` tasks.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Traversal state and metrics are explicit in this existing vacuum interface"
+)]
 fn list_orphans_under_prefix(
     store: Arc<dyn ObjectStore>,
     prefix: Path,

--- a/crates/core/src/operations/vacuum.rs
+++ b/crates/core/src/operations/vacuum.rs
@@ -827,7 +827,7 @@ fn is_skippable_root_prefix(path: &Path) -> bool {
 /// Every listed object increments `scanned`.
 #[expect(
     clippy::too_many_arguments,
-    reason = "Traversal state and metrics are explicit in this existing vacuum interface"
+    reason = "Pass the traversal state and metrics together"
 )]
 fn expand_partition_prefixes(
     store: Arc<dyn ObjectStore>,
@@ -939,7 +939,7 @@ fn expand_partition_prefixes(
 /// driven from concurrent `buffer_unordered` tasks.
 #[expect(
     clippy::too_many_arguments,
-    reason = "Traversal state and metrics are explicit in this existing vacuum interface"
+    reason = "Pass the traversal state and metrics together"
 )]
 fn list_orphans_under_prefix(
     store: Arc<dyn ObjectStore>,

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -441,6 +441,10 @@ fn drop_internal_column(
     Ok(Arc::new(ProjectionExec::try_new(expressions, plan)?))
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Keep the existing write execution interface consistent with its sibling functions"
+)]
 pub(crate) async fn write_exec_plan(
     session: &dyn Session,
     log_store: &dyn LogStore,

--- a/crates/core/src/operations/write/execution.rs
+++ b/crates/core/src/operations/write/execution.rs
@@ -441,10 +441,7 @@ fn drop_internal_column(
     Ok(Arc::new(ProjectionExec::try_new(expressions, plan)?))
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "Keep the existing write execution interface consistent with its sibling functions"
-)]
+#[expect(clippy::too_many_arguments, reason = "Match the other write functions")]
 pub(crate) async fn write_exec_plan(
     session: &dyn Session,
     log_store: &dyn LogStore,

--- a/crates/core/src/operations/write/metrics.rs
+++ b/crates/core/src/operations/write/metrics.rs
@@ -8,7 +8,6 @@ use datafusion::physical_plan::{ExecutionPlan, metrics::MetricBuilder};
 use datafusion::{
     catalog::Session,
     physical_planner::{ExtensionPlanner, PhysicalPlanner},
-    prelude::Expr,
 };
 
 use crate::delta_datafusion::{logical::MetricObserver, physical::MetricObserverExec};

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -420,14 +420,14 @@ impl DeltaOperation {
     /// Parameters configured for operation.
     pub fn operation_parameters(&self) -> DeltaResult<HashMap<String, Value>> {
         let value = serde_json::to_value(self)?;
-        if let Value::Object(mut operation) = value {
-            if let Some(Value::Object(parameters)) = operation.values_mut().next() {
-                return Ok(take(parameters)
-                    .into_iter()
-                    .filter(|item| !item.1.is_null())
-                    .map(|(key, value)| (key, operation_parameter_value(value)))
-                    .collect());
-            }
+        if let Value::Object(mut operation) = value
+            && let Some(Value::Object(parameters)) = operation.values_mut().next()
+        {
+            return Ok(take(parameters)
+                .into_iter()
+                .filter(|item| !item.1.is_null())
+                .map(|(key, value)| (key, operation_parameter_value(value)))
+                .collect());
         }
 
         Err(DeltaTableError::Generic(

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -281,13 +281,12 @@ impl RecordBatchWriter {
     /// stripped before encoding) but must otherwise conform to the writer's
     /// schema. Returns the writer's current arrow schema.
     ///
-    /// With [`WriteMode::MergeSchema`] new columns widen the writer's schema
-    /// (sealing the files written so far) and the merged schema is returned; a
-    /// widening write on a partitioned table is rejected as unsupported.
-    /// A later [`flush_and_commit`](super::DeltaWriter::flush_and_commit) commits
-    /// the evolved metadata along with the data; on the [`flush`](super::DeltaWriter::flush)
-    /// followed by a manual commit path, committing the evolved metadata is the caller's
-    /// responsibility.
+    /// With [`WriteMode::MergeSchema`], new columns widen the writer's schema and
+    /// seal the open files. Returns the merged schema. Schema changes on partitioned
+    /// tables are rejected.
+    /// [`flush_and_commit`](super::DeltaWriter::flush_and_commit) commits the updated
+    /// metadata with the data. Callers that use [`flush`](super::DeltaWriter::flush)
+    /// must commit the updated metadata themselves.
     ///
     /// Validation errors fail only this call and leave the flush window untouched.
     pub async fn write_partition(

--- a/crates/core/src/writer/record_batch.rs
+++ b/crates/core/src/writer/record_batch.rs
@@ -286,7 +286,7 @@ impl RecordBatchWriter {
     /// widening write on a partitioned table is rejected as unsupported.
     /// A later [`flush_and_commit`](super::DeltaWriter::flush_and_commit) commits
     /// the evolved metadata along with the data; on the [`flush`](super::DeltaWriter::flush)
-    /// + manual-commit path, committing the evolved metadata is the caller's
+    /// followed by a manual commit path, committing the evolved metadata is the caller's
     /// responsibility.
     ///
     /// Validation errors fail only this call and leave the flush window untouched.

--- a/crates/core/src/writer/stats.rs
+++ b/crates/core/src/writer/stats.rs
@@ -11,7 +11,7 @@ use delta_kernel::table_properties::DataSkippingNumIndexedCols;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use parquet::basic::Type;
-use parquet::basic::{ConvertedType, DecimalType, IntType, LogicalType, TimestampType};
+use parquet::basic::{ConvertedType, DecimalType, LogicalType};
 use parquet::file::metadata::ParquetMetaData;
 use parquet::schema::types::{ColumnDescriptor, SchemaDescriptor};
 use parquet::{
@@ -643,6 +643,7 @@ mod tests {
         protocol::{ColumnCountStat, ColumnValueStat},
         table::builder::DeltaTableBuilder,
     };
+    use parquet::basic::{IntType, TimestampType};
     use parquet::data_type::{ByteArray, FixedLenByteArray};
     use parquet::file::statistics::ValueStatistics;
     use parquet::{basic::Compression, file::properties::WriterProperties};

--- a/crates/core/tests/it_datafusion/command_optimize.rs
+++ b/crates/core/tests/it_datafusion/command_optimize.rs
@@ -16,6 +16,7 @@ use deltalake_core::ensure_table_uri;
 use deltalake_core::errors::DeltaTableError;
 use deltalake_core::kernel::transaction::{CommitBuilder, CommitProperties, TransactionError};
 use deltalake_core::kernel::{Action, Add, DataType, PrimitiveType, StructField, StructType};
+use deltalake_core::logstore::parquet_reader::ParquetObjectReader;
 use deltalake_core::logstore::{
     CommitOrBytes, LogStore, LogStoreConfig, LogStoreRef, ObjectStoreRef, get_actions,
 };
@@ -30,7 +31,6 @@ use deltalake_core::{
 };
 use futures::TryStreamExt;
 use object_store::ObjectStoreExt as _;
-use parquet::arrow::async_reader::ParquetObjectReader;
 use parquet::arrow::{ArrowWriter, ParquetRecordBatchStreamBuilder};
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;

--- a/crates/test/src/acceptance/data.rs
+++ b/crates/test/src/acceptance/data.rs
@@ -6,9 +6,10 @@ use arrow_ord::sort::{lexsort_to_indices, SortColumn};
 use arrow_schema::{DataType, Schema};
 use arrow_select::{concat::concat_batches, take::take};
 use delta_kernel::DeltaResult;
+use deltalake_core::logstore::parquet_reader::ParquetObjectReader;
 use futures::{stream::TryStreamExt, StreamExt};
 use object_store::{local::LocalFileSystem, ObjectStore};
-use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
+use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
 use pretty_assertions::assert_eq;
 
 use super::TestCaseInfo;


### PR DESCRIPTION
# Description
So I reviewed the rouge agent's work in #4700 and pulled out all the good stuff and polished it up 

This PR builds on #4692 and replaces consuming deletion masks with lookups keyed by file id and parquet row position. 

This keeps deletion filtering consistent across batch boundaries, repeated execution, and cancellation. Preserve the surviving row ordinals used by MERGE.

Validate file metadata, reader settings, and footer row counts before applying deletion vectors. Keep the physical row position column internal to the scan and share cached Parquet metadata by object store and path. Existing restrictions on predicate pushdown and repartitioning remain in place.

Add coverage for reader compatibility, child plan replacement, cancellation, and surviving row ordinals across batches and files.

I am planning on another follow up PR that will restore predicate pushdown and parallel scans to capture the expected performance impact.

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
