### PR TITLE
fix: bound in-flight parquet file uploads

### DIFF
--- a/crates/core/src/datafile/writer.rs
+++ b/crates/core/src/datafile/writer.rs
@@ -1,7 +1,7 @@
 //! Abstractions and implementations for writing data to delta tables
 
 use std::collections::HashMap;
-use std::num::NonZeroU64;
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 use std::sync::OnceLock;
 
@@ -35,6 +35,7 @@ use parquet::file::metadata::ParquetMetaData;
 const DEFAULT_WRITE_BATCH_SIZE: usize = 1024;
 const DEFAULT_UPLOAD_PART_SIZE: usize = 1024 * 1024 * 5;
 const DEFAULT_MAX_CONCURRENCY_TASKS: usize = 10;
+const DEFAULT_MAX_IN_FLIGHT_UPLOADS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
 
 fn upload_part_size() -> usize {
     static UPLOAD_SIZE: OnceLock<usize> = OnceLock::new();
@@ -66,6 +67,16 @@ fn get_max_concurrency_tasks() -> usize {
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
             .unwrap_or(DEFAULT_MAX_CONCURRENCY_TASKS)
+    })
+}
+
+fn max_in_flight_uploads() -> NonZeroUsize {
+    static MAX_UPLOADS: OnceLock<NonZeroUsize> = OnceLock::new();
+    *MAX_UPLOADS.get_or_init(|| {
+        std::env::var("DELTARS_MAX_IN_FLIGHT_UPLOADS")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_MAX_IN_FLIGHT_UPLOADS)
     })
 }
 
@@ -549,6 +560,8 @@ pub struct PartitionWriterConfig {
     write_batch_size: usize,
     /// Concurrency level for writing to object store
     max_concurrency_tasks: usize,
+    /// Maximum number of rolled files awaiting upload completion per partition.
+    max_in_flight_uploads: NonZeroUsize,
     /// Defer the `target_file_size` roll until the current row group is complete, so no
     /// file ends in a truncated row group. See
     /// [`PartitionWriterConfig::with_roll_on_row_group_boundary`].
@@ -587,8 +600,20 @@ impl PartitionWriterConfig {
             target_file_size,
             write_batch_size,
             max_concurrency_tasks: max_concurrency_tasks.unwrap_or_else(get_max_concurrency_tasks),
+            max_in_flight_uploads: max_in_flight_uploads(),
             roll_on_row_group_boundary: roll_on_row_group_boundary_default(),
         })
+    }
+
+    /// Limit pending file uploads per partition, applying backpressure before rolling another file.
+    ///
+    /// Defaults to `DELTARS_MAX_IN_FLIGHT_UPLOADS`, or 2 when unset, invalid, or zero.
+    /// This is separate from `DELTARS_MAX_CONCURRENCY_TASKS`, which limits multipart tasks
+    /// within each file. The current file's encoding buffer and other partitions' writers
+    /// are additional to this limit; it is not a process-wide memory budget.
+    pub fn with_max_in_flight_uploads(mut self, limit: NonZeroUsize) -> Self {
+        self.max_in_flight_uploads = limit;
+        self
     }
 
     /// Defer the `target_file_size` file roll until the parquet writer's current row group is
@@ -696,6 +721,7 @@ pub struct PartitionWriter {
     /// Stats columns, specific columns to collect stats from, takes precedence over num_indexed_cols
     stats_columns: Option<Vec<String>>,
     in_flight_writers: JoinSet<DeltaResult<(Path, usize, ParquetMetaData)>>,
+    completed_writes: Vec<(Path, usize, ParquetMetaData)>,
     /// Approximate encoded size of files already rolled to background upload;
     /// keeps `buffered_size` monotonic across rolls.
     rolled_bytes: usize,
@@ -722,6 +748,7 @@ impl PartitionWriter {
             num_indexed_cols,
             stats_columns,
             in_flight_writers: JoinSet::new(),
+            completed_writes: Vec::new(),
             rolled_bytes: 0,
         })
     }
@@ -745,7 +772,33 @@ impl PartitionWriter {
         )
     }
 
-    fn reset_writer(&mut self) -> DeltaResult<()> {
+    fn record_upload(
+        &mut self,
+        result: Result<DeltaResult<(Path, usize, ParquetMetaData)>, tokio::task::JoinError>,
+    ) -> DeltaResult<()> {
+        let data = result.map_err(|e| DeltaTableError::GenericError {
+            source: Box::new(e),
+        })??;
+        self.completed_writes.push(data);
+        Ok(())
+    }
+
+    fn drain_finished_uploads(&mut self) -> DeltaResult<()> {
+        while let Some(result) = self.in_flight_writers.try_join_next() {
+            self.record_upload(result)?;
+        }
+        Ok(())
+    }
+
+    async fn reset_writer(&mut self) -> DeltaResult<()> {
+        self.drain_finished_uploads()?;
+        // Wait before replacing the active writer: a cancelled wait leaves its
+        // buffers and multipart upload reachable by `abort`.
+        while self.in_flight_writers.len() >= self.config.max_in_flight_uploads.get() {
+            if let Some(result) = self.in_flight_writers.join_next().await {
+                self.record_upload(result)?;
+            }
+        }
         let next_path = self.next_data_path();
         let new_writer = Self::create_writer(self.object_store.clone(), next_path, &self.config);
         let state = std::mem::replace(&mut self.writer, new_writer);
@@ -793,6 +846,7 @@ impl PartitionWriter {
     /// The `close` method has to be invoked to write all data still buffered
     /// and get the list of all written files.
     pub async fn write(&mut self, batch: &RecordBatch) -> DeltaResult<()> {
+        self.drain_finished_uploads()?;
         if batch.schema() != self.config.file_schema {
             return Err(WriteError::SchemaMismatch {
                 schema: batch.schema(),
@@ -851,7 +905,7 @@ impl PartitionWriter {
                 && (boundary.is_none() || self.writer.in_progress_rows() == 0)
             {
                 debug!("Writing file with estimated size {estimated_size:?} in background.");
-                self.reset_writer()?;
+                self.reset_writer().await?;
             }
         }
 
@@ -862,36 +916,32 @@ impl PartitionWriter {
     ///
     /// This will flush any remaining data and collect all Add actions from background tasks.
     pub async fn close(mut self) -> DeltaResult<Vec<Add>> {
-        if let LazyArrowWriter::Writing(path, arrow_writer) = self.writer {
-            self.in_flight_writers
-                .spawn(upload_parquet_file(arrow_writer, path));
+        // The final partial file obeys the same limit as size-triggered rolls.
+        // If an earlier upload failed, abort the active file and drain siblings.
+        if let Err(e) = self.reset_writer().await {
+            if let Err(abort_err) = self.abort().await {
+                warn!("failed to abort writer after upload error: {abort_err}");
+            }
+            return Err(e);
         }
 
         // On a failed upload, keep draining the siblings rather than returning
         // early: dropping the JoinSet would cancel them mid-multipart, leaking
         // parts vacuum can't see (completed files are orphans it can reclaim).
-        let mut results = Vec::new();
         let mut first_err: Option<DeltaTableError> = None;
         while let Some(result) = self.in_flight_writers.join_next().await {
-            match result {
-                Ok(Ok(data)) => results.push(data),
-                Ok(Err(e)) => {
-                    first_err.get_or_insert(e);
-                }
-                Err(e) => {
-                    first_err.get_or_insert(DeltaTableError::GenericError {
-                        source: Box::new(e),
-                    });
-                }
+            if let Err(e) = self.record_upload(result) {
+                first_err.get_or_insert(e);
             }
         }
         if let Some(e) = first_err {
             return Err(e);
         }
 
-        sort_completed_writes_by_path(&mut results);
+        sort_completed_writes_by_path(&mut self.completed_writes);
 
-        let adds = results
+        let adds = self
+            .completed_writes
             .into_iter()
             .map(|(path, file_size, metadata)| {
                 create_add(
@@ -939,6 +989,9 @@ impl DataFileWriter for PartitionWriter {
         PartitionWriter::abort(*self).await
     }
 }
+
+#[cfg(test)]
+mod backpressure_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/datafile/writer/backpressure_tests.rs
+++ b/crates/core/src/datafile/writer/backpressure_tests.rs
@@ -1,0 +1,493 @@
+use super::*;
+use std::fmt::{Display, Formatter};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use arrow_array::Int32Array;
+use arrow_schema::{DataType, Field, Schema};
+use futures::{TryStreamExt, stream::BoxStream};
+use object_store::memory::InMemory;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult, UploadPart,
+};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use tokio::sync::Semaphore;
+
+/// Small rolled files take the single-PUT path. Hold their payloads until the
+/// test releases them, without relying on a particular network speed or sleep.
+#[derive(Debug)]
+struct GatedStore {
+    inner: InMemory,
+    permits: Semaphore,
+    started: Semaphore,
+    completed: AtomicUsize,
+    active: AtomicUsize,
+    peak: AtomicUsize,
+    fail_next: AtomicBool,
+    multipart_gate: Option<Arc<MultipartGate>>,
+}
+
+impl GatedStore {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: InMemory::new(),
+            permits: Semaphore::new(0),
+            started: Semaphore::new(0),
+            completed: AtomicUsize::new(0),
+            active: AtomicUsize::new(0),
+            peak: AtomicUsize::new(0),
+            fail_next: AtomicBool::new(false),
+            multipart_gate: None,
+        })
+    }
+}
+
+impl Display for GatedStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GatedStore")
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for GatedStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.peak.fetch_max(active, Ordering::SeqCst);
+        self.started.add_permits(1);
+        self.permits.acquire().await.unwrap().forget();
+        let result = if self.fail_next.swap(false, Ordering::SeqCst) {
+            Err(object_store::Error::Generic {
+                store: "GatedStore",
+                source: "injected upload failure".into(),
+            })
+        } else {
+            self.inner.put_opts(location, payload, opts).await
+        };
+        self.active.fetch_sub(1, Ordering::SeqCst);
+        self.completed.fetch_add(1, Ordering::SeqCst);
+        result
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        let inner = self.inner.put_multipart_opts(location, opts).await?;
+        match &self.multipart_gate {
+            Some(gate) => {
+                gate.created.fetch_add(1, Ordering::SeqCst);
+                Ok(Box::new(GatedMultipartUpload {
+                    inner,
+                    gate: gate.clone(),
+                }))
+            }
+            None => Ok(inner),
+        }
+    }
+
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        self.inner.copy_opts(from, to, options).await
+    }
+}
+
+#[derive(Debug)]
+struct MultipartGate {
+    permits: Semaphore,
+    finishing: Semaphore,
+    created: AtomicUsize,
+    completed: AtomicUsize,
+    aborted: AtomicUsize,
+}
+
+#[derive(Debug)]
+struct GatedMultipartUpload {
+    inner: Box<dyn MultipartUpload>,
+    gate: Arc<MultipartGate>,
+}
+
+#[async_trait::async_trait]
+impl MultipartUpload for GatedMultipartUpload {
+    fn put_part(&mut self, data: PutPayload) -> UploadPart {
+        self.inner.put_part(data)
+    }
+
+    async fn complete(&mut self) -> object_store::Result<PutResult> {
+        self.gate.finishing.add_permits(1);
+        self.gate.permits.acquire().await.unwrap().forget();
+        let result = self.inner.complete().await;
+        self.gate.completed.fetch_add(1, Ordering::SeqCst);
+        result
+    }
+
+    async fn abort(&mut self) -> object_store::Result<()> {
+        self.gate.aborted.fetch_add(1, Ordering::SeqCst);
+        self.inner.abort().await
+    }
+}
+
+fn batch(rows: usize) -> RecordBatch {
+    RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
+        vec![Arc::new(Int32Array::from_iter_values(0..rows as i32))],
+    )
+    .unwrap()
+}
+
+fn writer(store: Arc<GatedStore>, batch: &RecordBatch) -> PartitionWriter {
+    let props = WriterProperties::builder()
+        .set_compression(Compression::UNCOMPRESSED)
+        .set_dictionary_enabled(false)
+        .set_max_row_group_row_count(Some(32))
+        .build();
+    let config = PartitionWriterConfig::try_new(
+        batch.schema(),
+        IndexMap::new(),
+        Some(props),
+        NonZeroU64::new(1),
+        Some(32),
+        None,
+        None,
+    )
+    .unwrap()
+    .with_max_in_flight_uploads(NonZeroUsize::new(2).unwrap());
+    PartitionWriter::try_with_config(
+        store,
+        config,
+        DataSkippingNumIndexedCols::NumColumns(32),
+        None,
+    )
+    .unwrap()
+}
+
+#[rstest::rstest]
+#[case(1)]
+#[case(2)]
+#[case(4)]
+#[tokio::test]
+async fn rolled_uploads_backpressure_and_preserve_rows(#[case] limit: usize) {
+    let store = GatedStore::new();
+    let batch = batch(32 * 20);
+    let mut writer = writer(store.clone(), &batch);
+    writer.config = writer
+        .config
+        .with_max_in_flight_uploads(NonZeroUsize::new(limit).unwrap());
+    let mut write = Box::pin(writer.write(&batch));
+
+    // A single batch rolls twenty files. With storage blocked, it must yield
+    // instead of detaching all twenty payloads and reporting write success.
+    let pending = futures::poll!(&mut write).is_pending();
+    tokio::task::yield_now().await;
+    eprintln!(
+        "blocked store: pending={pending}, active uploads={}",
+        store.active.load(Ordering::SeqCst)
+    );
+    assert!(pending);
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        store.started.acquire_many(limit as u32),
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .forget();
+    assert_eq!(store.active.load(Ordering::SeqCst), limit);
+    store.permits.add_permits(20);
+    tokio::time::timeout(Duration::from_secs(5), write)
+        .await
+        .unwrap()
+        .unwrap();
+    let adds = writer.close().await.unwrap();
+    assert_eq!(adds.len(), 20);
+    assert!(store.peak.load(Ordering::SeqCst) <= limit);
+    assert_eq!(store.completed.load(Ordering::SeqCst), 20);
+    assert!(adds.windows(2).all(|pair| pair[0].path < pair[1].path));
+
+    let mut actual = Vec::new();
+    for add in adds {
+        let bytes = store
+            .get(&Path::from(add.path))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!(bytes.len() as i64, add.size);
+        for batch in ParquetRecordBatchReaderBuilder::try_new(bytes)
+            .unwrap()
+            .build()
+            .unwrap()
+        {
+            let batch = batch.unwrap();
+            actual.extend_from_slice(
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values(),
+            );
+        }
+    }
+    actual.sort_unstable();
+    assert_eq!(actual, (0..640).collect::<Vec<i32>>());
+}
+
+#[tokio::test]
+async fn rolled_upload_failure_stops_writing_and_drains_siblings() {
+    let store = GatedStore::new();
+    let batch = batch(32 * 20);
+    let mut writer = writer(store.clone(), &batch);
+    store.fail_next.store(true, Ordering::SeqCst);
+    store.permits.add_permits(20);
+    let result = writer.write(&batch).await;
+    assert!(
+        result.is_err(),
+        "background failure must surface during write"
+    );
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("injected upload failure")
+    );
+    writer.abort().await.unwrap();
+    assert_eq!(store.active.load(Ordering::SeqCst), 0);
+    assert!(store.completed.load(Ordering::SeqCst) < 20);
+}
+
+#[tokio::test]
+async fn cancelled_backpressure_wait_can_be_aborted() {
+    let store = GatedStore::new();
+    let batch = batch(32 * 20);
+    let mut writer = writer(store.clone(), &batch);
+    let mut write = Box::pin(writer.write(&batch));
+    assert!(futures::poll!(&mut write).is_pending());
+    tokio::time::timeout(Duration::from_secs(5), store.started.acquire_many(2))
+        .await
+        .unwrap()
+        .unwrap()
+        .forget();
+    drop(write);
+
+    let mut abort = Box::pin(writer.abort());
+    assert!(futures::poll!(&mut abort).is_pending());
+    store.permits.add_permits(2);
+    tokio::time::timeout(Duration::from_secs(5), abort)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(store.active.load(Ordering::SeqCst), 0);
+    assert_eq!(store.completed.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn cancelled_wait_aborts_active_multipart_upload() {
+    use arrow_array::Int64Array;
+    let gate = Arc::new(MultipartGate {
+        permits: Semaphore::new(0),
+        finishing: Semaphore::new(0),
+        created: AtomicUsize::new(0),
+        completed: AtomicUsize::new(0),
+        aborted: AtomicUsize::new(0),
+    });
+    let mut store = GatedStore::new();
+    Arc::get_mut(&mut store).unwrap().multipart_gate = Some(gate.clone());
+    // Each file exceeds BufWriter's 5 MiB threshold and opens an actual multipart upload.
+    let rows = 768 * 1024;
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)])),
+        vec![Arc::new(Int64Array::from_iter_values(0..rows as i64))],
+    )
+    .unwrap();
+    let props = WriterProperties::builder()
+        .set_compression(Compression::UNCOMPRESSED)
+        .set_dictionary_enabled(false)
+        .set_max_row_group_row_count(Some(rows))
+        .build();
+    let config = PartitionWriterConfig::try_new(
+        batch.schema(),
+        IndexMap::new(),
+        Some(props),
+        NonZeroU64::new(1),
+        Some(rows),
+        Some(1),
+        None,
+    )
+    .unwrap()
+    .with_max_in_flight_uploads(NonZeroUsize::new(2).unwrap());
+    let mut writer = PartitionWriter::try_with_config(
+        store.clone(),
+        config,
+        DataSkippingNumIndexedCols::NumColumns(32),
+        None,
+    )
+    .unwrap();
+    let mut write = Box::pin(async {
+        for _ in 0..3 {
+            writer.write(&batch).await?;
+        }
+        Ok::<_, DeltaTableError>(())
+    });
+    assert!(futures::poll!(&mut write).is_pending());
+    tokio::time::timeout(Duration::from_secs(5), gate.finishing.acquire_many(2))
+        .await
+        .unwrap()
+        .unwrap()
+        .forget();
+    assert_eq!(gate.created.load(Ordering::SeqCst), 3);
+    drop(write);
+    gate.permits.add_permits(2);
+    tokio::time::timeout(Duration::from_secs(5), writer.abort())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(gate.completed.load(Ordering::SeqCst), 2);
+    assert_eq!(gate.aborted.load(Ordering::SeqCst), 1);
+    let files: Vec<_> = store.list(None).try_collect().await.unwrap();
+    assert_eq!(
+        files.len(),
+        2,
+        "the active file must not be finalized by abort"
+    );
+}
+
+#[tokio::test]
+async fn final_partial_file_obeys_backpressure() {
+    let store = GatedStore::new();
+    let batch = batch(65);
+    let mut writer = writer(store.clone(), &batch);
+    // Full 32-row groups exceed this target; the last row stays buffered.
+    writer.config.target_file_size = NonZeroU64::new(128);
+    writer.write(&batch).await.unwrap();
+    let mut close = Box::pin(writer.close());
+    assert!(futures::poll!(&mut close).is_pending());
+    tokio::time::timeout(Duration::from_secs(5), store.started.acquire_many(2))
+        .await
+        .unwrap()
+        .unwrap()
+        .forget();
+    // Yield to any incorrectly spawned third upload as well.
+    tokio::task::yield_now().await;
+    assert_eq!(store.active.load(Ordering::SeqCst), 2);
+    store.permits.add_permits(3);
+    let adds = tokio::time::timeout(Duration::from_secs(5), close)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(adds.len(), 3);
+    assert!(store.peak.load(Ordering::SeqCst) <= 2);
+}
+
+#[tokio::test]
+async fn close_failure_drains_pending_uploads() {
+    let store = GatedStore::new();
+    let batch = batch(65);
+    let mut writer = writer(store.clone(), &batch);
+    writer.config.target_file_size = NonZeroU64::new(128);
+    writer.write(&batch).await.unwrap();
+    store.fail_next.store(true, Ordering::SeqCst);
+    store.permits.add_permits(3);
+    let result = tokio::time::timeout(Duration::from_secs(5), writer.close())
+        .await
+        .unwrap();
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("injected upload failure")
+    );
+    assert_eq!(store.active.load(Ordering::SeqCst), 0);
+    assert_eq!(store.completed.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn partitioned_write_preserves_all_files_under_backpressure() {
+    let store = GatedStore::new();
+    let values = batch(32 * 20);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("partition", DataType::Int32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            values.column(0).clone(),
+            Arc::new(Int32Array::from_iter_values((0..640).map(|i| i % 2))),
+        ],
+    )
+    .unwrap();
+    let props = WriterProperties::builder()
+        .set_compression(Compression::UNCOMPRESSED)
+        .set_dictionary_enabled(false)
+        .set_max_row_group_row_count(Some(32))
+        .build();
+    let config = WriterConfig::new(
+        batch.schema(),
+        vec!["partition".into()],
+        Some(props),
+        NonZeroU64::new(1),
+        Some(32),
+        DataSkippingNumIndexedCols::NumColumns(32),
+        None,
+    );
+    let mut writer = DeltaWriter::new(store.clone(), config);
+    let mut write = Box::pin(writer.write(&batch));
+    assert!(futures::poll!(&mut write).is_pending());
+    store.permits.add_permits(20);
+    tokio::time::timeout(Duration::from_secs(5), write)
+        .await
+        .unwrap()
+        .unwrap();
+    let adds = writer.close().await.unwrap();
+    assert_eq!(adds.len(), 20);
+    assert_eq!(
+        adds.iter()
+            .filter(|add| add.partition_values["partition"].as_deref() == Some("0"))
+            .count(),
+        10
+    );
+    assert_eq!(
+        adds.iter()
+            .filter(|add| add.partition_values["partition"].as_deref() == Some("1"))
+            .count(),
+        10
+    );
+    // The file limit is per partition, so two partitions can have four uploads.
+    assert!(store.peak.load(Ordering::SeqCst) <= 4);
+    assert_eq!(store.active.load(Ordering::SeqCst), 0);
+}

--- a/docs/usage/writing/index.md
+++ b/docs/usage/writing/index.md
@@ -55,6 +55,23 @@ target table.
 
 {{ code_example('operations', 'replace_where', ['replaceWhere'])}}
 
+## Upload backpressure
+
+When writing to a slow object store, completed Parquet files can be produced
+faster than they are uploaded. Each partition writer limits pending file uploads
+to two by default, waiting for an upload to finish before rolling another file.
+This also applies to the final partial file when the writer closes.
+
+Set `DELTARS_MAX_IN_FLIGHT_UPLOADS` to a positive integer before the first write
+to change this limit. An unset, invalid, or zero value uses the default of two.
+The setting is separate from `DELTARS_MAX_CONCURRENCY_TASKS`, which controls
+multipart concurrency **within each file**.
+
+This bounds pending file uploads per partition writer, not total process memory.
+The current file's encoding buffers, input batches, completed-file metadata, and
+other partition writers also consume memory. More active partitions or concurrent
+writers increase total memory usage.
+
 ## Using Writer Properties
 
 You can customize the Rust Parquet writer by using the


### PR DESCRIPTION
Fixes #4701.

Rolling a Parquet file currently detaches its upload without limiting pending files. If storage cannot keep up, each roll retains another upload's buffers. `DELTARS_MAX_CONCURRENCY_TASKS` only limits multipart concurrency within a file.

This limits pending file uploads to two per partition writer by default, awaiting completion before rolling another file, including the final partial file. Completed tasks are drained during writing so upload errors surface before end-of-stream. Successful metadata retains the existing sorted `Add` output. Cancelling a capacity wait leaves the active writer reachable by `abort`; failed closes drain sibling uploads before returning the original error.

The limit is configurable through `DELTARS_MAX_IN_FLIGHT_UPLOADS` or `PartitionWriterConfig::with_max_in_flight_uploads(NonZeroUsize)`. Input batches, the active encoder, completed-file metadata, and additional partition writers remain separate memory costs.

## Validation

- The original six regression cases fail on the unchanged base. With storage blocked, it returns write success with 20 active uploads; the patch waits with two.
- Final writer tests: **24 passed**, including nine new cases covering limits of 1/2/4, exact data readback, file sizes/order, tail files, upload errors, cancellation, and partitioned writes. The multipart case confirms that two rolled uploads finish while the active third upload is aborted.
- After merging current `main` (`596f1c5`) into PR head `8699574`, Rust 1.94.1 / Windows x64: **1,229 core library tests passed with `datafusion`**, with two upstream ignored tests and no failures. This includes all 24 writer tests. Official DAT v0.0.3 fixtures were installed.
- `cargo clippy -p deltalake-core --features datafusion --tests --locked`, `cargo fmt --all -- --check`, and `git diff --check` pass. Lint warnings are in unchanged code.

### Local MinIO comparison

Native Rust dev builds, 64 approximately 1 MiB uncompressed Parquet files, aggregate upload bandwidth limited to 2 MiB/s, multipart concurrency 1, 120-second request timeout, and retries disabled:

| Metric | Base | Patch (limit 2) |
|---|---:|---:|
| Peak client RSS | 84.66 MiB | 20.49 MiB |
| Peak concurrent upload requests | 64 | 2 |
| Write and close elapsed | 34.68 s | 36.85 s |

Memory fell 75.8%, with a 6.3% elapsed-time increase in this case. All 16 final probe runs verified file lengths and every row value. These measurements cover the native writer on local MinIO; they are not a production throughput benchmark or the full Polars OOM reproduction.

A follow-up native MinIO experiment on September 10 used 67,108,864 rows and ten Int64 columns, producing 32 files of 167,833,868 bytes each (5,370,683,776 bytes total, approximately 5 GiB), with every row and column read back. At a 16 MiB/s aggregate upload limit, the patch peaked at approximately 601 MiB client RSS and finished write/close in 362.3 seconds. The same baseline workload was deliberately stopped after exceeding a 2.5 GiB client-RSS safety limit; it has no completed throughput result. This was Windows/native `PartitionWriter`, not the exact Polars/Docker/Toxiproxy reproduction. The experiment was not repeated for this main synchronization.

Linux/macOS and the full Python binding suite have not been run locally. The new-head GitHub build, integration, Python, docs, and chores workflows currently require maintainer approval (`action_required`); their previous-head green results do not validate this synchronization.

AI assistance: Codex generated the implementation, regression tests, and validation harness and executed the reported local checks.

